### PR TITLE
Adding a new slash command prow-job:list-qe-jobs

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -215,6 +215,7 @@ A plugin to analyze and inspect Prow CI job results
 - **`/prow-job:analyze-resource` `prowjob-url resource-name`** - Analyze Kubernetes resource lifecycle in Prow job artifacts
 - **`/prow-job:analyze-test-failure` `prowjob-url test-name`** - Analyzes test errors from console logs and Prow CI job artifacts
 - **`/prow-job:extract-must-gather` `prowjob-url`** - Extract and decompress must-gather archives from Prow job artifacts
+- **`/prow-job:list-qe-jobs` `keywords`** - List all OpenShift QE CI jobs with optional filtering
 
 See [plugins/prow-job/README.md](plugins/prow-job/README.md) for detailed documentation.
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -535,6 +535,12 @@
           "description": "Extract and decompress must-gather archives from Prow job artifacts",
           "name": "extract-must-gather",
           "synopsis": "/prow-job:extract-must-gather <prowjob-url>"
+        },
+        {
+          "argument_hint": "keywords",
+          "description": "List all OpenShift QE CI jobs with optional filtering",
+          "name": "list-qe-jobs",
+          "synopsis": "/prow-job:list-qe-jobs [keywords]"
         }
       ],
       "description": "A plugin to analyze and inspect Prow CI job results",
@@ -566,6 +572,11 @@
           "description": "Extract and decompress must-gather archives from Prow CI job artifacts, generating an interactive HTML file browser with filters",
           "id": "prow-job-extract-must-gather",
           "name": "Prow Job Extract Must-Gather"
+        },
+        {
+          "description": "List all jobs for further debugging or analysis",
+          "id": "prow-job-list-qe-jobs",
+          "name": "Prow Job list jobs"
         }
       ],
       "version": "0.0.1"

--- a/plugins/prow-job/commands/list-qe-jobs.md
+++ b/plugins/prow-job/commands/list-qe-jobs.md
@@ -1,0 +1,29 @@
+---
+description: List all OpenShift QE CI jobs with optional filtering
+argument-hint: keywords
+---
+
+## Name
+prow-job:list-qe-jobs
+
+## Synopsis
+```
+/prow-job:list-qe-jobs [keywords]
+```
+
+## Description
+OpenShift QE often needs to debug ci job failures, get fault trends, the first step is to get job names and job links.
+
+## Implementation
+Pass the user's request to the skill, which will:
+- Load environment variable "LIST_QE_JOBS_BEARER"
+- If environment variable "LIST_QE_JOBS_BEARER" is not given, ask user to give one, otherwise stop the skill
+- Access https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec API with above environment variable LIST_QE_JOBS_BEARER as bearer token and list all [spec/job, status/url, status/state] in the response json. 
+- Accepts an optional name argument ($1)
+- If $1 is provided, "$1" is a space-delimited list of words, outputs all jobs whose name contains each word in "$1"
+- If no argument is provided, outputs all jobs
+- Get all job names, URL and state
+- Generate an interactive HTML report which can filter jobs by job name
+- The command is stateless and has no side effects
+
+The skill handles all the implementation details including extract data from URL and HTML report generation.

