### PR TITLE
feat(jira): add jira:test command for generating manual test guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ Comprehensive Jira automation including:
 - **Issue Analysis & Solutions** (`/jira:solve`) - Analyze JIRA issues and create pull requests to solve them
 - **Weekly Status Rollups** (`/jira:status-rollup`) - Generate status summaries by analyzing all child issues
 - **Backlog Grooming** (`/jira:grooming`) - Analyze new bugs and cards for grooming meetings
+- **Test Generation** (`/jira:generate-test-plan`) - Generate comprehensive test steps for JIRA issues by analyzing related PRs
 
 See [plugins/jira/README.md](plugins/jira/README.md) for full documentation.
+
+### Utils Plugin
+
+General-purpose utilities for development workflows:
+- **PR Test Generation** (`/utils:generate-test-plan`) - Generate test steps for one or more related PRs
+
+See [plugins/utils/commands/generate-test-plan.md](plugins/utils/commands/generate-test-plan.md) for full documentation.
 
 ## Plugin Development
 

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -7,6 +7,7 @@ Comprehensive Jira integration for Claude Code, providing AI-powered tools to an
 - 🔍 **Issue Analysis and Solutions** - Analyze JIRA issues and create pull requests to solve them
 - 📊 **Status Rollups** - Generate comprehensive weekly status rollup comments for any Jira issue
 - 📋 **Backlog Grooming** - Analyze new bugs and cards for grooming meetings
+- 🧪 **Test Generation** - Generate comprehensive test steps for JIRA issues by analyzing related PRs
 - 🤖 **Automated Workflows** - From issue analysis to PR creation, fully automated
 - 💬 **Smart Comment Analysis** - Extracts blockers, risks, and key insights from comments
 
