### PR TITLE
chore(owners): re-add bryan-cox to approvers and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - enxebre
+- bryan-cox
 - bentito
 - brandisher
 - dgoodwin
@@ -7,6 +8,7 @@ approvers:
 - stbenjam
 reviewers:
 - enxebre
+- bryan-cox
 - bentito
 - brandisher
 - dgoodwin


### PR DESCRIPTION
Re-add bryan-cox to the OWNERS file approvers and reviewers lists to restore previous maintainer access.