### PR TITLE
must-gather: Add IPsec tunnel analyzer

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -156,6 +156,7 @@ A plugin to analyze and report on must-gather data
 
 **Commands:**
 - **`/must-gather:analyze` `[must-gather-path] [component]`** - Quick analysis of must-gather data - runs all analysis scripts and provides comprehensive cluster diagnostics
+- **`/must-gather:ipsec` `[must-gather-path]`** - Analyze IPsec configuration and tunnel status from must-gather
 - **`/must-gather:ovn-dbs` `[must-gather-path]`** - Analyze OVN databases from a must-gather using ovsdb-tool
 
 See [plugins/must-gather/README.md](plugins/must-gather/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -698,6 +698,12 @@
         },
         {
           "argument_hint": "[must-gather-path]",
+          "description": "Analyze IPsec configuration and tunnel status from must-gather",
+          "name": "ipsec",
+          "synopsis": "/must-gather:ipsec [must-gather-path] [node-name]"
+        },
+        {
+          "argument_hint": "[must-gather-path]",
           "description": "Analyze OVN databases from a must-gather using ovsdb-tool",
           "name": "ovn-dbs",
           "synopsis": "/must-gather:ovn-dbs [must-gather-path] [--node <node-name>] [--query <json>]"

--- a/plugins/must-gather/README.md
+++ b/plugins/must-gather/README.md
@@ -251,6 +251,56 @@ Active alerts: 2 total (0 pending, 2 firing)
 ================================================================================
 ```
 
+#### `analyze_ipsec.py`
+
+Analyzes IPsec configuration and tunnel status.
+
+```bash
+# Analyze IPsec for all nodes
+./analyze_ipsec.py <must-gather-path>
+
+# Analyze IPsec for a specific node
+./analyze_ipsec.py <must-gather-path> <node-name>
+```
+
+Shows:
+- IPsec configuration status (enabled/disabled and mode)
+- ovn-ipsec-host daemonset pod status
+- Per-pod IPsec tunnel establishment status
+- Connection names and their establishment state
+- Summary of total, established, and failed connections
+
+Output includes:
+```plaintext
+====================================================================================================
+IPSEC CONFIGURATION
+====================================================================================================
+Status: ✓ ENABLED
+Mode:   Full
+
+====================================================================================================
+OVN-IPSEC-HOST PODS (Daemonset)
+====================================================================================================
+
+Found 3 ovn-ipsec-host pod(s):
+NAME                                      READY      STATUS          RESTARTS   NODE
+ovn-ipsec-host-abc123                     1/1        Running         0          worker-0
+
+====================================================================================================
+IPSEC TUNNEL STATUS
+====================================================================================================
+
+Total Connections: 6
+Established:       5 ✓
+Not Established:   1 ✗
+```
+
+**Use cases:**
+- Verify IPsec is enabled and configured correctly
+- Troubleshoot IPsec tunnel connectivity issues
+- Identify which specific tunnels failed to establish
+- Monitor IPsec daemonset pod health
+
 ### Slash Commands
 
 #### `/must-gather:analyze [path] [component]`
@@ -296,6 +346,34 @@ Provides detailed analysis of:
 - Node filtering with partial name matching
 
 **Requirements:** `ovsdb-tool` installed
+
+#### `/must-gather:ipsec [path] [node-name]`
+Analyzes IPsec configuration and tunnel status from must-gather.
+
+```bash
+# Analyze IPsec for all nodes
+/must-gather:ipsec ./must-gather.local.123456789
+
+# Analyze IPsec for a specific node
+/must-gather:ipsec ./must-gather.local.123456789 worker-0
+
+# Check if IPsec is enabled
+/must-gather:ipsec ./must-gather.local.123456789
+```
+
+Provides analysis of:
+- IPsec configuration (whether enabled and mode)
+- ovn-ipsec-host daemonset pod status on each node
+- IPsec tunnel establishment status
+- Per-connection status showing which tunnels are established
+- Node filtering to troubleshoot specific node issues
+
+**Use cases:**
+- Verify IPsec deployment and configuration
+- Troubleshoot connectivity issues
+- Identify failed IPsec tunnels
+- Validate cluster upgrades
+- Audit IPsec health across nodes
 
 ## Installation
 

--- a/plugins/must-gather/commands/analyze.md
+++ b/plugins/must-gather/commands/analyze.md
@@ -22,6 +22,7 @@ The command can analyze:
 - Pod failures, restarts, and crash loops
 - Network configuration and OVN health
 - OVN databases - logical topology, ACLs, pods
+- IPsec configuration and tunnel status
 - Kubernetes events (warnings and errors)
 - etcd cluster health and quorum status
 - Persistent volume and claim status
@@ -55,9 +56,11 @@ Analysis scripts are bundled with this plugin at:
 ├── analyze_pods.py
 ├── analyze_network.py
 ├── analyze_ovn_dbs.py
+├── analyze_ipsec.py
 ├── analyze_events.py
 ├── analyze_etcd.py
-└── analyze_pvs.py
+├── analyze_pvs.py
+└── analyze_prometheus.py
 ```
 
 Where `<plugin-root>` is the directory where this plugin is installed (typically `~/.cursor/commands/ai-helpers/plugins/must-gather/` or similar).
@@ -116,6 +119,7 @@ The command performs the following steps:
    - "etcd", "etcd health", "quorum" → `analyze_etcd.py` ONLY
    - "network", "networking", "ovn", "connectivity" → `analyze_network.py` ONLY
    - "ovn databases", "ovn-dbs", "ovn db", "logical switches", "acls" → `analyze_ovn_dbs.py` ONLY
+   - "ipsec", "ipsec tunnels", "ipsec status", "ipsec configuration" → `analyze_ipsec.py` ONLY
    - "nodes", "node status", "node conditions" → `analyze_nodes.py` ONLY
    - "operators", "cluster operators", "degraded" → `analyze_clusteroperators.py` ONLY
    - "version", "cluster version", "update", "upgrade" → `analyze_clusterversion.py` ONLY
@@ -131,10 +135,11 @@ The command performs the following steps:
    3. Nodes (`analyze_nodes.py`)
    4. Pods - problems only (`analyze_pods.py --problems-only`)
    5. Network (`analyze_network.py`)
-   6. Events - warnings only (`analyze_events.py --type Warning --count 50`)
-   7. etcd (`analyze_etcd.py`)
-   8. Storage (`analyze_pvs.py`)
-   9. Monitoring (`analyze_prometheus.py`)
+   6. IPsec (`analyze_ipsec.py`)
+   7. Events - warnings only (`analyze_events.py --type Warning --count 50`)
+   8. etcd (`analyze_etcd.py`)
+   9. Storage (`analyze_pvs.py`)
+   10. Monitoring (`analyze_prometheus.py`)
 
 3. **Locate Plugin Scripts**:
    - Use the script availability check from the Error Handling section to find the plugin root
@@ -191,6 +196,9 @@ PROBLEMATIC PODS:
 NETWORK STATUS:
 [output from analyze_network.py]
 
+IPSEC STATUS:
+[output from analyze_ipsec.py]
+
 WARNING EVENTS (Last 50):
 [output from analyze_events.py --type Warning --count 50]
 
@@ -245,6 +253,12 @@ Logs to Review:
    /must-gather:analyze ./must-gather/registry-ci-openshift-org-origin-4-20-...-sha256-abc123/ show me network issues
    ```
    Runs only `analyze_network.py` for network-specific analysis.
+
+5. **Check IPsec tunnel status**:
+   ```
+   /must-gather:analyze ./must-gather/registry-ci-openshift-org-origin-4-20-...-sha256-abc123/ analyze ipsec tunnels
+   ```
+   Runs only `analyze_ipsec.py` to check IPsec configuration and tunnel establishment.
 
 ## Notes
 

--- a/plugins/must-gather/commands/ipsec.md
+++ b/plugins/must-gather/commands/ipsec.md
@@ -1,0 +1,248 @@
+---
+description: Analyze IPsec configuration and tunnel status from must-gather
+argument-hint: [must-gather-path]
+---
+
+## Name
+must-gather:ipsec
+
+## Synopsis
+```
+/must-gather:ipsec [must-gather-path] [node-name]
+```
+
+## Description
+
+The `ipsec` command analyzes IPsec configuration and tunnel status from OpenShift must-gather data. It examines the `ovn-ipsec-host` daemonset pods that run on each node to configure IPsec tunnels, and verifies the establishment status of all IPsec connections.
+
+**What it analyzes:**
+- **IPsec Configuration**: Checks if IPsec is enabled in the cluster network configuration
+- **ovn-ipsec-host Pods**: Status of the daemonset pods that configure IPsec on each node
+- **Tunnel Status**: Per-pod connection status by parsing IPsec configuration and status logs
+
+The command parses the `network_logs/ipsec/<pod>_ipsec.d/openshift.conf` file to extract connection names, then checks the corresponding status logs to verify that each connection has established an IKE SA (indicated by the presence of `ESTABLISHED_CHILD_SA` in the status logs).
+
+**Node Filtering**: You can optionally specify a node name to analyze only the IPsec pod and tunnels for that specific node. This is useful when troubleshooting node-specific connectivity issues. Use `all` or omit the parameter to analyze all nodes.
+
+## Prerequisites
+
+The must-gather should contain:
+```plaintext
+cluster-scoped-resources/
+└── operator.openshift.io/
+    └── networks/
+        └── cluster.yaml                            # Cluster network configuration (IPsec settings)
+
+namespaces/
+└── openshift-ovn-kubernetes/
+    └── pods/
+        └── ovn-ipsec-host-<pod-id>/               # Pod metadata and status
+            └── ovn-ipsec-host-<pod-id>.yaml
+
+network_logs/
+└── ipsec/
+    ├── <pod>_ipsec.d/
+    │   └── openshift.conf                          # IPsec connection configurations
+    └── status/
+        └── <pod>.log                               # Connection status logs
+```
+
+**Analysis Script:**
+
+The script is located in the plugin directory:
+```plaintext
+plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py
+```
+
+Claude will automatically locate it from the plugin installation.
+
+## Implementation
+
+The command performs the following steps:
+
+1. **Parse Arguments**:
+   - Extract must-gather path (required)
+   - Extract node name filter (optional) - if provided, only analyze that node's IPsec pod and tunnels
+
+2. **Check IPsec Configuration**:
+   - Read cluster network configuration from `cluster-scoped-resources/operator.openshift.io/networks/cluster.yaml`
+   - Check if `ipsecConfig` is present under `ovnKubernetesConfig`
+   - Extract IPsec mode and other configuration details
+
+3. **Check ovn-ipsec-host Pods**:
+   - Locate all `ovn-ipsec-host-*` pods in the `openshift-ovn-kubernetes` namespace
+   - If node filter is specified, only include pods running on that node
+   - Check pod status (Running, CrashLoopBackOff, etc.)
+   - Count ready containers and restart counts
+   - Map pods to their corresponding nodes
+
+4. **Analyze Tunnel Status** (from `network_logs/ipsec/`):
+   - For each `<pod>_ipsec.d/` directory:
+     - Match pod to node name using pod metadata
+     - If node filter is specified, skip pods not on that node
+     - Parse `<pod>_ipsec.d/openshift.conf` to extract connection names (lines starting with `conn <name>`)
+     - Locate status log in `network_logs/ipsec/status/<pod>.log` (status directory is a sibling, not inside the pod directory)
+     - For each connection, grep the status log for the connection name
+     - Check if `ESTABLISHED_CHILD_SA` is present in the matching lines
+   - Report established vs. not established connections per pod
+
+5. **Generate Summary**:
+   - Overall IPsec health status
+   - Count of total, established, and failed connections (for analyzed nodes)
+   - List of issues detected (if any)
+
+## Return Value
+
+The command outputs a comprehensive analysis including:
+
+```plaintext
+====================================================================================================
+IPSEC CONFIGURATION
+====================================================================================================
+Status: ✓ ENABLED
+Mode:   Full
+
+====================================================================================================
+OVN-IPSEC-HOST PODS (Daemonset)
+====================================================================================================
+
+Found 3 ovn-ipsec-host pod(s):
+NAME                                      READY      STATUS          RESTARTS   NODE
+ovn-ipsec-host-abc123                     1/1        Running         0          worker-0
+ovn-ipsec-host-def456                     1/1        Running         0          worker-1
+ovn-ipsec-host-ghi789                     1/1        Running         0          master-0
+
+====================================================================================================
+IPSEC TUNNEL STATUS
+====================================================================================================
+
+Total Connections: 6
+Established:       5 ✓
+Not Established:   1 ✗
+
+----------------------------------------------------------------------------------------------------
+Pod: ovn-ipsec-host-abc123
+----------------------------------------------------------------------------------------------------
+
+  Connections (2):
+  CONNECTION NAME                                    STATUS          INFO
+  -----------------------------------------------------------------------------------------------
+  ✓ conn-to-10-0-1-20                                ESTABLISHED     ESTABLISHED_CHILD_SA
+  ✗ conn-to-10-0-1-30                                NOT ESTABLISHED No ESTABLISHED_CHILD_SA found
+
+====================================================================================================
+SUMMARY
+====================================================================================================
+
+⚠ Issues Detected:
+1. 1 IPsec connections not established
+```
+
+## Examples
+
+1. **Analyze IPsec for all nodes**:
+   ```bash
+   /must-gather:ipsec ./must-gather.local.123456789
+   ```
+   Shows complete IPsec analysis including configuration, all pods, and tunnel status for all nodes.
+
+2. **Analyze IPsec for a specific node**:
+   ```bash
+   /must-gather:ipsec ./must-gather.local.123456789 worker-0
+   ```
+   Shows IPsec analysis filtered to only the `worker-0` node. Useful when troubleshooting node-specific issues.
+
+3. **Explicitly analyze all nodes**:
+   ```bash
+   /must-gather:ipsec ./must-gather.local.123456789 all
+   ```
+   Same as omitting the node parameter - analyzes all nodes.
+
+4. **Interactive usage without path**:
+   ```bash
+   /must-gather:ipsec
+   ```
+   The command will ask for the must-gather path.
+
+5. **Check if IPsec is enabled**:
+   ```bash
+   /must-gather:ipsec ./must-gather/...
+   ```
+   The output's "IPSEC CONFIGURATION" section shows whether IPsec is enabled and its mode.
+
+6. **Verify tunnel establishment for specific node**:
+   ```bash
+   /must-gather:ipsec ./must-gather/... master-0
+   ```
+   The "IPSEC TUNNEL STATUS" section shows which connections are established on master-0.
+
+7. **Troubleshoot connection failures on a node**:
+   ```bash
+   /must-gather:ipsec ./must-gather/... worker-1
+   ```
+   Look for connections with "NOT ESTABLISHED" status on worker-1 - these indicate tunnels that failed to come up.
+
+## Error Handling
+
+**Missing network_logs/ipsec directory:**
+```plaintext
+No IPsec tunnel data found in network_logs/ipsec/
+(Expected location: network_logs/ipsec/<pod>_ipsec.d/)
+```
+This indicates either IPsec is not enabled or the must-gather didn't collect IPsec logs.
+
+**Missing openshift.conf:**
+```plaintext
+⚠ Error: openshift.conf not found
+```
+The IPsec configuration file is missing for this pod.
+
+**Missing status logs:**
+```plaintext
+⚠ status directory not found
+```
+Status logs are not available to verify connection state.
+
+**No ovn-ipsec-host pods found:**
+```plaintext
+No ovn-ipsec-host pods found
+(This is expected if IPsec is not enabled)
+```
+Either IPsec is disabled or the daemonset failed to deploy.
+
+## Notes
+
+- **IPsec Daemonset**: The `ovn-ipsec-host` daemonset runs one pod per node to manage IPsec configuration
+- **Connection Naming**: Connections in `openshift.conf` follow the pattern `conn <name>`
+- **Establishment Check**: A connection is considered established only if `ESTABLISHED_CHILD_SA` appears in the status log
+- **Per-Node Analysis**: Each node has its own set of IPsec connections to other nodes
+- **Network Logs Structure**: IPsec logs are collected under `network_logs/ipsec/`
+  - `<pod>_ipsec.d/openshift.conf`: Contains all connection definitions for that pod/node
+  - `status/<pod>.log`: Contains runtime status information for all connections (status is a sibling directory to the pod directories)
+
+## Use Cases
+
+1. **Verify IPsec Deployment**:
+   - Check if IPsec is enabled in cluster configuration
+   - Verify ovn-ipsec-host pods are running on all nodes
+   - Confirm certificates and secrets are present
+
+2. **Troubleshoot Connectivity Issues**:
+   - Identify which IPsec tunnels failed to establish
+   - Check for pod failures or high restart counts
+   - Look for patterns in failed connections (e.g., all to same node)
+
+3. **Validate Cluster Upgrade**:
+   - Verify IPsec remains functional after upgrade
+   - Check for certificate issues
+   - Ensure all connections re-established
+
+4. **Audit IPsec Health**:
+   - Get count of total vs. established connections
+   - Identify nodes with connection problems
+   - Review pod status across all nodes
+
+## Arguments
+
+- **$1** (must-gather-path): Optional. Path to the must-gather directory. If not provided, user will be prompted.
+- **$2** (node-name): Optional. Node name to filter analysis. If provided, only analyze the IPsec pod and tunnels for that specific node. Use `all` or omit to analyze all nodes. Examples: `worker-0`, `master-1`.

--- a/plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py
+++ b/plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""
+Analyze IPsec configuration and tunnel status from must-gather data.
+
+This script analyzes:
+1. IPsec configuration from cluster network resources
+2. ovn-ipsec-host daemonset pod status
+3. IPsec tunnel establishment status per pod
+
+Usage:
+    analyze_ipsec.py <must-gather-path> [node-name]
+
+Arguments:
+    must-gather-path: Path to the must-gather directory
+    node-name: Optional. Filter analysis to specific node. Use 'all' or omit for all nodes.
+
+Examples:
+    # Analyze all nodes
+    analyze_ipsec.py ./must-gather.local.123456789
+
+    # Analyze specific node
+    analyze_ipsec.py ./must-gather.local.123456789 worker-0
+
+    # Explicitly analyze all nodes
+    analyze_ipsec.py ./must-gather.local.123456789 all
+"""
+
+import sys
+import os
+import yaml
+import re
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+
+
+def parse_yaml_file(file_path: Path) -> Optional[Dict[str, Any]]:
+    """Parse a YAML file and return the document."""
+    try:
+        with open(file_path, 'r') as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Warning: File not found: {file_path}", file=sys.stderr)
+        return None
+    except yaml.YAMLError as e:
+        print(f"Warning: Invalid YAML in {file_path}: {e}", file=sys.stderr)
+        return None
+
+
+def get_ipsec_config(must_gather_path: Path) -> Optional[Dict[str, Any]]:
+    """
+    Get IPsec configuration from cluster network resources.
+
+    Looks for: cluster-scoped-resources/operator.openshift.io/networks/cluster.yaml
+
+    Returns dict with:
+        - enabled: bool indicating if IPsec is enabled (mode != 'Disabled')
+        - mode: IPsec mode ('Full', 'External', or 'Disabled')
+        - config: Full ipsecConfig dict if available
+    """
+    patterns = [
+        "cluster-scoped-resources/operator.openshift.io/networks/cluster.yaml",
+        "*/cluster-scoped-resources/operator.openshift.io/networks/cluster.yaml",
+    ]
+
+    for pattern in patterns:
+        for network_file in must_gather_path.glob(pattern):
+            network = parse_yaml_file(network_file)
+            if not network:
+                continue
+
+            spec = network.get('spec', {})
+            default_network = spec.get('defaultNetwork', {})
+            ovn_config = default_network.get('ovnKubernetesConfig', {})
+            ipsec_config = ovn_config.get('ipsecConfig')
+
+            mode = ipsec_config.get('mode') if ipsec_config else None
+            return {
+                'enabled': ipsec_config is not None and mode != 'Disabled',
+                'mode': mode,
+                'config': ipsec_config
+            }
+
+    return None
+
+
+def analyze_ovn_ipsec_host_pods(must_gather_path: Path, filter_node: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    Analyze ovn-ipsec-host daemonset pods.
+
+    Args:
+        must_gather_path: Path to must-gather directory
+        filter_node: Optional node name to filter results. None means all nodes.
+
+    Returns list of pod info dicts with:
+        - name: Pod name
+        - ready: Ready containers ratio (e.g., "1/1")
+        - status: Pod phase (Running, CrashLoopBackOff, etc.)
+        - restarts: Total restart count across all containers
+        - node: Node name where pod is scheduled
+    """
+    pods = []
+
+    patterns = [
+        "namespaces/openshift-ovn-kubernetes/pods/ovn-ipsec-host-*/*.yaml",
+        "*/namespaces/openshift-ovn-kubernetes/pods/ovn-ipsec-host-*/*.yaml",
+    ]
+
+    seen = set()  # Track pod names to avoid duplicates
+
+    for pattern in patterns:
+        for pod_file in must_gather_path.glob(pattern):
+            # Skip aggregated pods.yaml files
+            if pod_file.name == 'pods.yaml':
+                continue
+
+            pod = parse_yaml_file(pod_file)
+            if not pod:
+                continue
+
+            name = pod.get('metadata', {}).get('name', 'unknown')
+
+            # Only process ovn-ipsec-host pods
+            if not name.startswith('ovn-ipsec-host-'):
+                continue
+
+            # Skip duplicates
+            if name in seen:
+                continue
+            seen.add(name)
+
+            spec = pod.get('spec', {})
+            status = pod.get('status', {})
+            node_name = spec.get('nodeName', 'Unknown')
+
+            # Apply node filter if specified
+            if filter_node and filter_node.lower() != 'all' and node_name != filter_node:
+                continue
+
+            phase = status.get('phase', 'Unknown')
+            containers = spec.get('containers', [])
+            container_statuses = status.get('containerStatuses', [])
+
+            total = len(containers)
+            ready = sum(1 for cs in container_statuses if cs.get('ready', False))
+
+            # Calculate total restarts across all containers
+            restart_count = sum(cs.get('restartCount', 0) for cs in container_statuses)
+
+            pods.append({
+                'name': name,
+                'ready': f"{ready}/{total}",
+                'status': phase,
+                'restarts': restart_count,
+                'node': node_name
+            })
+
+    return sorted(pods, key=lambda x: x['name'])
+
+
+def parse_ipsec_connections(openshift_conf_path: Path) -> List[str]:
+    """
+    Parse openshift.conf to extract IPsec connection names.
+
+    Connection definitions start with 'conn <name>' where <name> is the connection identifier.
+    Ignores special connections like '%default'.
+
+    Returns list of connection names.
+    """
+    connections = []
+
+    if not openshift_conf_path.exists():
+        return connections
+
+    try:
+        with open(openshift_conf_path, 'r', errors='ignore') as f:
+            for line in f:
+                # Match lines like: "conn connection-name"
+                match = re.match(r'^\s*conn\s+(\S+)', line)
+                if match:
+                    conn_name = match.group(1)
+                    # Skip special connection names
+                    if conn_name not in ['%default']:
+                        connections.append(conn_name)
+    except OSError as e:
+        print(f"Warning: Failed to parse {openshift_conf_path}: {e}", file=sys.stderr)
+
+    return connections
+
+
+def check_connection_status(status_log_path: Path, connection_name: str) -> Dict[str, Any]:
+    """
+    Check if a connection is established by examining the status log.
+
+    A connection is considered established if 'ESTABLISHED_CHILD_SA' appears in
+    a log line that also mentions the connection name.
+
+    Args:
+        status_log_path: Path to the status log file
+        connection_name: Name of the connection to check
+
+    Returns dict with:
+        - established: bool indicating if ESTABLISHED_CHILD_SA was found
+        - info: String with status information
+    """
+    if not status_log_path.exists():
+        return {
+            'established': False,
+            'info': 'Status log not found'
+        }
+
+    try:
+        with open(status_log_path, 'r', errors='ignore') as f:
+            for line in f:
+                # Look for lines mentioning this connection
+                if connection_name in line:
+                    # Check if this line indicates established state
+                    if 'ESTABLISHED_CHILD_SA' in line:
+                        return {
+                            'established': True,
+                            'info': 'ESTABLISHED_CHILD_SA'
+                        }
+    except OSError as e:
+        print(f"Warning: Failed to read {status_log_path}: {e}", file=sys.stderr)
+        return {
+            'established': False,
+            'info': f'Error reading log: {e}'
+        }
+
+    return {
+        'established': False,
+        'info': 'No ESTABLISHED_CHILD_SA found'
+    }
+
+
+def analyze_ipsec_tunnels(must_gather_path: Path, filter_node: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Analyze IPsec tunnel status from network_logs/ipsec/ directory.
+
+    Directory structure:
+        network_logs/ipsec/
+            ├── <pod>_ipsec.d/
+            │   └── openshift.conf      # Connection definitions
+            └── status/
+                └── <pod>.log           # Connection status logs
+
+    Args:
+        must_gather_path: Path to must-gather directory
+        filter_node: Optional node name to filter results
+
+    Returns dict with:
+        - pods: List of pod tunnel analyses
+        - total_connections: Total number of connections found
+        - established_connections: Number of established connections
+        - failed_connections: Number of not established connections
+    """
+    tunnel_analysis = {
+        'pods': [],
+        'total_connections': 0,
+        'established_connections': 0,
+        'failed_connections': 0
+    }
+
+    # Build a mapping of pod name to node name from the pod analysis
+    # This requires re-reading pod info, so we'll do a lightweight version
+    pod_to_node = {}
+    patterns = [
+        "namespaces/openshift-ovn-kubernetes/pods/ovn-ipsec-host-*/*.yaml",
+        "*/namespaces/openshift-ovn-kubernetes/pods/ovn-ipsec-host-*/*.yaml",
+    ]
+
+    seen_pods = set()
+    for pattern in patterns:
+        for pod_file in must_gather_path.glob(pattern):
+            if pod_file.name == 'pods.yaml':
+                continue
+
+            pod = parse_yaml_file(pod_file)
+            if pod:
+                name = pod.get('metadata', {}).get('name', '')
+                if name.startswith('ovn-ipsec-host-') and name not in seen_pods:
+                    seen_pods.add(name)
+                    node = pod.get('spec', {}).get('nodeName', 'Unknown')
+                    pod_to_node[name] = node
+
+    # Look for ipsec directories
+    ipsec_d_patterns = [
+        "network_logs/ipsec/*_ipsec.d",
+        "*/network_logs/ipsec/*_ipsec.d"
+    ]
+
+    for pattern in ipsec_d_patterns:
+        for ipsec_d_dir in must_gather_path.glob(pattern):
+            if not ipsec_d_dir.is_dir():
+                continue
+
+            # Extract pod name from directory (e.g., "ovn-ipsec-host-abc_ipsec.d" -> "ovn-ipsec-host-abc")
+            pod_name = ipsec_d_dir.name.replace('_ipsec.d', '')
+
+            # Apply node filter if specified
+            node_name = pod_to_node.get(pod_name, 'Unknown')
+            if filter_node and filter_node.lower() != 'all' and node_name != filter_node:
+                continue
+
+            openshift_conf = ipsec_d_dir / 'openshift.conf'
+            # Status directory is at network_logs/ipsec/status, not inside the pod's ipsec.d directory
+            status_dir = ipsec_d_dir.parent / 'status'
+
+            pod_info = {
+                'pod': pod_name,
+                'node': node_name,
+                'config_found': openshift_conf.exists(),
+                'status_dir_found': status_dir.exists(),
+                'connections': []
+            }
+
+            if not openshift_conf.exists():
+                pod_info['error'] = 'openshift.conf not found'
+                tunnel_analysis['pods'].append(pod_info)
+                continue
+
+            # Parse connections from openshift.conf
+            connections = parse_ipsec_connections(openshift_conf)
+            tunnel_analysis['total_connections'] += len(connections)
+
+            # Status log file follows naming convention: status/<pod_name>.log
+            status_log = status_dir / f"{pod_name}.log" if status_dir.exists() else None
+            # Check status for each connection
+            for conn_name in connections:
+                if status_log:
+
+                    conn_status = check_connection_status(status_log, conn_name)
+                    established = conn_status['established']
+                    info = conn_status['info']
+                else:
+                    established = False
+                    info = 'Status log not found'
+
+                pod_info['connections'].append({
+                    'name': conn_name,
+                    'established': established,
+                    'info': info
+                })
+
+                if established:
+                    tunnel_analysis['established_connections'] += 1
+                else:
+                    tunnel_analysis['failed_connections'] += 1
+
+            if not status_dir.exists():
+                pod_info['status_warning'] = 'status directory not found'
+
+            tunnel_analysis['pods'].append(pod_info)
+
+    return tunnel_analysis
+
+
+def print_section_header(title: str):
+    """Print a section header with separator lines."""
+    print("=" * 100)
+    print(title)
+    print("=" * 100)
+
+
+def print_subsection_separator():
+    """Print a subsection separator line."""
+    print("-" * 100)
+
+
+def print_ipsec_analysis(ipsec_config: Optional[Dict], ipsec_pods: List[Dict],
+                        tunnel_analysis: Dict, filter_node: Optional[str] = None):
+    """
+    Print the complete IPsec analysis report.
+
+    Follows the format specified in ipsec.md command specification.
+    """
+
+    # Section 1: IPsec Configuration
+    print_section_header("IPSEC CONFIGURATION")
+
+    if ipsec_config:
+        enabled = ipsec_config.get('enabled', False)
+        status_symbol = "✓" if enabled else "✗"
+        status_text = "ENABLED" if enabled else "DISABLED"
+
+        print(f"Status: {status_symbol} {status_text}")
+
+        if enabled and ipsec_config.get('mode'):
+            mode = ipsec_config['mode']
+            print(f"Mode:   {mode}")
+    else:
+        print("Status: Unable to determine IPsec configuration")
+        print("(Network configuration not found in must-gather)")
+
+    print()
+
+    # Section 2: OVN-IPSEC-HOST Pods
+    print_section_header("OVN-IPSEC-HOST PODS (Daemonset)")
+    print()
+
+    if ipsec_pods:
+        filter_msg = f" (filtered to node: {filter_node})" if filter_node and filter_node.lower() != 'all' else ""
+        print(f"Found {len(ipsec_pods)} ovn-ipsec-host pod(s){filter_msg}:")
+        print(f"{'NAME':<40} {'READY':<10} {'STATUS':<15} {'RESTARTS':<10} NODE")
+        print_subsection_separator()
+
+        for pod in ipsec_pods:
+            name = pod['name'][:40]
+            ready = pod['ready']
+            status = pod['status'][:15]
+            restarts = str(pod['restarts'])
+            node = pod['node'][:35]
+
+            # Add warning marker for problematic pods
+            marker = ""
+            if pod['status'] != 'Running':
+                marker = " ⚠"
+            elif pod['restarts'] > 5:
+                marker = " ⚠"
+
+            print(f"{name:<40} {ready:<10} {status:<15} {restarts:<10} {node}{marker}")
+    else:
+        if filter_node and filter_node.lower() != 'all':
+            print(f"No ovn-ipsec-host pods found for node: {filter_node}")
+        else:
+            print("No ovn-ipsec-host pods found")
+            print("(This is expected if IPsec is not enabled)")
+
+    print()
+
+    # Section 3: IPsec Tunnel Status
+    print_section_header("IPSEC TUNNEL STATUS")
+    print()
+
+    if tunnel_analysis['pods']:
+        print(f"Total Connections: {tunnel_analysis['total_connections']}")
+        print(f"Established:       {tunnel_analysis['established_connections']} ✓")
+        print(f"Not Established:   {tunnel_analysis['failed_connections']} ✗")
+        print()
+
+        for pod_info in tunnel_analysis['pods']:
+            print_subsection_separator()
+            pod_display = f"Pod: {pod_info['pod']}"
+            if pod_info['node'] != 'Unknown':
+                pod_display += f" (Node: {pod_info['node']})"
+            print(pod_display)
+            print_subsection_separator()
+
+            if 'error' in pod_info:
+                print(f"  ⚠ Error: {pod_info['error']}")
+                print()
+                continue
+
+            if not pod_info['config_found']:
+                print("  ⚠ Error: openshift.conf not found")
+                print()
+                continue
+
+            if 'status_warning' in pod_info:
+                print(f"  ⚠ {pod_info['status_warning']}")
+
+            if pod_info['connections']:
+                print(f"\n  Connections ({len(pod_info['connections'])}):")
+                print(f"  {'CONNECTION NAME':<50} {'STATUS':<15} INFO")
+                print("  " + "-" * 95)
+
+                for conn in pod_info['connections']:
+                    conn_name = conn['name'][:48]
+                    marker = "✓" if conn['established'] else "✗"
+                    status_text = "ESTABLISHED" if conn['established'] else "NOT ESTABLISHED"
+                    info = conn['info'][:40]
+
+                    print(f"  {marker} {conn_name:<48} {status_text:<15} {info}")
+            else:
+                print("  No connections found in openshift.conf")
+
+            print()
+    else:
+        if filter_node and filter_node.lower() != 'all':
+            print(f"No IPsec tunnel data found for node: {filter_node}")
+        else:
+            print("No IPsec tunnel data found in network_logs/ipsec/")
+            print("(Expected location: network_logs/ipsec/<pod>_ipsec.d/)")
+
+    print()
+
+    # Section 4: Summary
+    print_section_header("SUMMARY")
+    print()
+
+    issues = []
+    mode = ipsec_config.get('mode') if ipsec_config else None
+
+    # Only check for pods and tunnels in Full mode
+    # External mode is expected to have no ovn-ipsec-host pods or tunnel data
+    if ipsec_config and ipsec_config.get('enabled') and mode == 'Full':
+        if not ipsec_pods:
+            if filter_node and filter_node.lower() != 'all':
+                issues.append(f"No ovn-ipsec-host pods found for node {filter_node}")
+            else:
+                issues.append("IPsec is enabled but no ovn-ipsec-host pods found")
+
+        if any(p['status'] != 'Running' for p in ipsec_pods):
+            issues.append("Some ovn-ipsec-host pods are not in Running state")
+
+        if tunnel_analysis['failed_connections'] > 0:
+            issues.append(f"{tunnel_analysis['failed_connections']} IPsec connections not established")
+
+        if not tunnel_analysis['pods'] and not filter_node:
+            issues.append("No IPsec tunnel data found in network_logs/ipsec/")
+
+    if issues:
+        print("⚠ Issues Detected:")
+        for idx, issue in enumerate(issues, 1):
+            print(f"{idx}. {issue}")
+    else:
+        if ipsec_config and ipsec_config.get('enabled'):
+            if mode == 'External':
+                print("✓ IPsec is enabled in External mode (managed outside of OVN)")
+            elif tunnel_analysis['total_connections'] > 0:
+                print(f"✓ All {tunnel_analysis['established_connections']} IPsec connections are established")
+            else:
+                print("✓ IPsec is enabled (no tunnel data available for verification)")
+        else:
+            print("IPsec is not enabled on this cluster")
+
+    print()
+
+
+def analyze_ipsec(must_gather_path: str, node_filter: Optional[str] = None):
+    """
+    Analyze IPsec configuration and status in a must-gather directory.
+
+    Args:
+        must_gather_path: Path to the must-gather directory
+        node_filter: Optional node name to filter results. None or 'all' for all nodes.
+
+    Returns:
+        0 on success, 1 on error
+    """
+    base_path = Path(must_gather_path)
+
+    if not base_path.exists():
+        print(f"Error: Directory not found: {must_gather_path}", file=sys.stderr)
+        return 1
+
+    if not base_path.is_dir():
+        print(f"Error: Not a directory: {must_gather_path}", file=sys.stderr)
+        return 1
+
+    # Normalize node filter
+    filter_node = None
+    if node_filter and node_filter.lower() != 'all':
+        filter_node = node_filter
+
+    # Get IPsec configuration
+    ipsec_config = get_ipsec_config(base_path)
+
+    # Only analyze pods and tunnels if IPsec mode is "Full"
+    # In "Disabled" or "External" mode, no ovn-ipsec-host pods or tunnels exist
+    ipsec_pods = []
+    tunnel_analysis = {
+        'pods': [],
+        'total_connections': 0,
+        'established_connections': 0,
+        'failed_connections': 0
+    }
+
+    mode = ipsec_config.get('mode') if ipsec_config else None
+    if mode == 'Full':
+        # Analyze ovn-ipsec-host pods
+        ipsec_pods = analyze_ovn_ipsec_host_pods(base_path, filter_node)
+
+        # Analyze IPsec tunnels
+        tunnel_analysis = analyze_ipsec_tunnels(base_path, filter_node)
+
+    # Print analysis
+    print_ipsec_analysis(ipsec_config, ipsec_pods, tunnel_analysis, filter_node)
+
+    return 0
+
+
+def main():
+    """Main entry point for the script."""
+    if len(sys.argv) < 2:
+        print("Usage: analyze_ipsec.py <must-gather-directory> [node-name]", file=sys.stderr)
+        print("\nArguments:", file=sys.stderr)
+        print("  must-gather-directory  Path to the must-gather directory", file=sys.stderr)
+        print("  node-name             Optional. Node to analyze (default: all nodes)", file=sys.stderr)
+        print("\nExamples:", file=sys.stderr)
+        print("  # Analyze all nodes", file=sys.stderr)
+        print("  analyze_ipsec.py ./must-gather.local.123456789", file=sys.stderr)
+        print("\n  # Analyze specific node", file=sys.stderr)
+        print("  analyze_ipsec.py ./must-gather.local.123456789 worker-0", file=sys.stderr)
+        return 1
+
+    must_gather_path = sys.argv[1]
+    node_filter = sys.argv[2] if len(sys.argv) > 2 else None
+
+    return analyze_ipsec(must_gather_path, node_filter)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Introduces `/must-gather:ipsec` command to analyze IPsec configuration and tunnel establishment status in OpenShift clusters. The analyzer:
  - Checks IPsec enablement in cluster network configuration
  - Validates ovn-ipsec-host daemonset pod health
  - Verifies tunnel establishment by parsing connection configs and
    status logs for ESTABLISHED_CHILD_SA markers
  - Supports node-specific filtering for targeted troubleshooting

The analysis script examines network_logs/ipsec/ data to report on all IPsec connections across the cluster mesh.
Assisted-by: Claude <noreply@anthropic.com>

Example output 1:
```
> /must-gather:ipsec is running… /mnt/sdn-issues/ipsec-upgrade/4.21/quay-proxy-ci-openshift-org-openshift-ci-sha256-271512c45b445012535d9370b718c0db2143ce119d3042f0f02fcb1c652c1365 

● I'll analyze the IPsec configuration and tunnel status from the must-gather data.

● Bash(python3 plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py "/mnt/sdn-issues/ipsec-upgrade/4.21/quay-proxy-ci-openshift-org-openshift-ci-sh…)
  ⎿  status log directory                                                                                                                                                                                  
     ovn-ipsec-host-42r4s
     /mnt/sdn-issues/ipsec-upgrade/4.21/quay-proxy-ci-openshift-org-openshift-ci-sha256-271512c45b445012535d9370b718c0db2143ce119d3042f0f02fcb1c652c1365/network_logs/ipsec/status/ovn-ipsec-host-42r4s.log
     … +157 lines (ctrl+o to expand)

● IPsec Analysis Results

  The IPsec analysis shows a healthy cluster configuration:

  Key Findings

  Configuration Status:
  - IPsec is enabled in Full mode
  - All 6 ovn-ipsec-host pods are running with 2/2 containers ready
  - Zero restarts across all pods

  Tunnel Health:
  - 60/60 connections established (100% success rate)
  - Each of the 6 nodes has 10 bidirectional IPsec connections (5 inbound + 5 outbound)
  - All connections show ESTABLISHED_CHILD_SA status, indicating active encrypted tunnels

  Node Coverage:
  The IPsec daemonset is running on all 6 nodes:
  - ip-10-0-90-216.us-west-1.compute.internal
  - ip-10-0-39-115.us-west-1.compute.internal
  - ip-10-0-114-30.us-west-1.compute.internal
  - ip-10-0-48-5.us-west-1.compute.internal
  - ip-10-0-117-247.us-west-1.compute.internal
  - ip-10-0-78-134.us-west-1.compute.internal

  Conclusion

  No issues detected. The IPsec encryption is fully operational across the entire cluster with all node-to-node tunnels successfully established.

```
Example output 2:
```
> /must-gather:ipsec is running… /mnt/sdn-issues/egressip-stale-snat-lrp/must-gather.local.1056168555590501156/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-4e4aab0ca41f3711e720fff2d053ebe4e16b7698a8cc171f438e914c844055b9 

● I'll analyze the IPsec configuration and tunnel status from this must-gather data.

● Bash(python3 plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py "/mnt/sdn-issues/egressip-stale-snat-lrp/must-gather.local.1056168555590501156/…)
  ⎿  ====================================================================================================
     IPSEC CONFIGURATION
     ====================================================================================================
     … +21 lines (ctrl+o to expand)

● IPsec Analysis Results

  The analysis shows that IPsec is not enabled on this cluster.

  Key Findings

  Configuration Status:
  - IPsec is DISABLED in the cluster network configuration
  - No ovn-ipsec-host daemonset pods are present (expected when IPsec is disabled)
  - No IPsec tunnel data collected in the must-gather

  Conclusion

  This cluster is not using IPsec encryption for overlay network traffic. This is a valid configuration - IPsec is an optional security feature in OpenShift that provides encryption for pod-to-pod traffic across nodes.

  If you were expecting IPsec to be enabled, you would need to configure it in the cluster's Network operator configuration by adding ipsecConfig under the ovnKubernetesConfig section.

```
Example output 3:
```
> /must-gather:ipsec is running… /mnt/sdn-issues/ipsec-failure-lane/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-6a74019b7c3262e3ea77a084c42a21b71abab96c29478cbc2b9bcf8072638d6a 

● I'll analyze the IPsec configuration and tunnel status from this must-gather data.

● Bash(python3 plugins/must-gather/skills/must-gather-analyzer/scripts/analyze_ipsec.py "/mnt/sdn-issues/ipsec-failure-lane/quay-io-openshift-release-dev-ocp-v4-0-art-…)
  ⎿  status log directory                                                                                                                                                                                        
     ovn-ipsec-host-5w5bf
     /mnt/sdn-issues/ipsec-failure-lane/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-6a74019b7c3262e3ea77a084c42a21b71abab96c29478cbc2b9bcf8072638d6a/network_logs/ipsec/status/ovn-ipsec-host-5w5bf.log
     … +158 lines (ctrl+o to expand)

● IPsec Analysis Results

  The analysis reveals one failed IPsec tunnel in an otherwise healthy configuration.

  Key Findings

  Configuration Status:
  - IPsec is enabled in Full mode
  - All 6 ovn-ipsec-host pods are running with 2/2 containers ready
  - Zero restarts across all pods

  Tunnel Health:
  - 59/60 connections established (98.3% success rate)
  - 1 connection failed to establish

  Failed Connection Details

  Pod: ovn-ipsec-host-5w5bf (Node: ip-10-0-127-96.us-east-2.compute.internal)

  Failed Connection: ovn-0f62a7-0-in-1 (inbound direction)
  - The corresponding outbound connection ovn-0f62a7-0-out-1 is established
  - This suggests a unidirectional tunnel failure

  Analysis

  This is an asymmetric tunnel failure where:
  - Outbound traffic from node ip-10-0-127-96 to the remote peer (identified by 0f62a7) works
  - Inbound traffic from that remote peer back to ip-10-0-127-96 is not encrypted

  The remote peer appears to be node ip-10-0-65-62 (pod ovn-ipsec-host-cfqt5), which shows both directions of connection ovn-0f62a7 as established on its side. This indicates a mismatch in tunnel state between the two nodes.

  Recommendations

  1. Check for timing issues: The tunnel may have failed to establish during initial cluster setup or after a network disruption
  2. Review pod logs: Examine logs from ovn-ipsec-host-5w5bf for IKE negotiation failures
  3. Check certificate validity: Verify IPsec certificates haven't expired or become invalid
  4. Consider tunnel restart: Restarting the affected pod may re-establish the tunnel

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IPsec analysis added to Must-Gather: inspects IPsec configuration, checks per-node pod health, evaluates tunnels and per-connection status, supports optional node filtering, and summarizes findings.
  * New must-gather command (/must-gather:ipsec [must-gather-path] [node-name]) to run IPsec analysis against must-gather data.

* **Documentation**
  * Comprehensive IPsec docs: usage examples, updated analysis workflow, example outputs, logs-to-review and troubleshooting guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->