@@ -94,6 +95,22 @@ Analyze and organize new bugs and cards added over a specified time period to pr
 ```
 See [commands/grooming.md](commands/grooming.md) for full documentation.
 
+---
+
+### `/jira:generate-test-plan` - Generate Test Steps
+
+Generate comprehensive test steps for a JIRA issue by analyzing related pull requests. The command supports auto-discovery of PRs from the JIRA issue or manual specification of specific PRs to analyze.
+
+**Usage:**
+```bash
+# Auto-discover all PRs from JIRA
+/jira:generate-test-plan CNTRLPLANE-205
+
+# Test only specific PRs
+/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888
+```
+
+See [commands/generate-test-plan.md](commands/generate-test-plan.md) for full documentation.
 
 ## Troubleshooting
 

--- a/plugins/jira/commands/generate-test-plan.md
+++ b/plugins/jira/commands/generate-test-plan.md
@@ -1,0 +1,184 @@
+---
+description: Generate test steps for a JIRA issue
+argument-hint: [JIRA issue key] [GitHub PR URLs]
+---
+
+## Name
+jira:generate-test-plan
+
+Generate comprehensive test steps for a JIRA issue by analyzing related pull requests.
+
+[Extended thinking: This command takes a JIRA issue key and optionally a list of PR URLs. It fetches the JIRA issue details, retrieves all related PRs (or uses the provided PR list), analyzes the changes, and generates a comprehensive manual testing guide.]
+
+**JIRA Issue Test Guide Generator**
+
+## Usage Examples:
+
+1. **Generate test steps for JIRA with auto-discovered PRs**:
+   `/jira:generate-test-plan CNTRLPLANE-205`
+
+2. **Generate test steps for JIRA with specific PRs only**:
+   `/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888`
+
+3. **Generate test steps for multiple specific PRs**:
+   `/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888 https://github.com/openshift/hypershift/pull/6889`
+
+## Implementation Details:
+
+- The command uses curl to fetch JIRA data via REST API: https://issues.redhat.com/rest/api/2/issue/{$1}
+- Uses WebFetch to extract PR links from JIRA issue if no PRs provided
+- Uses `gh pr view` to fetch PR details for each PR
+- Analyzes changes across all PRs to understand implementation
+- Generates comprehensive manual test scenarios
+
+## Process Flow:
+
+1. **JIRA Analysis**: Fetch and parse JIRA issue details:
+   - Use curl to fetch JIRA issue data: `curl -s "https://issues.redhat.com/rest/api/2/issue/{$1}"`
+   - Parse JSON response to extract:
+     - Issue summary and description
+     - Context and acceptance criteria
+     - Steps to reproduce (for bugs)
+     - Expected vs actual behavior
+   - Extract issue type (Story, Bug, Task, etc.)
+
+2. **PR Discovery**: Get list of PRs to analyze:
+   - **If no PRs provided in arguments** ($2, $3, etc. are empty):
+     - Use WebFetch on https://issues.redhat.com/browse/{$1}
+     - Extract all GitHub PR links from:
+       - "Issue Links" section
+       - "Development" section
+       - PR links in comments
+   - **If PRs provided in arguments**:
+     - Use only the PRs provided in $2, $3, $4, etc.
+     - Ignore any other PRs linked to the JIRA
+
+3. **PR Analysis**: For each PR, fetch and analyze:
+   - Use `gh pr view {PR_NUMBER} --repo <your repo> --json title,body,commits,files,labels`
+   - Extract:
+     - PR title and description
+     - Changed files and their diffs
+     - Commit messages
+     - PR status (merged, open, closed)
+   - Read changed files to understand implementation details
+   - Use Grep and Glob tools to:
+     - Find related test files
+     - Locate configuration or documentation
+     - Identify dependencies
+
+4. **Change Analysis**: Understand what was changed across all PRs:
+   - Identify the overall objective (bug fix, feature, refactor)
+   - Determine affected components (API, CLI, operator, control-plane, etc.)
+   - Find platform-specific changes (AWS, Azure, KubeVirt, etc.)
+   - Map which PR addresses which aspect of the JIRA
+   - Identify any dependencies between PRs
+
+5. **Test Scenario Generation**: Create comprehensive test plan:
+   - Map JIRA acceptance criteria to test scenarios
+   - For bugs: Use reproduction steps as test cases
+   - Generate test scenarios covering:
+     - Happy path scenarios (based on acceptance criteria)
+     - Edge cases and error handling
+     - Platform-specific variations if applicable
+     - Regression scenarios
+   - For multiple PRs:
+     - Create integrated test scenarios
+     - Verify PRs work correctly together
+     - Test each PR's contribution to the overall solution
+
+6. **Test Guide Creation**: Generate detailed manual testing document:
+   - **Filename**: Always use JIRA key format: `test-{JIRA_KEY}.md`
+     - Convert JIRA key to lowercase
+     - Examples: `test-cntrlplane-205.md`, `test-ocpbugs-12345.md`
+   - **Structure**:
+     - **JIRA Summary**: Include JIRA key, title, description, acceptance criteria
+     - **PR Summary**: List all PRs with titles and how they relate to the JIRA
+     - **Prerequisites**:
+       - Required infrastructure and tools
+       - Environment setup requirements
+       - Access requirements
+     - **Test Scenarios**:
+       - Map each test to JIRA acceptance criteria
+       - Numbered test cases with clear steps
+       - Expected results with verification commands
+       - Platform-specific test variations
+     - **Regression Testing**:
+       - Related features to verify
+       - Areas that might be affected
+     - **Success Criteria**:
+       - Checklist mapping to JIRA acceptance criteria
+     - **Troubleshooting**:
+       - Common issues and debug steps
+     - **Notes**:
+       - Known limitations
+       - Links to JIRA and all PRs
+       - Critical test cases highlighted
+
+7. **Exclusions**: Apply smart filtering:
+   - **Skip PRs that don't require testing**:
+     - PRs that only add documentation (.md files only)
+     - PRs that only add CI/tooling (.github/, .claude/ directories)
+     - PRs marked with labels like "skip-testing" or "docs-only"
+   - **Note skipped PRs** in the test guide with reasoning
+   - Focus test scenarios on PRs with actual code changes
+
+8. **Output**: Display the testing guide:
+   - Show the file path where the guide was saved
+   - Provide a summary of:
+     - JIRA issue being tested
+     - Number of PRs included
+     - Number of test scenarios generated
+     - Critical test cases to focus on
+   - Highlight any PRs that were skipped and why
+   - Ask if the user would like any modifications to the test guide
+
+## Arguments:
+
+- **$1**: JIRA issue key (required) - e.g., CNTRLPLANE-205, OCPBUGS-12345
+- **$2, $3, ..., $N**: Optional GitHub PR URLs
+  - If provided: Only these PRs will be analyzed
+  - If omitted: All PRs linked to the JIRA will be discovered and analyzed
+
+## Smart Features:
+
+1. **Automatic PR Discovery**:
+   - Scans JIRA issue for all related PRs
+   - Identifies PRs in "Issue Links", "Development" section, and comments
+
+2. **Selective PR Testing**:
+   - Allows manual override to test specific PRs only
+   - Useful when JIRA has many PRs but only some need testing
+
+3. **Context-Aware Test Generation**:
+   - Bug fixes: Focus on reproduction steps and verification
+   - Features: Focus on acceptance criteria and user workflows
+   - Refactors: Focus on regression and functional equivalence
+
+4. **Multi-PR Integration**:
+   - Understands how multiple PRs work together
+   - Creates integration test scenarios
+   - Identifies dependencies and testing order
+
+5. **Build/Deploy Section Exclusion**:
+   - Does NOT include build or deployment steps
+   - Assumes environment is already set up
+   - Focuses purely on testing procedures
+
+6. **Cleanup Section Exclusion**:
+   - Does NOT include cleanup steps
+   - Focuses on test execution and verification
+
+## Example Workflow:
+
+```bash
+# Auto-discover all PRs from JIRA
+/jira:generate-test-plan CNTRLPLANE-205
+
+# Test only specific PRs
+/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888
+
+# Test multiple specific PRs
+/jira:generate-test-plan OCPBUGS-12345 https://github.com/openshift/hypershift/pull/1234 https://github.com/openshift/hypershift/pull/1235
+```
+
+The command will provide a comprehensive manual testing guide that QE or developers can use to thoroughly test the JIRA issue implementation.

