### PR TITLE
Add /openshift:analyze-pattern command

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -230,7 +230,7 @@ OpenShift development utilities and helpers
 
 **Commands:**
 - **`/openshift:analyze-pattern` `<pattern-name> [--orgs org1,org2] [--repos N] [--language LANG]`** - Analyze how OpenShift repos implement a design pattern and get custom recommendations
-- **`/openshift:bootstrap-om` `""`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
+- **`/openshift:bootstrap-om`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
 - **`/openshift:bump-deps` `<dependency> [version] [--create-jira] [--create-pr]`** - Bump dependencies in OpenShift projects with automated analysis and PR creation
 - **`/openshift:cluster-health-check` `[--verbose] [--output-format]`** - Perform comprehensive health check on OpenShift cluster and report issues
 - **`/openshift:crd-review` `[repository-path]`** - Review Kubernetes CRDs against Kubernetes and OpenShift API conventions

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -229,6 +229,7 @@ See [plugins/olm/README.md](plugins/olm/README.md) for detailed documentation.
 OpenShift development utilities and helpers
 
 **Commands:**
+- **`/openshift:analyze-pattern` `<pattern-name> [--orgs org1,org2] [--repos N] [--language LANG]`** - Analyze how OpenShift repos implement a design pattern and get custom recommendations
 - **`/openshift:bootstrap-om` `""`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
 - **`/openshift:bump-deps` `<dependency> [version] [--create-jira] [--create-pr]`** - Bump dependencies in OpenShift projects with automated analysis and PR creation
 - **`/openshift:cluster-health-check` `[--verbose] [--output-format]`** - Perform comprehensive health check on OpenShift cluster and report issues

