### PR TITLE
Improve git:cherry-pick-by-patch command

### DIFF
--- a/plugins/git/commands/cherry-pick-by-patch.md
+++ b/plugins/git/commands/cherry-pick-by-patch.md
@@ -37,7 +37,9 @@ Fail, if there is no `commit_hash` in the current repository checkout.
     ```bash
     git show commit_hash | patch -p1 --no-backup-if-mismatch
     ```
-and check if exit code is zero. Fail if exit code is not zero.
+and check if exit code is zero. If exit code is not zero, find conflicted files in the output and apply
+changes for them from the patch manually. Print file names which required manual changes. Fail workload
+if you cannot apply any required change manually.
 
 2. Find files removed from local checkout by the patch command and execute `git rm` for them.
 


### PR DESCRIPTION
Let AI to apply changes manually for conflicted files. See commit description for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patch-apply error handling: when a patch fails to apply cleanly, the workflow now detects conflicted files and attempts manual conflict resolution.
  * Filenames needing manual changes are reported for transparency.
  * The operation now only fails if required manual changes cannot be applied, instead of failing immediately on a non-zero patch exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->