--- a/plugins/utils/commands/generate-test-plan.md
+++ b/plugins/utils/commands/generate-test-plan.md
@@ -1,0 +1,112 @@
+---
+description: Generate test steps for one or more related PRs
+argument-hint: [GitHub PR URLs]
+---
+
+## Name
+utils:generate-test-plan
+
+Generate test steps for one or more related PRs.
+
+[Extended thinking: This command takes one or more GitHub PR URLs, fetches the PR details including description, commits, and file changes, analyzes the changes to understand what features/fixes were implemented, and generates a comprehensive manual testing guide with step-by-step instructions. When multiple PRs are provided, it analyzes them collectively to understand how they work together to fix a bug or implement a feature.]
+
+**PR Testing Guide Generator**
+
+## Usage Examples:
+
+1. **Generate test steps for a single PR**:
+   `/utils:generate-test-plan https://github.com/openshift/hypershift/pull/6888`
+
+2. **Generate test steps for multiple related PRs**:
+   `/utils:generate-test-plan https://github.com/openshift/hypershift/pull/6888 https://github.com/openshift/hypershift/pull/6889 https://github.com/openshift/hypershift/pull/6890`
+
+## Implementation Details:
+
+- The command uses `gh pr view` to fetch PR data for one or more PRs
+- Analyzes PR descriptions, commits, and changed files across all provided PRs
+- Identifies relationships and dependencies between multiple PRs
+- Generates test scenarios based on the collective changes
+- Creates a comprehensive testing guide with prerequisites and verification steps
+
+## Process Flow:
+
+1. **PR Analysis**: Parse GitHub URLs and fetch PR details:
+   - Extract PR numbers from all provided URLs (supports multiple PRs)
+   - For each PR, use `gh pr view {PR_NUMBER} --json title,body,commits,files,labels` to fetch:
+     - PR title and description
+     - Commit messages and history
+     - Changed files and their diffs
+     - PR labels (bug, enhancement, etc.)
+   - Read the changed files to understand the implementation
+   - When multiple PRs are provided:
+     - Identify common JIRA issues or bug references across PRs
+     - Analyze how changes in different PRs complement each other
+     - Determine the order in which PRs should be tested (if dependencies exist)
+
+2. **Change Analysis**: Understand what was changed:
+   - For single PR:
+     - Identify the type of change (feature, bug fix, refactor, etc.)
+     - Determine affected components (API, CLI, operator, control-plane, etc.)
+     - Find related platform-specific changes (AWS, Azure, KubeVirt, etc.)
+   - For multiple PRs:
+     - Identify the overall objective (complete bug fix, multi-component feature, etc.)
+     - Map which PR addresses which component or aspect of the fix
+     - Identify overlapping or complementary changes
+     - Determine if PRs target different repositories or components
+   - Review test files to understand expected behavior
+   - Use Grep and Glob tools to:
+     - Find related configuration or documentation
+     - Locate example usage in existing tests
+     - Identify dependencies or related features
+
+3. **Test Scenario Generation**: Create comprehensive test plan:
+   - Analyze the PR description(s) for:
+     - Feature requirements and acceptance criteria
+     - Bug reproduction steps
+     - Related JIRA issues or issue references
+   - For multiple PRs, create integrated test scenarios that:
+     - Test the complete fix/feature with all PRs applied
+     - Verify each PR's contribution to the overall solution
+     - Ensure PRs work correctly together without conflicts
+   - Generate test scenarios covering:
+     - Happy path scenarios
+     - Edge cases and error handling
+     - Platform-specific variations if applicable
+     - Upgrade/downgrade scenarios if relevant
+     - Performance impact if significant changes
+
+4. **Test Guide Creation**: Create detailed manual testing document:
+   - For single PR: Save to `test-pr-{PR_NUMBER}.md`
+   - For multiple PRs: Save to `test-pr-{PR_NUMBER1}-{PR_NUMBER2}-{PR_NUMBERN}.md` (e.g., `test-pr-6888-6889-6890.md`)
+   - Include the following sections:
+     - **PR Summary**:
+       - For single PR: Title, description, and key changes
+       - For multiple PRs: List all PRs with their titles, show the common objective, and explain how they work together
+     - **Prerequisites**:
+       - Required infrastructure (AWS account, S3 bucket, etc.)
+       - Tools and CLI versions needed
+       - Environment setup steps
+     - **Test Scenarios**:
+       - Numbered test cases with clear steps
+       - Expected results for each step
+       - Verification commands and their expected output
+       - For multiple PRs: Include integration test scenarios
+     - **Regression Testing**:
+       - Suggestions for related features to verify
+     - **Notes**:
+       - Known limitations or areas requiring special attention
+       - Links to related PRs or documentation
+       - For multiple PRs: Dependencies between PRs and recommended testing order
+
+5. **Output**: Display the testing guide:
+   - Show the file path where the guide was saved
+   - Provide a brief summary of the test scenarios
+   - Highlight any critical test cases or prerequisites
+   - Ask if the user would like any modifications to the test guide
+
+## Arguments:
+- $1, $2, $3, ..., $N: One or more GitHub PR URLs (at least one required)
+  - Single PR: `/utils:generate-test-plan https://github.com/openshift/hypershift/pull/6888`
+  - Multiple PRs: `/utils:generate-test-plan https://github.com/openshift/hypershift/pull/6888 https://github.com/openshift/hypershift/pull/6889`
+
+The command will provide a comprehensive manual testing guide that can be used by QE or developers to thoroughly test the PR changes. When multiple PRs are provided, the guide will include integrated test scenarios that verify the PRs work correctly together.


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a new `jira:test` command to the jira plugin that generates comprehensive manual test steps for JIRA issues by analyzing related pull requests.

The command supports:
- Auto-discovery of PRs linked to JIRA issues
- Manual specification of specific PRs to analyze
- Context-aware test scenario generation based on issue type (bug/feature/refactor)
- Structured test guide output with prerequisites, test scenarios, success criteria, and troubleshooting
- Smart filtering to exclude documentation-only and CI-only PRs

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

This command follows the same structure and conventions as the existing `jira:solve` and `jira:status-rollup` commands. The implementation is defined in the command markdown file following the plugin architecture.

Key features:
- Works with both auto-discovered and manually specified PRs
- Generates test files with naming convention `test-{jira-key}.md`
- Excludes build/deployment and cleanup steps, focusing purely on testing procedures
- Handles multi-PR scenarios with integrated test cases

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)