### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Please follow our contributing guidelines located at TBD.
+
+In general, please:
+- open the PR in draft mode
+- keep commits as small and focused on specific changes as much as possible
+- try to use conventional commits
+- prefix your PR with a Jira ticket number if available
+- fill out the PR description template below
+
+Feel free to delete this comment text block before submitting the PR.
+-->
+
+## What this PR does / why we need it:
+
+## Which issue(s) this PR fixes:
+<!--
+(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
+-->
+Fixes 
+
+## Special notes for your reviewer:
+
+## Checklist:
+- [ ] Subject and description added to both, commit and PR.
+- [ ] Relevant issues have been referenced.
+- [ ] This change includes docs. 


### PR DESCRIPTION
Add a comprehensive PR template that guides contributors to:
- Follow best practices (draft mode, small focused commits)
- Use conventional commits and test changes locally
- Prefix PRs with Jira ticket numbers if available
- Provide structured PR descriptions with issue references
- Complete a checklist