--- a/plugins/prow-job/skills/prow-job-list-qe-jobs/README.md
+++ b/plugins/prow-job/skills/prow-job-list-qe-jobs/README.md
@@ -1,0 +1,83 @@
+# Prow Job List Job Skill
+
+This skill lists all Prow CI jobs by accessing https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec.
+
+## Overview
+
+The skill provides a Claude Code skill interface for listing Prow CI jobs. It helps get current test coverage and job status.
+
+## Components
+
+### 1. SKILL.md
+Claude Code skill definition that provides detailed implementation instructions for the AI assistant.
+
+### 2. Python Scripts
+
+#### generate_report.py
+Generates interactive HTML reports from parsed job data.
+- Get job data from https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec
+- Fill job data into html
+- Creates interactive filterable table
+- Adds filtering and search capabilities
+
+**Usage:**
+```bash
+python3 plugins/prow-job/skills/prow-job-list-qe-jobs/generate_report.py \
+  -t plugins/prow-job/skills/prow-job-list-qe-jobs/template.html \
+  -d .work/prow-job-list-qe-jobs/filtered_jobs.json \
+  -o .work/prow-job-list-qe-jobs/prow_jobs_report.html \
+  -k "{KEYWORDS}"
+```
+
+### 3. HTML Template
+
+#### template.html
+Modern, responsive HTML template for reports featuring:
+- Color-coded job state
+- Filtering by job state
+- Search functionality
+- Mobile-responsive design
+
+## Prerequisites
+
+1. **Python 3**      - For running parser and report generator scripts
+2. **Bearer token**  - Export bearer token, the token can be found in https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/topology/all-namespaces?view=graph -> click your name in right-top corner -> click `Copy login command` -> the token can be found in the new page
+
+## Workflow
+
+1. **Get Data**
+   - Access https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec
+   - Extract [spec/job, status/url, status/state] from the response json
+
+2. **Report Generation**
+   - Render HTML with template
+   - Output to `.work/prow-job-list-qe-jobs/prow_jobs_report.html`
+
+## Output
+
+### HTML Report
+- Header with metadata
+- Filterable job entries
+- Search functionality
+
+### Directory Structure
+```
+.
+└── prow-job-list-qe-jobs
+    ├── all_jobs.json
+    ├── filtered_jobs.json
+    ├── prow_jobs_report.html
+```
+
+## Using with Claude Code
+
+When you ask Claude to list Prow jobs, it will automatically use this skill. The skill provides detailed instructions that guide Claude through:
+- Give keywords if needed
+- Generating reports
+
+You can simply ask:
+> "List all prow jobs whose names contain release-4.21 and upgrade"
+Or
+> /prow-job:list-qe-jobs "release-4.21 upgrade"
+
+Claude will execute the workflow and generate the interactive HTML report.

--- a/plugins/prow-job/skills/prow-job-list-qe-jobs/SKILL.md
+++ b/plugins/prow-job/skills/prow-job-list-qe-jobs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: Prow Job list jobs
+description: List all jobs for further debugging or analysis
+allowed-tools: Read, Grep, Glob
+---
+
+## Version History
+- v1.0.0 (2025-11-18): Initial release
+
+
+# Prow Job list jobs
+
+This skill lists all Prow CI jobs by accessing https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec.
+
+## When to Use This Skill
+
+Use this skill when the user wants to:
+- Analyze a batch of CI jobs
+- Check which area have been covered
+- Share CI jobs
+
+## Prerequisites
+
+Before starting, verify these prerequisites:
+
+1. **Python 3** - For running parser and report generator scripts
+2. **Bearer token**  - Export bearer token, the token can be found in https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/topology/all-namespaces?view=graph -> click your name in right-top corner -> click `Copy login command` -> the token can be found in the new page
+   - Example: `sha256~_xxxxxxxxxxxxxxxxxxxx`
+
+## Input Format
+
+The user will provide:
+1. **Key words** - space-delimited list in format `word1 word2 word3`
+   - Example: `release-4.21 upgrade`
+
+## Implementation Steps
+
+### Step 1: Create directory structure
+
+**Usage:**
+   ```bash
+   mkdir -p .work/prow-job-list-qe-jobs/
+   ```
+
+### Step 2: get all jobs data by accessing URL
+
+**Usage:**
+```bash
+curl -f -H "Authorization: Bearer {LIST_QE_JOBS_BEARER}" \
+  -o .work/prow-job-list-qe-jobs/all_jobs.json \
+  https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec
+
+# Verify the download succeeded
+if [ ! -s .work/prow-job-list-qe-jobs/all_jobs.json ]; then
+  echo "Error: Failed to fetch jobs data. Check your bearer token and network connectivity."
+  exit 1
+fi
+```
+
+### Step 3: filter out the jobs which name contains all keywords
+
+**IMPORTANT: Use the provided shell script `filter_jobs.sh` from the skill directory.**
+
+**Usage:**
+```bash
+sh plugins/prow-job/skills/prow-job-list-qe-jobs/filter_jobs.sh \
+   .work/prow-job-list-qe-jobs/all_jobs.json \
+   .work/prow-job-list-qe-jobs/filtered_jobs.json \
+   "{KEYWORDS}"
+```
+
+### Step 4: Generate HTML Report
+
+**IMPORTANT: Use the provided Python script `generate_report.py` from the skill directory.**
+
+**Usage:**
+```bash
+python3 plugins/prow-job/skills/prow-job-list-qe-jobs/generate_report.py \
+  -t plugins/prow-job/skills/prow-job-list-qe-jobs/template.html \
+  -d .work/prow-job-list-qe-jobs/filtered_jobs.json \
+  -o .work/prow-job-list-qe-jobs/prow_jobs_report.html \
+  -k "{KEYWORDS}"
+```
+
+### Step 5: Present Results to User
+
+1. **Open report in browser**
+   - Detect platform and automatically open the HTML report in the default browser
+   - Linux: `xdg-open .work/prow-job-list-qe-jobs/prow_jobs_report.html`
+   - macOS: `open .work/prow-job-list-qe-jobs/prow_jobs_report.html`
+   - Windows: `start .work/prow-job-list-qe-jobs/prow_jobs_report.html`
+   - On Linux (most common for this environment), use `xdg-open`

