### PR TITLE
Add skill to launch CAMGI for must-gather

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -155,6 +155,7 @@ A plugin to analyze and report on must-gather data
 
 **Commands:**
 - **`/must-gather:analyze` `[must-gather-path] [component]`** - Quick analysis of must-gather data - runs all analysis scripts and provides comprehensive cluster diagnostics
+- **`/must-gather:camgi` `[must-gather-path|stop]`** - Launch CAMGI (Cluster Autoscaler Must-Gather Inspector) web interface to analyze cluster infrastructure and autoscaler behavior
 - **`/must-gather:ovn-dbs` `[must-gather-path]`** - Analyze OVN databases from a must-gather using ovsdb-tool
 
 See [plugins/must-gather/README.md](plugins/must-gather/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -686,6 +686,12 @@
           "synopsis": "/must-gather:analyze [must-gather-path] [component]"
         },
         {
+          "argument_hint": "[must-gather-path|stop]",
+          "description": "Launch CAMGI (Cluster Autoscaler Must-Gather Inspector) web interface to analyze cluster infrastructure and autoscaler behavior",
+          "name": "camgi",
+          "synopsis": "/must-gather:camgi [must-gather-path]"
+        },
+        {
           "argument_hint": "[must-gather-path]",
           "description": "Analyze OVN databases from a must-gather using ovsdb-tool",
           "name": "ovn-dbs",

--- a/plugins/must-gather/README-CAMGI.md
+++ b/plugins/must-gather/README-CAMGI.md
@@ -1,0 +1,184 @@
+# OKD-CAMGI Integration
+
+Integration of [okd-camgi](https://github.com/elmiko/okd-camgi) (Cluster Autoscaler Must-Gather Inspector) for analyzing must-gather data.
+
+## What is CAMGI?
+
+CAMGI is a web-based tool for examining must-gather records to investigate cluster infrastructure and autoscaler behavior in OKD/OpenShift environments.
+
+**CAMGI analyzes:**
+- Cluster autoscaler configuration and behavior
+- Autoscaler scaling decisions and events
+- Cluster operators status and health
+- Machines, MachineSets, and Nodes configuration
+- Control Plane MachineSets
+- Machine API operator status
+- Machine Config operator status
+- Cloud Controller Manager details
+- Node group status and autoscaler-related issues
+
+## Quick Start
+
+```bash
+./run-camgi.sh /path/to/must-gather
+```
+
+Or use the slash command from anywhere:
+```
+/must-gather:camgi /path/to/must-gather
+```
+
+The script will automatically:
+1. Detect must-gather subdirectory structure
+2. **Check and fix file permissions** (with your confirmation)
+3. Start camgi (containerized or local install)
+4. Open web interface at [http://127.0.0.1:8080](http://127.0.0.1:8080)
+
+## Commands
+
+### Start CAMGI
+```bash
+./run-camgi.sh <must-gather-path>
+# Or
+/must-gather:camgi <must-gather-path>
+```
+
+### Stop CAMGI
+```bash
+./run-camgi.sh stop
+# Or
+/must-gather:camgi stop
+```
+
+## Key Features
+
+### ✅ Automatic Permission Fixing
+- Detects restrictive file permissions
+- Prompts: "Fix permissions now? (Y/n)"
+- Runs `chmod -R a+r` with user confirmation
+- No manual chmod needed!
+
+### ✅ SELinux Compatible
+- Uses `:Z` volume mount flag for proper SELinux labeling
+- Works with SELinux in enforcing mode
+- No security-opt disabling required
+
+### ✅ Automatic Browser Opening
+- Opens [http://127.0.0.1:8080](http://127.0.0.1:8080) automatically
+- Uses IPv4 address (avoids IPv6 issues)
+
+### ✅ Smart Container Management
+- Auto-detects podman/docker
+- Falls back to containerized version if camgi not installed locally
+- Simple stop command cleans up all containers
+
+### ✅ User-Friendly
+- Clear colored output
+- Helpful error messages
+- Ctrl+C works properly
+
+## Installation Methods
+
+### Method 1: Containerized (Default)
+No installation needed! The script automatically uses the container image.
+
+**Prerequisites:**
+- Podman or Docker
+
+### Method 2: Local Install (Optional)
+```bash
+pip3 install okd-camgi --user
+```
+
+**Benefits:**
+- Faster startup
+- Uses `--webbrowser` flag
+- No container overhead
+
+## Technical Details
+
+### Container Command
+```bash
+podman run --rm -it -p 8080:8080 \
+  -v /path/to/must-gather:/must-gather:Z \
+  quay.io/elmiko/okd-camgi
+```
+
+### Flags Explained
+- `--rm` - Auto-remove container when stopped
+- `-it` - Interactive terminal (Ctrl+C works)
+- `-p 8080:8080` - Port mapping
+- `-v path:/must-gather:Z` - Volume mount + SELinux relabeling
+- **No** `--security-opt label=disable` - SELinux stays enabled!
+
+### File Permissions
+The script checks for restrictive permissions and offers to fix them.
+
+**Manual fix (if needed):**
+```bash
+chmod -R a+r /path/to/must-gather
+```
+
+This is safe - must-gather data should not contain secrets.
+
+## Troubleshooting
+
+### Permission Errors
+**Symptom:** `PermissionError: [Errno 13] Permission denied`
+
+**Solution:** The script will prompt you to fix this. Press Y to allow automatic fixing.
+
+**Manual fix:**
+```bash
+chmod -R a+r /path/to/must-gather
+```
+
+### Cannot Connect to Browser
+**Symptom:** Browser can't access localhost:8080
+
+**Solution:** Use http://127.0.0.1:8080 instead of localhost
+
+This is due to IPv6 compatibility with rootless podman.
+
+### Port Already in Use
+**Symptom:** Port 8080 is occupied
+
+**Solution:** Stop other containers or run manually with different port:
+```bash
+podman run --rm -it -p 9090:8080 \
+  -v /path/to/must-gather:/must-gather:Z \
+  quay.io/elmiko/okd-camgi
+```
+
+Then access at http://127.0.0.1:9090
+
+### SELinux Denials
+**Check status:**
+```bash
+getenforce
+```
+
+**View denials:**
+```bash
+sudo ausearch -m AVC -ts recent
+```
+
+The `:Z` flag should handle all SELinux labeling automatically.
+
+## Files Included
+
+1. **run-camgi.sh** - Main executable script
+2. **README-CAMGI.md** - This documentation
+
+## References
+
+- CAMGI GitHub: https://github.com/elmiko/okd-camgi
+- CAMGI on PyPI: https://pypi.org/project/okd-camgi/
+- Must-Gather Documentation: https://docs.openshift.com/container-platform/latest/support/gathering-cluster-data.html
+
+## Future Enhancements
+
+- `--port` flag for custom port selection
+- Support for tar.gz must-gather files
+- `--no-browser` flag to skip automatic opening
+- Custom container registry support

--- a/plugins/must-gather/commands/camgi.md
+++ b/plugins/must-gather/commands/camgi.md
@@ -1,0 +1,217 @@
+---
+description: Launch CAMGI (Cluster Autoscaler Must-Gather Inspector) web interface to analyze cluster infrastructure and autoscaler behavior
+argument-hint: [must-gather-path|stop]
+---
+
+## Name
+must-gather:camgi
+
+## Synopsis
+```
+/must-gather:camgi [must-gather-path]
+/must-gather:camgi stop
+```
+
+## Description
+
+The `must-gather:camgi` command launches the CAMGI (Cluster Autoscaler Must-Gather Inspector) web-based tool to examine must-gather records and investigate cluster infrastructure and autoscaler behavior in OpenShift environments.
+
+CAMGI is a specialized tool from the [okd-camgi project](https://github.com/elmiko/okd-camgi) that provides a web interface for analyzing:
+- Cluster autoscaler configuration and behavior
+- Autoscaler scaling decisions and events
+- Cluster operators status and health
+- Machines, MachineSets, and Nodes configuration
+- Control Plane MachineSets
+- Machine API operator status
+- Machine Config operator status
+- Cloud Controller Manager details
+- Node group status and autoscaler-related issues
+
+## Prerequisites
+
+**Container Runtime:**
+
+The command requires one of the following:
+- **Podman** (recommended)
+- **Docker**
+- **Local install** (optional): `pip3 install okd-camgi --user`
+
+**Must-Gather Data:**
+
+Must-gather data with autoscaler information:
+```
+must-gather/
+└── registry-ci-openshift-org-origin-...-sha256-<hash>/
+    ├── cluster-scoped-resources/
+    ├── namespaces/
+    └── ...
+```
+
+**File Permissions:**
+
+Must-gather files need read permissions for the container user. The launcher script will automatically detect and offer to fix permission issues.
+
+## Error Handling
+
+**Permission Errors:**
+
+If container shows permission denied errors, the script will prompt:
+```
+Fix permissions now? (Y/n)
+```
+
+Press Y to allow the script to make files readable (`chmod -R a+r`). This is safe for must-gather data which should not contain secrets.
+
+**Manual fix** (if needed):
+```bash
+chmod -R a+r /path/to/must-gather
+```
+
+**Port Already in Use:**
+
+If port 8080 is occupied, stop existing CAMGI containers:
+```bash
+/must-gather:camgi stop
+```
+
+**Browser Doesn't Open:**
+
+If the web interface is not accessible:
+- The script opens [http://127.0.0.1:8080](http://127.0.0.1:8080) automatically
+- If it doesn't open, manually navigate to [http://127.0.0.1:8080](http://127.0.0.1:8080)
+- Use 127.0.0.1 (IPv4) instead of localhost to avoid IPv6 compatibility issues
+
+**SELinux Issues:**
+
+The script uses `:Z` volume mount flag for automatic SELinux relabeling. No manual SELinux configuration needed.
+
+## Implementation
+
+The command performs the following steps:
+
+1. **Determine Action**:
+   - If argument is "stop", stop all running CAMGI containers
+   - Otherwise, proceed with launching CAMGI
+
+2. **Get Must-Gather Path**:
+   - If path not provided as argument, ask the user
+   - Accept either root must-gather directory or exact subdirectory
+   - Script will auto-detect the subdirectory structure if needed
+
+3. **Launch CAMGI**:
+   Execute the CAMGI launcher script:
+   ```bash
+   plugins/must-gather/skills/must-gather-analyzer/scripts/run-camgi.sh <must-gather-path>
+   ```
+
+   The script will:
+   - Auto-detect the must-gather subdirectory structure
+   - Check file permissions and prompt to fix if necessary
+   - Start CAMGI using containerized version (podman/docker) or local install
+   - Open browser automatically at [http://127.0.0.1:8080](http://127.0.0.1:8080)
+
+4. **Inform User**:
+   After launching, provide usage instructions and how to stop CAMGI
+
+## Return Value
+
+The command provides status information:
+
+**On Successful Launch:**
+```
+CAMGI is now running!
+
+The web interface should open automatically in your browser at:
+[http://127.0.0.1:8080](http://127.0.0.1:8080)
+
+If the browser didn't open automatically, click the URL above.
+
+Use CAMGI to:
+- Examine cluster autoscaler configuration and behavior
+- Investigate autoscaler scaling decisions and events
+- Review cluster operators status and health
+- Inspect Machines, MachineSets, and Nodes configuration
+- Analyze Control Plane MachineSets
+- Check Machine API operator status
+- Review Machine Config operator status
+- Examine Cloud Controller Manager details
+- Debug autoscaler and cluster infrastructure issues
+
+To stop CAMGI when you're done:
+Ctrl+C in this terminal, or run:
+  /must-gather:camgi stop
+```
+
+**On Stop:**
+```
+Stopping all CAMGI containers...
+CAMGI stopped successfully.
+```
+
+## Technical Details
+
+**Container Command:**
+
+```bash
+podman run --rm -it -p 8080:8080 \
+  -v /path/to/must-gather:/must-gather:Z \
+  quay.io/elmiko/okd-camgi
+```
+
+**Key Flags:**
+- `--rm`: Auto-remove container when stopped
+- `-it`: Interactive terminal (Ctrl+C works)
+- `-p 8080:8080`: Port mapping for web interface
+- `-v path:/must-gather:Z`: Volume mount + SELinux relabeling
+- No `--security-opt label=disable`: SELinux stays enabled
+
+**Port:**
+- CAMGI runs on port 8080
+- Accessible at [http://127.0.0.1:8080](http://127.0.0.1:8080)
+- Uses IPv4 (127.0.0.1) to avoid IPv6 compatibility issues with rootless podman
+
+**SELinux:**
+- The `:Z` flag handles SELinux labeling automatically
+- No security-opt disabling needed
+
+## Examples
+
+1. **Start CAMGI with path**:
+   ```
+   /must-gather:camgi /home/user/must-gather
+   ```
+   Launches CAMGI with the provided must-gather path and opens browser.
+
+2. **Start CAMGI interactively**:
+   ```
+   /must-gather:camgi
+   ```
+   Asks for must-gather path, then launches CAMGI.
+
+3. **Stop CAMGI**:
+   ```
+   /must-gather:camgi stop
+   ```
+   Stops all running CAMGI containers.
+
+## Notes
+
+- **Foreground Execution**: CAMGI runs in the foreground - use Ctrl+C to stop, or run the stop command
+- **File Permissions**: Must-gather files need read permissions for the container user
+- **IPv4 vs localhost**: Uses IPv4 (127.0.0.1) to avoid IPv6 compatibility issues with rootless podman
+- **SELinux Friendly**: The `:Z` flag handles SELinux labeling automatically
+- **No Installation Required**: Uses containerized version, no need to install okd-camgi locally
+- **Container Cleanup**: The `--rm` flag ensures containers are automatically removed when stopped
+
+## Additional Resources
+
+- CAMGI GitHub: [https://github.com/elmiko/okd-camgi](https://github.com/elmiko/okd-camgi)
+- CAMGI PyPI: [https://pypi.org/project/okd-camgi/](https://pypi.org/project/okd-camgi/)
+- Launcher Script: `plugins/must-gather/skills/must-gather-analyzer/scripts/run-camgi.sh`
+
+## Arguments
+
+- **$1** (must-gather-path|stop): Optional. Either:
+  - Path to the must-gather directory (root or subdirectory)
+  - The keyword "stop" to stop all running CAMGI containers
+  - If not provided and not "stop", the user will be asked for the path

--- a/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
+++ b/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
@@ -189,6 +189,33 @@ Shows monitoring information:
 - Alerts (state, namespace, name, active since, labels)
 - Total of pending/firing alerts
 
+#### CAMGI - Cluster Infrastructure and Autoscaler Inspector
+```bash
+# Start CAMGI web interface
+./scripts/run-camgi.sh <must-gather-path>
+
+# Stop CAMGI containers
+./scripts/run-camgi.sh stop
+
+# Or use slash command
+/must-gather:camgi <must-gather-path>
+/must-gather:camgi stop
+```
+
+Interactive web-based analysis for cluster infrastructure and autoscaler:
+- Examines cluster autoscaler configuration and behavior
+- Reviews cluster operators status and health
+- Analyzes Machines, MachineSets, and Nodes configuration
+- Inspects Control Plane MachineSets
+- Checks Machine API operator status
+- Reviews Machine Config operator status
+- Examines Cloud Controller Manager details
+- Provides visual interface for investigating autoscaler scaling decisions
+- Helps debug autoscaler and cluster infrastructure issues
+- Automatically handles permissions and browser launching
+- Runs on [http://127.0.0.1:8080](http://127.0.0.1:8080)
+- See `scripts/README-CAMGI.md` for detailed documentation
+
 ### 3. Interpret and Report
 
 After running the scripts:
@@ -249,6 +276,13 @@ Output: etcd cluster health and member status
 Parses: `cluster-scoped-resources/core/persistentvolumes/`, `namespaces/*/core/persistentvolumeclaims.yaml`
 Output: PV and PVC status tables
 
+### scripts/run-camgi.sh
+Launches: CAMGI (Cluster Autoscaler Must-Gather Inspector) web interface
+Output: Interactive web UI at [http://127.0.0.1:8080](http://127.0.0.1:8080) for cluster infrastructure and autoscaler analysis
+Analysis: Cluster operators, machines, machinesets, nodes, autoscaler configuration, Machine API/Config operators, Cloud Controller Manager
+Prerequisites: Podman/Docker (containerized) or `pip3 install okd-camgi` (local)
+See: `scripts/README-CAMGI.md` for detailed documentation
+
 ## Tips for Analysis
 
 1. **Start with Cluster Operators**: They often reveal system-wide issues
@@ -274,6 +308,12 @@ Output: PV and PVC status tables
 1. Run `analyze_network.py` - check network health
 2. Run `analyze_pods.py --namespace openshift-ovn-kubernetes`
 3. Check PodNetworkConnectivityCheck results
+
+### "Cluster infrastructure or autoscaler problems"
+1. Run `run-camgi.sh <must-gather-path>` - launch interactive cluster infrastructure inspector
+2. Use CAMGI web UI to examine cluster operators, machines, machinesets, and nodes
+3. Review autoscaler configuration, scaling events, and decisions
+4. Inspect Machine API operator, Machine Config operator, and Cloud Controller Manager status
 
 ## Next Steps After Analysis
 

--- a/plugins/must-gather/skills/must-gather-analyzer/scripts/run-camgi.sh
+++ b/plugins/must-gather/skills/must-gather-analyzer/scripts/run-camgi.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# run-camgi.sh
+#
+# Runs okd-camgi (Cluster Autoscaler Must-Gather Inspector) with web browser UI
+# camgi is a tool for examining must-gather records to investigate cluster autoscaler behavior
+#
+# Usage: ./run-camgi.sh <must-gather-path>
+#
+# Prerequisites:
+#   - Python 3 and pip
+#   - okd-camgi installed (pip3 install okd-camgi --user)
+#   OR
+#   - Podman/Docker (to run containerized version)
+
+set -uo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to stop camgi containers
+stop_camgi() {
+    echo -e "${BLUE}Stopping camgi containers...${NC}"
+
+    # Check for podman
+    if command_exists podman; then
+        local containers
+        containers=$(podman ps -q --filter ancestor=quay.io/elmiko/okd-camgi)
+        if [ -n "$containers" ]; then
+            echo -e "${YELLOW}Found running camgi container(s)${NC}"
+            echo "$containers" | while read container; do
+                echo -e "${BLUE}Stopping container: $container${NC}"
+                podman stop "$container"
+            done
+            echo -e "${GREEN}Stopped camgi container(s)${NC}"
+        else
+            echo -e "${YELLOW}No running camgi containers found${NC}"
+        fi
+    fi
+
+    # Check for docker
+    if command_exists docker; then
+        local containers
+        containers=$(docker ps -q --filter ancestor=quay.io/elmiko/okd-camgi)
+        if [ -n "$containers" ]; then
+            echo -e "${YELLOW}Found running camgi container(s)${NC}"
+            echo "$containers" | while read container; do
+                echo -e "${BLUE}Stopping container: $container${NC}"
+                docker stop "$container"
+            done
+            echo -e "${GREEN}Stopped camgi container(s)${NC}"
+        else
+            echo -e "${YELLOW}No running camgi containers found${NC}"
+        fi
+    fi
+
+    exit 0
+}
+
+# Parse arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <must-gather-path>"
+    echo "       $0 stop|--stop"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/must-gather    # Start camgi"
+    echo "  $0 stop                     # Stop running camgi containers"
+    echo ""
+    echo "This script runs okd-camgi to analyze cluster autoscaler behavior"
+    echo "in your must-gather data via an interactive web browser interface."
+    echo ""
+    echo "Prerequisites:"
+    echo "  Option 1 (Local): pip3 install okd-camgi --user"
+    echo "  Option 2 (Container): podman or docker"
+    exit 1
+fi
+
+# Check if user wants to stop camgi
+if [ "$1" = "stop" ] || [ "$1" = "--stop" ]; then
+    stop_camgi
+fi
+
+MG_PATH="$1"
+
+# Validate must-gather path
+if [ ! -d "$MG_PATH" ]; then
+    echo -e "${RED}Error: Directory not found: $MG_PATH${NC}"
+    exit 1
+fi
+
+# Check if we need to find the subdirectory with hash
+if [ ! -d "$MG_PATH/cluster-scoped-resources" ]; then
+    echo -e "${YELLOW}Looking for must-gather subdirectory...${NC}"
+    # Find subdirectory containing cluster-scoped-resources
+    SUBDIR=$(find "$MG_PATH" -maxdepth 2 -type d -name "*sha256*" | head -n 1)
+    if [ -n "$SUBDIR" ]; then
+        echo -e "${GREEN}Found: $SUBDIR${NC}"
+        MG_PATH="$SUBDIR"
+    else
+        echo -e "${YELLOW}Warning: Could not find standard must-gather structure${NC}"
+        echo -e "${YELLOW}Attempting to run camgi anyway...${NC}"
+    fi
+fi
+
+# Check and fix permissions if needed
+echo -e "${BLUE}Checking file permissions...${NC}"
+# Check for any files that don't have world-read permission
+# Focus on common must-gather file locations that CAMGI needs to access
+PERMISSION_ISSUES=0
+if find "$MG_PATH" -type f ! -perm -004 2>/dev/null | head -n 1 | grep -q .; then
+    PERMISSION_ISSUES=1
+fi
+
+if [ $PERMISSION_ISSUES -eq 1 ]; then
+    echo -e "${YELLOW}Warning: Some files have restrictive permissions${NC}"
+    echo -e "${YELLOW}CAMGI needs read access to all must-gather files${NC}"
+    echo ""
+    read -p "Fix permissions now? (Y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+        echo -e "${BLUE}Fixing permissions...${NC}"
+        chmod -R a+r "$MG_PATH" 2>/dev/null
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}Permissions updated successfully${NC}"
+        else
+            echo -e "${YELLOW}Note: Some permission updates may have failed${NC}"
+            echo -e "${YELLOW}You may need to run: chmod -R a+r $MG_PATH${NC}"
+        fi
+    else
+        echo -e "${YELLOW}Skipping permission fix. CAMGI may encounter errors.${NC}"
+        echo -e "${YELLOW}To fix manually: chmod -R a+r $MG_PATH${NC}"
+    fi
+else
+    echo -e "${GREEN}Permissions OK${NC}"
+fi
+echo ""
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}OKD-CAMGI - Cluster Autoscaler Inspector${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo "Must-Gather Path: $MG_PATH"
+echo ""
+
+# Try to run camgi using available methods
+run_camgi() {
+    # Method 1: Check if okd-camgi is installed locally
+    if command_exists okd-camgi; then
+        echo -e "${GREEN}Found okd-camgi installed locally${NC}"
+        echo -e "${BLUE}Starting camgi with web browser...${NC}"
+        echo ""
+        okd-camgi --webbrowser "$MG_PATH"
+        return $?
+    fi
+
+    # Method 2: Try with python3 -m (in case it's installed but not in PATH)
+    if command_exists python3; then
+        if python3 -c "import okd_camgi" 2>/dev/null; then
+            echo -e "${GREEN}Found okd-camgi Python module${NC}"
+            echo -e "${BLUE}Starting camgi with web browser...${NC}"
+            echo ""
+            python3 -m okd_camgi --webbrowser "$MG_PATH"
+            return $?
+        fi
+    fi
+
+    # Method 3: Try containerized version
+    if command_exists podman; then
+        echo -e "${YELLOW}okd-camgi not found locally, using containerized version${NC}"
+        echo -e "${BLUE}Starting camgi container on http://127.0.0.1:8080${NC}"
+        echo -e "${YELLOW}Press Ctrl+C to stop the server${NC}"
+        echo ""
+
+        # Open browser in background
+        (sleep 2 && xdg-open http://127.0.0.1:8080 2>/dev/null) &
+
+        # Use :Z flag for SELinux relabeling (recommended by camgi documentation)
+        podman run --rm -it -p 8080:8080 -v "$MG_PATH:/must-gather:Z" quay.io/elmiko/okd-camgi
+        return $?
+    fi
+
+    if command_exists docker; then
+        echo -e "${YELLOW}okd-camgi not found locally, using containerized version${NC}"
+        echo -e "${BLUE}Starting camgi container on http://127.0.0.1:8080${NC}"
+        echo -e "${YELLOW}Press Ctrl+C to stop the server${NC}"
+        echo ""
+
+        # Open browser in background
+        (sleep 2 && xdg-open http://127.0.0.1:8080 2>/dev/null) &
+
+        docker run --rm -it -p 8080:8080 -v "$MG_PATH:/must-gather:Z" quay.io/elmiko/okd-camgi
+        return $?
+    fi
+
+    # No method available
+    echo -e "${RED}Error: okd-camgi is not installed and no container runtime found${NC}"
+    echo ""
+    echo "Please install okd-camgi using one of these methods:"
+    echo ""
+    echo "  Method 1 (Local installation - recommended):"
+    echo -e "    ${GREEN}pip3 install okd-camgi --user${NC}"
+    echo ""
+    echo "  Method 2 (Container - requires podman/docker):"
+    echo -e "    ${GREEN}podman run --rm -it -p 8080:8080 -v $MG_PATH:/must-gather:Z quay.io/elmiko/okd-camgi${NC}"
+    echo ""
+    echo "  For more information:"
+    echo "    GitHub: https://github.com/elmiko/okd-camgi"
+    echo "    README: $(dirname "$0")/README-CAMGI.md"
+    return 1
+}
+
+# Run camgi
+run_camgi
+exit_code=$?
+
+if [ $exit_code -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}CAMGI Session Ended${NC}"
+    echo -e "${GREEN}========================================${NC}"
+else
+    echo ""
+    echo -e "${RED}========================================${NC}"
+    echo -e "${RED}CAMGI encountered an error${NC}"
+    echo -e "${RED}========================================${NC}"
+    echo ""
+    echo -e "${YELLOW}Common fixes:${NC}"
+    echo ""
+    echo "  1. If you see Permission errors, fix must-gather permissions:"
+    echo -e "     ${GREEN}chmod -R a+r \"$MG_PATH\"${NC}"
+    echo ""
+    echo "  2. For more details, see:"
+    echo "     $(dirname "$0")/README-CAMGI.md"
+fi
+
+exit $exit_code


### PR DESCRIPTION
split the camgi part out of #133 to make it easier to review and more readable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CAMGI (Cluster Autoscaler Must‑Gather Inspector) to must-gather — start/stop via /must-gather:camgi [must-gather-path|stop], launches an interactive web UI for autoscaler and cluster infrastructure analysis; supports local or containerized execution, auto-browser opening, and permission handling.

* **Documentation**
  * Added comprehensive CAMGI docs, quick start, examples, troubleshooting, usage tips, and integration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->