### PR TITLE
Add ci:pr-retest plugin command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "name": "teams",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -63,10 +63,13 @@ Tools for working with OpenShift CI and analyzing Prow job results
 - **`/ci:analyze-regression` `<regression id>`** - Analyze details about a Component Readiness regression and suggest next steps
 - **`/ci:ask-sippy` `[question]`** - Ask the Sippy AI agent questions about OpenShift CI payloads, jobs, and test results
 - **`/ci:check-if-jira-regression-is-ongoing` `<jira-key-or-url>`** - Check if the regression described in a Jira bug is still ongoing or has resolved
+- **`/ci:e2e-retest` `[repo] <pr-number>`** - Find and retest failed e2e CI jobs on a PR
 - **`/ci:extract-prow-job-must-gather` `prowjob-url`** - Extract and decompress must-gather archives from Prow job artifacts
 - **`/ci:fetch-test-report` `<test-name> [release]`** - Fetch a test report from Sippy showing pass rates, test ID, and Jira component
 - **`/ci:list-step` `<workflow-or-chain-name>`** - List the step for the given workflow or chain name
 - **`/ci:list-unstable-tests` `<version> <keywords> [sippy-url]`** - List unstable tests with pass rate below 95%
+- **`/ci:payload-retest` `[repo] <pr-number>`** - Find and retest failed payload jobs on a PR
+- **`/ci:pr-retest` `[repo] <pr-number>`** - Find and retest failed e2e CI jobs and payload jobs on a PR
 - **`/ci:query-job-status` `<execution-id>`** - Query the status of a gangway job execution by ID
 - **`/ci:query-test-result` `<version> <keywords> [sippy-url]`** - Query test results from Sippy by version and test keywords
 - **`/ci:revert-pr` `<pr-url> <jira-ticket>`** - Revert a merged PR that is breaking CI or nightly payloads

--- a/docs/data.json
+++ b/docs/data.json
@@ -328,7 +328,7 @@
           "argument_hint": "[repo] <pr-number>",
           "description": "Find and retest failed e2e CI jobs on a PR",
           "name": "e2e-retest",
