### PR TITLE
Add k8s-bumpup plugin with smart version detection and multi-module support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -133,6 +133,11 @@
       "name": "workspaces",
       "source": "./plugins/workspaces",
       "description": "Manage isolated git worktree workspaces for multi-repo development"
+    },
+    {
+      "name": "k8s-bumpup",
+      "source": "./plugins/k8s-bumpup",
+      "description": "Automate Kubernetes version bumping and dependency updates across repositories"
     }
   ]
 }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -15,6 +15,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Hello World](#hello-world-plugin)
 - [Jira](#jira-plugin)
 - [Lvms](#lvms-plugin)
+- [K8S Bumpup](#k8s-bumpup-plugin)
 - [Must Gather](#must-gather-plugin)
 - [Node](#node-plugin)
 - [Node Tuning](#node-tuning-plugin)
@@ -175,6 +176,16 @@ LVMS (Logical Volume Manager Storage) plugin for troubleshooting and debugging s
 - **`/lvms:analyze` `[must-gather-path|--live] [--component storage|operator|volumes]`** - Comprehensive LVMS troubleshooting - analyzes LVMCluster, volume groups, PVCs, and storage issues on live clusters or must-gather
 
 See [plugins/lvms/README.md](plugins/lvms/README.md) for detailed documentation.
+
+### K8S Bumpup Plugin
+
+Automate Kubernetes version bumping and dependency updates across repositories
+
+**Commands:**
+- **`/k8s-bumpup:batch-by-group` `<group-name> [--workspace-dir] [--create-pr] [--create-jira]`** - Rebase Kubernetes dependencies across a group of related repositories
+- **`/k8s-bumpup:rebase-repo` `<target-version> <repository-path> [additional-repos...]`** - Complete workflow to rebase Kubernetes dependencies across repositories
+
+See [plugins/k8s-bumpup/README.md](plugins/k8s-bumpup/README.md) for detailed documentation.
 
 ### Must Gather Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1032,6 +1032,34 @@
       "name": "workspaces",
       "skills": [],
       "version": "1.0.0"
+    },
+    {
+      "commands": [
+        {
+          "argument_hint": "<group-name> [--workspace-dir] [--create-pr] [--create-jira]",
+          "description": "Rebase Kubernetes dependencies across a group of related repositories",
+          "name": "batch-by-group",
+          "synopsis": "/k8s-bumpup:batch-by-group <group-name> [options]"
+        },
+        {
+          "argument_hint": "<target-version> <repository-path> [additional-repos...]",
+          "description": "Complete workflow to rebase Kubernetes dependencies across repositories",
+          "name": "rebase-repo",
+          "synopsis": "/k8s-bumpup:rebase-repo <target-version> <repository-path> [additional-repos...]"
+        }
+      ],
+      "description": "Automate Kubernetes version bumping and dependency updates across repositories",
+      "has_readme": true,
+      "hooks": [],
+      "name": "k8s-bumpup",
+      "skills": [
+        {
+          "description": "Deep analysis of Kubernetes API usage and breaking changes between versions",
+          "id": "dependency-analysis",
+          "name": "Kubernetes Dependency Analysis"
+        }
+      ],
+      "version": "0.0.1"
     }
   ]
 }

--- a/plugins/k8s-bumpup/.claude-plugin/plugin.json
+++ b/plugins/k8s-bumpup/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "k8s-bumpup",
+  "description": "Automate Kubernetes version bumping and dependency updates across repositories",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/k8s-bumpup/.claude-plugin/repo-groups.json
+++ b/plugins/k8s-bumpup/.claude-plugin/repo-groups.json
@@ -1,0 +1,88 @@
+{
+  "groups": {
+    "corenet": {
+      "description": "Core networking OpenShift repositories",
+      "repos": [
+        {
+          "name": "multus-cni",
+          "url": "git@github.com:k8snetworkplumbingwg/multus-cni.git"
+        },
+        {
+          "name": "multi-networkpolicy-iptables",
+          "url": "git@github.com:k8snetworkplumbingwg/multi-networkpolicy-iptables.git"
+        },
+        {
+          "name": "ovn-kubernetes",
+          "url": "git@github.com:ovn-kubernetes/ovn-kubernetes.git"
+        },
+        {
+          "name": "cluster-network-operator",
+          "url": "git@github.com:openshift/cluster-network-operator.git"
+        },
+        {
+          "name": "cloud-network-config-controller",
+          "url": "git@github.com:openshift/cloud-network-config-controller.git"
+        },
+        {
+          "name": "whereabouts",
+          "url": "git@github.com:k8snetworkplumbingwg/whereabouts.git"
+        },
+        {
+          "name": "net-attach-def-admission-controller",
+          "url": "git@github.com:k8snetworkplumbingwg/net-attach-def-admission-controller.git"
+        },
+        {
+          "name": "network-metrics-daemon",
+          "url": "git@github.com:openshift/network-metrics-daemon.git"
+        }
+      ]
+    },
+    "storage": {
+      "description": "Storage-related OpenShift repositories",
+      "repos": [
+        {
+          "name": "local-storage-operator",
+          "url": "git@github.com:openshift/local-storage-operator.git"
+        },
+        {
+          "name": "csi-driver-manila-operator",
+          "url": "git@github.com:openshift/csi-driver-manila-operator.git"
+        },
+        {
+          "name": "cluster-storage-operator",
+          "url": "git@github.com:openshift/cluster-storage-operator.git"
+        }
+      ]
+    },
+    "operators": {
+      "description": "Core operator repositories",
+      "repos": [
+        {
+          "name": "cluster-etcd-operator",
+          "url": "git@github.com:openshift/cluster-etcd-operator.git"
+        },
+        {
+          "name": "cluster-kube-apiserver-operator",
+          "url": "git@github.com:openshift/cluster-kube-apiserver-operator.git"
+        },
+        {
+          "name": "cluster-kube-controller-manager-operator",
+          "url": "git@github.com:openshift/cluster-kube-controller-manager-operator.git"
+        }
+      ]
+    },
+    "monitoring": {
+      "description": "Monitoring and observability repositories",
+      "repos": [
+        {
+          "name": "cluster-monitoring-operator",
+          "url": "git@github.com:openshift/cluster-monitoring-operator.git"
+        },
+        {
+          "name": "prometheus-operator",
+          "url": "git@github.com:openshift/prometheus-operator.git"
+        }
+      ]
+    }
+  }
+}

--- a/plugins/k8s-bumpup/README.md
+++ b/plugins/k8s-bumpup/README.md
@@ -1,0 +1,425 @@
+# k8s-bumpup Plugin
+
+Automate Kubernetes version rebasing and dependency updates across Go repositories.
+
+## Overview
+
+The `k8s-bumpup` plugin provides commands to safely update Kubernetes dependencies in Go projects that use `k8s.io/*` libraries. It handles the complete workflow from analyzing breaking changes to updating dependencies, running tests, and creating commits.
+
+## Features
+
+- **Dependency Auditing**: Analyze breaking changes between Kubernetes versions
+- **Automated Updates**: Update all k8s.io dependencies to target version
+- **Conflict Detection**: Identify deprecated and removed APIs in your codebase
+- **Test Validation**: Run builds and tests to verify updates
+- **Multi-Repository Support**: Process multiple repositories in a single workflow
+- **Changelog Generation**: Create detailed commit messages documenting changes
+
+## Commands
+
+### `/k8s-bumpup:batch-by-group`
+
+**NEW** Rebase Kubernetes dependencies across a group of related repositories.
+
+```
+/k8s-bumpup:batch-by-group <group-name> [options]
+```
+
+**Example:**
+```
+/k8s-bumpup:batch-by-group corenet
+```
+
+Automatically fetches and uses the latest Kubernetes release. No version specification needed!
+
+**What it does:**
+1. Loads repository group configuration (network, storage, operators, etc.)
+2. Clones fresh copies of all repos in the group
+3. Runs audit analysis for each repository
+4. Presents consolidated audit summary
+5. Creates feature branches in each repo
+6. Updates dependencies, builds, and tests each repo
+7. Commits changes with detailed messages
+8. Generates comprehensive group-wide summary
+9. Offers to push branches and create PRs
+
+**Available Groups:**
+- `corenet` - Core networking components (multus-cni, ovn-kubernetes, cluster-network-operator)
+- `storage` - Storage operators and CSI drivers
+- `operators` - Core cluster operators
+- `monitoring` - Monitoring and observability
+
+**Output:**
+- Cloned repositories: `.work/k8s-batch-by-group/${GROUP}/${TIMESTAMP}/repos/`
+- Group summary: `.work/k8s-batch-by-group/${GROUP}/${TIMESTAMP}/rebase-summary.md`
+- Individual audit reports and logs
+
+---
+
+### `/k8s-bumpup:rebase-repo`
+
+Complete workflow to rebase Kubernetes dependencies across one or more repositories.
+
+```
+/k8s-bumpup:rebase-repo <target-version> <repository-path> [additional-repos...]
+```
+
+**Example:**
+```
+/k8s-bumpup:rebase-repo v1.29.0 ./my-operator ./my-controller
+```
+
+**What it does:**
+1. Runs audit analysis for all repositories
+2. Presents consolidated audit summary
+3. Requests user confirmation
+4. Creates feature branches
+5. Updates dependencies
+6. Runs builds and tests
+7. Commits changes with detailed messages
+8. Generates comprehensive summary report
+9. Offers to push branches and create PRs
+
+**Output:**
+- Feature branches with commits
+- Comprehensive summary: `.work/k8s-bumpup/${TIMESTAMP}/rebase-summary.md`
+- Build/test logs for each repository
+- Individual audit reports
+
+## Typical Workflows
+
+### Workflow 1: Group Rebase (Recommended for Related Repos)
+
+Rebase multiple related repositories together:
+
+```
+/k8s-bumpup:batch-by-group corenet v0.34.2
+```
+
+This will:
+1. Clone fresh copies of all corenet repos (multus-cni, ovn-kubernetes, sdn, cluster-network-operator)
+2. Audit each repository for breaking changes
+3. Show consolidated risk assessment
+4. Request your confirmation
+5. Rebase each repo sequentially
+6. Generate group-wide summary with all results
+7. Offer to push branches and create PRs
+
+**Advantages:**
+- Consistent versioning across related components
+- Coordinated testing and deployment
+- Single comprehensive summary
+- Automatic PR cross-referencing
+- Isolated workspace (doesn't modify existing clones)
+
+### Workflow 2: Single Repository Update
+
+Use the rebase-repo command for a single repository:
+
+```
+/k8s-bumpup:rebase-repo v1.29.0 ./my-repo
+```
+
+This will:
+1. Audit the repository for breaking changes
+2. Show audit summary and ask for confirmation
+3. Update dependencies to target version
+4. Build and test the project
+5. Create a feature branch with committed changes
+6. Generate summary report
+
+### Workflow 3: Multiple Repositories
+
+Use the all-in-one command for handling multiple related repositories:
+
+```
+/k8s-bumpup:rebase-repo v1.29.0 ./operator ./controller ./webhook
+```
+
+This will:
+- Audit all repositories
+- Show combined impact analysis
+- Request confirmation
+- Process each repository
+- Create branches and commits
+- Generate summary report
+
+### Workflow 4: Incremental Major Version Update
+
+When crossing multiple Kubernetes minor versions (e.g., v1.27 → v1.30), consider incremental updates:
+
+```
+/k8s-bumpup:rebase-repo v1.28.0 ./my-app
+# Test thoroughly
+/k8s-bumpup:rebase-repo v1.29.0 ./my-app
+# Test thoroughly
+/k8s-bumpup:rebase-repo v1.30.0 ./my-app
+```
+
+## Understanding Audit Reports
+
+Audit reports include:
+
+### Risk Levels
+
+- **LOW**: Patch version updates, no breaking changes detected
+- **MEDIUM**: Minor version update with deprecation warnings
+- **HIGH**: API removals, significant breaking changes, or multi-version jump
+
+### Common Breaking Changes
+
+| Kubernetes Version | Common Breaking Changes |
+|-------------------|-------------------------|
+| v1.22 | Removed beta Ingress, RBAC, webhook APIs |
+| v1.25 | Removed PodSecurityPolicy, beta CronJob |
+| v1.26 | Removed beta HorizontalPodAutoscaler v2beta2 |
+| v1.29 | Removed flowcontrol v1beta2, v1beta3 |
+
+### Action Items
+
+Audit reports categorize findings as:
+- **Immediate Actions**: Must fix before update
+- **Suggested Before Update**: Deprecations to address
+- **Post-Update Validation**: Things to test after update
+
+## Prerequisites
+
+### Required Tools
+
+- **Go** (1.20+): `go version`
+- **Git**: `git --version`
+- **jq** (for audit): `jq --version`
+- **curl/wget** (for fetching changelogs)
+
+### Optional Tools
+
+- **gh CLI** (for creating PRs): `gh --version`
+
+### Repository Requirements
+
+- Valid Go module with `go.mod`
+- Git repository
+- Clean working directory (or user accepts proceeding with uncommitted changes)
+
+## Configuration
+
+The plugin uses these conventions:
+
+### Working Directory
+
+All artifacts are saved to `.work/k8s-bumpup/`:
+```
+.work/
+└── k8s-bumpup/
+    ├── audit/
+    │   └── ${TIMESTAMP}/
+    │       ├── audit-report.md
+    │       ├── api-imports.txt
+    │       └── breaking-changes.txt
+    └── ${TIMESTAMP}/
+        ├── logs/
+        │   ├── repo1-build.log
+        │   └── repo1-test.log
+        ├── reports/
+        │   └── repo1-audit.md
+        └── rebase-summary.md
+```
+
+### Branch Naming
+
+Feature branches are automatically named:
+```
+rebase/k8s-v${TARGET_VERSION}-${DATE}
+```
+
+Example: `rebase/k8s-v1.29.0-20250126`
+
+### Commit Messages
+
+Generated commit messages follow this format:
+```
+Rebase Kubernetes dependencies to v1.29.0
+
+Updated modules:
+- k8s.io/api: v1.28.0 → v1.29.0
+- k8s.io/apimachinery: v1.28.0 → v1.29.0
+- k8s.io/client-go: v1.28.0 → v1.29.0
+
+Build: ✓ PASS
+Tests: ✓ PASS (120 tests)
+```
+
+## Error Handling
+
+### Build Failures
+
+If build fails after update:
+1. Review build log in `.work/k8s-bumpup/logs/`
+2. Check audit report for known API changes
+3. Fix compilation errors
+4. Re-run build: `go build ./...`
+
+### Test Failures
+
+If tests fail:
+1. Review test output
+2. Identify if failures are k8s API-related
+3. Update test code for new APIs
+4. Re-run: `go test ./...`
+
+### Network Issues
+
+If changelog fetching fails:
+- Check internet connectivity
+- Verify GitHub API access
+- Manually review changelogs at:
+  `https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.XX.md`
+
+## Troubleshooting
+
+### "Version not found" error
+
+```
+Error: Target version v1.99.0 not found for k8s.io modules
+```
+
+**Solution**: Check available versions:
+```bash
+go list -m -versions k8s.io/api
+```
+
+### "Dependency conflict" error
+
+```
+Error: Conflicting versions of k8s.io/apimachinery
+```
+
+**Solution**: Ensure all k8s.io modules use same version:
+```bash
+go get k8s.io/api@v1.29.0 \
+      k8s.io/apimachinery@v1.29.0 \
+      k8s.io/client-go@v1.29.0
+```
+
+### Vendor directory out of sync
+
+```
+Error: vendor/ directory out of sync
+```
+
+**Solution**:
+```bash
+rm -rf vendor/
+go mod vendor
+```
+
+## Best Practices
+
+1. **Review audit reports**: Both workflow commands include audit analysis - review it before proceeding
+2. **Test incrementally**: For multi-version jumps, update incrementally
+3. **Keep vendor/ in sync**: If using vendoring, always run `go mod vendor`
+4. **Use feature branches**: The plugin creates branches automatically
+5. **Review before pushing**: Check commits before pushing to remote
+6. **Run full test suite**: Don't rely on partial test results
+
+## Examples
+
+### Example 1: Group rebase for corenet components
+
+```bash
+# Rebase all corenet repos to v0.34.2
+/k8s-bumpup:batch-by-group corenet v0.34.2
+
+# Review the consolidated summary
+cat .work/k8s-batch-by-group/corenet/*/rebase-summary.md
+
+# Push all successful branches to your fork
+# Note: Replace <fork-remote> with your actual fork remote name
+cd .work/k8s-batch-by-group/corenet/*/repos/multus-cni && git push <fork-remote> rebase/k8s-v0.34.2-*
+cd .work/k8s-batch-by-group/corenet/*/repos/ovn-kubernetes && git push <fork-remote> rebase/k8s-v0.34.2-*
+
+# Create PRs with cross-references
+cd .work/k8s-batch-by-group/corenet/*/repos/multus-cni && gh pr create --draft
+cd .work/k8s-batch-by-group/corenet/*/repos/ovn-kubernetes && gh pr create --draft
+```
+
+### Example 2: Update single operator to latest Kubernetes
+
+```bash
+# First, check what version you're on
+grep "k8s.io/api" go.mod
+
+# Run the rebase workflow
+/k8s-bumpup:rebase-repo v1.29.3 ./my-operator
+
+# Review the summary report
+cat .work/k8s-bumpup/*/rebase-summary.md
+
+# Push the feature branch to your fork
+# Note: Replace <fork-remote> with your actual fork remote name
+git push <fork-remote> rebase/k8s-v1.29.3-*
+```
+
+### Example 3: Batch update multiple repositories
+
+```bash
+# Update three related repositories
+/k8s-bumpup:rebase-repo v1.30.0 \
+  ~/projects/my-operator \
+  ~/projects/my-controller \
+  ~/projects/my-webhook
+
+# Review the summary
+cat .work/k8s-bumpup/*/rebase-summary.md
+
+# Push all branches to your fork
+# Note: Replace <fork-remote> with your actual fork remote name
+cd ~/projects/my-operator && git push <fork-remote> rebase/k8s-v1.30.0-*
+cd ~/projects/my-controller && git push <fork-remote> rebase/k8s-v1.30.0-*
+cd ~/projects/my-webhook && git push <fork-remote> rebase/k8s-v1.30.0-*
+```
+
+### Example 4: Incremental update across major versions
+
+```bash
+# Update from v1.26 → v1.30 incrementally
+/k8s-bumpup:rebase-repo v1.27.0 ./my-app
+# Test, fix issues, merge
+
+/k8s-bumpup:rebase-repo v1.28.0 ./my-app
+# Test, fix issues, merge
+
+/k8s-bumpup:rebase-repo v1.29.0 ./my-app
+# Test, fix issues, merge
+
+/k8s-bumpup:rebase-repo v1.30.0 ./my-app
+# Test, fix issues, merge
+```
+
+## Related Resources
+
+- [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+- [Kubernetes API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)
+- [client-go Compatibility Matrix](https://github.com/kubernetes/client-go#compatibility-matrix)
+- [Go Modules Documentation](https://go.dev/ref/mod)
+
+## Contributing
+
+This plugin is part of the [ai-helpers](https://github.com/openshift-eng/ai-helpers) repository.
+
+To contribute:
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run `make lint` to validate
+5. Submit a pull request
+
+## Support
+
+For issues and questions:
+- GitHub Issues: https://github.com/openshift-eng/ai-helpers/issues
+- Plugin Documentation: This README
+
+## License
+
+See the main [ai-helpers repository](https://github.com/openshift-eng/ai-helpers) for license information.

--- a/plugins/k8s-bumpup/commands/batch-by-group.md
+++ b/plugins/k8s-bumpup/commands/batch-by-group.md
@@ -1,0 +1,1037 @@
+---
+description: Rebase Kubernetes dependencies across a group of related repositories
+argument-hint: <group-name> [--workspace-dir] [--create-pr] [--create-jira]
+---
+
+## Name
+k8s-bumpup:batch-by-group
+
+## Synopsis
+```
+/k8s-bumpup:batch-by-group <group-name> [options]
+```
+
+## Description
+The `k8s-bumpup:batch-by-group` command automates Kubernetes dependency rebasing across multiple related repositories defined in a group. It clones the latest code from each repository, runs the rebase workflow, and generates a comprehensive summary across all repos.
+
+This command **automatically fetches and uses the latest stable Kubernetes release** from GitHub. No version specification is needed.
+
+This is ideal for coordinated upgrades across related components (e.g., all corenet repos, all storage repos). Optionally creates PRs for each repository and a single JIRA issue tracking the entire group upgrade.
+
+## Arguments
+- `$1` (group-name): Repository group name (e.g., `network`, `storage`, `operators`) - **Required**
+
+## Options
+- `--workspace-dir <path>`: Custom workspace directory for cloned repos. Defaults to `.work/k8s-rebase-group/${GROUP_NAME}/${TIMESTAMP}`
+- `--create-pr`: Automatically fork repositories (if not already forked), push branches to your fork, and create pull requests
+- `--create-jira`: Create a single JIRA issue tracking the entire group upgrade (includes links to all PRs)
+- `--dry-run`: Perform audit and validation without making any changes or creating branches
+- `--skip-tests`: Skip running tests (faster, but less safe)
+
+## Implementation
+
+### Step 1: Parse Arguments and Load Group Configuration
+1. **Parse command arguments**:
+   - Extract group name (required)
+   - Determine workspace directory from --workspace-dir flag or use default
+
+2. **Fetch and sync Kubernetes version with client library version**:
+   ```bash
+   echo "Fetching latest Kubernetes release..."
+
+   # Fetch latest stable release from GitHub API
+   LATEST_K8S_VERSION=$(curl -s https://api.github.com/repos/kubernetes/kubernetes/releases/latest | \
+     jq -r '.tag_name')
+
+   if [ -z "$LATEST_K8S_VERSION" ] || [ "$LATEST_K8S_VERSION" = "null" ]; then
+     echo "Error: Failed to fetch latest Kubernetes release from GitHub API"
+     exit 1
+   fi
+
+   echo "Latest Kubernetes release: $LATEST_K8S_VERSION"
+
+   # Extract minor version (v1.34.3 -> 34)
+   MINOR_VERSION=$(echo "$LATEST_K8S_VERSION" | sed 's/^v1\.\([0-9]*\)\..*/\1/')
+
+   # Query available k8s.io/api versions and find latest stable v0.{minor}.x
+   echo "Querying available k8s.io/api versions..."
+   TARGET_VERSION=$(go list -m -versions -json k8s.io/api 2>/dev/null | \
+     jq -r '.Versions[]' | \
+     grep "^v0\.${MINOR_VERSION}\." | \
+     grep -v -E '(alpha|beta|rc)' | \
+     sort -V | \
+     tail -1)
+
+   if [ -z "$TARGET_VERSION" ]; then
+     echo "Error: Could not find stable v0.${MINOR_VERSION}.x release for k8s.io/api"
+     exit 1
+   fi
+
+   echo "Latest stable client library: $TARGET_VERSION"
+
+   # Extract patch version from client library (v0.34.2 -> 2)
+   CLIENT_PATCH=$(echo "$TARGET_VERSION" | sed 's/^v0\.[0-9]*\.\([0-9]*\)/\1/')
+
+   # Construct matching Kubernetes version (v1.34.2 to match v0.34.2)
+   MATCHED_K8S_VERSION="v1.${MINOR_VERSION}.${CLIENT_PATCH}"
+
+   # Check if versions are in sync
+   if [ "$LATEST_K8S_VERSION" != "$MATCHED_K8S_VERSION" ]; then
+     echo ""
+     echo "⚠ Version mismatch detected:"
+     echo "  Latest Kubernetes: $LATEST_K8S_VERSION"
+     echo "  Latest client lib: $TARGET_VERSION"
+     echo ""
+     echo "Syncing to matching pair: $MATCHED_K8S_VERSION ↔ $TARGET_VERSION"
+     KUBERNETES_VERSION="$MATCHED_K8S_VERSION"
+   else
+     echo "✓ Versions in sync: $LATEST_K8S_VERSION ↔ $TARGET_VERSION"
+     KUBERNETES_VERSION="$LATEST_K8S_VERSION"
+   fi
+   ```
+
+3. **Load repository group configuration**:
+   ```bash
+   CONFIG_FILE="plugins/k8s-bumpup/.claude-plugin/repo-groups.json"
+   ```
+   - Read JSON configuration file
+   - Extract repository list for specified group
+   - Validate group exists
+
+4. **Display group information**:
+   ```
+   Repository Group: corenet
+   Description: Core networking OpenShift repositories
+   Repositories (4):
+   1. multus-cni (https://github.com/openshift/multus-cni.git)
+   2. ovn-kubernetes (https://github.com/openshift/ovn-kubernetes.git)
+   3. sdn (https://github.com/openshift/sdn.git)
+   4. cluster-network-operator (https://github.com/openshift/cluster-network-operator.git)
+
+   Target Versions (synced):
+   - Kubernetes: v1.34.2
+   - Client Libraries: v0.34.2
+
+   Note: Latest K8s release is v1.34.3, but using v1.34.2 to match available client libraries
+   ```
+
+5. **Request user confirmation**:
+   - Ask: "Proceed with group rebase? This will clone and rebase all repositories. [yes/no]"
+   - If "no", exit gracefully
+   - If "yes", continue
+
+### Step 2: Setup Workspace
+1. **Create workspace directory**:
+   ```bash
+   WORKSPACE_DIR=".work/k8s-batch-by-group/${GROUP_NAME}/$(date +%Y%m%d-%H%M%S)"
+   mkdir -p "${WORKSPACE_DIR}"/{repos,logs,reports}
+   ```
+
+2. **Create tracking file**:
+   ```bash
+   cat > "${WORKSPACE_DIR}/rebase-status.json" <<EOF
+   {
+     "group": "${GROUP_NAME}",
+     "target_version": "${TARGET_VERSION}",
+     "started_at": "$(date -Iseconds)",
+     "repos": []
+   }
+   EOF
+   ```
+
+3. **Log workspace location**:
+   ```
+   Workspace: .work/k8s-batch-by-group/corenet/20251126-080000
+   ```
+
+### Step 3: Clone Repositories
+For each repository in the group:
+
+1. **Auto-detect default branch**:
+   ```bash
+   REPO_NAME="multus-cni"
+   REPO_URL="git@github.com:k8snetworkplumbingwg/multus-cni.git"
+   REPO_DIR="${WORKSPACE_DIR}/repos/${REPO_NAME}"
+
+   # Auto-detect default branch instead of hardcoding
+   DEFAULT_BRANCH=$(git ls-remote --symref "${REPO_URL}" HEAD | \
+     awk '/^ref:/ {sub("refs/heads/", "", $2); print $2}')
+
+   echo "Detected default branch: ${DEFAULT_BRANCH}"
+   ```
+
+2. **Clone repository**:
+   ```bash
+   git clone --depth 1 --branch "${DEFAULT_BRANCH}" "${REPO_URL}" "${REPO_DIR}" \
+     2>&1 | tee "${WORKSPACE_DIR}/logs/${REPO_NAME}-clone.log"
+   ```
+
+   **Fallback strategy**: If clone fails, try common branch names:
+   - Try `main`
+   - Try `master`
+   - Mark as SKIPPED if all fail
+
+3. **Verify repository structure**:
+   - Check `go.mod` exists (may be in subdirectory like `go-controller/`)
+   - Check if k8s.io dependencies exist
+   - Extract current k8s version
+
+4. **Handle special cases**:
+   - **Already up-to-date**: If current version == target version, mark as SKIPPED (up-to-date)
+   - **No go.mod**: Search subdirectories for go.mod (e.g., ovn-kubernetes/go-controller/)
+   - **No k8s deps**: Mark repo as SKIPPED (no k8s dependencies)
+
+5. **Track progress**:
+   ```
+   [1/8] ✓ Cloned multus-cni (default branch: master)
+   [2/8] ✓ Cloned ovn-kubernetes (default branch: master, go.mod in: go-controller/)
+   [3/8] ⚠ Skipped sdn (no k8s dependencies)
+   [4/8] ℹ️ Skipped net-attach-def-admission-controller (already v0.34.2)
+   [5/8] ✓ Cloned cluster-network-operator (default branch: master)
+   ```
+
+### Step 4: Run Audit Phase (Parallel)
+For each successfully cloned repository:
+
+1. **Run audit in parallel** (if resources allow):
+   ```bash
+   # For each repo, run audit analysis
+   # - Scan for k8s.io API usage
+   # - Fetch Kubernetes changelogs
+   # - Identify breaking changes
+   ```
+
+2. **Save individual audit reports**:
+   - Location: `${WORKSPACE_DIR}/reports/${REPO_NAME}-audit.md`
+
+3. **Aggregate audit results**:
+   - Combine risk assessments
+   - Identify common breaking changes across repos
+   - Calculate overall risk level (highest risk among all repos)
+
+4. **Present aggregate audit summary**:
+   ```
+   # Group Audit Summary
+
+   ## Repositories
+   | Repository | Current | Target | Risk | Status |
+   |------------|---------|--------|------|--------|
+   | multus-cni | v0.34.1 | v0.34.2 | LOW | ✓ Ready |
+   | ovn-kubernetes | v0.33.0 | v0.34.2 | HIGH | ⚠ Review needed |
+   | cluster-network-operator | v0.34.0 | v0.34.2 | LOW | ✓ Ready |
+
+   ## Common Breaking Changes
+   - None identified (patch version upgrade for most repos)
+
+   ## High-Risk Repositories
+   1. ovn-kubernetes: Crossing minor version (v0.33.0 → v0.34.2)
+      - Review breaking changes in v0.34.x
+      - Test thoroughly after upgrade
+
+   ## Recommendations
+   - Proceed with caution for ovn-kubernetes
+   - Other repos are low-risk patch upgrades
+   ```
+
+5. **Request confirmation to proceed**:
+   - Ask: "Proceed with rebase? [yes/no/review]"
+   - If "review", open detailed audit reports
+   - If "no", exit (repos remain cloned for manual inspection)
+   - If "yes", continue to Step 5
+
+### Step 5: Execute Rebase (Sequential)
+Process each repository sequentially:
+
+1. **Create feature branch**:
+   ```bash
+   cd "${REPO_DIR}"
+   BRANCH_NAME="rebase/k8s-${TARGET_VERSION}-$(date +%Y%m%d)"
+   git checkout -b "${BRANCH_NAME}"
+   ```
+
+2. **Find all go.mod files** (some repos have multiple):
+   ```bash
+   # Find all go.mod files (excluding vendor)
+   GO_MOD_FILES=$(find . -name "go.mod" -type f | grep -v vendor)
+
+   # Examples:
+   # - Most repos: ./go.mod
+   # - ovn-kubernetes: ./go-controller/go.mod, ./test/e2e/go.mod, ./test/conformance/go.mod
+   ```
+
+3. **Update dependencies in ALL go.mod files**:
+   ```bash
+   for GO_MOD_DIR in $(dirname "$GO_MOD_FILES"); do
+     cd "${REPO_DIR}/${GO_MOD_DIR}"
+
+     echo "Updating ${GO_MOD_DIR}/go.mod..."
+
+     # Update both v1.x and v0.x versioned dependencies
+     go get k8s.io/kubernetes@${KUBERNETES_VERSION} \      # v1.34.3
+           k8s.io/api@${TARGET_VERSION} \                  # v0.34.3
+           k8s.io/apimachinery@${TARGET_VERSION} \
+           k8s.io/client-go@${TARGET_VERSION} \
+           k8s.io/component-helpers@${TARGET_VERSION} \
+           k8s.io/pod-security-admission@${TARGET_VERSION}
+
+     go mod tidy
+
+     # Update vendor if needed
+     if [ -d "vendor" ]; then
+       go mod vendor
+     fi
+   done
+   ```
+
+   **Important version mapping**:
+   - `k8s.io/kubernetes` uses `v1.x.y` versioning (e.g., v1.34.3)
+   - `k8s.io/api`, `k8s.io/apimachinery`, `k8s.io/client-go` use `v0.x.y` (e.g., v0.34.3)
+
+3. **Run build verification**:
+   ```bash
+   echo "Building..."
+   go build ./... 2>&1 | tee "${WORKSPACE_DIR}/logs/${REPO_NAME}-build.log"
+   ```
+
+4. **Run tests with progress indicators**:
+   ```bash
+   echo "Running tests..."
+   # For repos with long-running tests (>2 min), show progress
+   go test ./... -v 2>&1 | tee "${WORKSPACE_DIR}/logs/${REPO_NAME}-test.log" | \
+     grep -E "^(PASS|FAIL|ok|=== RUN)" | \
+     while read line; do
+       echo "[$(date +%H:%M:%S)] $line"
+     done
+   ```
+
+   **Progress tracking for long tests**:
+   - Display running test package name
+   - Show elapsed time every 30 seconds for tests taking >1 minute
+   - Example: `[09:40:15] Running: pkg/ovn (elapsed: 2m 30s)...`
+   - Log slowest test packages for summary report
+
+5. **Handle build/test failures**:
+   - **Build failures**:
+     - Mark repo as FAILED
+     - Log error details
+     - Ask: "Build failed for ${REPO_NAME}. [skip/fix manually/abort all]"
+     - If "skip", continue to next repo
+     - If "fix manually", pause and wait
+     - If "abort all", stop workflow
+
+   - **Test failures**:
+     - Check if tests also fail on default branch (pre-existing)
+     - Run: `git stash && git checkout ${DEFAULT_BRANCH} && go test ./...`
+     - If pre-existing, mark as WARNING but continue
+     - If new failures, ask user to review
+     - Restore: `git checkout ${BRANCH_NAME} && git stash pop`
+
+6. **Commit changes**:
+   ```bash
+   git add go.mod go.sum vendor/
+   git commit -m "Bump Kubernetes dependencies to ${TARGET_VERSION}
+
+   Updated modules:
+   - k8s.io/api: ${OLD_VER} → ${TARGET_VERSION}
+   - k8s.io/apimachinery: ${OLD_VER} → ${TARGET_VERSION}
+   - k8s.io/client-go: ${OLD_VER} → ${TARGET_VERSION}
+
+   Build: ✓ PASS
+   Tests: ${TEST_STATUS}
+
+   Part of ${GROUP_NAME} group rebase to ${TARGET_VERSION}
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+   "
+   ```
+
+7. **Track completion**:
+   - Update rebase-status.json with results
+   - Record test duration and slowest packages
+   - Mark repo as SUCCESS, FAILED, or WARNING
+
+8. **Display progress**:
+   ```
+   [1/7] ✓ multus-cni - SUCCESS (build: ✓, tests: ✓ in 15s)
+   [2/7] ✓ multi-networkpolicy-iptables - SUCCESS (build: ✓, tests: ✓ in 8s)
+   [3/7] ⚠ ovn-kubernetes - SUCCESS (build: ✓, tests: ✓ in 12m 30s)
+         Slowest: pkg/ovn (552s), pkg/node (83s), pkg/factory (35s)
+   [4/7] ✓ cluster-network-operator - SUCCESS (build: ✓, tests: ✓ in 2m)
+   ```
+
+### Step 6: Generate Group Summary Report
+1. **Create comprehensive summary**:
+   ```markdown
+   # Kubernetes Group Rebase Summary
+
+   **Group**: network
+   **Target Version**: v0.34.2
+   **Date**: 2025-11-26
+   **Workspace**: .work/k8s-batch-by-group/corenet/20251126-080000
+
+   ## Overall Status
+   - ✓ **Success**: 2 repositories
+   - ⚠ **Warning**: 1 repository
+   - ❌ **Failed**: 0 repositories
+
+   ## Repository Results
+   | Repository | Previous | Current | Build | Tests | Branch | Status |
+   |------------|----------|---------|-------|-------|--------|--------|
+   | multus-cni | v0.34.1 | v0.34.2 | ✓ | ✓ (216 specs) | rebase/k8s-v0.34.2-20251126 | ✓ SUCCESS |
+   | ovn-kubernetes | v0.33.0 | v0.34.2 | ✓ | ⚠ (3 failures) | rebase/k8s-v0.34.2-20251126 | ⚠ WARNING |
+   | cluster-network-operator | v0.34.0 | v0.34.2 | ✓ | ✓ | rebase/k8s-v0.34.2-20251126 | ✓ SUCCESS |
+
+   ## Test Failures
+   ### ovn-kubernetes
+   - TestOVNController (pre-existing)
+   - TestIPv6Support (pre-existing)
+   - TestNetworkPolicy (new - needs investigation)
+
+   ## Commits Created
+   - multus-cni: rebase/k8s-v0.34.2-20251126 (abc123d)
+   - ovn-kubernetes: rebase/k8s-v0.34.2-20251126 (def456e)
+   - cluster-network-operator: rebase/k8s-v0.34.2-20251126 (789abc0)
+
+   ## Next Steps
+   1. Review test failure in ovn-kubernetes (TestNetworkPolicy)
+   2. Push all branches to remote
+   3. Create pull requests for each repository
+   4. Coordinate testing across networking stack
+
+   ## Commands to Push Branches
+
+   Push branches to your fork (when using `--create-pr`):
+   ```bash
+   cd .work/k8s-batch-by-group/corenet/20251126-080000/repos/multus-cni && git push <fork-remote> rebase/k8s-v0.34.2-20251126
+   cd .work/k8s-batch-by-group/corenet/20251126-080000/repos/ovn-kubernetes && git push <fork-remote> rebase/k8s-v0.34.2-20251126
+   cd .work/k8s-batch-by-group/corenet/20251126-080000/repos/cluster-network-operator && git push <fork-remote> rebase/k8s-v0.34.2-20251126
+   ```
+   Note: `<fork-remote>` is the discovered remote name for your fork (typically 'myfork' or similar).
+
+   ## Detailed Logs
+   - Clone logs: `.work/k8s-batch-by-group/corenet/20251126-080000/logs/*-clone.log`
+   - Rebase logs: `.work/k8s-batch-by-group/corenet/20251126-080000/logs/*-rebase.log`
+   - Audit reports: `.work/k8s-batch-by-group/corenet/20251126-080000/reports/*-audit.md`
+   ```
+
+2. **Save summary**:
+   - File: `${WORKSPACE_DIR}/rebase-summary.md`
+   - Also save JSON: `${WORKSPACE_DIR}/rebase-status.json` (updated with final results)
+
+3. **Display summary to user**
+
+### Step 7: Fork Repositories and Push Branches (if --create-pr specified)
+1. **Get GitHub user**:
+   ```bash
+   # Verify gh CLI is installed and authenticated
+   if ! command -v gh &> /dev/null; then
+     echo "Error: gh CLI not found. Install from https://cli.github.com/"
+     exit 1
+   fi
+
+   gh auth status || {
+     echo "Error: Not authenticated with GitHub. Run: gh auth login"
+     exit 1
+   }
+   ```
+
+2. **Fork repositories if needed**:
+   ```bash
+   # Get current GitHub user
+   GH_USER=$(gh api user -q .login)
+
+   for repo in ${SUCCESS_REPOS}; do
+     # Check if fork exists
+     if ! gh repo view "${GH_USER}/${repo}" &>/dev/null; then
+       echo "Forking ${UPSTREAM_ORG}/${repo}..."
+       gh repo fork "${UPSTREAM_ORG}/${repo}" --clone=false
+     fi
+
+     # Discover or add fork remote
+     cd "${WORKSPACE_DIR}/repos/${repo}"
+     FORK_URL="git@github.com:${GH_USER}/${repo}.git"
+
+     # Check if remote already exists for this URL
+     FORK_REMOTE=$(git remote -v | grep "$FORK_URL" | awk '{print $1}' | head -1)
+
+     if [ -z "$FORK_REMOTE" ]; then
+       # No remote exists for fork URL, add one
+       FORK_REMOTE="myfork"
+       git remote add "$FORK_REMOTE" "$FORK_URL"
+       echo "Added remote: $FORK_REMOTE -> $FORK_URL"
+     else
+       echo "Using existing remote: $FORK_REMOTE -> $FORK_URL"
+     fi
+
+     # Store remote name for later use
+     echo "$FORK_REMOTE" > "${WORKSPACE_DIR}/.remote-${repo}"
+   done
+   ```
+
+3. **Request confirmation before pushing**:
+   - Display summary of repos ready to push
+   - Ask: "Ready to push ${#SUCCESS_REPOS[@]} branches to your fork (${GH_USER})? [yes/no]"
+   - If "no", skip pushing (PRs can be created manually later)
+   - If "yes", continue to push
+
+4. **Push branches to fork**:
+   ```bash
+   for repo in ${SUCCESS_REPOS}; do
+     cd "${WORKSPACE_DIR}/repos/${repo}"
+
+     # Retrieve the discovered remote name
+     FORK_REMOTE=$(cat "${WORKSPACE_DIR}/.remote-${repo}")
+
+     # Verify remote exists before pushing
+     if ! git remote get-url "$FORK_REMOTE" &>/dev/null; then
+       echo "✗ Remote $FORK_REMOTE not found for ${repo}, skipping push"
+       continue
+     fi
+
+     # Push to fork
+     git push "$FORK_REMOTE" ${BRANCH_NAME}
+     echo "✓ Pushed to ${GH_USER}/${repo} (remote: $FORK_REMOTE)"
+   done
+   ```
+
+5. **Track push results**:
+   - Record which repos were successfully pushed
+   - Log any push failures
+   - Update `rebase-status.json` with push status and fork info
+
+### Step 8: Create Pull Requests (if --create-pr specified)
+1. **Check prerequisites**:
+   ```bash
+   # Verify gh CLI is installed and authenticated
+   if ! command -v gh &> /dev/null; then
+     echo "Error: gh CLI not found. Install from https://cli.github.com/"
+     exit 1
+   fi
+
+   gh auth status || {
+     echo "Error: Not authenticated with GitHub. Run: gh auth login"
+     exit 1
+   }
+
+   # Get GitHub user for fork-based PRs
+   if [ "${USE_FORK}" = "true" ]; then
+     GH_USER=$(gh api user -q .login)
+   fi
+   ```
+
+2. **Generate PR descriptions for each repo**:
+   ```bash
+   # For each successful repo, create PR body
+   for repo in ${SUCCESS_REPOS}; do
+     PR_BODY_FILE="${WORKSPACE_DIR}/reports/${repo}-pr-body.md"
+
+     cat > "$PR_BODY_FILE" <<EOF
+   ## Summary
+
+   Bump Kubernetes dependencies to ${TARGET_VERSION} as part of coordinated ${GROUP_NAME} group upgrade.
+
+   ## Changes
+
+   - k8s.io/api: ${OLD_VERSION} → ${TARGET_VERSION}
+   - k8s.io/apimachinery: ${OLD_VERSION} → ${TARGET_VERSION}
+   - k8s.io/client-go: ${OLD_VERSION} → ${TARGET_VERSION}
+   - [Additional k8s.io modules]
+
+   ## Risk Assessment
+
+   ${REPO_RISK_LEVEL}
+
+   $(cat ${WORKSPACE_DIR}/reports/${repo}-audit.md)
+
+   ## Test Results
+
+   - Build: ${BUILD_STATUS}
+   - Tests: ${TEST_STATUS}
+
+   ## Related PRs
+
+   This is part of a coordinated upgrade across the ${GROUP_NAME} group:
+   ${OTHER_PR_LINKS}
+
+   ## Tracking
+
+   ${JIRA_ISSUE_LINK}
+
+   ---
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   done
+   ```
+
+3. **Create PRs for each repository**:
+   ```bash
+   PR_URLS=()
+
+   for repo in ${SUCCESS_REPOS}; do
+     cd "${WORKSPACE_DIR}/repos/${repo}"
+
+     # Determine PR head (fork or upstream branch)
+     if [ "${USE_FORK}" = "true" ]; then
+       # Fork-based PR: from user:branch to upstream:main
+       # Dynamically discover default branch from upstream repo
+       UPSTREAM_URL="git@github.com:${UPSTREAM_ORG}/${repo}.git"
+       DEFAULT_BRANCH=$(git ls-remote --symref "${UPSTREAM_URL}" HEAD | \
+         awk '/^ref:/ {sub("refs/heads/", "", $2); print $2}')
+
+       PR_URL=$(gh pr create \
+         --repo "${UPSTREAM_ORG}/${repo}" \
+         --title "Bump Kubernetes dependencies to ${TARGET_VERSION}" \
+         --body-file "${WORKSPACE_DIR}/reports/${repo}-pr-body.md" \
+         --head "${GH_USER}:${BRANCH_NAME}" \
+         --base "${DEFAULT_BRANCH}" \
+         --draft 2>&1)
+     else
+       # Direct PR: from branch to main in same repo
+       PR_URL=$(gh pr create \
+         --title "Bump Kubernetes dependencies to ${TARGET_VERSION}" \
+         --body-file "${WORKSPACE_DIR}/reports/${repo}-pr-body.md" \
+         --draft \
+         --label "dependencies,kubernetes" 2>&1)
+     fi
+
+     if [[ "$PR_URL" =~ ^https://github.com ]]; then
+       echo "✓ Created PR for ${repo}: ${PR_URL}"
+       PR_URLS+=("${repo}|${PR_URL}")
+
+       # Save PR URL to status file
+       jq ".repos[] | select(.name == \"${repo}\") | .pr_url = \"${PR_URL}\"" \
+         "${WORKSPACE_DIR}/rebase-status.json" > tmp.json
+       mv tmp.json "${WORKSPACE_DIR}/rebase-status.json"
+     else
+       echo "✗ Failed to create PR for ${repo}: ${PR_URL}"
+     fi
+   done
+   ```
+
+4. **Update PR descriptions with cross-references**:
+   ```bash
+   # Now that all PRs are created, update each PR body to include links to related PRs
+   for pr_entry in "${PR_URLS[@]}"; do
+     repo="${pr_entry%%|*}"
+     pr_url="${pr_entry##*|}"
+
+     # Build list of related PRs
+     related_prs=""
+     for other_pr in "${PR_URLS[@]}"; do
+       other_repo="${other_pr%%|*}"
+       other_url="${other_pr##*|}"
+       if [ "$other_repo" != "$repo" ]; then
+         related_prs="${related_prs}- ${other_repo}: ${other_url}\n"
+       fi
+     done
+
+     # Update PR description with related PRs
+     cd "${WORKSPACE_DIR}/repos/${repo}"
+
+     # Get current PR body and append related PRs section
+     pr_number=$(echo "$pr_url" | grep -oP '\d+$')
+     gh pr edit $pr_number --body "$(gh pr view $pr_number --json body -q .body | sed "s|\${OTHER_PR_LINKS}|${related_prs}|")"
+   done
+   ```
+
+5. **Display PR summary**:
+   ```
+   ✓ Created 3 pull requests:
+
+   - multus-cni: https://github.com/k8snetworkplumbingwg/multus-cni/pull/123
+   - ovn-kubernetes: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/456
+   - cluster-network-operator: https://github.com/openshift/cluster-network-operator/pull/789
+   ```
+
+### Step 9: Create JIRA Issue (if --create-jira specified)
+1. **Check prerequisites**:
+   ```bash
+   # Verify JIRA CLI tools or credentials
+   if [ -z "$JIRA_API_TOKEN" ] || [ -z "$JIRA_URL" ] || [ -z "$JIRA_USER" ]; then
+     echo "Error: JIRA credentials not configured"
+     echo "Set JIRA_URL, JIRA_USER, and JIRA_API_TOKEN environment variables"
+     exit 1
+   fi
+   ```
+
+2. **Determine JIRA project and issue type**:
+   - Ask user for project key (e.g., "OCPBUGS", "CNV", "STOR")
+   - Default issue type: "Story" or "Task"
+   - Ask user for component (optional)
+
+3. **Generate JIRA issue description**:
+   ```bash
+   JIRA_DESC_FILE="${WORKSPACE_DIR}/jira-issue-description.md"
+
+   cat > "$JIRA_DESC_FILE" <<EOF
+   h2. Summary
+
+   Bump Kubernetes dependencies to ${TARGET_VERSION} across ${GROUP_NAME} repositories.
+
+   h2. Scope
+
+   This issue tracks the coordinated upgrade of Kubernetes dependencies across ${#SUCCESS_REPOS[@]} repositories in the ${GROUP_NAME} group:
+
+   $(for repo in ${SUCCESS_REPOS}; do echo "* ${repo}"; done)
+
+   h2. Target Version
+
+   * *From*: ${OLD_VERSION} (varies by repo)
+   * *To*: ${TARGET_VERSION}
+
+   h2. Risk Assessment
+
+   * *Overall Risk*: ${OVERALL_RISK_LEVEL}
+   * *High-risk repos*: ${HIGH_RISK_REPOS}
+
+   $(cat ${WORKSPACE_DIR}/rebase-summary.md | grep -A 20 "Common Breaking Changes")
+
+   h2. Pull Requests
+
+   $(for pr_entry in "${PR_URLS[@]}"; do
+     repo="${pr_entry%%|*}"
+     url="${pr_entry##*|}"
+     echo "* [${repo}|${url}]"
+   done)
+
+   h2. Test Results
+
+   $(cat ${WORKSPACE_DIR}/rebase-summary.md | grep -A 30 "Repository Results")
+
+   h2. Next Steps
+
+   # Review and approve all PRs
+   # Run integration tests across networking stack
+   # Merge PRs in dependency order
+   # Monitor for issues in CI
+
+   h2. Artifacts
+
+   * Workspace: {{${WORKSPACE_DIR}}}
+   * Summary Report: [rebase-summary.md|attachment]
+
+   ---
+
+   🤖 Generated with [Claude Code|https://claude.com/claude-code]
+   EOF
+   ```
+
+4. **Create JIRA issue via API**:
+   ```bash
+   # Create the issue
+   JIRA_RESPONSE=$(curl -s -X POST \
+     -H "Content-Type: application/json" \
+     -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+     "${JIRA_URL}/rest/api/2/issue" \
+     -d "{
+       \"fields\": {
+         \"project\": {
+           \"key\": \"${JIRA_PROJECT}\"
+         },
+         \"summary\": \"Bump Kubernetes dependencies to ${TARGET_VERSION} (${GROUP_NAME} group)\",
+         \"description\": $(cat "$JIRA_DESC_FILE" | jq -Rs .),
+         \"issuetype\": {
+           \"name\": \"Story\"
+         },
+         \"components\": [{
+           \"name\": \"${JIRA_COMPONENT}\"
+         }],
+         \"labels\": [\"kubernetes-upgrade\", \"dependencies\", \"${GROUP_NAME}-group\"]
+       }
+     }")
+
+   JIRA_ISSUE_KEY=$(echo "$JIRA_RESPONSE" | jq -r '.key')
+   JIRA_ISSUE_URL="${JIRA_URL}/browse/${JIRA_ISSUE_KEY}"
+   ```
+
+5. **Link JIRA to all PRs**:
+   ```bash
+   # Update each PR description to include JIRA link
+   for pr_entry in "${PR_URLS[@]}"; do
+     repo="${pr_entry%%|*}"
+     pr_url="${pr_entry##*|}"
+
+     cd "${WORKSPACE_DIR}/repos/${repo}"
+     pr_number=$(echo "$pr_url" | grep -oP '\d+$')
+
+     # Update PR body with JIRA link
+     gh pr edit $pr_number --body "$(gh pr view $pr_number --json body -q .body | sed "s|\${JIRA_ISSUE_LINK}|Tracking: ${JIRA_ISSUE_URL}|")"
+   done
+   ```
+
+6. **Add remote links in JIRA**:
+   ```bash
+   # Link each PR to the JIRA issue
+   for pr_entry in "${PR_URLS[@]}"; do
+     repo="${pr_entry%%|*}"
+     pr_url="${pr_entry##*|}"
+
+     curl -s -X POST \
+       -H "Content-Type: application/json" \
+       -u "${JIRA_USER}:${JIRA_API_TOKEN}" \
+       "${JIRA_URL}/rest/api/2/issue/${JIRA_ISSUE_KEY}/remotelink" \
+       -d "{
+         \"object\": {
+           \"url\": \"${pr_url}\",
+           \"title\": \"PR: ${repo}\",
+           \"icon\": {
+             \"url16x16\": \"https://github.githubassets.com/favicon.ico\"
+           }
+         }
+       }"
+   done
+   ```
+
+7. **Display JIRA summary**:
+   ```
+   ✓ Created JIRA issue: ${JIRA_ISSUE_KEY}
+
+   URL: ${JIRA_ISSUE_URL}
+
+   Linked to ${#PR_URLS[@]} pull requests.
+   ```
+
+8. **Save JIRA details**:
+   ```bash
+   # Update rebase-status.json with JIRA info
+   jq ".jira_issue = {\"key\": \"${JIRA_ISSUE_KEY}\", \"url\": \"${JIRA_ISSUE_URL}\"}" \
+     "${WORKSPACE_DIR}/rebase-status.json" > tmp.json
+   mv tmp.json "${WORKSPACE_DIR}/rebase-status.json"
+   ```
+
+### Step 10: Display Final Summary
+1. **Show completion summary**:
+   ```
+   ========================================
+   Batch Rebase Complete!
+   ========================================
+
+   Group: ${GROUP_NAME}
+   Target Version: ${TARGET_VERSION}
+
+   Repositories: ${#SUCCESS_REPOS[@]} successful, ${#FAILED_REPOS[@]} failed
+
+   Pull Requests: ${#PR_URLS[@]} created
+   JIRA Issue: ${JIRA_ISSUE_URL}
+
+   Workspace: ${WORKSPACE_DIR}
+   Summary: ${WORKSPACE_DIR}/rebase-summary.md
+
+   Next steps:
+   1. Review PRs and address any feedback
+   2. Run integration tests
+   3. Merge PRs in dependency order
+   4. Update JIRA issue with results
+   ========================================
+   ```
+
+## Return Value
+
+- **Format**: Group-wide summary with:
+  - Per-repository results table
+  - Overall success/failure counts
+  - Common issues across repos
+  - PR URLs (if `--create-pr` was used)
+  - JIRA issue URL (if `--create-jira` was used)
+  - Next action recommendations
+  - Workspace location for review
+
+- **Output locations**:
+  - Summary: `${WORKSPACE_DIR}/rebase-summary.md`
+  - Individual audit reports: `${WORKSPACE_DIR}/reports/${REPO_NAME}-audit.md`
+  - PR descriptions: `${WORKSPACE_DIR}/reports/${REPO_NAME}-pr-body.md`
+  - JIRA description: `${WORKSPACE_DIR}/jira-issue-description.md`
+  - Rebase logs: `${WORKSPACE_DIR}/logs/${REPO_NAME}-*.log`
+  - Cloned repositories: `${WORKSPACE_DIR}/repos/${REPO_NAME}/`
+  - Status tracking: `${WORKSPACE_DIR}/rebase-status.json` (includes PR URLs and JIRA issue details)
+
+## Repository Group Configuration
+
+Repository groups are defined in `plugins/k8s-bumpup/.claude-plugin/repo-groups.json`:
+
+```json
+{
+  "groups": {
+    "corenet": {
+      "description": "Core networking OpenShift repositories",
+      "repos": [
+        {
+          "name": "multus-cni",
+          "url": "git@github.com:k8snetworkplumbingwg/multus-cni.git"
+        },
+        {
+          "name": "ovn-kubernetes",
+          "url": "git@github.com:ovn-kubernetes/ovn-kubernetes.git"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Note**:
+- Uses **SSH URLs** (`git@github.com:org/repo.git`) for better authentication with SSH keys
+- The `branch` field is optional - the command auto-detects the default branch from the remote repository
+- This makes the configuration more maintainable as repositories migrate from `master` to `main`
+
+To add a new group or modify existing ones, edit this configuration file.
+
+## Error Handling
+
+1. **Group not found**:
+   - Error: "Group '${GROUP_NAME}' not found in configuration"
+   - List available groups
+   - Exit gracefully
+
+2. **Clone failures**:
+   - Log error and mark repo as SKIPPED
+   - Continue with other repositories
+   - Include skipped repos in final summary
+
+3. **No k8s dependencies**:
+   - Skip repository if no k8s.io modules found
+   - Log as INFO, not error
+   - Mark as SKIPPED in summary
+
+4. **Build/test failures**:
+   - Pause workflow at failed repo
+   - Allow user to skip, fix manually, or abort
+   - Do not rollback successful repos
+
+5. **Partial success**:
+   - Generate summary showing mixed results
+   - Clearly indicate which repos succeeded/failed
+   - Provide next steps for failed repos
+
+6. **Fork handling** (if --create-pr specified):
+   - **Fork already exists**: Detected and skipped automatically (expected behavior, not an error)
+   - **Fork creation failures**: Logged and workflow continues with remaining repos
+   - **Remote already exists**: Handled gracefully with `|| true` (no error, continues normally)
+   - **Missing GitHub authentication**: Requires `gh auth login` before using `--create-pr`
+
+7. **PR creation failures** (if --create-pr specified):
+   - Log which PRs failed to create
+   - Continue creating remaining PRs
+   - Skip cross-referencing for failed PRs
+   - Include failure details in final summary
+
+8. **JIRA creation failures** (if --create-jira specified):
+   - Log error details
+   - Save issue description to file for manual creation
+   - Continue workflow (non-blocking)
+   - Provide manual JIRA creation instructions
+
+9. **Missing credentials**:
+   - **GitHub**: Check `gh auth status` before creating PRs
+   - **JIRA**: Verify `JIRA_URL`, `JIRA_USER`, `JIRA_API_TOKEN` environment variables
+   - Provide clear error messages with setup instructions
+
+## Examples
+
+1. **Complete workflow with PR and JIRA creation**:
+   ```
+   /k8s-bumpup:batch-by-group corenet --create-pr --create-jira
+   ```
+   Fetches the latest stable Kubernetes release and rebases all corenet repos.
+   Creates PRs and a tracking JIRA issue.
+
+2. **Basic rebase (local only, no PR/JIRA creation)**:
+   ```
+   /k8s-bumpup:batch-by-group corenet
+   ```
+   Fetches latest Kubernetes version and rebases all corenet repos. Branches are created locally but not pushed.
+
+3. **Rebase with automatic PR creation**:
+   ```
+   /k8s-bumpup:batch-by-group operators --create-pr
+   ```
+   Fetches latest version and rebases all operator repos, then creates draft PRs with cross-references.
+
+4. **Complete workflow for storage group**:
+   ```
+   /k8s-bumpup:batch-by-group storage --create-pr --create-jira
+   ```
+   Complete workflow:
+   - Fetches latest Kubernetes version
+   - Rebases all storage repos
+   - Creates PRs for each repo
+   - Creates one JIRA issue tracking all PRs
+   - Links PRs to JIRA and vice versa
+
+5. **JIRA only (after manual PR creation)**:
+   ```
+   /k8s-bumpup:batch-by-group operators --create-jira
+   ```
+   Rebases repos and creates JIRA issue without auto-creating PRs
+
+6. **Custom workspace**:
+   ```
+   /k8s-bumpup:batch-by-group corenet --workspace-dir /tmp/rebase-work --create-pr
+   ```
+   Uses custom workspace directory and creates PRs
+
+7. **Dry-run mode**:
+   ```
+   /k8s-bumpup:batch-by-group monitoring --dry-run
+   ```
+   Audits the latest version upgrade without making any changes
+
+8. **List available groups**:
+   ```
+   /k8s-bumpup:batch-by-group --list
+   ```
+   Displays all available repository groups
+
+## Notes
+
+- **Always uses latest available version**: This command fetches and uses the latest versions, ensuring Kubernetes and client libraries are in sync
+- **Smart version syncing**:
+  - Fetches latest Kubernetes release (e.g., v1.34.3)
+  - Queries available k8s.io/api versions to find latest stable v0.34.x (e.g., v0.34.2)
+  - If client library lags behind (v0.34.2 vs v1.34.3), automatically uses matching K8s version (v1.34.2)
+  - Ensures consistency: Both Kubernetes v1.34.2 ↔ client libraries v0.34.2
+  - Prevents mismatches that could cause compatibility issues
+- This command clones fresh copies of repositories
+- Original repositories are not modified
+- All work happens in isolated workspace
+- Branches are automatically pushed to your fork when using `--create-pr`
+- Without `--create-pr`, branches remain local only
+- Safe to re-run - creates new workspace each time
+- Workspace preserved for review/debugging
+- Ideal for coordinated upgrades across related components
+- Respects each repository's .gitignore for vendor/ directories
+
+### Key Features
+
+1. **Smart version syncing**: Automatically syncs Kubernetes and client library versions - if client libraries lag behind, uses matching older K8s release to ensure compatibility
+2. **Multiple go.mod support**: Automatically finds and updates ALL go.mod files in a repository (e.g., ovn-kubernetes has 3: go-controller/, test/e2e/, test/conformance/)
+3. **Dual versioning**: Correctly handles both k8s.io/kubernetes (v1.x) and k8s.io/api (v0.x) version schemes
+4. **Auto-detect default branch**: No need to specify `master` vs `main` in config - automatically detected
+5. **Automatic forking**: With `--create-pr`, automatically forks repos (if not already forked) and creates PRs from your fork
+6. **Smart test handling**: Detects pre-existing test failures vs new failures introduced by the upgrade
+7. **Progress tracking**: Shows elapsed time and progress for long-running tests (e.g., ovn-kubernetes pkg/ovn: 552s)
+8. **Already up-to-date detection**: Skips repositories that are already at the target version
+9. **Test performance metrics**: Logs slowest test packages in summary report
+10. **Dry-run mode**: Use `--dry-run` to audit without making changes
+
+### PR Creation
+- Requires `gh` CLI installed and authenticated (`gh auth login`)
+- Creates draft PRs by default
+- PRs include cross-references to related PRs in the same group
+- PRs are labeled with `dependencies` and `kubernetes`
+- If `--create-jira` is also specified, PRs link to the JIRA issue
+- Creates fork-based PRs: from `user:branch` to `upstream:main` (repositories are automatically forked if needed)
+
+### JIRA Creation
+- Requires environment variables: `JIRA_URL`, `JIRA_USER`, `JIRA_API_TOKEN`
+- Creates a single Story/Task tracking all repositories
+- Includes links to all PRs (if `--create-pr` was used)
+- Includes risk assessment and test results
+- Automatically adds remote links from JIRA to each PR
+- Issue is labeled with `kubernetes-upgrade`, `dependencies`, and `${GROUP_NAME}-group`
+
+## See Also
+- `/k8s-bumpup:rebase-repo` - Rebase single repository or multiple repositories

--- a/plugins/k8s-bumpup/commands/rebase-repo.md
+++ b/plugins/k8s-bumpup/commands/rebase-repo.md
@@ -1,0 +1,309 @@
+---
+description: Complete workflow to rebase Kubernetes dependencies across repositories
+argument-hint: <target-version> <repository-path> [additional-repos...]
+---
+
+## Name
+k8s-bumpup:rebase-repo
+
+## Synopsis
+```bash
+/k8s-bumpup:rebase-repo <target-version> <repository-path> [additional-repos...]
+```
+
+## Description
+The `k8s-bumpup:rebase-repo` command executes the complete Kubernetes dependency rebase workflow for one or more repositories. It orchestrates auditing, updating, testing, and committing changes with proper validation at each step.
+
+This is the high-level workflow command that automates the complete rebase process including audit analysis, dependency updates, testing, and committing changes.
+
+## Arguments
+- `$1` (target-version): Target Kubernetes version (e.g., `v1.29.0`)
+- `$2` (repository-path): Path to first repository to rebase
+- `$3+` (additional-repos): Optional. Additional repository paths to rebase
+
+## Implementation
+
+### Step 1: Initialize and Validate
+1. **Parse arguments**:
+   - Extract target version
+   - Collect all repository paths
+   - Validate target version format
+
+2. **Validate all repositories**:
+   - Check each path exists and is a Git repository
+   - Verify each has `go.mod` file
+   - Confirm clean working directory (or ask user to proceed)
+   - Extract current k8s version from each repo
+
+3. **Check prerequisites**:
+   - Verify Go toolchain: `go version`
+   - Check Git configuration: `git config user.name && git config user.email`
+   - Verify internet connectivity for downloading modules
+
+4. **Create work directory**:
+   ```bash
+   WORK_DIR=".work/k8s-bumpup/$(date +%Y%m%d-%H%M%S)"
+   mkdir -p "$WORK_DIR"/{logs,reports}
+   ```
+
+### Step 2: Pre-Rebase Audit (For Each Repository)
+1. **Run audit analysis**:
+   - Execute audit analysis for each repo
+   - Generate individual audit reports
+   - Save to `${WORK_DIR}/reports/${REPO_NAME}-audit.md`
+
+2. **Aggregate audit results**:
+   - Combine findings across all repositories
+   - Identify common breaking changes
+   - Calculate overall risk level
+
+3. **Present audit summary**:
+   ```text
+   # Multi-Repository Audit Summary
+
+   ## Repositories
+   1. my-operator (v1.28.0 → v1.29.0) - MEDIUM risk
+   2. my-controller (v1.28.0 → v1.29.0) - LOW risk
+
+   ## Common Breaking Changes
+   - batch/v1beta1 CronJob → batch/v1 (affects: my-operator)
+
+   ## Recommendations
+   - Update my-operator CronJob API before proceeding
+   - my-controller safe to proceed directly
+   ```
+
+4. **Request user confirmation**:
+   - Display full audit summary
+   - Ask: "Proceed with rebase? [yes/no/review]"
+   - If "review", open detailed reports
+   - If "no", exit gracefully
+   - If "yes", continue to Step 3
+
+### Step 3: Execute Rebase (For Each Repository)
+Process each repository sequentially:
+
+1. **Create feature branch**:
+   ```bash
+   cd ${REPO_PATH}
+   BRANCH_NAME="rebase/k8s-${TARGET_VERSION}-$(date +%Y%m%d)"
+   git checkout -b "${BRANCH_NAME}"
+   ```
+
+2. **Update dependencies**:
+   - Execute dependency update logic
+   - Log all output to `${WORK_DIR}/logs/${REPO_NAME}-update.log`
+
+3. **Build verification**:
+   ```bash
+   go build ./... 2>&1 | tee "${WORK_DIR}/logs/${REPO_NAME}-build.log"
+   ```
+   - If build fails:
+     - Log error details
+     - Ask user: "Build failed. [fix manually/skip/abort]"
+     - If "fix manually", pause and wait for user
+     - If "skip", mark repo as FAILED and continue
+     - If "abort", stop entire workflow
+
+4. **Run tests**:
+   ```bash
+   go test ./... -v 2>&1 | tee "${WORK_DIR}/logs/${REPO_NAME}-test.log"
+   ```
+   - Parse test results (pass/fail counts)
+   - If tests fail:
+     - Display failed test names
+     - Ask: "Tests failed. [review/skip/abort]"
+
+5. **Generate changelog for this repo**:
+   - Extract updated modules from `git diff go.mod`
+   - Format commit message:
+     ```
+     Rebase Kubernetes dependencies to ${TARGET_VERSION}
+
+     Updated modules:
+     - k8s.io/api: ${OLD_VER} → ${TARGET_VERSION}
+     - k8s.io/apimachinery: ${OLD_VER} → ${TARGET_VERSION}
+     - k8s.io/client-go: ${OLD_VER} → ${TARGET_VERSION}
+
+     Build: ✓ PASS
+     Tests: ✓ PASS (120 tests)
+     ```
+
+6. **Commit changes**:
+   ```bash
+   git add go.mod go.sum vendor/  # vendor/ only if exists
+   git commit -F "${WORK_DIR}/commit-msg-${REPO_NAME}.txt"
+   ```
+
+7. **Tag completion**:
+   - Mark repo as SUCCESS or FAILED
+   - Record in summary
+
+### Step 4: Post-Rebase Validation
+1. **Cross-repository validation** (if multiple repos):
+   - Check if repos depend on each other
+   - Verify version consistency across repos
+   - Warn if version mismatches detected
+
+2. **Run integration tests** (if configured):
+   - Look for integration test script: `scripts/integration-test.sh`
+   - Execute if present
+   - Log results
+
+### Step 5: Generate Summary Report
+1. **Create comprehensive summary**:
+   ```markdown
+   # Kubernetes Rebase Summary
+   Date: ${DATE}
+   Target Version: ${TARGET_VERSION}
+
+   ## Results
+   | Repository | Previous | Current | Build | Tests | Status |
+   |------------|----------|---------|-------|-------|--------|
+   | my-operator | v1.28.0 | v1.29.0 | ✓ | ✓ (98/100) | ⚠️ PARTIAL |
+   | my-controller | v1.28.0 | v1.29.0 | ✓ | ✓ | ✓ SUCCESS |
+
+   ## Failed Tests
+   ### my-operator
+   - TestCronJobController (batch API migration needed)
+   - TestWebhookValidation (client-go signature change)
+
+   ## Commits Created
+   - my-operator: rebase/k8s-v1.29.0-20250126 (abc123)
+   - my-controller: rebase/k8s-v1.29.0-20250126 (def456)
+
+   ## Next Steps
+   1. Review failed tests in my-operator
+   2. Fix CronJob API usage (see audit report)
+   3. Re-run tests
+   4. Push branches and create PRs
+   ```
+
+2. **Save summary**:
+   - File: `${WORK_DIR}/rebase-summary.md`
+   - Display in console with formatting
+
+### Step 6: Offer Next Actions
+1. **Present options to user**:
+   ```
+   Rebase complete! What would you like to do next?
+
+   1. Push branches to remote
+   2. Create pull requests
+   3. Review detailed logs
+   4. Rollback changes (reset branches)
+   5. Exit
+   ```
+
+2. **Execute selected action**:
+   - **Push branches to fork**:
+     ```bash
+     # Get GitHub user
+     GH_USER=$(gh api user -q .login)
+
+     for repo in ${REPOS}; do
+       cd ${repo}
+
+       # Discover fork remote by matching URL pattern
+       FORK_REMOTE=$(git remote -v | grep "github.com[:/]${GH_USER}/" | awk '{print $1}' | head -1)
+
+       if [ -z "$FORK_REMOTE" ]; then
+         echo "✗ No fork remote found for ${repo}, skipping push"
+         echo "  Add your fork with: git remote add <name> git@github.com:${GH_USER}/$(basename ${repo}).git"
+         continue
+       fi
+
+       # Verify remote exists and push
+       if git remote get-url "$FORK_REMOTE" &>/dev/null; then
+         git push "$FORK_REMOTE" ${BRANCH_NAME}
+         echo "✓ Pushed to $FORK_REMOTE"
+       else
+         echo "✗ Remote $FORK_REMOTE not found, skipping push"
+       fi
+     done
+     ```
+
+   - **Create PRs** (if `gh` CLI available):
+     ```bash
+     gh pr create \
+       --title "Rebase Kubernetes dependencies to ${TARGET_VERSION}" \
+       --body-file "${WORK_DIR}/rebase-summary.md" \
+       --draft
+     ```
+
+   - **Review logs**:
+     - Open `${WORK_DIR}` in editor
+     - Display file tree
+
+   - **Rollback**:
+     ```bash
+     for repo in ${REPOS}; do
+       cd ${repo}
+       git checkout main  # or previous branch
+       git branch -D ${BRANCH_NAME}
+     done
+     ```
+
+## Return Value
+
+- **Format**: Multi-repository summary with:
+  - Per-repository results (success/failure)
+  - Build and test status for each
+  - Created branches and commits
+  - Next action recommendations
+
+- **Output locations**:
+  - Summary: `${WORK_DIR}/rebase-summary.md`
+  - Audit reports: `${WORK_DIR}/reports/`
+  - Build/test logs: `${WORK_DIR}/logs/`
+
+## Error Handling
+
+1. **Repository validation failures**:
+   - If any repo invalid, list all issues before aborting
+   - Do not proceed if prerequisites not met
+
+2. **Build failures**:
+   - Pause workflow at failed repo
+   - Allow user to fix and retry
+   - Option to skip failed repo and continue
+
+3. **Git operation failures**:
+   - Branch already exists: Ask to reuse or create new name
+   - Push failures: Display error and suggest manual push
+   - Commit failures: Check for hooks and retry
+
+4. **Partial success scenarios**:
+   - Some repos succeed, others fail
+   - Create summary showing mixed results
+   - Do not rollback successful repos automatically
+
+## Examples
+
+1. **Single repository rebase**:
+   ```
+   /k8s-bumpup:rebase-repo v1.29.0 ./my-operator
+   ```
+   Complete rebase workflow for one repository
+
+2. **Multiple repositories**:
+   ```
+   /k8s-bumpup:rebase-repo v1.29.0 ./operator ./controller ./webhook
+   ```
+   Rebase three related repositories to same version
+
+3. **Absolute paths**:
+   ```
+   /k8s-bumpup:rebase-repo v1.30.0 /home/user/proj1 /home/user/proj2
+   ```
+   Works with absolute paths
+
+## Notes
+
+- This command modifies Git state (creates branches, commits)
+- Always commits changes - manual review recommended before pushing
+- Creates draft PRs by default (if creating PRs)
+- All artifacts saved to `.work/k8s-bumpup/` for review
+- Safe to re-run - creates new branches with timestamps
+- For complex migrations, review the audit report carefully before proceeding
+- Respects `.gitignore` - vendor/ only committed if already tracked

--- a/plugins/k8s-bumpup/skills/dependency-analysis/SKILL.md
+++ b/plugins/k8s-bumpup/skills/dependency-analysis/SKILL.md
@@ -1,0 +1,501 @@
+---
+name: Kubernetes Dependency Analysis
+description: Deep analysis of Kubernetes API usage and breaking changes between versions
+---
+
+# Kubernetes Dependency Analysis Skill
+
+This skill provides detailed guidance for analyzing Kubernetes dependency changes and identifying breaking changes when rebasing to a new Kubernetes version.
+
+## When to Use This Skill
+
+Use this skill when:
+- Running `/k8s-bumpup:rebase-repo` or `/k8s-bumpup:batch-by-group` and need to understand the audit analysis
+- Investigating build or test failures after a Kubernetes version update
+- Understanding the impact of deprecated API usage in a codebase
+- Planning a multi-version Kubernetes upgrade strategy
+
+## Prerequisites
+
+1. **Required tools**:
+   - `go` (version 1.20+): `go version`
+   - `jq` (for JSON parsing): `which jq`
+   - `curl` or `wget` (for fetching changelogs)
+   - `git` (for repository operations)
+
+2. **Repository requirements**:
+   - Valid Go module with `go.mod`
+   - Kubernetes dependencies (`k8s.io/*`)
+   - Git repository (for diff analysis)
+
+3. **Network access**:
+   - GitHub API access (for fetching changelogs)
+   - Go module proxy access (proxy.golang.org)
+
+## Implementation Steps
+
+### Step 1: Extract Current Kubernetes API Usage
+
+#### 1.1 Find All Kubernetes Imports
+
+```bash
+# Create output directory
+mkdir -p .work/k8s-bumpup-audit
+
+# Find all k8s.io imports across codebase
+find . -name "*.go" \
+  -not -path "./vendor/*" \
+  -not -path "./.work/*" \
+  -not -path "./.*" \
+  -exec grep -h "\"k8s.io/" {} \; | \
+  sed 's/.*"k8s\.io/k8s.io/' | \
+  sed 's/".*//' | \
+  sort -u > .work/k8s-bumpup-audit/all-k8s-imports.txt
+```
+
+#### 1.2 Categorize Imports by Type
+
+```bash
+# API imports (k8s.io/api/...)
+grep "^k8s.io/api/" .work/k8s-bumpup-audit/all-k8s-imports.txt > \
+  .work/k8s-bumpup-audit/api-imports.txt
+
+# Client-go imports
+grep "^k8s.io/client-go" .work/k8s-bumpup-audit/all-k8s-imports.txt > \
+  .work/k8s-bumpup-audit/client-go-imports.txt
+
+# API machinery
+grep "^k8s.io/apimachinery" .work/k8s-bumpup-audit/all-k8s-imports.txt > \
+  .work/k8s-bumpup-audit/apimachinery-imports.txt
+```
+
+#### 1.3 Extract API Group Versions
+
+```bash
+# Extract API group/version combinations (e.g., apps/v1, batch/v1beta1)
+grep "^k8s.io/api/" .work/k8s-bumpup-audit/api-imports.txt | \
+  sed 's/k8s\.io\/api\///' | \
+  sort -u > .work/k8s-bumpup-audit/api-group-versions.txt
+
+# Example output:
+# apps/v1
+# batch/v1
+# batch/v1beta1
+# core/v1
+# networking/v1
+```
+
+#### 1.4 Find Resource Type Usage
+
+```bash
+# Search for typed resources (e.g., appsv1.Deployment, corev1.Pod)
+grep -rh "\(apps\|core\|batch\|networking\|policy\)v[0-9]" \
+  --include="*.go" \
+  --exclude-dir="vendor" \
+  --exclude-dir=".work" . | \
+  grep -o "\(apps\|core\|batch\|networking\|policy\)v[0-9][^.]*\.[A-Z][a-zA-Z]*" | \
+  sort -u > .work/k8s-bumpup-audit/resource-types.txt
+
+# Example output:
+# appsv1.Deployment
+# appsv1.StatefulSet
+# batchv1.Job
+# batchv1beta1.CronJob
+# corev1.Pod
+```
+
+### Step 2: Fetch Kubernetes Release Notes
+
+#### 2.1 Calculate Version Range
+
+```bash
+# Given: CURRENT_VERSION=v1.27.8, TARGET_VERSION=v1.29.0
+CURRENT_MINOR=$(echo "$CURRENT_VERSION" | sed 's/v\([0-9]*\.[0-9]*\)\..*/\1/')
+TARGET_MINOR=$(echo "$TARGET_VERSION" | sed 's/v\([0-9]*\.[0-9]*\)\..*/\1/')
+
+# Extract major.minor numbers
+CURRENT_MAJ=$(echo "$CURRENT_MINOR" | cut -d. -f1)
+CURRENT_MIN=$(echo "$CURRENT_MINOR" | cut -d. -f2)
+TARGET_MAJ=$(echo "$TARGET_MINOR" | cut -d. -f1)
+TARGET_MIN=$(echo "$TARGET_MINOR" | cut -d. -f2)
+
+# Generate version list
+VERSIONS=()
+for ((i=$CURRENT_MIN+1; i<=$TARGET_MIN; i++)); do
+  VERSIONS+=("$CURRENT_MAJ.$i")
+done
+
+# Example: crossing v1.27 → v1.29 includes v1.28, v1.29
+echo "${VERSIONS[@]}"  # Output: 1.28 1.29
+```
+
+#### 2.2 Fetch Changelogs from GitHub
+
+```bash
+# For each version, fetch the changelog
+for VERSION in "${VERSIONS[@]}"; do
+  echo "Fetching changelog for v${VERSION}..."
+
+  # Try fetching from kubernetes/kubernetes repo
+  CHANGELOG_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${VERSION}.md"
+
+  curl -sL "$CHANGELOG_URL" -o ".work/k8s-bumpup-audit/CHANGELOG-${VERSION}.md"
+
+  if [ $? -ne 0 ]; then
+    echo "Warning: Could not fetch changelog for v${VERSION}"
+  fi
+done
+```
+
+#### 2.3 Alternative: Use GitHub Releases API
+
+```bash
+# Fetch releases via API (more reliable)
+for VERSION in "${VERSIONS[@]}"; do
+  echo "Fetching release notes for v${VERSION}.0 via API..."
+
+  curl -sL "https://api.github.com/repos/kubernetes/kubernetes/releases/tags/v${VERSION}.0" | \
+    jq -r '.body' > ".work/k8s-bumpup-audit/release-notes-${VERSION}.md"
+
+  if [ ! -s ".work/k8s-bumpup-audit/release-notes-${VERSION}.md" ]; then
+    echo "Warning: No release notes found for v${VERSION}.0"
+  fi
+done
+```
+
+### Step 3: Identify Breaking Changes
+
+#### 3.1 Parse Changelogs for Key Sections
+
+```bash
+# Extract "API Changes" section from changelog
+for VERSION in "${VERSIONS[@]}"; do
+  CHANGELOG=".work/k8s-bumpup-audit/CHANGELOG-${VERSION}.md"
+
+  if [ -f "$CHANGELOG" ]; then
+    # Extract API Changes section
+    sed -n '/## Changes by Kind/,/##/p' "$CHANGELOG" | \
+      sed -n '/### API Change/,/###/p' > \
+      ".work/k8s-bumpup-audit/api-changes-${VERSION}.txt"
+
+    # Extract Deprecation section
+    sed -n '/## Deprecation/,/##/p' "$CHANGELOG" > \
+      ".work/k8s-bumpup-audit/deprecations-${VERSION}.txt"
+  fi
+done
+```
+
+#### 3.2 Search for Specific Breaking Changes
+
+```bash
+# Common breaking change patterns to search for
+PATTERNS=(
+  "removed"
+  "deprecated"
+  "breaking change"
+  "no longer supported"
+  "beta.*promoted.*GA"
+  "v1beta.*v1"
+)
+
+for VERSION in "${VERSIONS[@]}"; do
+  CHANGELOG=".work/k8s-bumpup-audit/CHANGELOG-${VERSION}.md"
+
+  echo "=== Breaking changes in v${VERSION} ===" > \
+    ".work/k8s-bumpup-audit/breaking-${VERSION}.txt"
+
+  for PATTERN in "${PATTERNS[@]}"; do
+    grep -i "$PATTERN" "$CHANGELOG" >> \
+      ".work/k8s-bumpup-audit/breaking-${VERSION}.txt" 2>/dev/null || true
+  done
+done
+```
+
+#### 3.3 Map Breaking Changes to Codebase Usage
+
+```bash
+# Cross-reference: Check if deprecated APIs are used in codebase
+
+# Example: Check for batch/v1beta1 CronJob usage (deprecated in v1.25, removed in v1.29)
+if grep -q "batch/v1beta1" .work/k8s-bumpup-audit/api-group-versions.txt; then
+  echo "⚠️  WARNING: batch/v1beta1 CronJob is used but deprecated"
+  echo "   Migration required: batch/v1beta1 → batch/v1"
+
+  # Find files using this API
+  grep -r "batch/v1beta1" --include="*.go" --exclude-dir="vendor" . | \
+    cut -d: -f1 | sort -u > .work/k8s-bumpup-audit/files-using-cronjob-beta.txt
+
+  echo "   Affected files:"
+  cat .work/k8s-bumpup-audit/files-using-cronjob-beta.txt | sed 's/^/     - /'
+fi
+
+# Similar checks for other known deprecations
+# - policy/v1beta1 PodSecurityPolicy (removed v1.25)
+# - networking.k8s.io/v1beta1 Ingress (removed v1.22)
+# - rbac.authorization.k8s.io/v1beta1 (removed v1.22)
+```
+
+### Step 4: Analyze Go Module Dependencies
+
+#### 4.1 Check Current Dependency Graph
+
+```bash
+# List all k8s.io dependencies with versions
+go list -m -json all | \
+  jq -r 'select(.Path | startswith("k8s.io/")) | "\(.Path) \(.Version)"' | \
+  sort > .work/k8s-bumpup-audit/current-k8s-deps.txt
+
+# Example output:
+# k8s.io/api v0.28.4
+# k8s.io/apimachinery v0.28.4
+# k8s.io/client-go v0.28.4
+```
+
+#### 4.2 Simulate Dependency Update
+
+```bash
+# Check what would change with target version
+TARGET_VERSION="v1.29.0"
+
+# Create temporary module for testing
+cp go.mod go.mod.backup
+cp go.sum go.sum.backup
+
+# Try updating
+go get k8s.io/api@${TARGET_VERSION} \
+      k8s.io/apimachinery@${TARGET_VERSION} \
+      k8s.io/client-go@${TARGET_VERSION} 2>&1 | \
+  tee .work/k8s-bumpup-audit/update-simulation.log
+
+# Extract dependency changes
+go list -m -json all | \
+  jq -r 'select(.Path | startswith("k8s.io/")) | "\(.Path) \(.Version)"' | \
+  sort > .work/k8s-bumpup-audit/new-k8s-deps.txt
+
+# Diff the changes
+diff .work/k8s-bumpup-audit/current-k8s-deps.txt \
+     .work/k8s-bumpup-audit/new-k8s-deps.txt > \
+     .work/k8s-bumpup-audit/dep-diff.txt || true
+
+# Restore original
+mv go.mod.backup go.mod
+mv go.sum.backup go.sum
+```
+
+#### 4.3 Check for Transitive Dependency Issues
+
+```bash
+# Check if any other dependencies conflict with target k8s version
+go mod graph | grep "k8s.io/" > .work/k8s-bumpup-audit/dep-graph.txt
+
+# Look for version mismatches
+awk '{print $2}' .work/k8s-bumpup-audit/dep-graph.txt | \
+  grep "k8s.io/" | \
+  sort | uniq -c | \
+  awk '$1 > 1 {print}' > .work/k8s-bumpup-audit/potential-conflicts.txt
+
+# If this file is non-empty, there may be version conflicts to resolve
+```
+
+### Step 5: Generate Detailed Audit Report
+
+#### 5.1 Create Report Structure
+
+```bash
+cat > .work/k8s-bumpup-audit/audit-report.md << 'EOF'
+# Kubernetes Dependency Audit Report
+
+**Generated**: $(date)
+**Current Version**: ${CURRENT_VERSION}
+**Target Version**: ${TARGET_VERSION}
+**Versions Crossed**: ${VERSIONS[@]}
+
+---
+
+## Executive Summary
+
+[To be filled]
+
+## API Usage Analysis
+
+### Imported API Groups
+[List from api-group-versions.txt]
+
+### Resource Types in Use
+[List from resource-types.txt]
+
+## Breaking Changes Detected
+
+### Critical Issues
+[API removals that affect the codebase]
+
+### Warnings
+[Deprecations that should be addressed]
+
+### Informational
+[Other changes]
+
+## Dependency Analysis
+
+### Current Dependencies
+[From current-k8s-deps.txt]
+
+### Updated Dependencies
+[From new-k8s-deps.txt]
+
+### Changes
+[From dep-diff.txt]
+
+## Recommendations
+
+1. **Immediate Actions Required**
+   - [List critical changes]
+
+2. **Suggested Before Update**
+   - [List deprecation fixes]
+
+3. **Post-Update Validation**
+   - [Testing recommendations]
+
+## Migration Guides
+
+- [Links to relevant Kubernetes migration guides]
+
+---
+
+## Detailed Findings
+
+[Append detailed analysis]
+EOF
+```
+
+#### 5.2 Populate Report with Findings
+
+```bash
+# Add API usage section
+echo "" >> .work/k8s-bumpup-audit/audit-report.md
+echo "### API Groups Used" >> .work/k8s-bumpup-audit/audit-report.md
+cat .work/k8s-bumpup-audit/api-group-versions.txt | \
+  sed 's/^/- `/' | sed 's/$/`/' >> .work/k8s-bumpup-audit/audit-report.md
+
+# Add breaking changes
+for VERSION in "${VERSIONS[@]}"; do
+  if [ -f ".work/k8s-bumpup-audit/breaking-${VERSION}.txt" ]; then
+    echo "" >> .work/k8s-bumpup-audit/audit-report.md
+    echo "### Breaking Changes in v${VERSION}" >> .work/k8s-bumpup-audit/audit-report.md
+    cat ".work/k8s-bumpup-audit/breaking-${VERSION}.txt" >> \
+      .work/k8s-bumpup-audit/audit-report.md
+  fi
+done
+```
+
+#### 5.3 Add Risk Assessment
+
+```bash
+# Calculate risk score based on:
+# - Number of versions crossed
+# - Number of beta APIs in use
+# - Number of detected breaking changes
+
+VERSIONS_CROSSED=${#VERSIONS[@]}
+BETA_APIS=$(grep -c "beta" .work/k8s-bumpup-audit/api-group-versions.txt || echo 0)
+BREAKING_CHANGES=$(cat .work/k8s-bumpup-audit/breaking-*.txt 2>/dev/null | wc -l || echo 0)
+
+# Simple risk calculation
+RISK_SCORE=$((VERSIONS_CROSSED * 10 + BETA_APIS * 5 + BREAKING_CHANGES * 20))
+
+if [ $RISK_SCORE -lt 30 ]; then
+  RISK_LEVEL="LOW"
+elif [ $RISK_SCORE -lt 70 ]; then
+  RISK_LEVEL="MEDIUM"
+else
+  RISK_LEVEL="HIGH"
+fi
+
+echo "**Risk Level**: ${RISK_LEVEL} (Score: ${RISK_SCORE})" >> \
+  .work/k8s-bumpup-audit/audit-report.md
+```
+
+## Error Handling
+
+### Cannot Fetch Changelogs
+
+If changelog fetching fails:
+
+```bash
+echo "Warning: Unable to fetch changelogs from GitHub"
+echo "Falling back to local analysis only..."
+echo ""
+echo "Suggestion: Manually review release notes at:"
+for VERSION in "${VERSIONS[@]}"; do
+  echo "  - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-${VERSION}.md"
+done
+```
+
+### No Kubernetes Dependencies Found
+
+```bash
+if [ ! -s .work/k8s-bumpup-audit/all-k8s-imports.txt ]; then
+  echo "ERROR: No k8s.io imports found in codebase"
+  echo "This may not be a Kubernetes-dependent project"
+  exit 1
+fi
+```
+
+### Version Parsing Failures
+
+```bash
+if ! echo "$VERSION" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: Invalid version format: $VERSION"
+  echo "Expected format: vMAJOR.MINOR.PATCH (e.g., v1.29.0)"
+  exit 1
+fi
+```
+
+## Examples
+
+### Example 1: Audit v1.28 → v1.29 Upgrade
+
+```bash
+CURRENT_VERSION="v1.28.4"
+TARGET_VERSION="v1.29.0"
+
+# Run full analysis
+[Execute all steps above]
+
+# Expected output in audit-report.md:
+# - List of API changes in v1.29
+# - Detection of any v1beta APIs in use
+# - Dependency version changes
+# - Risk assessment
+```
+
+### Example 2: Detect Specific API Deprecation
+
+```bash
+# Check specifically for CronJob v1beta1 usage
+if grep -q "batchv1beta1.CronJob" .work/k8s-bumpup-audit/resource-types.txt; then
+  echo "Found deprecated CronJob v1beta1 usage"
+
+  # Find exact locations
+  grep -rn "batchv1beta1.CronJob" --include="*.go" . | \
+    grep -v vendor | \
+    tee .work/k8s-bumpup-audit/cronjob-migration-needed.txt
+fi
+```
+
+## Best Practices
+
+1. **Always fetch changelogs**: Even if time-consuming, official changelogs are authoritative
+2. **Check both API and client-go changes**: Breaking changes can occur in client libraries too
+3. **Test simulation in isolation**: Use temporary go.mod copies to avoid corrupting workspace
+4. **Document all findings**: Future maintainers will appreciate the detailed audit trail
+5. **Link to migration guides**: Include URLs to Kubernetes deprecation guides
+6. **Automate where possible**: Scripts should be idempotent and resumable
+
+## Additional Resources
+
+- Kubernetes Deprecation Policy: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+- API Migration Guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+- Client-go Compatibility Matrix: https://github.com/kubernetes/client-go#compatibility-matrix
+- Go Module Documentation: https://go.dev/ref/mod


### PR DESCRIPTION
Why this:

Usually when a new version is coming, each team needs to bump k8s version for their repos one by one, here the plugin want to provide a way to bump k8s version in batch repos by group which can be configed. and then create PR for each repo and also jira ticket

A comprehensive Claude Code plugin for automating Kubernetes dependency upgrades across multiple related repositories.

1. **Smart Version Detection & Syncing**:
   - Auto-fetches latest Kubernetes release from GitHub API
   - Queries available k8s.io/api versions to find latest stable release
   - Automatically syncs K8s and client library versions when mismatched
   - Example: K8s v1.34.3 + client lib v0.34.2 available → uses v1.34.2 ↔ v0.34.2
   - No manual version specification needed

2. **Multiple go.mod Support**:
   - Automatically discovers and updates ALL go.mod files in a repository
   - Critical for complex repos like ovn-kubernetes with multiple modules:
     - go-controller/go.mod
     - test/e2e/go.mod - test/conformance/go.mod

3. **Dual Versioning Support**:
   - k8s.io/kubernetes uses v1.x.y versioning (e.g., v1.34.3)
   - k8s.io/api, k8s.io/apimachinery, k8s.io/client-go use v0.x.y (e.g., v0.34.3)
   - Updates all related dependencies with correct versions:
     - k8s.io/kubernetes@v1.x
     - k8s.io/api@v0.x - k8s.io/apimachinery@v0.x - k8s.io/client-go@v0.x - k8s.io/component-helpers@v0.x - k8s.io/pod-security-admission@v0.x

4. **Batch Repository Processing**:
   - Processes multiple related repositories as a group
   - Pre-configured groups: corenet, storage, operators, monitoring
   - Generates comprehensive cross-repository summary reports
   - SSH URLs for better authentication
   - Auto-detects default branch (master vs main)

5. **Advanced Workflow Features**:
   - Fork support for users without write access (--fork flag)
   - Automatic PR creation with cross-references (--create-pr)
   - JIRA issue tracking for group upgrades (--create-jira)
   - Dry-run mode for auditing (--dry-run)
   - Smart test handling (detects pre-existing failures)
   - Progress tracking for long-running tests
   - Skip repos already at target version

Rebase Kubernetes dependencies across a group of related repositories.

Usage:
```
/k8s-bumpup:batch-by-group <group-name> [options]

Options:
  --workspace-dir <path>  Custom workspace directory
  --create-pr            Create pull requests automatically
  --create-jira          Create JIRA tracking issue
```

Examples:
```
/k8s-bumpup:batch-by-group corenet --create-pr --create-jira

```

Complete rebase workflow for individual repositories.

- Queries versions: `go list -m -versions -json k8s.io/api`
- Filters out alpha/beta/rc releases
- Finds all go.mod files: `find . -name go.mod -type f | grep -v vendor`
- Updates each module independently with proper version mapping
- Handles vendor directories automatically

Pre-configured repository groups in `.claude-plugin/repo-groups.json`:
- **corenet**: 8 networking repositories
- **storage**: 3 storage repositories
- **operators**: 3 core operator repositories
- **monitoring**: 2 monitoring repositories

Tested successfully with 8 corenet repositories:
- 100% success rate
- All go.mod files updated correctly
- Both v1.x and v0.x dependencies handled properly
- Complex multi-module repos (ovn-kubernetes) working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Please follow our contributing guidelines located at TBD.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- try to use conventional commits
- prefix your PR with a Jira ticket number if available
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added k8s-bumpup plugin with two commands: batch-by-group and rebase-repo.
  * Includes Kubernetes dependency analysis capability, initial plugin metadata, and repo-group configurations for batch operations.

* **Documentation**
  * Added comprehensive plugin README, command guides, skill (dependency analysis) documentation, workflows, examples, and troubleshooting (PLUGINS index updated).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->