### PR TITLE
Add utils plugin as generic catch-all for helper commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,11 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira"
+    },
+    {
+      "name": "utils",
+      "source": "./plugins/utils",
+      "description": "A generic utilities plugin serving as a catch-all for various helper commands"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,30 @@ Automate JIRA issue analysis and pull request creation.
 Want to contribute or create your own plugins? Check out the `plugins/` directory for examples.
 Make sure your commands and agents follow the conventions for the Sections structure presented in the hello-world reference implementation plugin (see [`hello-world:echo`](plugins/hello-world/commands/echo.md) for an example).
 
+### Adding New Commands
+
+When contributing new commands:
+
+1. **If your command fits an existing plugin**: Add it to the appropriate plugin's `commands/` directory
+2. **If your command doesn't have a clear parent plugin**: Add it to the **utils plugin** (`plugins/utils/commands/`)
+   - The utils plugin serves as a catch-all for commands that don't fit existing categories
+   - Once we accumulate several related commands in utils, they can be segregated into a new targeted plugin
+
+### Creating a New Plugin
+
+If you're contributing several related commands that warrant their own plugin:
+
+1. Create a new directory under `plugins/` with your plugin name
+2. Create the plugin structure:
+   ```
+   plugins/your-plugin/
+   ├── .claude-plugin/
+   │   └── plugin.json
+   └── commands/
+       └── your-command.md
+   ```
+3. Register your plugin in `.claude-plugin/marketplace.json`
+
 ## License
 
 See [LICENSE](LICENSE) for details.

--- a/plugins/utils/.claude-plugin/plugin.json
+++ b/plugins/utils/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "utils",
+  "description": "A generic utilities plugin serving as a catch-all for various helper commands and agents",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/utils/commands/placeholder.md
+++ b/plugins/utils/commands/placeholder.md
@@ -1,0 +1,26 @@
+---
+description: Placeholder command for the utils plugin
+---
+
+## Name
+utils:placeholder
+
+## Synopsis
+```
+/utils:placeholder
+```
+
+## Description
+This is a placeholder command for the utils plugin. The utils plugin serves as a catch-all location for introducing new generic commands. Once enough related commands are accumulated, they can be segregated into more targeted, specialized plugins.
+
+This placeholder exists to maintain the plugin structure and will be replaced with actual utility commands as they are developed.
+
+## Implementation
+The utils plugin provides a home for:
+- Generic helper commands that don't fit into existing specialized plugins
+- Experimental commands that may later be moved to dedicated plugins
+- Common utilities that benefit multiple workflows
+- Commands that are waiting to be grouped with similar functionality
+
+## Arguments:
+None


### PR DESCRIPTION
## Summary
- Add new utils plugin to serve as a catch-all location for generic helper commands
- Register utils plugin in marketplace.json
- Add README.md with installation instructions and plugin development guidelines

## Purpose
The utils plugin provides a home for generic commands that don't fit into existing specialized plugins. As related commands accumulate in utils, they can be segregated into more targeted plugins.

## Changes
- Created `plugins/utils/` directory with plugin structure
- Added placeholder command to maintain plugin structure
- Registered utils plugin in `.claude-plugin/marketplace.json`
- Added comprehensive README.md documenting installation and contribution guidelines

## Test plan
- [ ] Verify plugin can be installed from marketplace
- [ ] Confirm placeholder command is accessible via `/utils:placeholder`
- [ ] Validate README instructions for adding new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)