-          "synopsis": "/ci:e2e-retest <pr-number>"
+          "synopsis": "/ci:e2e-retest [repo] <pr-number>"
         },
         {
           "argument_hint": "prowjob-url",
@@ -358,13 +358,13 @@
           "argument_hint": "[repo] <pr-number>",
           "description": "Find and retest failed payload jobs on a PR",
           "name": "payload-retest",
-          "synopsis": "/ci:payload-retest <pr-number>"
+          "synopsis": "/ci:payload-retest [repo] <pr-number>"
         },
         {
           "argument_hint": "[repo] <pr-number>",
           "description": "Find and retest failed e2e CI jobs and payload jobs on a PR",
           "name": "pr-retest",
-          "synopsis": "/ci:pr-retest <pr-number>"
+          "synopsis": "/ci:pr-retest [repo] <pr-number>"
         },
         {
           "argument_hint": "<execution-id>",

--- a/docs/data.json
+++ b/docs/data.json
@@ -325,6 +325,12 @@
           "synopsis": "/ci:check-if-jira-regression-is-ongoing <jira-key-or-url>"
         },
         {
+          "argument_hint": "[repo] <pr-number>",
+          "description": "Find and retest failed e2e CI jobs on a PR",
+          "name": "e2e-retest",
+          "synopsis": "/ci:e2e-retest <pr-number>"
+        },
+        {
           "argument_hint": "prowjob-url",
           "description": "Extract and decompress must-gather archives from Prow job artifacts",
           "name": "extract-prow-job-must-gather",
@@ -347,6 +353,18 @@
           "description": "List unstable tests with pass rate below 95%",
           "name": "list-unstable-tests",
           "synopsis": "/ci:list-unstable-tests <version> <keywords> [sippy-url]"
+        },
+        {
+          "argument_hint": "[repo] <pr-number>",
+          "description": "Find and retest failed payload jobs on a PR",
+          "name": "payload-retest",
+          "synopsis": "/ci:payload-retest <pr-number>"
+        },
+        {
+          "argument_hint": "[repo] <pr-number>",
+          "description": "Find and retest failed e2e CI jobs and payload jobs on a PR",
+          "name": "pr-retest",
+          "synopsis": "/ci:pr-retest <pr-number>"
         },
         {
           "argument_hint": "<execution-id>",
@@ -391,6 +409,11 @@
       "name": "ci",
       "skills": [
         {
+          "description": "Helper scripts for analyzing and retesting failed e2e CI jobs on pull requests",
+          "id": "e2e-retest",
+          "name": "E2E Retest Helper Scripts"
+        },
+        {
           "description": "Fetch JIRA issue details including status, assignee, comments, and progress classification",
           "id": "fetch-jira-issue",
           "name": "Fetch JIRA Issue"
@@ -434,6 +457,16 @@
           "description": "Helper skill to retrieve OAuth tokens from the correct OpenShift cluster context when multiple clusters are configured",
           "id": "oc-auth",
           "name": "OC Authentication Helper"
+        },
+        {
+          "description": "Helper scripts for analyzing and retesting failed payload CI jobs on pull requests",
+          "id": "payload-retest",
+          "name": "Payload Retest Helper Scripts"
+        },
+        {
+          "description": "Wrapper script that combines e2e and payload retest functionality for comprehensive PR CI analysis",
+          "id": "pr-retest",
+          "name": "PR Retest Wrapper Script"
         },
         {
           "description": "Analyze OpenShift installation failures in Prow CI jobs by examining installer logs, log bundles, and sosreports. Use when CI job fails \"install should succeed\" tests at bootstrap, cluster creation or other stages.",
@@ -481,7 +514,7 @@
           "name": "Triage Regression"
         }
       ],
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "commands": [

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "openshift"
   }

--- a/plugins/ci/README.md
+++ b/plugins/ci/README.md
@@ -6,6 +6,177 @@ release quality.
 
 ## Commands
 
+### e2e-retest
+
+Find and retest failed e2e CI jobs on a pull request (fast, focused version).
+
+**Usage:**
+```bash
+# Auto-detect repo from current directory
+/ci:e2e-retest <pr-number>
+
+# Specify repo name (assumes openshift org)
+/ci:e2e-retest <repo> <pr-number>
+
+# Specify full org/repo
+/ci:e2e-retest <org>/<repo> <pr-number>
+```
+
+**What it does:**
+- Analyzes PR status checks to find failed e2e jobs
+- Parses prow history to count consecutive failures
+- Shows recent job statistics (fail/pass/abort counts)
+- Excludes currently running jobs from retest lists
+- Provides interactive options to retest selected or all failed jobs
+- Posts `/test` comments to GitHub
+
+**Examples:**
+
+1. **From within the repository**:
+   ```bash
+   cd ~/repos/ovn-kubernetes
+   /ci:e2e-retest 2782
+   ```
+
+2. **From anywhere, with repo name**:
+   ```bash
+   /ci:e2e-retest ovn-kubernetes 2782
+   ```
+
+3. **With full org/repo**:
+   ```bash
+   /ci:e2e-retest openshift/origin 5432
+   ```
+
+**Retest Options:**
+- **Retest selected**: Choose specific jobs to retest
+- **Retest all failed**: Automatically retest all currently failing jobs
+- **Use /retest**: Post a single `/retest` comment
+- **Just show list**: Display failures without taking action
+
+**Performance:**
+- **Immediate execution**: Bash script starts in background while Claude reads command file
+- **Phase 1 (Bash)**: Fetches PR status and prow history in parallel (~2-3 seconds)
+- **Phase 2 (Claude)**: Displays results and handles interaction (~3-5 seconds)
+- **Total time**: ~5-8 seconds from invocation to results
+
+### payload-retest
+
+Find and retest failed payload jobs on a pull request (fast, focused version).
+
+**Usage:**
+```bash
+# Auto-detect repo from current directory
+/ci:payload-retest <pr-number>
+
+# Specify repo name (assumes openshift org)
+/ci:payload-retest <repo> <pr-number>
+
+# Specify full org/repo
+/ci:payload-retest <org>/<repo> <pr-number>
+```
+
+**What it does:**
+- Searches PR comments for all payload run URLs
+- Fetches all payload pages in parallel
+- Analyzes all runs to track each job's status over time
+- For each job, finds its most recent status and counts consecutive failures
+- Shows all currently failing jobs with consecutive failure counts
+- Excludes currently running jobs from retest lists
+- Provides interactive options to retest selected or all failed jobs
+- Posts `/payload-job` comments to GitHub
+
+**Examples:**
+
+1. **From within the repository**:
+   ```bash
+   cd ~/repos/ovn-kubernetes
+   /ci:payload-retest 2782
+   ```
+
+2. **From anywhere, with repo name**:
+   ```bash
+   /ci:payload-retest ovn-kubernetes 2782
+   ```
+
+3. **With full org/repo**:
+   ```bash
+   /ci:payload-retest openshift/origin 5432
+   ```
+
+**Retest Options:**
+- **Retest selected**: Choose specific jobs to retest
+- **Retest all failed**: Automatically retest all currently failing jobs
+- **Just show list**: Display failures without taking action
+
+**Performance:**
+- **Immediate execution**: Bash script starts in background while Claude reads command file
+- **Phase 1 (Bash)**: Fetches all payload pages in parallel and analyzes (~2-5 seconds)
+- **Phase 2 (Claude)**: Displays results and handles interaction (~3-5 seconds)
+- **Total time**: ~5-10 seconds from invocation to results
+
+**Notes:**
+- Payload jobs are OpenShift-specific and may not exist for all PRs
+- Command gracefully exits if no payload runs found
+- Analyzes ALL payload runs to track job history
+- Handles jobs that don't appear in every run
+- Counts consecutive failures across multiple runs
+
+### pr-retest
+
+Find and retest failed e2e CI jobs and payload jobs on a pull request (combined version).
+
+**Usage:**
+```bash
+# Auto-detect repo from current directory
+/ci:pr-retest <pr-number>
+
+# Specify repo name (assumes openshift org)
+/ci:pr-retest <repo> <pr-number>
+
+# Specify full org/repo
+/ci:pr-retest <org>/<repo> <pr-number>
+```
+
+**What it does:**
+- Analyzes PR status checks to find failed e2e jobs
+- Parses prow history to track consecutive failures
+- Checks for failed payload jobs (if applicable)
+- Excludes currently running jobs from retest lists
+- Provides interactive options to retest selected or all failed jobs
+- Posts `/test` or `/payload-job` comments to GitHub
+
+**Examples:**
+
+1. **From within the repository**:
+   ```bash
+   cd ~/repos/ovn-kubernetes
+   /ci:pr-retest 2838
+   ```
+
+2. **From anywhere, with repo name**:
+   ```bash
+   /ci:pr-retest ovn-kubernetes 2838
+   ```
+
+3. **With full org/repo**:
+   ```bash
+   /ci:pr-retest openshift/origin 5432
+   ```
+
+**Retest Options:**
+- **Retest selected**: Choose specific jobs to retest
+- **Retest all failed**: Automatically retest all currently failing jobs
+- **Use /retest**: Post a single `/retest` comment (e2e jobs only)
+- **Just show list**: Display failures without taking action
+
+**Performance:**
+- **Immediate execution**: Both bash scripts start in background while Claude reads command file
+- **Phase 1 (Bash)**: Fetches e2e and payload data in parallel (~3-5 seconds, overlapped)
+- **Phase 2 (Claude)**: Displays results and handles interaction for both sections (~5-10 seconds)
+- **Total time**: ~10-15 seconds from invocation to completion
+- **Note**: For faster analysis of just e2e or just payload, use `/ci:e2e-retest` or `/ci:payload-retest`
+
 ### ask-sippy
 
 Query the Sippy Chat AI agent for CI/CD data analysis.  Sippy Chat has a

--- a/plugins/ci/commands/e2e-retest.md
+++ b/plugins/ci/commands/e2e-retest.md
@@ -8,6 +8,11 @@ ci:e2e-retest
 
 ## Synopsis
 ```
+/ci:e2e-retest [repo] <pr-number>
+```
+
+Alternative forms:
+```
 /ci:e2e-retest <pr-number>
 /ci:e2e-retest <repo> <pr-number>
 /ci:e2e-retest <org>/<repo> <pr-number>

--- a/plugins/ci/commands/e2e-retest.md
+++ b/plugins/ci/commands/e2e-retest.md
@@ -1,0 +1,244 @@
+---
+description: Find and retest failed e2e CI jobs on a PR
+argument-hint: "[repo] <pr-number>"
+---
+
+## Name
+ci:e2e-retest
+
+## Synopsis
+```
+/ci:e2e-retest <pr-number>
+/ci:e2e-retest <repo> <pr-number>
+/ci:e2e-retest <org>/<repo> <pr-number>
+```
+
+## Description
+Analyzes a pull request to find all failed e2e CI jobs from Prow status checks, showing consecutive failure counts and providing interactive options to retest them.
+
+The repository can be specified in multiple ways:
+- **Omit repo argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>` (e.g., `ovn-kubernetes` → `openshift/ovn-kubernetes`)
+- **Full org/repo**: Use any GitHub repository (e.g., `openshift/origin`, `kubernetes/kubernetes`)
+
+## Implementation
+
+**CRITICAL INSTRUCTIONS - READ FIRST:**
+1. DO NOT output any text to the user
+2. DO NOT explain what you are doing
+3. DO NOT say "I'll execute" or similar
+4. IMMEDIATELY execute the bash block below with NO preamble
+
+Execute the entire workflow in a single bash invocation:
+
+```bash
+# Use relative path from working directory
+SCRIPT_DIR="plugins/ci/skills/e2e-retest"
+
+# Extract PR number from arguments for temp file naming
+if [ $# -eq 1 ]; then
+  PR_NUM="$1"
+else
+  PR_NUM="$2"
+fi
+
+# Start data fetch in background
+bash "${SCRIPT_DIR}/fetch-e2e-data.sh" "$@" > /tmp/e2e_data_${PR_NUM}.json 2>&1 &
+DATA_PID=$!
+
+# Wait for completion
+wait $DATA_PID
+DATA=$(cat /tmp/e2e_data_${PR_NUM}.json)
+rm -f /tmp/e2e_data_${PR_NUM}.json
+
+# Parse and display
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+ERROR=$(echo "$DATA" | jq -r '.error // empty')
+
+# Check if PR is not open
+if [ -n "$ERROR" ] && [ "$ERROR" = "PR is not open" ]; then
+  PR_STATE=$(echo "$DATA" | jq -r '.state')
+  echo "Repository: $REPO"
+  echo "PR #$PR_NUMBER is $PR_STATE (not open)"
+  exit 0
+fi
+
+FAILED_COUNT=$(echo "$DATA" | jq '.failed_jobs | length')
+RUNNING_COUNT=$(echo "$DATA" | jq '.running_jobs | length')
+
+echo "Repository: $REPO"
+echo ""
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  echo "Failed e2e jobs:"
+  echo "$DATA" | jq -r '.failed_jobs[] | "  ❌ \(.name)\n     Consecutive failures: \(.consecutive)\n     Recent history: \(.fail) fail / \(.pass) pass / \(.abort) abort"'
+  echo ""
+fi
+
+if [ "$RUNNING_COUNT" -gt 0 ]; then
+  echo "⏳ Currently running ($RUNNING_COUNT jobs):"
+  echo "$DATA" | jq -r '.running_jobs[] | "  • \(.)"'
+  echo ""
+fi
+
+# Store data for later use
+echo "$DATA" > /tmp/e2e_final_data_${PR_NUM}.json
+```
+
+**AFTER BASH EXECUTION:**
+- If you see "Repository:" and job lists in the output above, that means SUCCESS
+- DO NOT say "there's an issue" - there is NO issue
+- DO NOT debug or re-run anything
+- IMMEDIATELY proceed to the next step below
+
+Check if there are failed jobs:
+
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+FAILED_COUNT=$(cat /tmp/e2e_final_data_${PR_NUM}.json | jq '.failed_jobs | length')
+```
+
+If `FAILED_COUNT > 0`, use AskUserQuestion to present these options:
+1. Retest selected
+2. Retest all failed
+3. Use /retest
+4. Just show list
+
+Then based on the user's choice:
+
+**Option 1 - Retest selected**: Ask user for job numbers, then:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+DATA=$(cat /tmp/e2e_final_data_${PR_NUM}.json)
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+
+# User provides job numbers like "1 3 5"
+# Build comment with selected jobs
+COMMENT=""
+for num in $USER_SELECTION; do
+  JOB=$(echo "$DATA" | jq -r ".failed_jobs[$((num-1))].name")
+  if [ -n "$JOB" ] && [ "$JOB" != "null" ]; then
+    COMMENT="${COMMENT}/test ${JOB}"$'\n'
+  fi
+done
+
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+rm -f /tmp/e2e_final_data_${PR_NUM}.json
+```
+
+**Option 2 - Retest all failed**:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+DATA=$(cat /tmp/e2e_final_data_${PR_NUM}.json)
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+
+COMMENT=$(echo "$DATA" | jq -r '.failed_jobs[] | "/test \(.name)"' | paste -sd '\n')
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+rm -f /tmp/e2e_final_data_${PR_NUM}.json
+```
+
+**Option 3 - Use /retest**:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+DATA=$(cat /tmp/e2e_final_data_${PR_NUM}.json)
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/retest"
+rm -f /tmp/e2e_final_data_${PR_NUM}.json
+```
+
+**Option 4 - Just show list**:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+rm -f /tmp/e2e_final_data_${PR_NUM}.json
+```
+
+## Example Commands
+
+### Parsing Failed Jobs
+
+```bash
+# Get failed e2e jobs from PR status
+gh pr view ${PR_NUMBER} --repo ${REPO} --json statusCheckRollup | \
+  jq -r '.statusCheckRollup[] |
+    select(.state == "FAILURE" or .state == "ERROR") |
+    select(.context | test("ci/prow/.*e2e")) |
+    .context | sub("ci/prow/"; "")'
+```
+
+### Counting Consecutive Failures
+
+```bash
+# For a specific job, extract its run history from prow HTML
+JOB_NAME="pull-ci-openshift-ovn-kubernetes-master-e2e-aws-ovn"
+grep -A 10 ">${JOB_NAME}<" /tmp/prow_history.html | \
+  grep -oE 'run-(success|failure|aborted)' | \
+  head -10
+```
+
+### Posting Retest Comment
+
+```bash
+# Post single comment with multiple /test commands
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/test e2e-aws-ovn
+/test e2e-gcp-ovn"
+```
+
+## Return Value
+
+The command displays:
+- Repository name
+- Summary of failed e2e jobs with consecutive failure counts and recent history statistics
+- List of currently running jobs (if any)
+- Interactive options to retest selected or all jobs
+- Confirmation of posted retest comments
+
+## Examples
+
+1. **Auto-detect repo from current directory**:
+   ```
+   cd ~/repos/ovn-kubernetes
+   /ci:e2e-retest 2782
+   ```
+   Output: `Repository: openshift/ovn-kubernetes`
+
+2. **Specify repo name only (assumes openshift org)**:
+   ```
+   /ci:e2e-retest ovn-kubernetes 2782
+   ```
+
+3. **Specify full org/repo**:
+   ```
+   /ci:e2e-retest openshift/origin 5432
+   ```
+
+4. **Non-OpenShift repository**:
+   ```
+   /ci:e2e-retest kubernetes/kubernetes 12345
+   ```
+
+## Arguments
+- **$1**: Repository specification (optional) OR PR number (required if repo omitted)
+  - Omit to auto-detect from current directory's git remote
+  - Repo name only (e.g., `ovn-kubernetes`) assumes `openshift/` org
+  - Full format (e.g., `openshift/origin` or `kubernetes/kubernetes`)
+- **$2**: Pull request number (required, last argument)
+  - Example: `2782`
+
+## Notes
+
+- **PR State Check**: Exits immediately if PR is not OPEN (merged, closed, etc.)
+- **Running Jobs**: Automatically excluded from retest lists (shown separately for visibility)
+- **Consecutive Failures**: Counted by parsing prow history table (newest runs first)
+- **Comment Format**: Multiple `/test` commands in a single comment
+- **Fast Execution**: Parallel fetching of PR status and prow history
+- **Accurate Parsing**: Robust HTML table parsing for failure statistics

--- a/plugins/ci/commands/payload-retest.md
+++ b/plugins/ci/commands/payload-retest.md
@@ -1,0 +1,257 @@
+---
+description: Find and retest failed payload jobs on a PR
+argument-hint: "[repo] <pr-number>"
+---
+
+## Name
+ci:payload-retest
+
+## Synopsis
+```
+/ci:payload-retest <pr-number>
+/ci:payload-retest <repo> <pr-number>
+/ci:payload-retest <org>/<repo> <pr-number>
+```
+
+## Description
+Analyzes a pull request to find failed payload jobs from the most recent `/payload` run, showing job statistics and providing interactive options to retest them.
+
+Payload jobs are OpenShift-specific CI jobs that test PRs against release payloads. This command:
+1. Searches PR comments for payload run URLs
+2. Identifies the most recent payload run by Created timestamp
+3. Parses failed and running jobs from that run
+4. Provides interactive retest options
+
+The repository can be specified in multiple ways:
+- **Omit repo argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>` (e.g., `ovn-kubernetes` → `openshift/ovn-kubernetes`)
+- **Full org/repo**: Use any GitHub repository (e.g., `openshift/origin`)
+
+**Note:** Payload jobs are optional and may not exist for all PRs. The command will gracefully exit if no payload runs are found.
+
+## Implementation
+
+**CRITICAL INSTRUCTIONS - READ FIRST:**
+1. DO NOT output any text to the user
+2. DO NOT explain what you are doing
+3. DO NOT say "I'll execute" or similar
+4. IMMEDIATELY execute the bash block below with NO preamble
+
+Execute the entire workflow in a single bash invocation:
+
+```bash
+# Use relative path from working directory
+SCRIPT_DIR="plugins/ci/skills/payload-retest"
+
+# Extract PR number from arguments for temp file naming
+if [ $# -eq 1 ]; then
+  PR_NUM="$1"
+else
+  PR_NUM="$2"
+fi
+
+# Start data fetch in background
+bash "${SCRIPT_DIR}/fetch-payload-data.sh" "$@" > /tmp/payload_data_${PR_NUM}.json 2>&1 &
+DATA_PID=$!
+
+# Wait for completion
+wait $DATA_PID
+DATA=$(cat /tmp/payload_data_${PR_NUM}.json)
+rm -f /tmp/payload_data_${PR_NUM}.json
+
+# Parse and display
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+ERROR=$(echo "$DATA" | jq -r '.error // empty')
+
+# Check if PR is not open
+if [ -n "$ERROR" ] && [ "$ERROR" = "PR is not open" ]; then
+  PR_STATE=$(echo "$DATA" | jq -r '.state')
+  echo "Repository: $REPO"
+  echo "PR #$PR_NUMBER is $PR_STATE (not open)"
+  exit 0
+fi
+
+PAYLOAD_RUNS=$(echo "$DATA" | jq -r '.payload_runs')
+FAILED_COUNT=$(echo "$DATA" | jq '.failed_jobs | length')
+RUNNING_COUNT=$(echo "$DATA" | jq '.running_jobs | length')
+
+# Exit if no payload runs
+if [ "$PAYLOAD_RUNS" -eq 0 ]; then
+  echo "No payload runs found for this PR"
+  exit 0
+fi
+
+echo "Repository: $REPO"
+echo "Found $PAYLOAD_RUNS payload run(s)"
+echo ""
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  echo "Failed payload jobs:"
+  echo "$DATA" | jq -r '.failed_jobs[] | "  ❌ \(.name)\n     Consecutive failures: \(.consecutive)"'
+  echo ""
+fi
+
+if [ "$RUNNING_COUNT" -gt 0 ]; then
+  echo "⏳ Currently running ($RUNNING_COUNT jobs):"
+  echo "$DATA" | jq -r '.running_jobs[] | "  • \(.)"'
+  echo ""
+fi
+
+# Store data for later use
+echo "$DATA" > /tmp/payload_final_data_${PR_NUM}.json
+```
+
+**AFTER BASH EXECUTION:**
+- If you see "Repository:" and job lists (or "No payload runs") in the output above, that means SUCCESS
+- DO NOT say "there's an issue" - there is NO issue
+- DO NOT debug or re-run anything
+- IMMEDIATELY proceed to the next step below
+
+Check if there are failed jobs:
+
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+FAILED_COUNT=$(cat /tmp/payload_final_data_${PR_NUM}.json | jq '.failed_jobs | length')
+```
+
+If `FAILED_COUNT > 0`, use AskUserQuestion to present these options:
+1. Retest selected
+2. Retest all failed
+3. Just show list
+
+Then based on the user's choice:
+
+**Option 1 - Retest selected**: Ask user for job numbers, then:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+DATA=$(cat /tmp/payload_final_data_${PR_NUM}.json)
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+
+# User provides job numbers like "1 3 5"
+# Build comment with selected jobs
+COMMENT=""
+for num in $USER_SELECTION; do
+  JOB=$(echo "$DATA" | jq -r ".failed_jobs[$((num-1))].name")
+  if [ -n "$JOB" ] && [ "$JOB" != "null" ]; then
+    COMMENT="${COMMENT}/payload-job ${JOB}"$'\n'
+  fi
+done
+
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+rm -f /tmp/payload_final_data_${PR_NUM}.json
+```
+
+**Option 2 - Retest all failed**:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+DATA=$(cat /tmp/payload_final_data_${PR_NUM}.json)
+REPO=$(echo "$DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$DATA" | jq -r '.pr_number')
+
+COMMENT=$(echo "$DATA" | jq -r '.failed_jobs[] | "/payload-job \(.name)"' | paste -sd '\n')
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+rm -f /tmp/payload_final_data_${PR_NUM}.json
+```
+
+**Option 3 - Just show list**:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+rm -f /tmp/payload_final_data_${PR_NUM}.json
+```
+
+## Example Commands
+
+### Finding Payload URLs
+
+```bash
+# Extract payload URLs from PR comments
+gh pr view ${PR_NUMBER} --repo ${REPO} --json comments | \
+  jq -r '.comments[].body' | \
+  grep -oE 'https://pr-payload-tests[^ )]+' | \
+  sort -u
+```
+
+### Finding Most Recent Run
+
+```bash
+# For each URL, extract Created timestamp and sort
+for url in $(payload_urls); do
+  timestamp=$(curl -sL "$url" | grep -E 'Created:' | sed -E 's/.*Created: ([^<]+).*/\1/')
+  echo "$timestamp|$url"
+done | sort | tail -1
+```
+
+### Parsing Job Results
+
+```bash
+# Failed jobs (text-danger class)
+curl -sL '<payload-url>' | \
+  grep -oE '<span class="text-danger">[^<]+</span>' | \
+  sed -E 's/<span class="text-danger">([^<]+)<\/span>/\1/'
+
+# Running jobs (empty class attribute)
+curl -sL '<payload-url>' | \
+  grep -oE '<span class="">[^<]+</span>' | \
+  sed -E 's/<span class="">([^<]+)<\/span>/\1/'
+```
+
+### Posting Retest Comment
+
+```bash
+# Post /payload-job commands
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/payload-job <full-job-name>"
+```
+
+## Return Value
+
+The command displays:
+- Repository name
+- Number of payload runs found
+- Most recent payload run URL and timestamp
+- Summary of failed payload jobs (if any)
+- List of currently running jobs (if any)
+- Interactive options to retest selected or all jobs
+- Confirmation of posted retest comments
+
+## Examples
+
+1. **Auto-detect repo from current directory**:
+   ```
+   cd ~/repos/ovn-kubernetes
+   /ci:payload-retest 2782
+   ```
+   Output: `Repository: openshift/ovn-kubernetes`
+
+2. **Specify repo name only (assumes openshift org)**:
+   ```
+   /ci:payload-retest ovn-kubernetes 2782
+   ```
+
+3. **Specify full org/repo**:
+   ```
+   /ci:payload-retest openshift/origin 5432
+   ```
+
+## Arguments
+- **$1**: Repository specification (optional) OR PR number (required if repo omitted)
+  - Omit to auto-detect from current directory's git remote
+  - Repo name only (e.g., `ovn-kubernetes`) assumes `openshift/` org
+  - Full format (e.g., `openshift/origin`)
+- **$2**: Pull request number (required, last argument)
+  - Example: `2782`
+
+## Notes
+
+- **PR State Check**: Exits immediately if PR is not OPEN (merged, closed, etc.)
+- **Payload Jobs**: Optional feature - gracefully exits if not present
+- **All Runs Analyzed**: Analyzes ALL payload runs to track job history across runs
+- **Running Jobs**: Shown separately, not offered for retest
+- **Comment Format**: Multiple `/payload-job` commands in a single comment
+- **Fast Execution**: Parallel fetching of all payload run pages
+- **Minimal Claude Overhead**: Data fetching in bash, interaction via AskUserQuestion

--- a/plugins/ci/commands/payload-retest.md
+++ b/plugins/ci/commands/payload-retest.md
@@ -8,6 +8,11 @@ ci:payload-retest
 
 ## Synopsis
 ```
+/ci:payload-retest [repo] <pr-number>
+```
+
+Alternative forms:
+```
 /ci:payload-retest <pr-number>
 /ci:payload-retest <repo> <pr-number>
 /ci:payload-retest <org>/<repo> <pr-number>

--- a/plugins/ci/commands/pr-retest.md
+++ b/plugins/ci/commands/pr-retest.md
@@ -1,0 +1,313 @@
+---
+description: Find and retest failed e2e CI jobs and payload jobs on a PR
+argument-hint: "[repo] <pr-number>"
+---
+
+## Name
+ci:pr-retest
+
+## Synopsis
+```
+/ci:pr-retest <pr-number>
+/ci:pr-retest <repo> <pr-number>
+/ci:pr-retest <org>/<repo> <pr-number>
+```
+
+## Description
+Analyzes a pull request to find all failed e2e CI jobs and payload jobs, providing detailed failure statistics and interactive options to retest them. This command combines both e2e and payload job analysis into a single workflow:
+
+1. **E2E Jobs Analysis**:
+   - Identifies failed e2e jobs from PR status checks
+   - Counts consecutive failures from prow history
+   - Shows recent statistics (fail/pass/abort counts)
+   - Provides interactive retest options
+
+2. **Payload Jobs Analysis**:
+   - Searches for all payload run URLs in PR comments
+   - Analyzes all runs to track job history
+   - Counts consecutive failures across multiple runs
+   - Provides interactive retest options
+
+The repository can be specified in multiple ways:
+- **Omit repo argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>` (e.g., `ovn-kubernetes` → `openshift/ovn-kubernetes`)
+- **Full org/repo**: Use any GitHub repository (e.g., `openshift/origin`, `kubernetes/kubernetes`)
+
+**Note:** This command runs both `/ci:e2e-retest` and `/ci:payload-retest` sequentially. For faster, focused analysis, use those individual commands.
+
+## Implementation
+
+**CRITICAL INSTRUCTIONS - READ FIRST:**
+1. DO NOT output any text to the user
+2. DO NOT explain what you are doing
+3. DO NOT say "I'll execute" or similar
+4. IMMEDIATELY execute the bash block below with NO preamble
+
+Execute the entire workflow in a single bash invocation:
+
+```bash
+# Use relative path from working directory
+SCRIPT_DIR="plugins/ci/skills"
+
+# Extract PR number from arguments for temp file naming
+if [ $# -eq 1 ]; then
+  PR_NUM="$1"
+else
+  PR_NUM="$2"
+fi
+
+# Start BOTH data fetches in background simultaneously
+bash "${SCRIPT_DIR}/e2e-retest/fetch-e2e-data.sh" "$@" > /tmp/e2e_data_${PR_NUM}.json 2>&1 &
+E2E_PID=$!
+bash "${SCRIPT_DIR}/payload-retest/fetch-payload-data.sh" "$@" > /tmp/payload_data_${PR_NUM}.json 2>&1 &
+PAYLOAD_PID=$!
+
+# Wait for both to complete
+wait $E2E_PID
+wait $PAYLOAD_PID
+
+# Read both results
+E2E_DATA=$(cat /tmp/e2e_data_${PR_NUM}.json)
+PAYLOAD_DATA=$(cat /tmp/payload_data_${PR_NUM}.json)
+rm -f /tmp/e2e_data_${PR_NUM}.json /tmp/payload_data_${PR_NUM}.json
+
+# Check if PR is open
+ERROR=$(echo "$E2E_DATA" | jq -r '.error // empty')
+if [ -n "$ERROR" ] && [ "$ERROR" = "PR is not open" ]; then
+  REPO=$(echo "$E2E_DATA" | jq -r '.repo')
+  PR_NUMBER=$(echo "$E2E_DATA" | jq -r '.pr_number')
+  PR_STATE=$(echo "$E2E_DATA" | jq -r '.state')
+  echo "Repository: $REPO"
+  echo "PR #$PR_NUMBER is $PR_STATE (not open)"
+  exit 0
+fi
+
+# Parse data
+REPO=$(echo "$E2E_DATA" | jq -r '.repo')
+PR_NUMBER=$(echo "$E2E_DATA" | jq -r '.pr_number')
+E2E_FAILED=$(echo "$E2E_DATA" | jq '.failed_jobs | length')
+E2E_RUNNING=$(echo "$E2E_DATA" | jq '.running_jobs | length')
+PAYLOAD_RUNS=$(echo "$PAYLOAD_DATA" | jq -r '.payload_runs')
+PAYLOAD_FAILED=$(echo "$PAYLOAD_DATA" | jq '.failed_jobs | length')
+PAYLOAD_RUNNING=$(echo "$PAYLOAD_DATA" | jq '.running_jobs | length')
+
+# Display E2E results
+echo "========================================="
+echo "E2E JOBS"
+echo "========================================="
+echo ""
+echo "Repository: $REPO"
+echo ""
+
+if [ "$E2E_FAILED" -gt 0 ]; then
+  echo "Failed e2e jobs:"
+  echo "$E2E_DATA" | jq -r '.failed_jobs[] | "  ❌ \(.name)\n     Consecutive failures: \(.consecutive)\n     Recent history: \(.fail) fail / \(.pass) pass / \(.abort) abort"'
+  echo ""
+fi
+
+if [ "$E2E_RUNNING" -gt 0 ]; then
+  echo "⏳ Currently running ($E2E_RUNNING jobs):"
+  echo "$E2E_DATA" | jq -r '.running_jobs[] | "  • \(.)"'
+  echo ""
+fi
+
+# Display Payload results
+echo "========================================="
+echo "PAYLOAD JOBS"
+echo "========================================="
+echo ""
+
+if [ "$PAYLOAD_RUNS" -eq 0 ]; then
+  echo "No payload runs found for this PR"
+else
+  echo "Found $PAYLOAD_RUNS payload run(s)"
+  echo ""
+
+  if [ "$PAYLOAD_FAILED" -gt 0 ]; then
+    echo "Failed payload jobs:"
+    echo "$PAYLOAD_DATA" | jq -r '.failed_jobs[] | "  ❌ \(.name)\n     Consecutive failures: \(.consecutive)"'
+    echo ""
+  fi
+
+  if [ "$PAYLOAD_RUNNING" -gt 0 ]; then
+    echo "⏳ Currently running ($PAYLOAD_RUNNING jobs):"
+    echo "$PAYLOAD_DATA" | jq -r '.running_jobs[] | "  • \(.)"'
+    echo ""
+  fi
+fi
+
+# Store data for later use
+echo "$E2E_DATA" > /tmp/e2e_final_data_${PR_NUM}.json
+echo "$PAYLOAD_DATA" > /tmp/payload_final_data_${PR_NUM}.json
+```
+
+**AFTER BASH EXECUTION:**
+- If you see "E2E JOBS" and "PAYLOAD JOBS" sections in the output above, that means SUCCESS
+- DO NOT say "there's an issue" - there is NO issue
+- DO NOT debug or re-run anything
+- IMMEDIATELY proceed to the next step below
+
+Check if there are failed jobs:
+
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+
+E2E_FAILED=$(cat /tmp/e2e_final_data_${PR_NUM}.json | jq '.failed_jobs | length')
+PAYLOAD_FAILED=$(cat /tmp/payload_final_data_${PR_NUM}.json | jq '.failed_jobs | length')
+```
+
+**If E2E_FAILED > 0**: Use AskUserQuestion with these options for e2e jobs:
+1. Retest selected jobs
+2. Retest all failed
+3. Use /retest
+4. Just show list
+
+Then execute the appropriate action using the data from `/tmp/e2e_final_data_${PR_NUM}.json`.
+
+**If PAYLOAD_FAILED > 0**: Use AskUserQuestion with these options for payload jobs:
+1. Retest selected jobs
+2. Retest all failed
+3. Just show list
+
+Then execute the appropriate action using the data from `/tmp/payload_final_data_${PR_NUM}.json`.
+
+**Always clean up** at the end:
+```bash
+# Extract PR number from arguments
+if [ $# -eq 1 ]; then PR_NUM="$1"; else PR_NUM="$2"; fi
+rm -f /tmp/e2e_final_data_${PR_NUM}.json /tmp/payload_final_data_${PR_NUM}.json
+```
+
+## Example Commands
+
+### E2E Jobs
+
+Fetch currently failing e2e jobs (excluding running ones):
+```bash
+# Get failed jobs (excluding PENDING)
+gh pr view ${PR_NUMBER} --repo ${REPO} --json statusCheckRollup | \
+  jq -r '.statusCheckRollup[] |
+    select(.state == "FAILURE" or .state == "ERROR") |
+    select(.context | test("ci/prow/.*e2e")) |
+    .context | sub("ci/prow/"; "")'
+
+# Get currently running jobs
+gh pr view ${PR_NUMBER} --repo ${REPO} --json statusCheckRollup | \
+  jq -r '.statusCheckRollup[] |
+    select(.state == "PENDING") |
+    select(.context | test("ci/prow/.*e2e")) |
+    .context | sub("ci/prow/"; "")'
+```
+
+Parse prow history for consecutive failures:
+```bash
+curl -sL "https://prow.ci.openshift.org/pr-history?org=${ORG}&repo=${REPO_NAME}&pr=${PR_NUMBER}" | \
+  grep -E 'job-history.*e2e|run-(success|failure|aborted)'
+```
+
+Post e2e retest comment:
+```bash
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/test <job-name>"
+```
+
+### Payload Jobs
+
+Extract payload run URLs from comments:
+```bash
+# Extract all payload URLs from PR comments
+gh pr view ${PR_NUMBER} --repo ${REPO} --json comments | \
+  jq -r '.comments[].body' | \
+  grep -oE 'https://pr-payload-tests[^ )]+' | \
+  sort -u
+```
+
+Find the most recent payload run by Created timestamp:
+```bash
+# For each URL, fetch its Created timestamp and find the most recent
+for url in $(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments | \
+             jq -r '.comments[].body' | \
+             grep -oE 'https://pr-payload-tests[^ )+' | \
+             sort -u); do
+  timestamp=$(curl -sL "$url" | grep -E 'Created:' | sed -E 's/.*Created: ([^<]+).*/\1/')
+  echo "$timestamp|$url"
+done | sort | tail -1 | cut -d'|' -f2
+```
+
+Parse payload run results (only completed jobs with success/danger classes):
+```bash
+# This grep filters for only text-success and text-danger, automatically excluding running jobs (plain text)
+curl -sL '<payload-run-url>' | \
+  grep -E 'text-(success|danger)' | \
+  sed -E 's/.*<span class="text-(success|danger)">(.*)<\/span>.*/\2|\1/'
+```
+
+Post payload retest comment:
+```bash
+gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/payload-job <full-job-name>"
+```
+
+## Return Value
+
+The command displays:
+- **E2E Jobs Section**:
+  - Repository name
+  - Failed e2e jobs with consecutive failure counts and recent history
+  - Currently running jobs (if any)
+  - Interactive menu for retest options
+  - Confirmation of posted retest comments
+- **Payload Jobs Section**:
+  - Number of payload runs found
+  - Failed payload jobs with consecutive failure counts
+  - Currently running jobs (if any)
+  - Interactive menu for retest options
+  - Confirmation of posted retest comments
+
+## Examples
+
+1. **Auto-detect repo from current directory**:
+   ```
+   cd ~/repos/ovn-kubernetes
+   /ci:pr-retest 2838
+   ```
+   Output: `ℹ️  Auto-detected repository: openshift/ovn-kubernetes`
+
+2. **Specify repo name only (assumes openshift org)**:
+   ```
+   /ci:pr-retest ovn-kubernetes 2838
+   ```
+   Output: `ℹ️  Using repository: openshift/ovn-kubernetes`
+
+3. **Specify full org/repo**:
+   ```
+   /ci:pr-retest openshift/origin 5432
+   ```
+   Output: `ℹ️  Using repository: openshift/origin`
+
+4. **Non-OpenShift repository**:
+   ```
+   /ci:pr-retest kubernetes/kubernetes 12345
+   ```
+   Output: `ℹ️  Using repository: kubernetes/kubernetes`
+
+## Arguments
+- **$1**: Repository specification (optional) OR PR number (required if repo omitted)
+  - Omit to auto-detect from current directory's git remote
+  - Repo name only (e.g., `ovn-kubernetes`) assumes `openshift/` org
+  - Full format (e.g., `openshift/origin` or `kubernetes/kubernetes`)
+- **$2**: Pull request number (required, last argument)
+  - Example: `2838`
+
+## Notes
+
+- **PR State Check**: Exits immediately if PR is not OPEN (merged, closed, etc.)
+- **Two-Part Analysis**: Runs e2e analysis first, then payload analysis
+- **E2E Jobs**: Always analyzed for all repositories
+- **Payload Jobs**: Optional feature - gracefully skipped if not present
+- **Running Jobs**: Automatically excluded from retest lists (shown separately for visibility)
+- **Consecutive Failures**:
+  - E2E: Counted from prow history (last 10 runs)
+  - Payload: Counted across ALL payload run URLs found in PR comments
+- **Comment Format**: Multiple `/test` or `/payload-job` commands in a single comment
+- **Performance**: Minimal Claude overhead - data fetching in bash, interaction via AskUserQuestion
+- **Individual Commands**: For faster analysis of just e2e or just payload, use `/ci:e2e-retest` or `/ci:payload-retest`

--- a/plugins/ci/commands/pr-retest.md
+++ b/plugins/ci/commands/pr-retest.md
@@ -8,6 +8,11 @@ ci:pr-retest
 
 ## Synopsis
 ```
+/ci:pr-retest [repo] <pr-number>
+```
+
+Alternative forms:
+```
 /ci:pr-retest <pr-number>
 /ci:pr-retest <repo> <pr-number>
 /ci:pr-retest <org>/<repo> <pr-number>
@@ -227,7 +232,7 @@ Find the most recent payload run by Created timestamp:
 # For each URL, fetch its Created timestamp and find the most recent
 for url in $(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments | \
              jq -r '.comments[].body' | \
-             grep -oE 'https://pr-payload-tests[^ )+' | \
+             grep -oE 'https://pr-payload-tests[^ )]+' | \
              sort -u); do
   timestamp=$(curl -sL "$url" | grep -E 'Created:' | sed -E 's/.*Created: ([^<]+).*/\1/')
   echo "$timestamp|$url"

--- a/plugins/ci/skills/e2e-retest/SKILL.md
+++ b/plugins/ci/skills/e2e-retest/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: E2E Retest Helper Scripts
+description: Helper scripts for analyzing and retesting failed e2e CI jobs on pull requests
+---
+
+# E2E Retest Helper Scripts
+
+This skill provides bash scripts that power the `/ci:e2e-retest` command. These scripts fetch and analyze e2e job failures from GitHub PR status checks and prow history.
+
+## When to Use This Skill
+
+This skill is automatically invoked by the `/ci:e2e-retest` command. You typically don't need to call these scripts directly.
+
+## Components
+
+### 1. `e2e-retest.sh`
+Interactive script that:
+- Fetches PR status checks and prow history in parallel
+- Parses failed and running e2e jobs
+- Counts consecutive failures and recent job statistics
+- Presents interactive options to retest selected or all failed jobs
+- Posts `/test <job-name>` comments to GitHub
+
+**Usage:**
+```bash
+./e2e-retest.sh [repo] <pr-number>
+```
+
+### 2. `fetch-e2e-data.sh`
+Non-interactive data fetching script that:
+- Fetches PR status and prow history
+- Outputs structured JSON with failed and running jobs
+- Used by the command implementation for data collection
+
+**Usage:**
+```bash
+./fetch-e2e-data.sh [repo] <pr-number>
+```
+
+**Output Format:**
+```json
+{
+  "repo": "org/repo",
+  "pr_number": 123,
+  "failed_jobs": [
+    {
+      "name": "job-name",
+      "consecutive": 3,
+      "fail": 5,
+      "pass": 2,
+      "abort": 1
+    }
+  ],
+  "running_jobs": ["job-name"]
+}
+```
+
+### 3. `common.sh`
+Shared utility functions:
+- `count_consecutive_failures()`: Parses prow history HTML to count consecutive failures and total run statistics
+
+**Note:** This file must be sourced by other scripts: `source "$(dirname "$0")/common.sh"`
+
+## Implementation Details
+
+### HTML Parsing
+The scripts parse prow history HTML to extract job run statuses. The HTML structure assumptions are documented in the code:
+- Job rows: `>${job_name}<`
+- Run status classes: `run-success`, `run-failure`, `run-aborted`, `run-pending`
+
+If prow HTML structure changes, these patterns may need updating.
+
+### JSON Construction
+Scripts use `jq` for safe JSON construction to handle special characters in job names and prevent injection issues.
+
+### Error Handling
+- Validates `gh pr view` succeeds before parsing
+- Checks that fetched files are non-empty
+- Provides clear error messages on failure
+
+## Prerequisites
+
+- `gh` CLI (GitHub CLI)
+- `jq` (JSON processor)
+- `curl`
+- Authenticated with GitHub (`gh auth login`)
+
+## Repository Detection
+
+Scripts accept repository in multiple formats:
+- **No argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>` (e.g., `origin` → `openshift/origin`)
+- **Full org/repo**: Use any GitHub repository (e.g., `openshift/origin`)

--- a/plugins/ci/skills/e2e-retest/common.sh
+++ b/plugins/ci/skills/e2e-retest/common.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# common.sh - Shared utility functions for e2e-retest
+
+# Count consecutive failures from prow history
+# Args: job_name, html_file
+# Output: consecutive|total_fail|total_pass|total_abort
+count_consecutive_failures() {
+  local job_name="$1"
+  local html_file="$2"
+
+  # Escape regex special characters in job name for safe grep pattern matching
+  local escaped_job_name=$(printf '%s\n' "$job_name" | sed 's/[[\.*^$/]/\\&/g')
+
+  local runs=$(grep -A 10 ">${escaped_job_name}<" "$html_file" | \
+    grep -oE "run-(success|failure|aborted|pending)" | \
+    head -10)
+
+  local consecutive=0
+  local total_fail=0
+  local total_pass=0
+  local total_abort=0
+  local found_non_failure=0
+
+  while IFS= read -r run; do
+    [ -z "$run" ] && continue
+    case "$run" in
+      run-failure)
+        total_fail=$((total_fail + 1))
+        if [ "$found_non_failure" -eq 0 ]; then
+          consecutive=$((consecutive + 1))
+        fi
+        ;;
+      run-success)
+        total_pass=$((total_pass + 1))
+        found_non_failure=1
+        ;;
+      run-aborted)
+        total_abort=$((total_abort + 1))
+        found_non_failure=1
+        ;;
+      run-pending)
+        ;;
+    esac
+  done <<< "$runs"
+
+  echo "${consecutive}|${total_fail}|${total_pass}|${total_abort}"
+}

--- a/plugins/ci/skills/e2e-retest/e2e-retest.sh
+++ b/plugins/ci/skills/e2e-retest/e2e-retest.sh
@@ -12,7 +12,7 @@ source "$(dirname "$0")/common.sh"
 if [ $# -eq 1 ]; then
   PR_NUMBER="$1"
   # Auto-detect from git remote
-  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  REPO=$(git remote -v | head -1 | sed -E 's/.*github\.com[:/]([^/]+\/[^ .]+).*/\1/' | sed 's/\.git$//' || true)
   if [ -z "$REPO" ]; then
     echo "❌ Error: Could not detect repository from git remote."
     echo "Please specify repo: $0 <repo> <pr-number>"

--- a/plugins/ci/skills/e2e-retest/e2e-retest.sh
+++ b/plugins/ci/skills/e2e-retest/e2e-retest.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ci:e2e-retest - Find and retest failed e2e CI jobs on a PR
+# Usage: ./e2e-retest.sh [repo] <pr-number>
+
+# Source shared utilities
+source "$(dirname "$0")/common.sh"
+
+# Parse arguments
+if [ $# -eq 1 ]; then
+  PR_NUMBER="$1"
+  # Auto-detect from git remote
+  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  if [ -z "$REPO" ]; then
+    echo "❌ Error: Could not detect repository from git remote."
+    echo "Please specify repo: $0 <repo> <pr-number>"
+    exit 1
+  fi
+  echo "Repository: $REPO"
+
+elif [ $# -eq 2 ]; then
+  REPO_ARG="$1"
+  PR_NUMBER="$2"
+
+  # Check if contains slash (org/repo format)
+  if [[ "$REPO_ARG" == *"/"* ]]; then
+    REPO="$REPO_ARG"
+  else
+    # Assume openshift org
+    REPO="openshift/$REPO_ARG"
+  fi
+  echo "Repository: $REPO"
+
+else
+  echo "❌ Error: Invalid arguments"
+  echo "Usage: $0 [repo] <pr-number>"
+  exit 1
+fi
+
+# Extract org and repo name
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+# Validate PR number
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "❌ Error: PR number must be numeric"
+  exit 1
+fi
+
+echo ""
+
+# Create unique temp directory and setup cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch data in parallel
+{
+  gh pr view ${PR_NUMBER} --repo ${REPO} --json statusCheckRollup,baseRefName > "$TMPDIR/e2e_pr_status.json" 2>/dev/null
+} &
+{
+  curl -sL "https://prow.ci.openshift.org/pr-history?org=${ORG}&repo=${REPO_NAME}&pr=${PR_NUMBER}" > "$TMPDIR/e2e_prow_history.html" 2>/dev/null
+} &
+wait
+
+# Validate fetched data exists and is non-empty
+if [ ! -s "$TMPDIR/e2e_pr_status.json" ]; then
+  echo "Error: Failed to fetch PR status checks from GitHub" >&2
+  exit 1
+fi
+
+if [ ! -s "$TMPDIR/e2e_prow_history.html" ]; then
+  echo "Error: Failed to fetch prow history" >&2
+  exit 1
+fi
+
+# Get base ref from PR data
+BASE_REF=$(jq -r '.baseRefName' "$TMPDIR/e2e_pr_status.json")
+
+# Parse failed and running jobs
+FAILED_E2E=$(cat "$TMPDIR/e2e_pr_status.json" | jq -r '.statusCheckRollup[] |
+  select(.state == "FAILURE" or .state == "ERROR") |
+  select(.context | test("ci/prow/.*e2e")) |
+  .context | sub("ci/prow/"; "")')
+
+RUNNING_E2E=$(cat "$TMPDIR/e2e_pr_status.json" | jq -r '.statusCheckRollup[] |
+  select(.state == "PENDING") |
+  select(.context | test("ci/prow/.*e2e")) |
+  .context | sub("ci/prow/"; "")')
+
+# Count them
+if [ -n "$FAILED_E2E" ]; then
+  NUM_FAILED=$(echo "$FAILED_E2E" | grep -c "^")
+else
+  NUM_FAILED=0
+fi
+
+if [ -n "$RUNNING_E2E" ]; then
+  NUM_RUNNING=$(echo "$RUNNING_E2E" | grep -c "^")
+else
+  NUM_RUNNING=0
+fi
+
+# Display failed jobs with statistics
+if [ "$NUM_FAILED" -gt 0 ]; then
+  echo "Failed e2e jobs:"
+  while IFS= read -r job; do
+    [ -z "$job" ] && continue
+
+    FULL_JOB="pull-ci-${ORG}-${REPO_NAME}-${BASE_REF}-${job}"
+
+    STATS=$(count_consecutive_failures "$FULL_JOB" "$TMPDIR/e2e_prow_history.html")
+    CONSEC=$(echo "$STATS" | cut -d'|' -f1)
+    FAIL=$(echo "$STATS" | cut -d'|' -f2)
+    PASS=$(echo "$STATS" | cut -d'|' -f3)
+    ABORT=$(echo "$STATS" | cut -d'|' -f4)
+
+    echo "  ❌ $job"
+    if [ "$CONSEC" -gt 0 ]; then
+      echo "     Consecutive failures: $CONSEC"
+    fi
+    if [ "$FAIL" -gt 0 ] || [ "$PASS" -gt 0 ] || [ "$ABORT" -gt 0 ]; then
+      echo "     Recent history: $FAIL fail / $PASS pass / $ABORT abort"
+    fi
+  done <<< "$FAILED_E2E"
+  echo ""
+fi
+
+# Display running jobs
+if [ "$NUM_RUNNING" -gt 0 ]; then
+  echo "⏳ Currently running ($NUM_RUNNING jobs):"
+  while IFS= read -r job; do
+    [ -z "$job" ] && continue
+    echo "  • $job"
+  done <<< "$RUNNING_E2E"
+  echo ""
+fi
+
+# Exit if no failed jobs
+if [ "$NUM_FAILED" -eq 0 ]; then
+  echo "✅ No failed e2e jobs!"
+  exit 0
+fi
+
+# Present retest options
+echo "What would you like to do?"
+echo "  1) Retest selected jobs"
+echo "  2) Retest all failed ($NUM_FAILED jobs)"
+echo "  3) Use /retest (single command)"
+echo "  4) Just show list (done)"
+echo ""
+read -p "Choose [1-4]: " choice
+
+case "$choice" in
+  1)
+    echo ""
+    echo "Available jobs:"
+    echo "$FAILED_E2E" | nl
+    echo ""
+    read -p "Enter job numbers to retest (space-separated, e.g., '1 3 5'): " job_nums
+
+    # Build comment with selected jobs
+    COMMENT=""
+    for num in $job_nums; do
+      job=$(echo "$FAILED_E2E" | sed -n "${num}p")
+      if [ -n "$job" ]; then
+        COMMENT="${COMMENT}/test ${job}"$'\n'
+      fi
+    done
+
+    if [ -n "$COMMENT" ]; then
+      echo ""
+      echo "Posting comment:"
+      echo "$COMMENT"
+      gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+      echo "✅ Done!"
+    else
+      echo "No valid jobs selected"
+    fi
+    ;;
+
+  2)
+    # Retest all failed jobs
+    COMMENT=""
+    while IFS= read -r job; do
+      [ -z "$job" ] && continue
+      COMMENT="${COMMENT}/test ${job}"$'\n'
+    done <<< "$FAILED_E2E"
+
+    echo ""
+    echo "Posting comment to retest all $NUM_FAILED jobs:"
+    echo "$COMMENT"
+    gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+    echo "✅ Done!"
+    ;;
+
+  3)
+    # Use /retest
+    echo ""
+    echo "Posting /retest comment..."
+    gh pr comment ${PR_NUMBER} --repo ${REPO} --body "/retest"
+    echo "✅ Done!"
+    ;;
+
+  4)
+    # Just show list
+    echo "Done."
+    ;;
+
+  *)
+    echo "Invalid choice"
+    exit 1
+    ;;
+esac
+
+# Cleanup handled by trap

--- a/plugins/ci/skills/e2e-retest/fetch-e2e-data.sh
+++ b/plugins/ci/skills/e2e-retest/fetch-e2e-data.sh
@@ -12,7 +12,7 @@ source "$(dirname "$0")/common.sh"
 # Parse arguments
 if [ $# -eq 1 ]; then
   PR_NUMBER="$1"
-  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  REPO=$(git remote -v | head -1 | sed -E 's/.*github\.com[:/]([^/]+\/[^ .]+).*/\1/' | sed 's/\.git$//' || true)
   if [ -z "$REPO" ]; then
     echo '{"error": "Could not detect repository from git remote"}' >&2
     exit 1

--- a/plugins/ci/skills/e2e-retest/fetch-e2e-data.sh
+++ b/plugins/ci/skills/e2e-retest/fetch-e2e-data.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# fetch-e2e-data.sh - Fetch and parse e2e job data (NO INTERACTION)
+# Usage: ./fetch-e2e-data.sh [repo] <pr-number>
+# Output: JSON structure with failed and running jobs
+
+# Source shared utilities
+source "$(dirname "$0")/common.sh"
+
+# Parse arguments
+if [ $# -eq 1 ]; then
+  PR_NUMBER="$1"
+  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  if [ -z "$REPO" ]; then
+    echo '{"error": "Could not detect repository from git remote"}' >&2
+    exit 1
+  fi
+elif [ $# -eq 2 ]; then
+  REPO_ARG="$1"
+  PR_NUMBER="$2"
+  if [[ "$REPO_ARG" == *"/"* ]]; then
+    REPO="$REPO_ARG"
+  else
+    REPO="openshift/$REPO_ARG"
+  fi
+else
+  echo '{"error": "Invalid arguments"}' >&2
+  exit 1
+fi
+
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo '{"error": "PR number must be numeric"}' >&2
+  exit 1
+fi
+
+# Check PR state and get base ref before doing expensive fetching
+if ! PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${REPO} --json state,baseRefName 2>/dev/null); then
+  echo '{"error": "Failed to fetch PR data from GitHub"}' >&2
+  exit 1
+fi
+PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+BASE_REF=$(echo "$PR_DATA" | jq -r '.baseRefName')
+
+if [ "$PR_STATE" != "OPEN" ]; then
+  echo '{"repo": "'"$REPO"'", "pr_number": '$PR_NUMBER', "state": "'"$PR_STATE"'", "error": "PR is not open", "failed_jobs": [], "running_jobs": []}'
+  exit 0
+fi
+
+# Create unique temp directory and setup cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch in parallel
+{
+  gh pr view ${PR_NUMBER} --repo ${REPO} --json statusCheckRollup > "$TMPDIR/e2e_pr_status.json" 2>/dev/null
+} &
+{
+  curl -sL "https://prow.ci.openshift.org/pr-history?org=${ORG}&repo=${REPO_NAME}&pr=${PR_NUMBER}" > "$TMPDIR/e2e_prow_history.html" 2>/dev/null
+} &
+wait
+
+# Parse failed and running jobs
+FAILED_E2E=$(cat "$TMPDIR/e2e_pr_status.json" | jq -r '.statusCheckRollup[] |
+  select(.state == "FAILURE" or .state == "ERROR") |
+  select(.context | test("ci/prow/.*e2e")) |
+  .context | sub("ci/prow/"; "")')
+
+RUNNING_E2E=$(cat "$TMPDIR/e2e_pr_status.json" | jq -r '.statusCheckRollup[] |
+  select(.state == "PENDING") |
+  select(.context | test("ci/prow/.*e2e")) |
+  .context | sub("ci/prow/"; "")')
+
+# Build JSON output using jq for safe escaping
+# Start with base structure
+jq -n \
+  --arg repo "$REPO" \
+  --argjson pr_number "$PR_NUMBER" \
+  '{repo: $repo, pr_number: $pr_number, failed_jobs: [], running_jobs: []}' \
+  > "$TMPDIR/e2e_output.json"
+
+# Add failed jobs
+while IFS= read -r job; do
+  [ -z "$job" ] && continue
+
+  FULL_JOB="pull-ci-${ORG}-${REPO_NAME}-${BASE_REF}-${job}"
+  STATS=$(count_consecutive_failures "$FULL_JOB" "$TMPDIR/e2e_prow_history.html")
+  CONSEC=$(echo "$STATS" | cut -d'|' -f1)
+  FAIL=$(echo "$STATS" | cut -d'|' -f2)
+  PASS=$(echo "$STATS" | cut -d'|' -f3)
+  ABORT=$(echo "$STATS" | cut -d'|' -f4)
+
+  jq \
+    --arg job "$job" \
+    --argjson cons "$CONSEC" \
+    --argjson fail "$FAIL" \
+    --argjson pass "$PASS" \
+    --argjson abort "$ABORT" \
+    '.failed_jobs += [{name: $job, consecutive: $cons, fail: $fail, pass: $pass, abort: $abort}]' \
+    $TMPDIR/e2e_output.json > $TMPDIR/e2e_output.json.tmp
+  mv $TMPDIR/e2e_output.json.tmp $TMPDIR/e2e_output.json
+done <<< "$FAILED_E2E"
+
+# Add running jobs
+while IFS= read -r job; do
+  [ -z "$job" ] && continue
+  jq \
+    --arg job "$job" \
+    '.running_jobs += [$job]' \
+    $TMPDIR/e2e_output.json > $TMPDIR/e2e_output.json.tmp
+  mv $TMPDIR/e2e_output.json.tmp $TMPDIR/e2e_output.json
+done <<< "$RUNNING_E2E"
+
+# Output final JSON
+cat $TMPDIR/e2e_output.json
+
+# Cleanup handled by trap

--- a/plugins/ci/skills/payload-retest/SKILL.md
+++ b/plugins/ci/skills/payload-retest/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: Payload Retest Helper Scripts
+description: Helper scripts for analyzing and retesting failed payload CI jobs on pull requests
+---
+
+# Payload Retest Helper Scripts
+
+This skill provides bash scripts that power the `/ci:payload-retest` command. These scripts fetch and analyze payload job failures from OpenShift-specific payload test runs.
+
+## When to Use This Skill
+
+This skill is automatically invoked by the `/ci:payload-retest` command. You typically don't need to call these scripts directly.
+
+## Components
+
+### 1. `payload-retest.sh`
+Interactive script that:
+- Searches PR comments for payload run URLs
+- Downloads all payload run pages in parallel
+- Identifies the most recent run by Created timestamp
+- Parses failed, successful, and running jobs
+- Tracks consecutive failures across multiple runs
+- Presents interactive options to retest selected or all failed jobs
+- Posts `/payload-job <job-name>` comments to GitHub
+
+**Usage:**
+```bash
+./payload-retest.sh [repo] <pr-number>
+```
+
+### 2. `fetch-payload-data.sh`
+Non-interactive data fetching script that:
+- Fetches payload URLs from PR comments
+- Downloads and parses payload run pages
+- Outputs structured JSON with failed and running jobs
+- Used by the command implementation for data collection
+
+**Usage:**
+```bash
+./fetch-payload-data.sh [repo] <pr-number>
+```
+
+**Output Format:**
+```json
+{
+  "repo": "org/repo",
+  "pr_number": 123,
+  "payload_runs": 2,
+  "failed_jobs": [
+    {
+      "name": "periodic-ci-job-name",
+      "consecutive": 3
+    }
+  ],
+  "running_jobs": ["periodic-ci-job-name"]
+}
+```
+
+## Implementation Details
+
+### HTML Parsing
+The scripts parse pr-payload-tests dashboard HTML to extract job statuses. The HTML structure assumptions are documented in the code:
+- Failed jobs: `<span class="text-danger">job-name</span>`
+- Success jobs: `<span class="text-success">job-name</span>`
+- Running jobs: `<span class="">job-name</span>`
+- Job names start with: `periodic-ci-`
+
+**Validation:** If no jobs are found but payload runs exist, the script warns that HTML structure may have changed.
+
+### Parallel Fetching
+Multiple payload run pages are downloaded in parallel using background processes for performance.
+
+### Consecutive Failure Tracking
+The script tracks job status across multiple payload runs:
+1. Sorts all job entries by timestamp (newest first)
+2. For each unique job, identifies most recent status
+3. Counts consecutive failures from most recent backward
+4. Stops counting at first non-failure result
+
+### JSON Construction
+Scripts use `jq` for safe JSON construction to handle special characters in job names and prevent injection issues.
+
+### Error Handling
+- Validates `gh pr view` succeeds before parsing
+- Checks that payload URLs are found
+- Provides clear error messages on failure
+- Gracefully exits if no payload runs exist for PR
+
+## Prerequisites
+
+- `gh` CLI (GitHub CLI)
+- `jq` (JSON processor)
+- `curl`
+- Authenticated with GitHub (`gh auth login`)
+
+## Repository Detection
+
+Scripts accept repository in multiple formats:
+- **No argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>` (e.g., `ovn-kubernetes` → `openshift/ovn-kubernetes`)
+- **Full org/repo**: Use any GitHub repository (e.g., `openshift/origin`)
+
+## Notes
+
+- Payload jobs are OpenShift-specific and may not exist for all PRs
+- Command gracefully exits if no payload runs found
+- Analyzes ALL payload runs to track job history across multiple runs
+- Handles jobs that don't appear in every run

--- a/plugins/ci/skills/payload-retest/fetch-payload-data.sh
+++ b/plugins/ci/skills/payload-retest/fetch-payload-data.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# fetch-payload-data.sh - Fetch and parse payload job data (NO INTERACTION)
+# Usage: ./fetch-payload-data.sh [repo] <pr-number>
+# Output: JSON structure with failed and running jobs
+
+# Parse arguments
+if [ $# -eq 1 ]; then
+  PR_NUMBER="$1"
+  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  if [ -z "$REPO" ]; then
+    echo '{"error": "Could not detect repository from git remote"}' >&2
+    exit 1
+  fi
+elif [ $# -eq 2 ]; then
+  REPO_ARG="$1"
+  PR_NUMBER="$2"
+  if [[ "$REPO_ARG" == *"/"* ]]; then
+    REPO="$REPO_ARG"
+  else
+    REPO="openshift/$REPO_ARG"
+  fi
+else
+  echo '{"error": "Invalid arguments"}' >&2
+  exit 1
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo '{"error": "PR number must be numeric"}' >&2
+  exit 1
+fi
+
+# Check PR state before doing expensive fetching
+if ! PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${REPO} --json state,comments 2>/dev/null); then
+  echo '{"error": "Failed to fetch PR data from GitHub"}' >&2
+  exit 1
+fi
+
+PR_STATE=$(echo "$PR_DATA" | jq -r '.state')
+
+if [ "$PR_STATE" != "OPEN" ]; then
+  echo '{"repo": "'"$REPO"'", "pr_number": '$PR_NUMBER', "state": "'"$PR_STATE"'", "error": "PR is not open", "payload_runs": 0, "failed_jobs": [], "running_jobs": []}'
+  exit 0
+fi
+
+# Get payload URLs from PR comments (already fetched in PR_DATA)
+PAYLOAD_URLS=$(echo "$PR_DATA" | \
+  jq -r '.comments[].body' | \
+  grep -oE 'https://pr-payload-tests[^ )]+' | \
+  sort -u || true)
+
+if [ -z "$PAYLOAD_URLS" ]; then
+  echo '{"repo": "'"$REPO"'", "pr_number": '$PR_NUMBER', "payload_runs": 0, "failed_jobs": [], "running_jobs": []}'
+  exit 0
+fi
+
+NUM_URLS=$(echo "$PAYLOAD_URLS" | wc -l)
+
+# Create unique temp directory and setup cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch all payload pages in parallel
+i=1
+while read -r url; do
+  {
+    curl -sL "$url" > "$TMPDIR/payload_$i.html" 2>/dev/null
+  } &
+  i=$((i+1))
+done <<< "$PAYLOAD_URLS"
+wait
+
+# Parse each payload run and build data structure
+
+i=1
+while read -r url; do
+  html_file="$TMPDIR/payload_$i.html"
+
+  timestamp=$(grep -E 'Created:' "$html_file" 2>/dev/null | \
+    sed -E 's/.*Created: ([^<]+).*/\1/' | head -1 || echo "")
+
+  if [ -z "$timestamp" ]; then
+    i=$((i+1))
+    continue
+  fi
+
+  # Parse all jobs with their status
+  # NOTE: This relies on specific HTML structure from pr-payload-tests dashboard:
+  #   - Failed jobs: <span class="text-danger">job-name</span>
+  #   - Success jobs: <span class="text-success">job-name</span>
+  #   - Running jobs: <span class="">job-name</span>
+  #   - Job names start with: periodic-ci-
+  # If HTML structure changes, parsing may fail silently.
+
+  # Write to per-iteration file to avoid concurrent append issues
+  jobs_file="$TMPDIR/jobs_$i.txt"
+
+  # Get failed jobs
+  grep -oE '<span class="text-danger">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="text-danger">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|failed" >> "$jobs_file"
+    done || true
+
+  # Get successful jobs
+  grep -oE '<span class="text-success">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="text-success">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|success" >> "$jobs_file"
+    done || true
+
+  # Get running jobs
+  grep -oE '<span class="">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|running" >> "$jobs_file"
+    done || true
+
+  i=$((i+1))
+done <<< "$PAYLOAD_URLS"
+
+# Concatenate all per-iteration job files
+cat "$TMPDIR"/jobs_*.txt > "$TMPDIR/payload_jobs.txt" 2>/dev/null || true
+
+if [ ! -f "$TMPDIR/payload_jobs.txt" ] || [ ! -s "$TMPDIR/payload_jobs.txt" ]; then
+  echo "NOTE: No payload jobs found. If payload runs exist, HTML structure may have changed." >&2
+  echo '{"repo": "'"$REPO"'", "pr_number": '$PR_NUMBER', "payload_runs": '$NUM_URLS', "failed_jobs": [], "running_jobs": []}'
+  exit 0
+fi
+
+# Sort all job entries by timestamp (newest first) and job name
+sort -t'|' -k2,2r -k1,1 "$TMPDIR/payload_jobs.txt" > "$TMPDIR/payload_jobs_sorted.txt"
+
+# Build consecutive failure counts
+declare -A job_most_recent_status
+declare -A job_consecutive_failures
+declare -A job_is_running
+
+unique_jobs=$(cut -d'|' -f1 "$TMPDIR/payload_jobs_sorted.txt" | sort -u)
+
+while read -r job; do
+  [ -z "$job" ] && continue
+
+  job_entries=$(awk -F'|' -v j="$job" '$1==j' "$TMPDIR/payload_jobs_sorted.txt")
+  most_recent_status=$(echo "$job_entries" | head -1 | cut -d'|' -f3)
+  job_most_recent_status["$job"]="$most_recent_status"
+
+  if [ "$most_recent_status" = "running" ]; then
+    job_is_running["$job"]=1
+  fi
+
+  if [ "$most_recent_status" = "failed" ]; then
+    consecutive=0
+    while IFS='|' read -r j ts status; do
+      if [ "$status" = "failed" ]; then
+        consecutive=$((consecutive + 1))
+      else
+        break
+      fi
+    done <<< "$job_entries"
+    job_consecutive_failures["$job"]=$consecutive
+  fi
+done <<< "$unique_jobs"
+
+# Build JSON output using jq for safe escaping
+jq -n \
+  --arg repo "$REPO" \
+  --argjson pr_number "$PR_NUMBER" \
+  --argjson payload_runs "$NUM_URLS" \
+  '{repo: $repo, pr_number: $pr_number, payload_runs: $payload_runs, failed_jobs: [], running_jobs: []}' \
+  > $TMPDIR/payload_output.json
+
+# Add failed jobs
+for job in "${!job_most_recent_status[@]}"; do
+  if [ "${job_most_recent_status[$job]}" = "failed" ]; then
+    consecutive=${job_consecutive_failures[$job]:-0}
+
+    jq \
+      --arg job "$job" \
+      --argjson cons "$consecutive" \
+      '.failed_jobs += [{name: $job, consecutive: $cons}]' \
+      $TMPDIR/payload_output.json > $TMPDIR/payload_output.json.tmp
+    mv $TMPDIR/payload_output.json.tmp $TMPDIR/payload_output.json
+  fi
+done
+
+# Add running jobs
+for job in "${!job_is_running[@]}"; do
+  jq \
+    --arg job "$job" \
+    '.running_jobs += [$job]' \
+    $TMPDIR/payload_output.json > $TMPDIR/payload_output.json.tmp
+  mv $TMPDIR/payload_output.json.tmp $TMPDIR/payload_output.json
+done
+
+# Output final JSON
+cat $TMPDIR/payload_output.json
+
+# Cleanup handled by trap

--- a/plugins/ci/skills/payload-retest/fetch-payload-data.sh
+++ b/plugins/ci/skills/payload-retest/fetch-payload-data.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Parse arguments
 if [ $# -eq 1 ]; then
   PR_NUMBER="$1"
-  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  REPO=$(git remote -v | head -1 | sed -E 's/.*github\.com[:/]([^/]+\/[^ .]+).*/\1/' | sed 's/\.git$//' || true)
   if [ -z "$REPO" ]; then
     echo '{"error": "Could not detect repository from git remote"}' >&2
     exit 1

--- a/plugins/ci/skills/payload-retest/payload-retest.sh
+++ b/plugins/ci/skills/payload-retest/payload-retest.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 if [ $# -eq 1 ]; then
   PR_NUMBER="$1"
   # Auto-detect from git remote
-  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  REPO=$(git remote -v | head -1 | sed -E 's/.*github\.com[:/]([^/]+\/[^ .]+).*/\1/' | sed 's/\.git$//' || true)
   if [ -z "$REPO" ]; then
     echo "❌ Error: Could not detect repository from git remote."
     echo "Please specify repo: $0 <repo> <pr-number>"

--- a/plugins/ci/skills/payload-retest/payload-retest.sh
+++ b/plugins/ci/skills/payload-retest/payload-retest.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ci:payload-retest - Find and retest failed payload jobs on a PR
+# Usage: ./payload-retest.sh [repo] <pr-number>
+
+# Parse arguments
+if [ $# -eq 1 ]; then
+  PR_NUMBER="$1"
+  # Auto-detect from git remote
+  REPO=$(git remote -v | head -1 | grep -oP '(?<=github.com[:/])[^/]+/[^.\s]+' | sed 's/\.git$//' || true)
+  if [ -z "$REPO" ]; then
+    echo "❌ Error: Could not detect repository from git remote."
+    echo "Please specify repo: $0 <repo> <pr-number>"
+    exit 1
+  fi
+  echo "Repository: $REPO"
+
+elif [ $# -eq 2 ]; then
+  REPO_ARG="$1"
+  PR_NUMBER="$2"
+
+  # Check if contains slash (org/repo format)
+  if [[ "$REPO_ARG" == *"/"* ]]; then
+    REPO="$REPO_ARG"
+  else
+    # Assume openshift org
+    REPO="openshift/$REPO_ARG"
+  fi
+  echo "Repository: $REPO"
+
+else
+  echo "❌ Error: Invalid arguments"
+  echo "Usage: $0 [repo] <pr-number>"
+  exit 1
+fi
+
+# Validate PR number
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "❌ Error: PR number must be numeric"
+  exit 1
+fi
+
+echo ""
+
+# Get payload URLs from PR comments
+echo "Searching for payload runs..."
+if ! PR_COMMENTS=$(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments 2>/dev/null); then
+  echo "Error: Failed to fetch PR data from GitHub" >&2
+  exit 1
+fi
+
+PAYLOAD_URLS=$(echo "$PR_COMMENTS" | \
+  jq -r '.comments[].body' | \
+  grep -oE 'https://pr-payload-tests[^ )]+' | \
+  sort -u || true)
+
+if [ -z "$PAYLOAD_URLS" ]; then
+  echo "No payload runs found for this PR"
+  exit 0
+fi
+
+NUM_URLS=$(echo "$PAYLOAD_URLS" | wc -l)
+echo "Found $NUM_URLS payload run(s)"
+echo ""
+
+# Create unique temp directory and setup cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Fetch all payload pages in parallel
+i=1
+while read -r url; do
+  {
+    curl -sL "$url" > "$TMPDIR/payload_$i.html" 2>/dev/null
+  } &
+  i=$((i+1))
+done <<< "$PAYLOAD_URLS"
+wait
+
+echo "Analyzing all payload runs..."
+echo ""
+
+# Parse each payload run and build a data structure
+# Format: job_name|timestamp|status (one line per job per run)
+
+i=1
+while read -r url; do
+  html_file="$TMPDIR/payload_$i.html"
+
+  # Get timestamp for this run
+  timestamp=$(grep -E 'Created:' "$html_file" 2>/dev/null | \
+    sed -E 's/.*Created: ([^<]+).*/\1/' | head -1 || echo "")
+
+  if [ -z "$timestamp" ]; then
+    i=$((i+1))
+    continue
+  fi
+
+  # Parse all jobs with their status
+  # NOTE: This relies on specific HTML structure from pr-payload-tests dashboard:
+  #   - Failed jobs: <span class="text-danger">job-name</span>
+  #   - Success jobs: <span class="text-success">job-name</span>
+  #   - Running jobs: <span class="">job-name</span>
+  #   - Job names start with: periodic-ci-
+  # If HTML structure changes, parsing may fail silently.
+
+  # Write to per-iteration file to avoid concurrent append issues
+  jobs_file="$TMPDIR/jobs_$i.txt"
+
+  # Get failed jobs
+  grep -oE '<span class="text-danger">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="text-danger">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|failed" >> "$jobs_file"
+    done || true
+
+  # Get successful jobs
+  grep -oE '<span class="text-success">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="text-success">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|success" >> "$jobs_file"
+    done || true
+
+  # Get running jobs
+  grep -oE '<span class="">[^<]+</span>' "$html_file" 2>/dev/null | \
+    sed -E 's/<span class="">([^<]+)<\/span>/\1/' | \
+    grep '^periodic-ci-' | \
+    while read -r job; do
+      echo "$job|$timestamp|running" >> "$jobs_file"
+    done || true
+
+  i=$((i+1))
+done <<< "$PAYLOAD_URLS"
+
+# Concatenate all per-iteration job files
+cat "$TMPDIR"/jobs_*.txt > "$TMPDIR/payload_jobs.txt" 2>/dev/null || true
+
+# Check if we found any jobs
+if [ ! -f "$TMPDIR/payload_jobs.txt" ] || [ ! -s "$TMPDIR/payload_jobs.txt" ]; then
+  echo "No payload jobs found in any run"
+  echo "NOTE: If payload runs exist but no jobs were found, the HTML structure may have changed."
+  exit 0
+fi
+
+# Sort all job entries by timestamp (newest first) and job name
+sort -t'|' -k2,2r -k1,1 "$TMPDIR/payload_jobs.txt" > "$TMPDIR/payload_jobs_sorted.txt"
+
+# Build consecutive failure counts
+# For each unique job, find its most recent status and count consecutive failures
+declare -A job_most_recent_status
+declare -A job_consecutive_failures
+declare -A job_is_running
+
+# Get unique job names
+unique_jobs=$(cut -d'|' -f1 "$TMPDIR/payload_jobs_sorted.txt" | sort -u)
+
+while read -r job; do
+  [ -z "$job" ] && continue
+
+  # Get all entries for this job, sorted by timestamp (newest first)
+  job_entries=$(awk -F'|' -v j="$job" '$1==j' "$TMPDIR/payload_jobs_sorted.txt")
+
+  # Most recent status is the first line
+  most_recent_status=$(echo "$job_entries" | head -1 | cut -d'|' -f3)
+  job_most_recent_status["$job"]="$most_recent_status"
+
+  # If most recent is running, mark it
+  if [ "$most_recent_status" = "running" ]; then
+    job_is_running["$job"]=1
+  fi
+
+  # Count consecutive failures (only if currently failed)
+  if [ "$most_recent_status" = "failed" ]; then
+    consecutive=0
+    while IFS='|' read -r j ts status; do
+      if [ "$status" = "failed" ]; then
+        consecutive=$((consecutive + 1))
+      else
+        break
+      fi
+    done <<< "$job_entries"
+    job_consecutive_failures["$job"]=$consecutive
+  fi
+done <<< "$unique_jobs"
+
+# Display currently failed jobs
+failed_jobs=()
+for job in "${!job_most_recent_status[@]}"; do
+  if [ "${job_most_recent_status[$job]}" = "failed" ]; then
+    failed_jobs+=("$job")
+  fi
+done
+
+# Display currently running jobs
+running_jobs=()
+for job in "${!job_is_running[@]}"; do
+  running_jobs+=("$job")
+done
+
+NUM_FAILED=${#failed_jobs[@]}
+NUM_RUNNING=${#running_jobs[@]}
+
+if [ "$NUM_FAILED" -gt 0 ]; then
+  echo "Failed payload jobs:"
+  for job in "${failed_jobs[@]}"; do
+    consecutive=${job_consecutive_failures[$job]:-0}
+    echo "  ❌ $job"
+    if [ "$consecutive" -gt 0 ]; then
+      echo "     Consecutive failures: $consecutive"
+    fi
+  done
+  echo ""
+fi
+
+if [ "$NUM_RUNNING" -gt 0 ]; then
+  echo "⏳ Currently running ($NUM_RUNNING jobs):"
+  for job in "${running_jobs[@]}"; do
+    echo "  • $job"
+  done
+  echo ""
+fi
+
+# Exit if no failed jobs
+if [ "$NUM_FAILED" -eq 0 ]; then
+  if [ "$NUM_RUNNING" -gt 0 ]; then
+    echo "✅ No failed payload jobs (waiting for $NUM_RUNNING running jobs)"
+  else
+    echo "✅ No failed payload jobs!"
+  fi
+  # Cleanup
+  rm -f /tmp/payload_${PR_NUMBER}_*.html /tmp/payload_${PR_NUMBER}_*.txt
+  exit 0
+fi
+
+# Present retest options
+echo "What would you like to do?"
+echo "  1) Retest selected jobs"
+echo "  2) Retest all failed ($NUM_FAILED jobs)"
+echo "  3) Just show list (done)"
+echo ""
+read -p "Choose [1-3]: " choice
+
+case "$choice" in
+  1)
+    echo ""
+    echo "Available jobs:"
+    i=1
+    for job in "${failed_jobs[@]}"; do
+      echo "  $i) $job"
+      i=$((i+1))
+    done
+    echo ""
+    read -p "Enter job numbers to retest (space-separated, e.g., '1 3 5'): " job_nums
+
+    # Build comment with selected jobs
+    COMMENT=""
+    for num in $job_nums; do
+      # Validate input is numeric
+      if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+        echo "Warning: Skipping invalid input '$num' (not a number)" >&2
+        continue
+      fi
+
+      idx=$((num - 1))
+      if [ $idx -ge 0 ] && [ $idx -lt ${#failed_jobs[@]} ]; then
+        job="${failed_jobs[$idx]}"
+        COMMENT="${COMMENT}/payload-job ${job}"$'\n'
+      else
+        echo "Warning: Job number $num is out of range (1-${#failed_jobs[@]})" >&2
+      fi
+    done
+
+    if [ -n "$COMMENT" ]; then
+      echo ""
+      echo "Posting comment:"
+      echo "$COMMENT"
+      gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+      echo "✅ Done!"
+    else
+      echo "No valid jobs selected"
+    fi
+    ;;
+
+  2)
+    # Retest all failed jobs
+    COMMENT=""
+    for job in "${failed_jobs[@]}"; do
+      COMMENT="${COMMENT}/payload-job ${job}"$'\n'
+    done
+
+    echo ""
+    echo "Posting comment to retest all $NUM_FAILED jobs:"
+    echo "$COMMENT"
+    gh pr comment ${PR_NUMBER} --repo ${REPO} --body "$COMMENT"
+    echo "✅ Done!"
+    ;;
+
+  3)
+    # Just show list
+    echo "Done."
+    ;;
+
+  *)
+    echo "Invalid choice"
+    rm -f /tmp/payload_${PR_NUMBER}_*.html /tmp/payload_${PR_NUMBER}_*.txt
+    exit 1
+    ;;
+esac
+
+# Cleanup
+rm -f /tmp/payload_${PR_NUMBER}_*.html /tmp/payload_${PR_NUMBER}_*.txt

--- a/plugins/ci/skills/pr-retest/SKILL.md
+++ b/plugins/ci/skills/pr-retest/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: PR Retest Wrapper Script
+description: Wrapper script that combines e2e and payload retest functionality for comprehensive PR CI analysis
+---
+
+# PR Retest Wrapper Script
+
+This skill provides a bash wrapper script that powers the `/ci:pr-retest` command. It orchestrates both e2e and payload job analysis by invoking the e2e-retest and payload-retest scripts sequentially.
+
+## When to Use This Skill
+
+This skill is automatically invoked by the `/ci:pr-retest` command. You typically don't need to call this script directly.
+
+## Components
+
+### 1. `pr-retest.sh`
+Wrapper script that:
+- Invokes `e2e-retest.sh` from the e2e-retest skill
+- Invokes `payload-retest.sh` from the payload-retest skill
+- Passes all arguments transparently to both scripts
+- Provides clear section separators in output
+
+**Usage:**
+```bash
+./pr-retest.sh [repo] <pr-number>
+```
+
+**What it does:**
+1. Displays "E2E JOBS" header
+2. Runs `../e2e-retest/e2e-retest.sh` with provided arguments
+3. Displays "PAYLOAD JOBS" header
+4. Runs `../payload-retest/payload-retest.sh` with provided arguments
+
+## Implementation Details
+
+### Script Orchestration
+The wrapper uses `set -euo pipefail` to ensure:
+- Exits on any command failure
+- Treats unset variables as errors
+- Catches failures in pipelines
+
+### Path Resolution
+Script locates sibling skill directories using:
+```bash
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+```
+
+This ensures correct paths regardless of where the script is invoked from.
+
+### Output Organization
+Clear section headers help distinguish between e2e and payload results:
+```
+=========================================
+E2E JOBS
+=========================================
+[e2e-retest output]
+
+=========================================
+PAYLOAD JOBS
+=========================================
+[payload-retest output]
+```
+
+## Prerequisites
+
+Same as the underlying skills:
+- `gh` CLI (GitHub CLI)
+- `jq` (JSON processor)
+- `curl`
+- Authenticated with GitHub (`gh auth login`)
+
+Plus:
+- `e2e-retest` skill scripts must exist in `../e2e-retest/`
+- `payload-retest` skill scripts must exist in `../payload-retest/`
+
+## Repository Detection
+
+The wrapper transparently passes repository arguments to both underlying scripts:
+- **No argument**: Auto-detect from current directory's git remote
+- **Repo name only**: Assumes `openshift/<repo>`
+- **Full org/repo**: Use any GitHub repository
+
+## Notes
+
+- This is a simple orchestration wrapper with no complex logic
+- All analysis and interaction is delegated to the underlying skills
+- If either e2e or payload analysis fails, the script exits immediately (due to `set -e`)
+- Total execution time is the sum of both analyses (~10-15 seconds)

--- a/plugins/ci/skills/pr-retest/SKILL.md
+++ b/plugins/ci/skills/pr-retest/SKILL.md
@@ -26,9 +26,9 @@ Wrapper script that:
 ```
 
 **What it does:**
-1. Displays "E2E JOBS" header
+1. Displays "E2E JOBS ANALYSIS" header
 2. Runs `../e2e-retest/e2e-retest.sh` with provided arguments
-3. Displays "PAYLOAD JOBS" header
+3. Displays "PAYLOAD JOBS ANALYSIS" header
 4. Runs `../payload-retest/payload-retest.sh` with provided arguments
 
 ## Implementation Details
@@ -51,12 +51,12 @@ This ensures correct paths regardless of where the script is invoked from.
 Clear section headers help distinguish between e2e and payload results:
 ```
 =========================================
-E2E JOBS
+E2E JOBS ANALYSIS
 =========================================
 [e2e-retest output]
 
 =========================================
-PAYLOAD JOBS
+PAYLOAD JOBS ANALYSIS
 =========================================
 [payload-retest output]
 ```

--- a/plugins/ci/skills/pr-retest/pr-retest.sh
+++ b/plugins/ci/skills/pr-retest/pr-retest.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ci:pr-retest - Find and retest failed e2e CI jobs and payload jobs on a PR
+# This is a wrapper that calls both e2e-retest and payload-retest
+# Usage: ./pr-retest.sh [repo] <pr-number>
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Call e2e-retest
+echo "========================================="
+echo "E2E JOBS ANALYSIS"
+echo "========================================="
+echo ""
+
+bash "${SCRIPT_DIR}/../e2e-retest/e2e-retest.sh" "$@"
+
+echo ""
+echo ""
+echo "========================================="
+echo "PAYLOAD JOBS ANALYSIS"
+echo "========================================="
+echo ""
+
+# Call payload-retest
+bash "${SCRIPT_DIR}/../payload-retest/payload-retest.sh" "$@"


### PR DESCRIPTION
will look at a PR and give options for retesting e2e's and any payload jobs that may have failures

I'm not sure how much "AI" this PR is currently, but it is a starting point. There are two bash scripts that
analyze CI jobs (e2e and payload jobs) for failures and quickly gives a summary and options for retesting
if the user wants.

You can run it as a /slash command from claude which adds all the AI overhead and actually takes
significantly longer to run the two bash scripts.

adding more understanding to the /ci:pr-retest slash command could expand this to help understand
if any of the job failures have typical patterns worth a deeper investigation or just "one more" /retest
would be ok.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /ci:e2e-retest, /ci:payload-retest, and /ci:pr-retest commands to locate and retest failed e2e jobs, payload jobs, or both on a PR.
  * Commands support repo auto-detection and repo argument variants, interactive retest options (selective, all, or /retest), and a combined PR-level wrapper.

* **Documentation**
  * Added user-facing docs with usage, examples, workflows, and expected outputs for the new retest commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->