--- a/docs/data.json
+++ b/docs/data.json
@@ -628,16 +628,16 @@
     {
       "commands": [
         {
-          "argument_hint": "\"\"",
-          "description": "Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery",
-          "name": "bootstrap-om",
-          "synopsis": "bash"
-        },
-        {
           "argument_hint": "<pattern-name> [--orgs org1,org2] [--repos N] [--language LANG]",
           "description": "Analyze how OpenShift repos implement a design pattern and get custom recommendations",
           "name": "analyze-pattern",
           "synopsis": "/openshift:analyze-pattern <pattern> [--orgs org1,org2] [--repos N] [--language LANG] [--refresh] [--skip-clone]"
+        },
+        {
+          "argument_hint": "",
+          "description": "Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery",
+          "name": "bootstrap-om",
+          "synopsis": "bash"
         },
         {
           "argument_hint": "<dependency> [version] [--create-jira] [--create-pr]",

--- a/docs/data.json
+++ b/docs/data.json
@@ -634,6 +634,12 @@
           "synopsis": "bash"
         },
         {
+          "argument_hint": "<pattern-name> [--orgs org1,org2] [--repos N] [--language LANG]",
+          "description": "Analyze how OpenShift repos implement a design pattern and get custom recommendations",
+          "name": "analyze-pattern",
+          "synopsis": "/openshift:analyze-pattern <pattern> [--orgs org1,org2] [--repos N] [--language LANG] [--refresh] [--skip-clone]"
+        },
+        {
           "argument_hint": "<dependency> [version] [--create-jira] [--create-pr]",
           "description": "Bump dependencies in OpenShift projects with automated analysis and PR creation",
           "name": "bump-deps",
@@ -709,6 +715,11 @@
           "description": "Generates and displays OVN-Kubernetes network topology diagrams showing logical switches, routers, ports with IP/MAC addresses in Mermaid format",
           "id": "generating-ovn-topology",
           "name": "generating-ovn-topology"
+        },
+        {
+          "description": "Analyze design pattern implementations across OpenShift/Kubernetes repositories using AI",
+          "id": "pattern-analyzer",
+          "name": "Pattern Analyzer"
         }
       ],
       "version": "0.0.1"

--- a/plugins/openshift/README.md
+++ b/plugins/openshift/README.md
@@ -228,6 +228,20 @@ Analyze how OpenShift and Kubernetes repositories implement specific design patt
 - References to best implementations
 - Cached results in `.work/design-patterns/<pattern>/`
 
+**Cache Management:**
+```bash
+# View cache size
+du -sh .work/design-patterns/
+
+# Clean up a specific pattern's cache
+rm -rf .work/design-patterns/NetworkPolicy/
+
+# Clean up all pattern analysis cache
+rm -rf .work/design-patterns/
+
+# Cache auto-expires after 7 days (forces re-analysis)
+```
+
 **Use Cases:**
 - Learning how to implement a new pattern
 - Understanding common approaches vs unique ones

--- a/plugins/openshift/README.md
+++ b/plugins/openshift/README.md
@@ -20,6 +20,12 @@ Automates the process of bumping dependencies in OpenShift organization projects
 the appropriate version to bump to, updates the necessary files (go.mod, go.sum, package.json, etc.), runs tests,
 and optionally creates Jira tickets and pull requests.
 
+### `/openshift:analyze-pattern`
+
+Analyze how OpenShift and Kubernetes repositories implement a design pattern and get custom recommendations.
+
+This command searches GitHub for pattern implementations, analyzes common approaches, and provides context-aware guidance tailored to your repository type.
+
 ### `/openshift:create-cluster`
 
 Extract OpenShift installer from release image and create an OCP cluster.
@@ -137,6 +143,106 @@ Automates dependency updates in OpenShift projects with comprehensive analysis, 
    ```
 
 See [commands/bump-deps.md](commands/bump-deps.md) for full documentation.
+
+### Pattern Analysis
+
+#### `/openshift:analyze-pattern` - Analyze Design Pattern Implementations
+
+Analyze how OpenShift and Kubernetes repositories implement specific design patterns and get context-aware recommendations tailored to your repository.
+
+**Basic Usage:**
+```bash
+# Analyze NetworkPolicy implementations
+/openshift:analyze-pattern NetworkPolicy
+
+# Analyze ValidatingWebhook across multiple orgs
+/openshift:analyze-pattern ValidatingWebhook --orgs openshift,kubernetes,kubernetes-sigs
+
+# Default: comprehensive analysis (50 repos)
+/openshift:analyze-pattern NetworkPolicy
+
+# Quick analysis with fewer repos (faster)
+/openshift:analyze-pattern MutatingWebhook --repos 10
+
+# Minimal analysis (fastest)
+/openshift:analyze-pattern CustomResourceDefinition --repos 5
+
+# Force refresh cached analysis
+/openshift:analyze-pattern NetworkPolicy --refresh
+```
+
+**What It Does:**
+- Searches GitHub for repositories implementing the pattern
+- Clones and analyzes top repositories
+- Detects common implementation approaches
+- Identifies key features and configurations
+- Finds repositories most similar to yours
+- Generates context-aware recommendations
+
+**Key Features:**
+- Analyzes up to 50 repositories by default for comprehensive insights
+- Statistical analysis ("X% of repos use approach Y") with high confidence
+- Context detection (understands your project type)
+- Similarity matching (finds repos like yours)
+- Getting started steps tailored to your repo
+- Caches results for fast subsequent runs
+
+**Arguments:**
+- `<pattern>` (required): Pattern name (e.g., NetworkPolicy, ValidatingWebhook)
+- `--orgs <org1,org2>`: GitHub organizations to search (default: openshift,kubernetes)
+- `--repos <N>`: Maximum repos to analyze (default: 50, range: 3-50)
+- `--refresh`: Force refresh cached analysis
+
+**Examples:**
+
+1. Basic pattern analysis:
+   ```bash
+   /openshift:analyze-pattern NetworkPolicy
+   ```
+   Output:
+   - 6/7 repos use ValidatingWebhooks
+   - 7/7 repos use namespace label selectors
+   - Follow cluster-network-operator (most similar to your operator project)
+   - Step-by-step implementation guide
+
+2. Analyze across multiple orgs:
+   ```bash
+   /openshift:analyze-pattern CustomResourceDefinition --orgs openshift,kubernetes,kubernetes-sigs
+   ```
+
+3. Quick analysis with fewer repos:
+   ```bash
+   /openshift:analyze-pattern MutatingWebhook --repos 5
+   ```
+
+**Prerequisites:**
+- Python 3.6+ (check: `python3 --version`)
+- Git installed (check: `git --version`)
+- Network access to GitHub
+- (Optional) `GITHUB_TOKEN` environment variable for higher API rate limits
+
+**Output:**
+- Repositories analyzed and ranked by quality
+- Statistical insights on common patterns
+- Context-aware recommendations for your repo
+- References to best implementations
+- Cached results in `.work/design-patterns/<pattern>/`
+
+**Use Cases:**
+- Learning how to implement a new pattern
+- Understanding common approaches vs unique ones
+- Getting started guidance tailored to your project
+- Finding high-quality reference implementations
+- Avoiding common implementation mistakes
+
+**Tier 1 MVP Features:**
+- GitHub repository search and ranking
+- Pattern detection and statistical analysis
+- Context detection (project type, existing patterns)
+- Similarity matching with analyzed repos
+- Getting started recommendations
+
+See [commands/analyze-pattern.md](commands/analyze-pattern.md) for full documentation.
 
 ### Cluster Management
 

--- a/plugins/openshift/commands/analyze-pattern.md
+++ b/plugins/openshift/commands/analyze-pattern.md
@@ -1,0 +1,267 @@
+---
+description: Analyze how OpenShift repos implement a design pattern and get custom recommendations
+argument-hint: <pattern-name> [--orgs org1,org2] [--repos N] [--language LANG]
+---
+
+## Name
+
+openshift:analyze-pattern
+
+## Synopsis
+
+```
+/openshift:analyze-pattern <pattern> [--orgs org1,org2] [--repos N] [--language LANG] [--refresh] [--skip-clone]
+```
+
+## Description
+
+The `openshift:analyze-pattern` command analyzes how OpenShift and Kubernetes repositories implement a specific design pattern and provides intelligent, context-aware recommendations tailored to your repository.
+
+**What makes this powerful:**
+- Analyzes up to 50 real-world implementations
+- Statistically identifies common approaches
+- Understands YOUR project structure and purpose
+- Provides complete, copy-paste-ready code examples
+- Explains WHY certain approaches are recommended
+
+**Use cases:**
+- Learning how to implement NetworkPolicy, ValidatingWebhook, etc.
+- Understanding ecosystem-wide best practices
+- Getting started with unfamiliar patterns
+- Finding high-quality reference implementations
+
+## Implementation
+
+**Architecture: Data + Intelligence**
+
+This command uses a two-layer approach:
+1. **Python scripts** gather data (fast, reliable)
+2. **Claude AI** analyzes and synthesizes (intelligent, adaptive)
+
+### Data Gathering (Automated)
+
+**Locate the script directory dynamically:**
+
+```bash
+# Find the analyze_pattern.sh script
+ANALYZER_SCRIPT=$(find ~ -name "analyze_pattern.sh" -path "*/pattern-analyzer/*" 2>/dev/null | head -1)
+
+if [ -z "$ANALYZER_SCRIPT" ]; then
+    echo "ERROR: Pattern analyzer script not found"
+    echo "Please ensure the openshift plugin from ai-helpers is properly installed"
+    exit 1
+fi
+```
+
+**Execute the analysis script:**
+
+```bash
+$ANALYZER_SCRIPT \
+  "<pattern>" \
+  --orgs "openshift,kubernetes" \
+  --repos 50
+```
+
+**Or use relative path if plugin is in workspace:**
+
+```bash
+plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh \
+  "<pattern>" \
+  --orgs "openshift,kubernetes" \
+  --repos 50
+```
+
+This script:
+1. **Searches GitHub Code Search API** for pattern usage
+   - Paginates through ALL results (up to 1000 matches)
+   - Searches all file types by default (Dockerfiles, shell scripts, YAML, Go, etc.)
+   - Optional `--language` filter for specific languages
+2. **Deduplicates results** to avoid counting the same file twice
+3. **Ranks and filters repos** by quality (stars, activity, relevance, recency)
+4. **Parallel clones top repos** (~50 repos max, up to 8 concurrent clones)
+5. **Creates analysis workspace** with all data for Claude AI
+
+**Output (in `.work/design-patterns/<pattern>/`):**
+- `repos.json` - Repository metadata (stars, URLs, descriptions, scores)
+- `analysis.log` - Execution log (also serves as cache marker)
+- `repos/` - Cloned repositories for exploration
+
+### Analysis and Synthesis (Claude AI)
+
+After data gathering completes, Claude should:
+
+1. **Read all JSON files** to understand the landscape
+
+2. **Explore cloned repositories:**
+   - Find the most similar repos to user's project
+   - Read actual struct definitions
+   - Extract real implementation code
+   - Review test examples
+
+3. **Analyze user's project:**
+   - Understand what they're building (from dependencies, CRDs, controllers)
+   - Identify where pattern fits in their architecture
+   - Determine specific files to create/modify
+
+4. **Generate intelligent recommendations:**
+   - Statistical insights ("X% of repos use approach Y")
+   - Code examples from actual repos (not templates!)
+   - Specific file paths for user's project structure
+   - Complete, working code samples
+   - Detailed implementation steps
+   - Testing guidance
+
+5. **Provide context-aware guidance:**
+   - Explain WHY this pattern is relevant to their project
+   - Show HOW it integrates with their existing code
+   - Reference similar implementations they can learn from
+
+### Key Principles
+
+- **Data-driven:** All recommendations based on analyzed repos
+- **Context-aware:** Tailored to user's specific project
+- **Complete:** Full working code, not snippets
+- **Explainable:** Every recommendation backed by data
+
+## Return Value
+
+**Terminal Output:**
+- Progress indicators during data gathering
+  - Pagination progress (Page 1, Page 2, etc.)
+  - Repository ranking and scoring
+  - Clone progress for each repository
+- Path to generated data files
+- Instructions for Claude to analyze
+
+**Files Created:**
+- `.work/design-patterns/<pattern>/repos.json` - Repository metadata with scores
+- `.work/design-patterns/<pattern>/analysis.log` - Complete execution log
+- `.work/design-patterns/<pattern>/repos/` - Cloned repositories (shallow)
+
+**Claude AI Analysis (generated after data gathering):**
+- `.work/design-patterns/<pattern>/ANALYSIS.md` - Complete analysis including:
+  - Statistical summary of implementations
+  - Code examples from actual repos
+  - Context-specific recommendations for your project
+  - Complete implementation guide
+  - References to similar repos
+
+## Examples
+
+### Example 1: Basic Pattern Analysis (Go types)
+
+```
+/openshift:analyze-pattern NetworkPolicy --language go
+```
+
+Analyzes 50 NetworkPolicy implementations in Go code, then Claude provides:
+- Statistical breakdown of approaches
+- Real code examples
+- Specific recommendations for your project
+
+### Example 2: Shell Script Analysis
+
+```
+/openshift:analyze-pattern "/usr/bin/gather"
+```
+
+Searches all file types (Dockerfiles, shell scripts, YAML) for gather scripts.
+Useful for analyzing operational patterns.
+
+### Example 3: Quick Analysis
+
+```
+/openshift:analyze-pattern ValidatingWebhook --repos 10
+```
+
+Analyzes fewer repos for faster results.
+
+### Example 4: Multi-org Search
+
+```
+/openshift:analyze-pattern CustomResourceDefinition --orgs openshift,kubernetes,kubernetes-sigs
+```
+
+Searches across multiple organizations.
+
+### Example 5: Use Cached Repos
+
+```
+/openshift:analyze-pattern ProxyConfig --skip-clone
+```
+
+Reuses already-cloned repos, only re-analyzes.
+
+### Example 6: Python Code Patterns
+
+```
+/openshift:analyze-pattern "must-gather" --language python --repos 20
+```
+
+Finds Python implementations of must-gather patterns.
+
+## Arguments
+
+- `$1` (required): **Pattern name**
+  - Examples: "NetworkPolicy", "ValidatingWebhook", "/usr/bin/gather"
+  - Can be Go types, file paths, or any search term
+  - Use quotes if pattern contains spaces or special characters
+
+- `--orgs <org1,org2>` (optional): **GitHub organizations**
+  - Default: "openshift,kubernetes"
+  - Comma-separated, no spaces
+  - Example: `--orgs openshift,kubernetes,kubernetes-sigs`
+
+- `--repos <N>` (optional): **Maximum repos to analyze**
+  - Default: 50 (comprehensive)
+  - Range: 3-50
+  - More repos = better statistics, slower analysis
+
+- `--language <LANG>` (optional): **Programming language filter**
+  - Default: all languages (searches everything)
+  - Examples: `go`, `python`, `shell`, `dockerfile`, `yaml`
+  - When omitted, searches Dockerfiles, shell scripts, YAML, Go, etc.
+  - Use for Go types: `--language go`
+
+- `--refresh` (optional): **Force refresh**
+  - Ignores cache (based on analysis.log age)
+  - Re-runs entire analysis
+  - Cache expires after 7 days automatically
+
+- `--skip-clone` (optional): **Skip cloning**
+  - Uses existing cloned repos
+  - Re-runs search only
+  - Saves 10-15 minutes
+
+## Prerequisites
+
+1. **Python 3.6+**
+2. **Git**
+3. **GitHub Token** (optional but recommended):
+   ```bash
+   export GITHUB_TOKEN="ghp_..."
+   ```
+4. **Disk space**: ~400-600MB per analysis (optimized shallow clones)
+
+## Notes
+
+- **Run from your target project directory** for best results
+- First run: ~5-8 minutes (search + parallel cloning)
+- Cached runs: Instant (if analysis.log < 7 days old)
+- With `--skip-clone`: ~2-5 minutes (search only)
+- Cache marker: `analysis.log` file (expires after 7 days)
+
+**Performance:**
+- **Parallel cloning:** Up to 8 concurrent git clones for maximum speed
+- **Optimized cloning:** Uses `--depth 1` (single commit) + `--filter=blob:none` (deferred blobs)
+- **GitHub API pagination:** Fetches ALL search results (up to 1000)
+- **Deduplication:** Removes duplicate file matches across pages
+- **Rate limiting:** 2-second delays between pagination requests
+- **Token recommended:** Set `GITHUB_TOKEN` for higher API limits
+
+**Critical:** This command generates data. Claude AI performs the intelligent analysis and recommendations.
+
+## See Also
+
+- Skill Documentation: `plugins/openshift/skills/pattern-analyzer/SKILL.md`
+- Python Scripts: `plugins/openshift/skills/pattern-analyzer/*.py`

--- a/plugins/openshift/commands/analyze-pattern.md
+++ b/plugins/openshift/commands/analyze-pattern.md
@@ -24,6 +24,13 @@ The `openshift:analyze-pattern` command analyzes how OpenShift and Kubernetes re
 - Provides complete, copy-paste-ready code examples
 - Explains WHY certain approaches are recommended
 
+**Context-Aware Analysis Strategy:**
+To avoid context window exhaustion when analyzing many repos, Claude uses a tiered approach:
+1. **Tier 1 (Deep analysis):** Top 3-5 repos most similar to user's project - full code review
+2. **Tier 2 (Pattern extraction):** Next 10 repos - extract struct definitions and key patterns only
+3. **Tier 3 (Statistical):** Remaining repos - count approaches, skip full code review
+This ensures comprehensive statistics without overwhelming the context window.
+
 **Use cases:**
 - Learning how to implement NetworkPolicy, ValidatingWebhook, etc.
 - Understanding ecosystem-wide best practices

--- a/plugins/openshift/skills/pattern-analyzer/README.md
+++ b/plugins/openshift/skills/pattern-analyzer/README.md
@@ -1,0 +1,189 @@
+# Pattern Analyzer
+
+**Minimal data gathering + Claude AI intelligence**
+
+## Architecture
+
+```
+┌──────────────────────────────────────────┐
+│  Python: search_repos.py                 │
+│  • GitHub Code Search API (paginated)    │
+│  • Deduplicates file matches             │
+│  • Ranks repos by quality                │
+│  ↓                                        │
+│  Output: repos.json                      │
+└──────────────────────────────────────────┘
+              ↓
+┌──────────────────────────────────────────┐
+│  Python: Parallel git clone (8 workers)  │
+│  • --depth 1 --filter=blob:none          │
+│  ↓                                        │
+│  Output: repos/ + analysis.log           │
+└──────────────────────────────────────────┘
+              ↓
+┌──────────────────────────────────────────┐
+│  Claude AI:                              │
+│  • Read repos.json                       │
+│  • Explore cloned repos                  │
+│  • Analyze user's project                │
+│  • Generate ANALYSIS.md                  │
+└──────────────────────────────────────────┘
+```
+
+**Key Features:**
+- ✅ **Parallel cloning:** Up to 8 concurrent clones (3-5x faster!)
+- ✅ **Pagination:** Fetches ALL search results (up to 1000)
+- ✅ **Deduplication:** Removes duplicate file matches
+- ✅ **All file types:** Searches Dockerfiles, shell scripts, YAML, Go, etc.
+- ✅ **Smart caching:** Uses `analysis.log` as 7-day cache marker
+
+## Quick Usage
+
+```bash
+# Navigate to YOUR project first!
+cd ~/your-operator-project
+
+# Locate the analyzer script
+ANALYZER_SCRIPT=$(find ~ -name "analyze_pattern.sh" -path "*/pattern-analyzer/*" 2>/dev/null | head -1)
+
+# Run data gathering
+$ANALYZER_SCRIPT \
+  "NetworkPolicy" \
+  --repos 50
+
+# Or if ai-helpers is in workspace:
+# plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh "NetworkPolicy" --repos 50
+```
+
+**Output:**
+```
+✅ DATA GATHERING COMPLETE
+
+Generated data:
+  • repos.json - 50 repositories metadata
+  • repos/ - 50 cloned repositories
+  • analysis.log - Execution log
+
+🤖 NEXT: Claude AI Analysis
+
+Claude should now:
+  1. READ repos.json
+  2. EXPLORE cloned repos
+  3. ANALYZE your project
+  4. GENERATE detailed recommendations
+  5. CREATE ANALYSIS.md with complete guide
+```
+
+## What You Get
+
+**Claude generates:** `.work/design-patterns/<pattern>/ANALYSIS.md`
+
+Contains:
+- Statistical insights from 50 repos
+- Real code examples (extracted from repos)
+- Specific recommendations for YOUR project
+- Complete struct definitions
+- Full implementation code
+- Step-by-step integration guide
+- Testing examples
+- References to similar repos
+
+## Scripts
+
+| Script | Purpose | Key Features |
+|--------|---------|--------------|
+| `analyze_pattern.sh` | Orchestration | Cache management, clone coordination |
+| `search_repos.py` | GitHub search | **Pagination**, deduplication, ranking |
+
+**Only 2 scripts!** Everything else is Claude AI.
+
+**What makes search_repos.py powerful:**
+- Paginates through all GitHub search results (not just first 100)
+- Deduplicates file matches across pages
+- Searches all file types by default (optional language filter)
+- Ranks repos by stars, activity, and relevance
+
+## Arguments
+
+```bash
+./analyze_pattern.sh <pattern> [options]
+```
+
+- `<pattern>` - Pattern name or search term
+  - Examples: "NetworkPolicy", "/usr/bin/gather", "must-gather"
+- `--orgs <orgs>` - GitHub orgs (default: openshift,kubernetes)
+- `--repos <N>` - Max repos (default: 50, range: 3-50)
+- `--language <LANG>` - Language filter (default: all)
+  - Examples: `go`, `python`, `shell`, `dockerfile`
+  - Omit to search all file types
+- `--refresh` - Force refresh (ignore cache)
+- `--skip-clone` - Use existing cloned repos
+
+## Examples
+
+### Example 1: Go Type Pattern
+```bash
+cd ~/my-operator
+./analyze_pattern.sh "NetworkPolicy" --language go --repos 50
+```
+
+### Example 2: Shell Script Pattern (all file types)
+```bash
+cd ~/must-gather-operator
+./analyze_pattern.sh "/usr/bin/gather" --repos 50
+# Searches: Dockerfiles, shell scripts, YAML, Makefiles, etc.
+```
+
+### Example 3: Quick Analysis
+```bash
+./analyze_pattern.sh "ValidatingWebhook" --repos 10
+```
+
+### Example 4: Use Cached Data
+```bash
+./analyze_pattern.sh "ProxyConfig" --skip-clone
+# Uses existing repos/, re-runs search only
+```
+
+**After data gathering completes:**
+```bash
+# Claude creates comprehensive analysis
+cat .work/design-patterns/<pattern>/ANALYSIS.md
+```
+
+## Why This Works
+
+**Python is good at:**
+- GitHub API calls
+- git clone operations
+- File system operations
+
+**Claude is good at:**
+- Reading and understanding code
+- Finding patterns and similarities
+- Generating context-specific recommendations
+- Writing complete, working implementations
+- Explaining reasoning
+
+**Use the right tool for each job!** 🎯
+
+## Output Structure
+
+```
+.work/design-patterns/<pattern>/
+├── repos.json          # Metadata (from Python)
+├── analysis.log        # Execution log (from bash)
+├── ANALYSIS.md         # Complete guide (from Claude) ⭐
+└── repos/              # Cloned repos (from git)
+    ├── cluster-network-operator/
+    ├── api/
+    ├── sdn/
+    └── ... (50 repos)
+```
+
+## Requirements
+
+- Python 3.6+
+- Git
+- ~400-600MB disk space for 50 repos (optimized shallow clones with `--depth 1`)
+- (Optional) GITHUB_TOKEN for higher API limits

--- a/plugins/openshift/skills/pattern-analyzer/SKILL.md
+++ b/plugins/openshift/skills/pattern-analyzer/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: Pattern Analyzer
+description: Analyze design pattern implementations across OpenShift/Kubernetes repositories using AI
+---
+
+# Pattern Analyzer Skill
+
+**Architecture:** Data (Python) + Intelligence (Claude AI)
+
+## Overview
+
+This skill uses a minimal data gathering approach followed by intelligent AI analysis:
+
+1. **Python script** searches GitHub (with pagination) and clones repos (fast, automated)
+2. **Claude AI** analyzes everything and generates recommendations (intelligent, adaptive)
+
+**Key capabilities:**
+- ✅ **Complete search coverage:** Paginates through ALL GitHub results (up to 1000)
+- ✅ **All file types:** Searches Dockerfiles, shell scripts, YAML, Go, Python, etc.
+- ✅ **Deduplication:** Removes duplicate file matches across pages
+- ✅ **Smart caching:** 7-day cache based on `analysis.log` timestamp
+
+**No hardcoded templates. No rigid patterns. Just data + AI.**
+
+## When to Use This Skill
+
+Use when implementing `/openshift:analyze-pattern` command to help developers understand how to implement design patterns (NetworkPolicy, ValidatingWebhook, ProxyConfig, etc.) in their Kubernetes/OpenShift projects.
+
+## Prerequisites
+
+**For the user:**
+- Python 3.6+
+- Git
+- GitHub token (optional): `export GITHUB_TOKEN="ghp_..."`
+- Must run from their target project directory
+
+**For you (Claude):**
+- Read JSON data files
+- Explore cloned repositories
+- Analyze user's project structure
+- Generate intelligent recommendations
+
+## Implementation
+
+### Step 1: Run Data Gathering Script
+
+**Locate the script dynamically:**
+
+```bash
+# Find the analyze_pattern.sh script
+ANALYZER_SCRIPT=$(find ~ -name "analyze_pattern.sh" -path "*/pattern-analyzer/*" 2>/dev/null | head -1)
+
+if [ -z "$ANALYZER_SCRIPT" ]; then
+    # Fallback: try relative path if in workspace
+    if [ -f "plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh" ]; then
+        ANALYZER_SCRIPT="plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh"
+    else
+        echo "ERROR: Pattern analyzer script not found"
+        echo "Please ensure the openshift plugin from ai-helpers is properly installed"
+        exit 1
+    fi
+fi
+```
+
+**Execute the analysis script:**
+
+```bash
+$ANALYZER_SCRIPT \
+  "<pattern>" \
+  [--orgs "openshift,kubernetes"] \
+  [--repos 50] \
+  [--language LANG] \
+  [--refresh] \
+  [--skip-clone]
+```
+
+**What this does:**
+1. **Searches GitHub Code Search API** (with pagination)
+   - Fetches ALL search results (up to 1000 matches across multiple pages)
+   - Searches all file types by default (Dockerfiles, scripts, YAML, Go, etc.)
+   - Optional `--language` filter for specific languages
+2. **Deduplicates file matches** across pagination results
+3. **Ranks repositories** by quality (stars, activity, relevance)
+4. **Parallel clones repositories** (up to 8 concurrent shallow clones, ~50 repos max)
+5. **Creates workspace** in `.work/design-patterns/<pattern>/`
+
+**Output files:**
+- `.work/design-patterns/<pattern>/repos.json` - Repository metadata with scores
+- `.work/design-patterns/<pattern>/repos/` - Cloned repositories
+- `.work/design-patterns/<pattern>/analysis.log` - Execution log (also cache marker)
+
+**Time:** 
+- First run: 5-8 minutes (search + parallel shallow clones with `--depth 1`)
+- Cached: Instant (if analysis.log < 7 days old)
+- With `--skip-clone`: 2-5 minutes (search only)
+
+### Step 2: Read the Repository Data
+
+**CRITICAL: Read this file to understand what was found**
+
+```bash
+cat .work/design-patterns/<pattern>/repos.json
+```
+
+**Extract:**
+- How many repos were found
+- Which repos have highest quality (stars, activity)
+- Repository descriptions (understand what each does)
+- URLs for reference
+
+**Example data structure:**
+```json
+{
+  "pattern": "NetworkPolicy",
+  "repos_selected": 50,
+  "repos": [
+    {
+      "name": "cluster-network-operator",
+      "org": "openshift",
+      "full_name": "openshift/cluster-network-operator",
+      "stars": 107,
+      "description": "...",
+      "clone_url": "...",
+      "relevance_score": 12.5
+    }
+  ]
+}
+```
+
+### Step 3: Explore the Cloned Repositories
+
+**The repos are cloned to:** `.work/design-patterns/<pattern>/repos/`
+
+**Your task:** Explore these repos to understand how the pattern is implemented.
+
+#### A. Find Similar Repos to User's Project
+
+First, understand user's project:
+```bash
+# Check if it's an operator
+ls api/ controllers/ config/
+
+# Check go.mod
+cat go.mod | grep -E 'operator-sdk|controller-runtime|module'
+
+# Check for existing patterns
+find . -name "*webhook*.go" -o -name "*controller*.go"
+```
+
+Then find repos with similar structure from the cloned set.
+
+#### B. Analyze Pattern Implementation
+
+For each relevant repo (focus on top 5-7 similar ones):
+
+```bash
+# Find struct definition
+grep -r "type <Pattern> struct" .work/design-patterns/<pattern>/repos/<repo-name>/ --include="*.go"
+
+# Find implementation files
+find .work/design-patterns/<pattern>/repos/<repo-name>/ -name "*<pattern>*.go" | grep -v vendor | grep -v generated
+
+# Read the actual code
+cat .work/design-patterns/<pattern>/repos/<repo-name>/<file>
+```
+
+**What to extract:**
+- Complete struct definitions (with all fields and comments)
+- Validation functions
+- Controller/Reconciler implementations
+- Webhook configurations (YAML)
+- Test examples
+- RBAC configurations
+
+#### C. Statistical Analysis
+
+Based on what you read from the repos:
+
+- Count approaches: "How many use ValidatingWebhook vs AdmissionController?"
+- Common fields: "What fields appear in most struct definitions?"
+- Common patterns: "Do they all validate URLs? Handle nil values?"
+- Testing practices: "What do tests check for?"
+
+### Step 4: Analyze User's Project
+
+**Explore their repository structure:**
+
+```bash
+# Check project type
+ls -la  # See directory structure
+
+# Operator?
+cat go.mod | grep operator-sdk
+
+# Read their CRDs
+find api/ -name "*_types.go" 2>/dev/null | head -5
+
+# Check existing controllers
+ls controllers/ pkg/controller/ 2>/dev/null
+
+# Check build system
+cat Makefile | head -20
+```
+
+**Understand:**
+- Project type (operator, application, library)
+- Directory layout (standard operator, pkg-based, custom)
+- Existing patterns (webhooks, CRDs, controllers)
+- Dependencies (what APIs they already use)
+- What components they manage (from controller names)
+
+### Step 5: Generate Intelligent Recommendations
+
+**Based on everything you learned, provide:**
+
+#### A. Statistical Summary
+
+```markdown
+## Pattern Analysis: <Pattern>
+
+Analyzed <N> repositories from <orgs>
+
+### Implementation Approaches
+- <X>/<N> (Y%) repos use <approach>
+- <X>/<N> (Y%) repos use <approach>
+...
+
+### Common Fields (from struct definitions)
+- Field1: appears in X/N repos (purpose: ...)
+- Field2: appears in X/N repos (purpose: ...)
+```
+
+#### B. Code Examples from Actual Repos
+
+**Show REAL code** (not templates):
+
+```markdown
+### Struct Definition (from <repo-name>)
+
+\`\`\`go
+// Complete struct from actual repo
+type ProxyConfig struct {
+    HTTPProxy *string `json:"httpProxy,omitempty"`
+    // ... all fields with comments
+}
+\`\`\`
+```
+
+#### C. Context-Specific Recommendations
+
+**For THEIR specific project:**
+
+```markdown
+## Recommendations for Your Project
+
+### Your Project Context
+- Type: Operator (controller-runtime v0.20.4)
+- Manages: SpireServer, SpireAgent, OIDCDiscoveryProvider
+- Structure: api/, controllers/, config/
+- Existing patterns: Has webhooks, uses kustomize
+
+### Implementation Plan
+
+**File 1: api/v1alpha1/<pattern>_types.go**
+
+Create this file with:
+
+\`\`\`go
+package v1alpha1
+
+// <Pattern> - based on openshift/cluster-network-operator implementation
+type <Pattern> struct {
+    // Actual fields from analyzed repos
+    Field1 string `json:"field1"`
+    // ...
+}
+\`\`\`
+
+**File 2: controllers/<pattern>_webhook.go**
+
+\`\`\`go
+// Complete webhook implementation
+// Based on <similar-repo>
+\`\`\`
+
+... (continue with complete, working code for each file)
+```
+
+#### D. Integration Steps
+
+**Specific commands for their setup:**
+
+```markdown
+1. Create api/v1alpha1/<pattern>_types.go
+2. Run: make manifests
+3. Create controllers/<pattern>_webhook.go
+4. Update main.go: (exact lines to add)
+5. Update config/rbac/role.yaml: (exact YAML to add)
+6. Test: make test
+```
+
+### Step 6: Create Summary Markdown File
+
+**CRITICAL: Save everything to a markdown file**
+
+Create: `.work/design-patterns/<pattern>/ANALYSIS.md`
+
+**Format:**
+
+```markdown
+# <Pattern> Implementation Analysis
+
+Generated: <timestamp>
+Analyzed: <N> repositories
+Target project: <repo-name>
+
+## Executive Summary
+
+[Brief overview of findings]
+
+## Statistical Insights
+
+[Approaches, features, testing practices]
+
+## Code Examples
+
+[Complete struct definitions, functions, configs from actual repos]
+
+## Recommendations for <repo-name>
+
+[Specific guidance for their project]
+
+## Files to Create/Modify
+
+### File: api/v1alpha1/<pattern>_types.go
+\`\`\`go
+[complete code]
+\`\`\`
+
+### File: controllers/<pattern>_webhook.go
+\`\`\`go
+[complete code]
+\`\`\`
+
+[... all files with complete code]
+
+## Implementation Steps
+
+1. [Step-by-step with exact commands]
+
+## Testing Guide
+
+[How to test the implementation]
+
+## References
+
+- Similar repos to review: [list]
+- Specific files to study: [list]
+- Cloned repos location: .work/design-patterns/<pattern>/repos/
+
+## Data Sources
+
+- Analysis date: <date>
+- Repositories analyzed: <N>
+- GitHub organizations: <orgs>
+- Data files: repos.json, analysis.log
+```
+
+**Save this file and inform the user:**
+```
+✅ Detailed analysis saved to:
+   .work/design-patterns/<pattern>/ANALYSIS.md
+
+📖 View with: cat .work/design-patterns/<pattern>/ANALYSIS.md
+```
+
+## Key Principles
+
+### DO:
+✅ Read ALL the cloned repositories  
+✅ Extract REAL code examples  
+✅ Understand user's SPECIFIC project  
+✅ Provide COMPLETE, working code  
+✅ Explain WHY (backed by statistics)  
+✅ Generate ANALYSIS.md with everything  
+✅ Be specific about file paths in THEIR repo  
+
+### DON'T:
+❌ Use generic templates  
+❌ Make assumptions without data  
+❌ Provide incomplete code snippets  
+❌ Skip exploring the actual repos  
+❌ Forget to create ANALYSIS.md  
+
+## Error Handling
+
+- If <3 repos cloned: Exit with error
+- If pattern not found: Suggest alternatives
+- If user's repo has unusual structure: Adapt recommendations
+
+## Success Criteria
+
+User should get:
+1. ✅ Statistical insights from 50 repos
+2. ✅ Real code examples (not templates)
+3. ✅ Specific recommendations for their project
+4. ✅ Complete implementation in ANALYSIS.md
+5. ✅ Clear next steps
+
+## Example Workflow
+
+```
+User: /openshift:analyze-pattern "/usr/bin/gather"
+
+1. Script searches GitHub (ALL file types):
+   → Fetches Page 1: 100 results
+   → Fetches Page 2: 52 results
+   → Total: 152 code matches
+   → Deduplicates: 0 duplicates
+   → Selects top 27 repos based on quality scores
+
+2. Script clones repos:
+   → Successfully clones 24 repos (3 failures due to permissions)
+   → Saves to .work/design-patterns/usr/bin/gather/repos/
+
+3. YOU (Claude) take over:
+   - Read repos.json (see 27 ranked repos)
+   - Explore must-gather, oadp-operator (similar to user's project)
+   - Find Dockerfiles with /usr/bin/gather
+   - Extract shell script patterns
+   - Understand user is building must-gather-operator
+   - Generate specific guide for their operator
+   - Create ANALYSIS.md with everything
+```
+
+## Output Structure
+
+```
+.work/design-patterns/<pattern>/
+├── repos.json              # Repo metadata (from Python)
+├── analysis.log            # Execution log (from bash)
+├── ANALYSIS.md             # Your comprehensive guide (CREATE THIS!)
+└── repos/                  # Cloned repos (from bash)
+    ├── cluster-network-operator/
+    ├── api/
+    └── ...
+```
+
+## See Also
+
+- Command: `plugins/openshift/commands/analyze-pattern.md`
+- Data script: `plugins/openshift/skills/pattern-analyzer/search_repos.py`
+- Wrapper: `plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh`

--- a/plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh
+++ b/plugins/openshift/skills/pattern-analyzer/analyze_pattern.sh
@@ -1,0 +1,331 @@
+#!/bin/bash
+#
+# Pattern Analyzer - Data Gathering Only
+# Claude AI handles all analysis and synthesis
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Parse arguments
+PATTERN=""
+ORGS="openshift,kubernetes"
+MAX_REPOS=50
+LANGUAGE=""
+REFRESH=false
+SKIP_CLONE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pattern) PATTERN="$2"; shift 2 ;;
+        --orgs) ORGS="$2"; shift 2 ;;
+        --repos) MAX_REPOS="$2"; shift 2 ;;
+        --language) LANGUAGE="$2"; shift 2 ;;
+        --refresh) REFRESH=true; shift ;;
+        --skip-clone) SKIP_CLONE=true; shift ;;
+        *) PATTERN="$1"; shift ;;
+    esac
+done
+
+# Validate
+if [ -z "$PATTERN" ]; then
+    echo "❌ ERROR: Pattern name is required"
+    echo ""
+    echo "Usage: $0 <pattern> [--orgs org1,org2] [--repos N] [--language LANG] [--refresh] [--skip-clone]"
+    echo ""
+    echo "Arguments:"
+    echo "  --orgs        Comma-separated GitHub orgs (default: openshift,kubernetes)"
+    echo "  --repos       Maximum repos to analyze (default: 50)"
+    echo "  --language    Filter by language (e.g., go, python, shell). Default: all languages"
+    echo "  --refresh     Force refresh (ignore cache)"
+    echo "  --skip-clone  Skip cloning, use existing repos"
+    echo ""
+    echo "Examples:"
+    echo "  $0 NetworkPolicy"
+    echo "  $0 ValidatingWebhook --repos 30"
+    echo "  $0 '/usr/bin/gather' --language shell"
+    echo "  $0 ProxyConfig --skip-clone"
+    exit 1
+fi
+
+# Setup
+WORK_DIR=".work/design-patterns/$PATTERN"
+LOG_FILE="$WORK_DIR/analysis.log"
+mkdir -p "$WORK_DIR"
+
+# Start logging
+exec 1> >(tee -a "$LOG_FILE")
+exec 2>&1
+
+echo ""
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo "  📊 PATTERN ANALYZER: $PATTERN"
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Current directory: $(pwd)"
+echo "  Repository: $(basename $(pwd))"
+echo "  Timestamp: $(date '+%Y-%m-%d %H:%M:%S')"
+echo ""
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo ""
+
+# Check cache (using analysis.log as marker)
+CACHE_FLAG="$WORK_DIR/analysis.log"
+if [ -f "$CACHE_FLAG" ] && [ "$REFRESH" = false ]; then
+    FILE_AGE=$(($(date +%s) - $(stat -c %Y "$CACHE_FLAG" 2>/dev/null || stat -f %m "$CACHE_FLAG")))
+    DAYS_OLD=$((FILE_AGE / 86400))
+    
+    if [ $FILE_AGE -lt 604800 ]; then  # 7 days
+        echo "✓ Cached analysis found (age: $DAYS_OLD days)"
+        echo ""
+        echo "📁 Cached data available in: $WORK_DIR/"
+        echo ""
+        echo "Files:"
+        ls -lh "$WORK_DIR"/*.json 2>/dev/null | awk '{print "  •", $9, "-", $5}' || true
+        echo ""
+        echo "Cloned repositories: $(ls -1 $WORK_DIR/repos 2>/dev/null | wc -l) repos"
+        echo ""
+        echo "────────────────────────────────────────────────────────────────────────────────"
+        echo "💡 TIP: Run with --refresh to force re-analysis"
+        echo "────────────────────────────────────────────────────────────────────────────────"
+        echo ""
+        echo "🤖 Claude: Please read the data files above and provide detailed recommendations."
+        echo ""
+        exit 0
+    fi
+    
+    echo "⚠️  Cache expired (>7 days old), running fresh analysis..."
+    echo ""
+fi
+
+# STEP 1: Search GitHub
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo "STEP 1/2: Searching GitHub for '$PATTERN' implementations"
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo ""
+echo "  Organizations: $ORGS"
+echo "  Max repositories: $MAX_REPOS"
+if [ -n "$LANGUAGE" ]; then
+    echo "  Language filter: $LANGUAGE"
+else
+    echo "  Language filter: all languages"
+fi
+echo ""
+
+if [ "$SKIP_CLONE" = true ] && [ -f "$WORK_DIR/repos.json" ]; then
+    echo "⏩ Skipping GitHub search (using cached repos.json)"
+    REPO_COUNT=$(python3 -c "import json; print(json.load(open('$WORK_DIR/repos.json'))['repos_selected'])" 2>/dev/null || echo "0")
+else
+    # Build search command
+    SEARCH_CMD="python3 \"$SCRIPT_DIR/search_repos.py\" --pattern \"$PATTERN\" --orgs \"$ORGS\" --max-repos \"$MAX_REPOS\" --output \"$WORK_DIR/repos.json\""
+    
+    # Add language filter if specified
+    if [ -n "$LANGUAGE" ]; then
+        SEARCH_CMD="$SEARCH_CMD --language \"$LANGUAGE\""
+    fi
+    
+    eval $SEARCH_CMD
+    
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "❌ ERROR: GitHub search failed"
+        echo ""
+        echo "Common issues:"
+        echo "  • Network connectivity"
+        echo "  • GitHub API rate limit (set GITHUB_TOKEN)"
+        echo "  • Invalid pattern name"
+        exit 2
+    fi
+    
+    REPO_COUNT=$(python3 -c "import json; print(json.load(open('$WORK_DIR/repos.json'))['repos_selected'])")
+fi
+
+echo ""
+echo "✅ Found $REPO_COUNT repositories to analyze"
+echo ""
+
+# Show top repos
+echo "Top repositories:"
+python3 -c "
+import json
+with open('$WORK_DIR/repos.json') as f:
+    data = json.load(f)
+for i, repo in enumerate(data['repos'][:5], 1):
+    print(f\"  {i}. {repo['full_name']} (⭐ {repo['stars']})\")
+if len(data['repos']) > 5:
+    print(f\"  ... and {len(data['repos']) - 5} more\")
+"
+echo ""
+
+# STEP 2: Clone Repositories
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo "STEP 2/2: Cloning repositories"
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo ""
+
+if [ "$SKIP_CLONE" = true ]; then
+    echo "⏩ Skipping clone (--skip-clone specified)"
+    echo "   Using existing repositories in $WORK_DIR/repos/"
+    CLONED_COUNT=$(ls -1 "$WORK_DIR/repos" 2>/dev/null | wc -l)
+    echo "   Found: $CLONED_COUNT repos"
+else
+    echo "Cloning repositories (8 parallel workers, shallow clone)..."
+    echo ""
+    
+    python3 -c "
+import json
+import subprocess
+import sys
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
+
+def clone_repo(repo_info):
+    \"\"\"Clone a single repository (designed for parallel execution)\"\"\"
+    idx, total, repo = repo_info
+    repo_name = repo['name']
+    clone_url = repo['clone_url']
+    repo_path = Path('$WORK_DIR/repos') / repo_name
+    
+    # Check if already exists
+    if repo_path.exists():
+        return (idx, total, repo_name, 'cached', None)
+    
+    # Clone the repo
+    try:
+        result = subprocess.run(
+            ['git', 'clone', '--depth', '1', '--filter=blob:none', '--quiet', clone_url, str(repo_path)],
+            capture_output=True,
+            timeout=120
+        )
+        if result.returncode == 0:
+            return (idx, total, repo_name, 'success', None)
+        else:
+            return (idx, total, repo_name, 'error', 'git error')
+    except subprocess.TimeoutExpired:
+        return (idx, total, repo_name, 'error', 'timeout')
+    except Exception as e:
+        return (idx, total, repo_name, 'error', str(e)[:20])
+
+# Load repos
+with open('$WORK_DIR/repos.json') as f:
+    data = json.load(f)
+
+repos_dir = Path('$WORK_DIR/repos')
+repos_dir.mkdir(parents=True, exist_ok=True)
+
+total = len(data['repos'])
+cloned = 0
+skipped = 0
+failed = []
+
+# Prepare repo info with indices
+repo_tasks = [(i+1, total, repo) for i, repo in enumerate(data['repos'])]
+
+# Use ThreadPoolExecutor for parallel cloning (max 8 concurrent clones)
+max_workers = min(8, total)
+print_lock = threading.Lock()
+
+with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    # Submit all clone tasks
+    futures = {executor.submit(clone_repo, task): task for task in repo_tasks}
+    
+    # Process results as they complete
+    for future in as_completed(futures):
+        idx, total, repo_name, status, error = future.result()
+        
+        with print_lock:
+            if status == 'cached':
+                print(f'  [{idx:2d}/{total}] ✓ {repo_name:40s} (already cloned)', flush=True)
+                cloned += 1
+                skipped += 1
+            elif status == 'success':
+                print(f'  [{idx:2d}/{total}] ✓ {repo_name:40s} (cloned)', flush=True)
+                cloned += 1
+            else:
+                print(f'  [{idx:2d}/{total}] ✗ {repo_name:40s} ({error})', flush=True)
+                failed.append(repo_name)
+
+print()
+print(f'Summary:')
+print(f'  • Successfully cloned: {cloned - skipped} new repos')
+print(f'  • Already cached: {skipped} repos')
+print(f'  • Total available: {cloned} repos')
+if failed:
+    print(f'  • Failed: {len(failed)} repos')
+
+if cloned < 3:
+    print()
+    print('❌ ERROR: Too few repos cloned (minimum 3 required)')
+    sys.exit(3)
+"
+    
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "❌ ERROR: Repository cloning failed"
+        exit 3
+    fi
+    
+    CLONED_COUNT=$(ls -1 "$WORK_DIR/repos" 2>/dev/null | wc -l)
+fi
+
+echo ""
+echo "✅ $CLONED_COUNT repositories available for analysis"
+echo ""
+
+# Note: analysis.log is automatically created by the logging redirection at the top
+
+# Summary
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo "  ✅ DATA GATHERING COMPLETE"
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo ""
+echo "📁 Analysis workspace: $WORK_DIR/"
+echo ""
+echo "Generated data:"
+echo "  • repos.json          - $REPO_COUNT repositories metadata (stars, URLs, descriptions)"
+echo "  • repos/              - $CLONED_COUNT cloned repositories ready for analysis"
+echo "  • analysis.log        - This execution log"
+echo ""
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo "🤖 NEXT: Claude AI Analysis"
+echo "────────────────────────────────────────────────────────────────────────────────"
+echo ""
+echo "Claude should now:"
+echo ""
+echo "  1. READ repos.json to see which repositories were found"
+echo ""
+echo "  2. EXPLORE the cloned repos in $WORK_DIR/repos/"
+echo "     • Read actual code (types, controllers, webhooks)"
+echo "     • Find struct definitions for $PATTERN"
+echo "     • Understand implementation approaches"
+echo "     • Extract validation/logic examples"
+echo ""
+echo "  3. ANALYZE your current repository:"
+echo "     • Explore directory structure"
+echo "     • Read go.mod for dependencies"
+echo "     • Find existing patterns (CRDs, controllers, webhooks)"
+echo "     • Understand what your project does"
+echo ""
+echo "  4. GENERATE detailed recommendations:"
+echo "     • Statistical insights (X% of repos use Y)"
+echo "     • Code examples from similar repos"
+echo "     • Specific file paths for YOUR project"
+echo "     • Complete, working implementation code"
+echo "     • Step-by-step integration guide"
+echo ""
+echo "  5. CREATE summary file:"
+echo "     • Save as: $WORK_DIR/ANALYSIS.md"
+echo "     • Include: Statistics, examples, recommendations, code"
+echo ""
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo ""
+echo "🔍 Quick start for Claude:"
+echo ""
+echo "  cat $WORK_DIR/repos.json"
+echo "  ls $WORK_DIR/repos/"
+echo "  # Explore repos, analyze code, generate ANALYSIS.md"
+echo ""
+echo "════════════════════════════════════════════════════════════════════════════════"
+echo ""

--- a/plugins/openshift/skills/pattern-analyzer/search_repos.py
+++ b/plugins/openshift/skills/pattern-analyzer/search_repos.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+Search GitHub for repositories implementing a specific pattern.
+
+This script uses the GitHub Code Search API to find repositories that implement
+a specific design pattern (e.g., NetworkPolicy, ValidatingWebhook).
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.parse
+import urllib.error
+import os
+import time
+from datetime import datetime
+
+
+def search_github(pattern, orgs, language=None, max_results=100):
+    """
+    Search GitHub Code Search API for pattern usage.
+    Paginates through ALL results to get comprehensive repository coverage.
+    
+    Args:
+        pattern: Pattern name to search for (e.g., "NetworkPolicy", "/usr/bin/gather")
+        orgs: List of GitHub organizations to search
+        language: Programming language filter (default: None = all languages)
+                 Set to 'go', 'python', 'shell', etc. to filter by language
+        max_results: Results per page (default: 100, GitHub API max per page)
+    
+    Returns:
+        List of ALL repository objects with metadata (across all pages)
+    """
+    # Construct search query
+    org_query = ' '.join([f'org:{org}' for org in orgs])
+    
+    # Only add language filter if explicitly specified
+    if language:
+        query = f'{pattern} {org_query} language:{language}'
+    else:
+        query = f'{pattern} {org_query}'
+    
+    encoded_query = urllib.parse.quote(query)
+    url = f'https://api.github.com/search/code?q={encoded_query}&per_page={max_results}'
+    
+    # Create request with headers
+    headers = {
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'openshift-pattern-analyzer/1.0'
+    }
+    
+    # Add GitHub token if available (increases rate limit)
+    github_token = os.environ.get('GITHUB_TOKEN')
+    if github_token:
+        headers['Authorization'] = f'token {github_token}'
+    
+    all_items = []
+    page = 1
+    max_pages = 10  # GitHub Code Search API limits to ~1000 results (10 pages * 100)
+    
+    print(f"Fetching code search results (paginated):", file=sys.stderr)
+    
+    while url and page <= max_pages:
+        print(f"  Page {page}...", end=' ', file=sys.stderr, flush=True)
+        
+        req = urllib.request.Request(url, headers=headers)
+        
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                data = json.loads(response.read().decode())
+                items = data.get('items', [])
+                all_items.extend(items)
+                
+                total_count = data.get('total_count', 0)
+                print(f"✓ ({len(items)} results, {len(all_items)}/{total_count} total)", file=sys.stderr)
+                
+                # Parse Link header for next page
+                link_header = response.headers.get('Link', '')
+                next_url = None
+                
+                # Parse Link header: <url>; rel="next", <url>; rel="last"
+                for link in link_header.split(','):
+                    if 'rel="next"' in link:
+                        # Extract URL from <...>
+                        next_url = link.split(';')[0].strip('<> ')
+                        break
+                
+                # No more pages
+                if not next_url:
+                    print(f"  ✓ All pages fetched ({len(all_items)} total results)", file=sys.stderr)
+                    break
+                
+                url = next_url
+                page += 1
+                
+                # Rate limiting between pages (GitHub allows 30 searches/min for authenticated)
+                # Sleep 2 seconds to be safe (allows ~30 requests/min)
+                time.sleep(2)
+                
+        except urllib.error.HTTPError as e:
+            if e.code == 403:
+                error_body = e.read().decode()
+                if 'rate limit' in error_body.lower():
+                    print("\n⚠️  Rate limit hit, waiting 60 seconds...", file=sys.stderr)
+                    time.sleep(60)
+                    # Don't exit, continue with what we have
+                    break
+                else:
+                    print(f"\nERROR: GitHub API returned 403: {error_body}", file=sys.stderr)
+                    if all_items:
+                        print(f"Continuing with {len(all_items)} results collected so far...", file=sys.stderr)
+                        break
+                    sys.exit(2)
+            else:
+                print(f"\nERROR: GitHub API request failed: {e}", file=sys.stderr)
+                if all_items:
+                    print(f"Continuing with {len(all_items)} results collected so far...", file=sys.stderr)
+                    break
+                sys.exit(2)
+        except urllib.error.URLError as e:
+            print(f"\nERROR: Network error: {e}", file=sys.stderr)
+            if all_items:
+                print(f"Continuing with {len(all_items)} results collected so far...", file=sys.stderr)
+                break
+            sys.exit(2)
+        except Exception as e:
+            print(f"\nERROR: Unexpected error: {e}", file=sys.stderr)
+            if all_items:
+                print(f"Continuing with {len(all_items)} results collected so far...", file=sys.stderr)
+                break
+            sys.exit(1)
+    
+    return all_items
+
+
+def get_repo_details(repo_full_name):
+    """
+    Get detailed repository information from GitHub API.
+    
+    Args:
+        repo_full_name: Full repository name (e.g., "openshift/cluster-network-operator")
+    
+    Returns:
+        Repository details dict
+    """
+    url = f'https://api.github.com/repos/{repo_full_name}'
+    
+    headers = {
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'openshift-pattern-analyzer/1.0'
+    }
+    
+    github_token = os.environ.get('GITHUB_TOKEN')
+    if github_token:
+        headers['Authorization'] = f'token {github_token}'
+    
+    req = urllib.request.Request(url, headers=headers)
+    
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return json.loads(response.read().decode())
+    except Exception as e:
+        print(f"WARNING: Failed to get details for {repo_full_name}: {e}", file=sys.stderr)
+        return None
+
+
+def score_repository(repo_details, match_count):
+    """
+    Score repository based on quality signals.
+    
+    Args:
+        repo_details: Repository details from GitHub API
+        match_count: Number of times pattern appears in repo
+    
+    Returns:
+        Quality score (float)
+    """
+    if not repo_details:
+        return 0.0
+    
+    score = 0.0
+    
+    # Stars (popularity/quality signal) - max 5 points
+    stars = repo_details.get('stargazers_count', 0)
+    score += min(stars / 10, 5.0)
+    
+    # Recent activity - max 3 points
+    updated_at = repo_details.get('updated_at', '')
+    if updated_at:
+        try:
+            updated_date = datetime.fromisoformat(updated_at.replace('Z', '+00:00'))
+            days_old = (datetime.now(updated_date.tzinfo) - updated_date).days
+            if days_old < 30:
+                score += 3.0
+            elif days_old < 90:
+                score += 2.0
+            elif days_old < 180:
+                score += 1.0
+        except:
+            pass
+    
+    # OpenShift org (trusted source) - 5 points
+    if repo_details.get('owner', {}).get('login') == 'openshift':
+        score += 5.0
+    
+    # Kubernetes org (trusted source) - 4 points
+    elif repo_details.get('owner', {}).get('login') == 'kubernetes':
+        score += 4.0
+    
+    # Not archived - 2 points
+    if not repo_details.get('archived', False):
+        score += 2.0
+    else:
+        score = 0.0  # Archived repos are not useful
+    
+    # Not a fork (prefer originals) - 1 point
+    if not repo_details.get('fork', False):
+        score += 1.0
+    
+    # Match count relevance - max 3 points
+    score += min(match_count / 5, 3.0)
+    
+    return score
+
+
+def filter_and_rank_repos(search_results, max_repos=7):
+    """
+    Filter and rank repositories by quality.
+    
+    Args:
+        search_results: List of code search results from GitHub
+        max_repos: Maximum number of repos to return
+    
+    Returns:
+        List of top-ranked repositories with metadata
+    """
+    # Deduplicate files first (in case pagination returns duplicates)
+    seen_files = set()
+    unique_results = []
+    
+    for item in search_results:
+        repo = item.get('repository', {})
+        repo_full_name = repo.get('full_name')
+        file_path = item.get('path', '')
+        
+        # Create unique key: repo + file path
+        unique_key = f"{repo_full_name}:{file_path}"
+        
+        if unique_key not in seen_files:
+            seen_files.add(unique_key)
+            unique_results.append(item)
+    
+    if len(unique_results) < len(search_results):
+        print(f"  ℹ️  Removed {len(search_results) - len(unique_results)} duplicate file entries", file=sys.stderr)
+    
+    # Group by repository and count matches
+    repo_matches = {}
+    for item in unique_results:
+        repo = item.get('repository', {})
+        repo_full_name = repo.get('full_name')
+        
+        if not repo_full_name:
+            continue
+        
+        if repo_full_name not in repo_matches:
+            repo_matches[repo_full_name] = {
+                'repo': repo,
+                'match_count': 0
+            }
+        repo_matches[repo_full_name]['match_count'] += 1
+    
+    # Get detailed info and score each repo
+    scored_repos = []
+    for repo_full_name, data in repo_matches.items():
+        print(f"  Analyzing {repo_full_name}...", end=' ', file=sys.stderr)
+        
+        # Get detailed repo info
+        repo_details = get_repo_details(repo_full_name)
+        
+        if not repo_details:
+            print("✗ (failed to fetch)", file=sys.stderr)
+            continue
+        
+        # Calculate score
+        score = score_repository(repo_details, data['match_count'])
+        
+        # Skip archived or very low quality repos
+        if score < 1.0:
+            print(f"✗ (score too low: {score:.1f})", file=sys.stderr)
+            continue
+        
+        print(f"✓ (score: {score:.1f})", file=sys.stderr)
+        
+        scored_repos.append({
+            'name': repo_details['name'],
+            'org': repo_details['owner']['login'],
+            'full_name': repo_full_name,
+            'url': repo_details['html_url'],
+            'clone_url': repo_details['clone_url'],
+            'stars': repo_details['stargazers_count'],
+            'last_updated': repo_details['updated_at'],
+            'language': repo_details.get('language', 'Unknown'),
+            'archived': repo_details.get('archived', False),
+            'fork': repo_details.get('fork', False),
+            'description': repo_details.get('description', ''),
+            'match_count': data['match_count'],
+            'relevance_score': round(score, 2)
+        })
+    
+    # Sort by score descending
+    scored_repos.sort(key=lambda x: x['relevance_score'], reverse=True)
+    
+    # Return top N
+    return scored_repos[:max_repos]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Search GitHub for repositories implementing a design pattern'
+    )
+    parser.add_argument('--pattern', required=True, help='Pattern name (e.g., NetworkPolicy, /usr/bin/gather)')
+    parser.add_argument('--orgs', required=True, help='Comma-separated list of GitHub orgs')
+    parser.add_argument('--max-repos', type=int, default=50, help='Maximum repos to return (default: 50)')
+    parser.add_argument('--language', help='Filter by language (e.g., go, python, shell). Default: search all languages')
+    parser.add_argument('--output', required=True, help='Output JSON file path')
+    
+    args = parser.parse_args()
+    
+    # Parse orgs
+    orgs = [org.strip() for org in args.orgs.split(',')]
+    
+    # Validate
+    if not args.pattern:
+        print("ERROR: Pattern name is required", file=sys.stderr)
+        sys.exit(1)
+    
+    if args.max_repos < 3 or args.max_repos > 50:
+        print("ERROR: --max-repos must be between 3 and 50", file=sys.stderr)
+        sys.exit(1)
+    
+    language_msg = f" (language: {args.language})" if args.language else " (all languages)"
+    print(f"Searching GitHub for '{args.pattern}' in {', '.join(orgs)}{language_msg}...", file=sys.stderr)
+    print("", file=sys.stderr)
+    
+    # Search GitHub (with pagination to get ALL results)
+    search_results = search_github(args.pattern, orgs, language=args.language)
+    
+    if not search_results:
+        print(f"\nERROR: No repositories found implementing '{args.pattern}'", file=sys.stderr)
+        print("Suggestions:", file=sys.stderr)
+        print("- Check pattern name spelling", file=sys.stderr)
+        print("- Try related patterns", file=sys.stderr)
+        print("- Add more orgs with --orgs flag", file=sys.stderr)
+        sys.exit(2)
+    
+    print(f"\n✓ Found {len(search_results)} code matches across all pages", file=sys.stderr)
+    print(f"\nFiltering and ranking repositories...", file=sys.stderr)
+    
+    # Filter and rank
+    top_repos = filter_and_rank_repos(search_results, args.max_repos)
+    
+    if not top_repos:
+        print(f"ERROR: No quality repositories found", file=sys.stderr)
+        sys.exit(2)
+    
+    print(f"\n✓ Selected top {len(top_repos)} repositories:\n", file=sys.stderr)
+    for i, repo in enumerate(top_repos, 1):
+        print(f"  {i}. {repo['full_name']} (⭐ {repo['stars']}, score: {repo['relevance_score']})", file=sys.stderr)
+    
+    # Prepare output
+    output = {
+        'pattern': args.pattern,
+        'search_date': datetime.now().isoformat(),
+        'orgs': orgs,
+        'repos_found': len(search_results),
+        'repos_selected': len(top_repos),
+        'repos': top_repos
+    }
+    
+    # Write to file
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with open(args.output, 'w') as f:
+        json.dump(output, f, indent=2)
+    
+    print(f"\n✓ Results saved to {args.output}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This PR focuses on adding /openshift:analyze-pattern command which helps developers learn design pattern (NetworkPolicy, ValidatingWebhook, etc.)  by searching GitHub (Openshift org, or any org user providers) for real-world implementations, cloning repos, and using Claude AI to generate context-specific recommendations.

This would reduce the time of manually searching the implementation over Github and trying to understand some new code-base, figuring out how to implement the same in your repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /openshift:analyze-pattern command and Pattern Analyzer capability to analyze design-pattern implementations across OpenShift/Kubernetes repos with flags for pattern, orgs, repos, language, refresh, and skip.
  * New CLI workspace flow to locate candidate repos, cache results, clone repos in parallel, and produce artifacts for AI-driven analysis.

* **Documentation**
  * Added comprehensive user docs, examples, usage notes, outputs, prerequisites, and next-step guidance for running pattern analyses.
* **Other**
  * Reordered Openshift plugin commands to include the new command before an existing entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->