--- a/plugins/prow-job/skills/prow-job-list-qe-jobs/filter_jobs.sh
+++ b/plugins/prow-job/skills/prow-job-list-qe-jobs/filter_jobs.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Script to filter jobs from all_jobs.json
+# Filters jobs where the name contains ALL specified keywords
+# Usage: ./filter_jobs.sh INPUT_FILE OUTPUT_FILE [keyword1]
+# Example: ./filter_jobs.sh input.json output.json
+# Example: ./filter_jobs.sh input.json output.json "release-4.21 upgrade"
+
+# Check if at least 2 arguments are provided (input and output files)
+if [ $# -lt 2 ]; then
+    echo "Error: Missing required arguments."
+    echo "Usage: $0 INPUT_FILE OUTPUT_FILE [keyword1]"
+    echo "Example: $0 all_jobs.json filtered_jobs.json"
+    echo "Example: $0 all_jobs.json filtered_jobs.json 'release-4.21 upgrade'"
+    exit 1
+fi
+
+INPUT_FILE="$1"
+OUTPUT_FILE="$2"
+shift 2  # Remove first two arguments, remaining are keywords
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install jq to use this script."
+    exit 1
+fi
+
+# Check if input file exists
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: Input file $INPUT_FILE not found."
+    exit 1
+fi
+
+echo "Filtering jobs from $INPUT_FILE..."
+
+# If no keywords provided, copy all jobs
+# Strip JavaScript variable wrapper: "var allBuilds = " prefix and trailing ";"
+jsonStr=$(sed 's/^var allBuilds = //' "$INPUT_FILE" | sed 's/;$//')
+
+# Validate we got valid JSON
+if ! echo "$jsonStr" | jq empty 2>/dev/null; then
+    echo "Error: Failed to extract valid JSON from $INPUT_FILE"
+    echo "Expected format: var allBuilds = {...};"
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    echo "No keywords provided - including all ProwJob items..."
+    echo "$jsonStr" | \
+        jq '.items[] | select(.kind == "ProwJob")' | \
+        jq -s 'map({name: .spec.job, state: .status.state, url: .status.url})' \
+        > "$OUTPUT_FILE"
+else
+    # Build the jq filter condition dynamically
+    echo "Looking for jobs containing ALL of the following keywords:"
+    JQ_FILTER=""
+    # shellcheck disable=SC2068
+    for keyword in $@; do
+        echo "  - $keyword"
+        JQ_FILTER="$JQ_FILTER | select(.spec.job | contains(\"$keyword\"))"
+    done
+    
+    echo -e "Filter: " '.items[] | select(.kind == "ProwJob")'"$JQ_FILTER"''
+
+    # Extract the JavaScript variable and convert to proper JSON, then filter
+    # The file starts with "var allBuilds = " so we need to strip that
+    
+    echo "$jsonStr" | \
+     	jq '.items[] | select(.kind == "ProwJob")'"$JQ_FILTER"'' | \
+    	jq -s 'map({name: .spec.job, state: .status.state, url: .status.url})'> "$OUTPUT_FILE"
+fi
+
+# Count the filtered jobs
+TOTAL_COUNT=$(echo "$jsonStr" | jq '.items | length' 2>/dev/null || echo "0")
+FILTERED_COUNT=$(jq 'length' "$OUTPUT_FILE" 2>/dev/null || echo "0")
+
+echo ""
+echo "Done!"
+echo "Total jobs: $TOTAL_COUNT"
+echo "Filtered jobs: $FILTERED_COUNT"
+echo "Output saved to: $OUTPUT_FILE"

--- a/plugins/prow-job/skills/prow-job-list-qe-jobs/generate_report.py
+++ b/plugins/prow-job/skills/prow-job-list-qe-jobs/generate_report.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+HTML Report Generator
+
+This script generates HTML reports from a template and job data.
+
+Usage:
+    python3 generate_report.py --template template.html --output report.html --data jobs.json
+    python3 generate_report.py --template template.html --output report.html --data jobs.json --keywords "release-4.21 upgrade"
+
+Data format (JSON):
+    [
+        {
+            "name": "job-name-1",
+            "state": "pending",
+            "url": "http://example.com/job1"
+        },
+        {
+            "name": "job-name-2",
+            "state": "success",
+            "url": "http://example.com/job2"
+        }
+    ]
+"""
+
+import json
+import sys
+import argparse
+import html
+from datetime import datetime
+from collections import Counter
+
+
+def load_template(template_file):
+    """Load HTML template from file."""
+    try:
+        with open(template_file, 'r') as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"Error: Template file '{template_file}' not found.")
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error loading template: {e}")
+        sys.exit(1)
+
+
+def load_job_data(data_file):
+    """Load job data from JSON file."""
+    try:
+        with open(data_file, 'r') as f:
+            data = json.load(f)
+
+    except FileNotFoundError:
+        print(f"Error: Data file '{data_file}' not found.")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON data: {e}")
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error loading data: {e}")
+        sys.exit(1)
+    else:
+        if not isinstance(data, list):
+            print("Error: Job data must be a JSON array/list.")
+            sys.exit(1)
+
+        return data
+
+
+def generate_stats_cards(jobs):
+    """Generate HTML for statistics cards."""
+    state_counts = Counter(job.get('state', 'unknown') for job in jobs)
+
+    stats_html = ''
+    for state, count in sorted(state_counts.items(), key=lambda x: x[1], reverse=True):
+        stats_html += f'''            <div class="stat-card">
+                <strong>{html.escape(state)}</strong>
+                <span>{count}</span>
+            </div>
+'''
+
+    return stats_html
+
+
+def generate_state_options(jobs):
+    """Generate HTML options for state filter dropdown."""
+    states = set(
+        job.get('state', 'unknown')
+        for job in jobs
+        if isinstance(job, dict)
+    )
+
+    options_html = ''
+    for state in sorted(states):
+        options_html += f'                    <option value="{html.escape(state, quote=True)}">{html.escape(state)}</option>\n'
+
+    return options_html
+
+
+def generate_job_rows(jobs):
+    """Generate HTML table rows for jobs."""
+    rows_html = ''
+
+    for job in jobs:
+        # Provide safe defaults for missing keys
+        name = job.get('name', 'Unknown Job')
+        state = job.get('state', 'unknown')
+        url = job.get('url', '#')
+        
+        state_lower = state.lower()
+        state_escaped = html.escape(state_lower, quote=True)
+        rows_html += f'''                    <tr data-state="{state_escaped}">
+                        <td class="job-name">{html.escape(name)}</td>
+                        <td><span class="state state-{state_escaped}">{html.escape(state)}</span></td>
+                        <td>
+                           <a href="{html.escape(url, quote=True)}" class="job-url" target="_blank">View Job</a>
+                        </td>
+                    </tr>
+ '''
+ 
+    return rows_html
+
+
+def generate_report(template_file, data_file, output_file, keywords=''):
+    """Generate HTML report from template and job data."""
+    # Load template and data
+    template = load_template(template_file)
+    jobs = load_job_data(data_file)
+    
+    # Ensure we only process well-formed job dicts
+    jobs = [job for job in jobs if isinstance(job, dict)]
+
+    # Filter by keywords if provided
+    if keywords:
+        keyword_list = keywords.lower().split()
+        jobs = [
+            job 
+            for job in jobs
+            if all(
+                kw in job.get('name', '').lower() 
+                for kw in keyword_list)
+            ]
+
+    # Generate components
+    stats_cards = generate_stats_cards(jobs)
+    state_options = generate_state_options(jobs)
+    job_rows = generate_job_rows(jobs)
+
+    # Replace placeholders
+    output_html = template.replace('{{KEYWORDS}}', html.escape(keywords if keywords else 'All Jobs'))
+    output_html = output_html.replace('{{TOTAL_JOBS}}', str(len(jobs)))
+    output_html = output_html.replace('{{GENERATED_TIME}}', datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+    output_html = output_html.replace('{{STATS_CARDS}}', stats_cards)
+    output_html = output_html.replace('{{STATE_OPTIONS}}', state_options)
+    output_html = output_html.replace('{{JOB_ROWS}}', job_rows)
+
+    # Write output
+    try:
+        with open(output_file, 'w') as f:
+            f.write(output_html)
+        print(f"✓ Report generated successfully: {output_file}")
+        print(f"✓ Total jobs: {len(jobs)}")
+
+        # Print statistics (defensive against missing state keys)
+        state_counts = Counter(
+            job.get('state', 'unknown')
+            for job in jobs
+            if isinstance(job, dict)
+        )
+        
+        print("✓ Statistics:")
+        for state, count in sorted(state_counts.items(), key=lambda x: x[1], reverse=True):
+            print(f"  - {state}: {count}")
+    except OSError as e:
+        print(f"Error writing output file: {e}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate HTML report from template and job data',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument(
+        '-t', '--template',
+        required=True,
+        help='Path to HTML template file'
+    )
+
+    parser.add_argument(
+        '-d', '--data',
+        required=True,
+        help='Path to JSON data file containing job list'
+    )
+
+    parser.add_argument(
+        '-o', '--output',
+        required=True,
+        help='Path to output HTML report file'
+    )
+
+    parser.add_argument(
+        '-k', '--keywords',
+        default='',
+        help='Keywords/description for the report (optional)'
+    )
+
+    args = parser.parse_args()
+
+    generate_report(args.template, args.data, args.output, args.keywords)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/prow-job/skills/prow-job-list-qe-jobs/template.html
+++ b/plugins/prow-job/skills/prow-job-list-qe-jobs/template.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prow Jobs Report - {{KEYWORDS}}</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #0d1117;
+            color: #c9d1d9;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+        .header {
+            background: #161b22;
+            padding: 24px;
+            border-radius: 8px;
+            margin-bottom: 24px;
+            border: 1px solid #30363d;
+        }
+        h1 {
+            color: #58a6ff;
+            font-size: 28px;
+            margin-bottom: 16px;
+        }
+        .metadata {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 12px;
+            margin-top: 16px;
+        }
+        .metadata-item {
+            background: #0d1117;
+            padding: 12px;
+            border-radius: 6px;
+            border: 1px solid #30363d;
+        }
+        .metadata-item strong {
+            color: #8b949e;
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            margin-bottom: 4px;
+        }
+        .metadata-item span {
+            color: #c9d1d9;
+            font-size: 18px;
+            font-weight: 600;
+        }
+        .filters {
+            background: #161b22;
+            padding: 16px;
+            border-radius: 8px;
+            margin-bottom: 16px;
+            border: 1px solid #30363d;
+        }
+        .filters label {
+            margin-right: 16px;
+            color: #8b949e;
+        }
+        .filters input, .filters select {
+            background: #0d1117;
+            color: #c9d1d9;
+            border: 1px solid #30363d;
+            padding: 6px 12px;
+            border-radius: 6px;
+            margin-left: 8px;
+        }
+        .filters input[type="text"] {
+            width: 300px;
+        }
+        .jobs-table {
+            background: #161b22;
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid #30363d;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        thead {
+            background: #0d1117;
+        }
+        th {
+            text-align: left;
+            padding: 12px 16px;
+            color: #8b949e;
+            font-weight: 600;
+            font-size: 12px;
+            text-transform: uppercase;
+            border-bottom: 1px solid #30363d;
+        }
+        td {
+            padding: 12px 16px;
+            border-bottom: 1px solid #21262d;
+        }
+        tr:hover {
+            background: #0d1117;
+        }
+        .job-name {
+            font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+            font-size: 13px;
+            color: #c9d1d9;
+        }
+        .job-url {
+            color: #58a6ff;
+            text-decoration: none;
+        }
+        .job-url:hover {
+            text-decoration: underline;
+        }
+        .state {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+        .state-success {
+            background: #238636;
+            color: #fff;
+        }
+        .state-failure {
+            background: #da3633;
+            color: #fff;
+        }
+        .state-pending {
+            background: #8b949e;
+            color: #fff;
+        }
+        .state-aborted {
+            background: #f85149;
+            color: #fff;
+        }
+        .state-triggered {
+            background: #1f6feb;
+            color: #fff;
+        }
+        .state-unknown {
+            background: #6e7681;
+            color: #fff;
+        }
+        .stats {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+        .stat-card {
+            background: #161b22;
+            padding: 16px;
+            border-radius: 8px;
+            border: 1px solid #30363d;
+            flex: 1;
+        }
+        .stat-card strong {
+            color: #8b949e;
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            margin-bottom: 8px;
+        }
+        .stat-card span {
+            font-size: 24px;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>OpenShift QE Prow Jobs Report</h1>
+            <div class="metadata">
+                <div class="metadata-item">
+                    <strong>Keywords</strong>
+                    <span>{{KEYWORDS}}</span>
+                </div>
+                <div class="metadata-item">
+                    <strong>Total Jobs</strong>
+                    <span id="total-jobs">{{TOTAL_JOBS}}</span>
+                </div>
+                <div class="metadata-item">
+                    <strong>Generated</strong>
+                    <span>{{GENERATED_TIME}}</span>
+                </div>
+            </div>
+        </div>
+
+        <div class="stats" id="stats">
+            {{STATS_CARDS}}
+        </div>
+
+        <div class="filters">
+            <label>
+                Search:
+                <input type="text" id="searchInput" placeholder="Filter by job name...">
+            </label>
+            <label>
+                State:
+                <select id="stateFilter">
+                    <option value="">All</option>
+                    {{STATE_OPTIONS}}
+                </select>
+            </label>
+        </div>
+
+        <div class="jobs-table">
+            <table id="jobsTable">
+                <thead>
+                    <tr>
+                        <th style="width: 60%">Job Name</th>
+                        <th style="width: 15%">State</th>
+                        <th style="width: 25%">URL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{JOB_ROWS}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <script>
+        // Search functionality
+        const searchInput = document.getElementById('searchInput');
+        const stateFilter = document.getElementById('stateFilter');
+        const table = document.getElementById('jobsTable');
+        const rows = table.getElementsByTagName('tbody')[0].getElementsByTagName('tr');
+        const totalJobsSpan = document.getElementById('total-jobs');
+
+        function filterTable() {
+            const searchTerm = searchInput.value.toLowerCase();
+            const selectedState = stateFilter.value.toLowerCase();
+            let visibleCount = 0;
+
+            for (let row of rows) {
+                const jobName = row.cells[0].textContent.toLowerCase();
+                const state = row.getAttribute('data-state').toLowerCase();
+
+                const matchesSearch = jobName.includes(searchTerm);
+                const matchesState = !selectedState || state === selectedState;
+
+                if (matchesSearch && matchesState) {
+                    row.style.display = '';
+                    visibleCount++;
+                } else {
+                    row.style.display = 'none';
+                }
+            }
+
+            totalJobsSpan.textContent = visibleCount;
+        }
+
+        searchInput.addEventListener('input', filterTable);
+        stateFilter.addEventListener('change', filterTable);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What this PR does / why we need it:
With this new slash command we can:
1. List all CI jobs for Openshift QE 
2. We can show current status report and platform coverage report
3. Save us time to search jobs

We can run this slash command by both:
> "List all prow jobs which name contains release-4.21 and upgrade"
Or
> /prow-job:list-qe-jobs "release-4.21 upgrade"

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 

Here is a sample report:
[prow_jobs_report.html](https://github.com/user-attachments/files/23165790/prow_jobs_report.html)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /prow-job:list-qe-jobs command to list OpenShift QE CI jobs with optional keyword filtering.
  * Produces an interactive dark-themed HTML report with job name, state, URL, live name/state filtering, and summary statistics; supports CLI-driven report generation and keyword-based filtering.

* **Documentation**
  * Added user-facing docs, README and skill instructions for fetching job data, authentication via bearer token, filtering, report generation, and viewing the HTML report.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->