### PR TITLE
Add github:what-next cmd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -201,6 +201,12 @@
       "source": "./plugins/ote-migration",
       "description": "Automate OpenShift Tests Extension (OTE) migration for component repositories",
       "version": "0.0.1"
+    },
+    {
+      "name": "github",
+      "source": "./plugins/github",
+      "description": "GitHub workflow automation and utilities",
+      "version": "0.0.1"
     }
   ]
 }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,6 +11,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Doc](#doc-plugin)
 - [Etcd](#etcd-plugin)
 - [Git](#git-plugin)
+- [Github](#github-plugin)
 - [Golang](#golang-plugin)
 - [Gwapi](#gwapi-plugin)
 - [Hcp](#hcp-plugin)
@@ -147,6 +148,15 @@ Git workflow automation and utilities
 - **`/git:summary`** - Show current branch, git status, and recent commits for quick context
 
 See [plugins/git/README.md](plugins/git/README.md) for detailed documentation.
+
+### Github Plugin
+
+GitHub workflow automation and utilities
+
+**Commands:**
+- **`/github:what-next` `[--contributing path]`** - Identify what to focus on next based on PRs, issues, and milestones
+
+See [plugins/github/README.md](plugins/github/README.md) for detailed documentation.
 
 ### Golang Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1574,6 +1574,22 @@
         }
       ],
       "version": "0.0.1"
+    },
+    {
+      "commands": [
+        {
+          "argument_hint": "[--contributing path]",
+          "description": "Identify what to focus on next based on PRs, issues, and milestones",
+          "name": "what-next",
+          "synopsis": "/github:what-next [--contributing path]"
+        }
+      ],
+      "description": "GitHub workflow automation and utilities",
+      "has_readme": true,
+      "hooks": [],
+      "name": "github",
+      "skills": [],
+      "version": "0.0.1"
     }
   ]
 }

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "github",
+  "description": "GitHub workflow automation and utilities",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,0 +1,48 @@
+# GitHub Plugin
+
+GitHub workflow automation and utilities for Claude Code.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/github:what-next` | Identify what to focus on next based on PRs, issues, and milestones |
+
+## Installation
+
+```bash
+# Add the marketplace
+/plugin marketplace add openshift-eng/ai-helpers
+
+# Install the plugin
+/plugin install github@ai-helpers
+```
+
+## Prerequisites
+
+- **GitHub CLI (`gh`)** must be installed and authenticated
+  - Check: `gh auth status`
+  - Install: [https://cli.github.com/](https://cli.github.com/)
+- Must be run from within a Git repository with a GitHub remote
+
+## Usage
+
+### What Next
+
+Get a prioritized list of what to work on:
+
+```bash
+/github:what-next
+```
+
+This analyzes:
+- PRs needing your review
+- Your open PRs and their status
+- Priority issues from the next milestone
+- Your draft PRs
+
+With a custom contributing file:
+
+```bash
+/github:what-next --contributing docs/CONTRIBUTING.md
+```

--- a/plugins/github/commands/what-next.md
+++ b/plugins/github/commands/what-next.md
@@ -1,0 +1,226 @@
+---
+description: Identify what to focus on next based on PRs, issues, and milestones
+argument-hint: "[--contributing path]"
+---
+
+## Name
+github:what-next
+
+## Synopsis
+```
+/github:what-next [--contributing path]
+```
+
+## Description
+The `github:what-next` command helps developers identify what to focus on next by analyzing open PRs, assigned work, and milestone issues. It presents a prioritized list of actionable items based on common open-source contribution workflows.
+
+This command is particularly useful for:
+- Starting your work day with a clear focus
+- Identifying PRs that need your review
+- Tracking the status of your own PRs
+- Finding priority issues to work on next
+- Understanding your current workload at a glance
+
+The command automatically:
+- Identifies PRs where your review is needed
+- Shows your open PRs and their review status
+- Finds priority issues from the next milestone
+- Respects contribution guidelines if present
+
+## Prerequisites
+
+1. **GitHub CLI (`gh`)** must be installed and authenticated
+   - Check: `gh auth status`
+   - Install: https://cli.github.com/
+
+2. **Repository context**: Must be run from within a Git repository that has a GitHub remote
+
+## Implementation
+
+Execute the following steps to gather information and present suggestions:
+
+### Step 1: Get GitHub Username
+```bash
+gh api user --jq '.login'
+```
+Store this as `GITHUB_USER` for filtering throughout.
+
+### Step 2: Read Contribution Guidelines (Optional)
+If `--contributing` path is provided, or if `CONTRIBUTING.md` exists in the repository root:
+- Read the file to understand project-specific review and priority conventions
+- Look for guidance on:
+  - Required number of reviewers
+  - Priority label conventions
+  - Milestone-based workflows
+  - Any special review request processes
+
+If no contributing file is found, use sensible defaults.
+
+### Step 3: Fetch Open PRs
+```bash
+gh pr list --state open --json number,title,author,isDraft,reviewRequests,reviews,assignees,updatedAt,url
+```
+
+Process the PR data into categories:
+
+**A. PRs Needing Your Review** (highest priority):
+- Exclude drafts (unless you're an assignee with recent comments)
+- Exclude PRs authored by you
+- Exclude PRs that are "sufficiently reviewed" (see heuristics below)
+- Prioritize PRs where you are explicitly in `reviewRequests`
+
+**B. Your Assigned PRs with Activity**:
+- PRs where you are an assignee (including drafts)
+- Check for recent comments that may need response:
+  ```bash
+  gh pr view <number> --json comments --jq '.comments[-1]'
+  ```
+
+**C. Your Open PRs (non-draft)**:
+- PRs authored by you that are not drafts
+- Categorize by review status:
+  - Has APPROVED and no CHANGES_REQUESTED = ready to merge
+  - Has CHANGES_REQUESTED = needs your attention
+  - No reviews yet = waiting for review
+
+**D. Your Drafts**:
+- Draft PRs authored by you
+- Note how recently they were updated
+
+### Step 4: Find Milestone Issues
+Get the next milestone with a due date:
+```bash
+gh api repos/:owner/:repo/milestones --jq '[.[] | select(.state == "open") | select(.due_on)] | sort_by(.due_on) | .[0] | {number, title, due_on}'
+```
+
+If a milestone exists, fetch its issues:
+```bash
+gh issue list --milestone "<milestone_title>" --state open --json number,title,labels,assignees,url
+```
+
+Sort issues by priority labels (common conventions):
+1. `priority/critical` or `critical` - highest
+2. `priority/high` or `high-priority`
+3. `priority/normal` or no priority label
+4. `priority/low` or `low-priority`
+
+Also recognize:
+- `good first issue` - suitable for newcomers
+- `help wanted` - explicitly seeking contributors
+
+Select up to 3 issues, preferring:
+1. Unassigned issues
+2. Issues assigned to the current user
+3. Issues with `help wanted` label
+
+### Step 5: Format Output
+
+Present findings as a prioritized action list:
+
+```markdown
+## What to Focus on Next
+
+### PRs Needing Your Review
+1. [PR #123](url) - "Title" by @author
+   - You were requested as reviewer
+   - Updated 2 hours ago
+
+### Your Assigned PRs with Activity
+1. [PR #456](url) - "Title" (draft)
+   - @someone commented 3 hours ago - may need response
+
+### Your Open PRs
+1. [PR #789](url) - "Title"
+   - Status: Approved, ready to merge
+2. [PR #790](url) - "Title"
+   - Status: Changes requested by @reviewer
+
+### Your Drafts
+1. [PR #791](url) - "Title"
+   - Last updated 3 days ago
+
+### Priority Issues for [Milestone Name] (due YYYY-MM-DD)
+1. [#100](url) - "Issue title" `priority/high`
+   - Unassigned
+2. [#101](url) - "Another issue" `help wanted`
+   - Assigned to you
+3. [#102](url) - "Third issue"
+   - Unassigned
+
+---
+*PRs take precedence over new work. Review others' PRs first, then address feedback on yours, then pick up new issues.*
+```
+
+If any section is empty, note it (e.g., "No PRs currently need your review").
+
+### Sufficient Review Heuristics
+
+A PR is considered "sufficiently reviewed" (exclude from review list) if:
+- Has 1+ APPROVED review AND no CHANGES_REQUESTED
+- Has CHANGES_REQUESTED (needs author attention, not more reviews)
+- Has 2+ reviews submitted in the last 24 hours (active discussion)
+- All explicitly requested reviewers have submitted reviews
+
+### Error Handling
+
+- **Not in a git repo**: Display error and suggest running from a repository
+- **gh not authenticated**: Display error with `gh auth login` instructions
+- **No GitHub remote**: Display error explaining GitHub remote is required
+- **No milestones**: Skip the milestone section, note "No open milestones with due dates"
+- **API rate limits**: Display warning and suggest waiting
+
+## Return Value
+
+- **Console Output**: Formatted markdown summary of prioritized work items
+- **Sections included**:
+  - PRs needing review (from others)
+  - Your assigned PRs with activity
+  - Your open PRs with status
+  - Your draft PRs
+  - Priority issues from next milestone
+
+## Examples
+
+1. **Basic usage**:
+   ```
+   /github:what-next
+   ```
+   Output: Prioritized list of PRs and issues based on default heuristics
+
+2. **With custom contributing file**:
+   ```
+   /github:what-next --contributing docs/CONTRIBUTING.md
+   ```
+   Output: Same as above, but uses project-specific conventions from the specified file
+
+3. **In a repo with no open PRs or milestones**:
+   ```
+   /github:what-next
+   ```
+   Output:
+   ```markdown
+   ## What to Focus on Next
+
+   ### PRs Needing Your Review
+   No PRs currently need your review.
+
+   ### Your Open PRs
+   You have no open PRs.
+
+   ### Priority Issues
+   No open milestones with due dates found.
+
+   ---
+   *Consider checking the issue tracker for unassigned issues or starting new work.*
+   ```
+
+## Arguments
+
+- `--contributing` (optional): Path to a contributing guidelines file
+  - Default: Looks for `CONTRIBUTING.md` in repository root
+  - If provided, reads project-specific conventions for review requirements and priority labels
+  - Example: `--contributing docs/CONTRIBUTING.md`
+
+## See Also
+- `git:summary` - Quick overview of repository state
+- `git:suggest-reviewers` - Find appropriate reviewers for your PR


### PR DESCRIPTION

## What this PR does / why we need it:

Adds the `github:what-next` command to help developers identify what to focus on next by analyzing open PRs, assigned work, and milestone issues. It presents a prioritized list of actionable items based on common open-source contribution workflows.

## Which issue(s) this PR fixes:

n/a

## Special notes for your reviewer:

Example output in a github repo I'm active on:

```
⏺ What to Focus on Next

  PRs Needing Your Review

  1. https://github.com/kagenti/mcp-gateway/pull/435 - "external mcp server doc updates" by @jasonmadigan
    - Has comment activity from @maleck13, last updated 1 day ago
    - No explicit approval yet
  2. https://github.com/kagenti/mcp-gateway/pull/434 - "docs: Add design document for tool prefix matching" by @trepel
    - You commented recently (today)
    - Active discussion ongoing
  3. https://github.com/kagenti/mcp-gateway/pull/423 - "Virtual server test - Filtered tools refactor" by @maleck13
    - No reviews yet, updated 1 day ago
  4. Dependabot PRs (3 total):
    - https://github.com/kagenti/mcp-gateway/pull/431 - bump gateway-api to 1.4.1
    - https://github.com/kagenti/mcp-gateway/pull/430 - bump mcp-go to 0.43.2
    - https://github.com/kagenti/mcp-gateway/pull/403 - bump go-redis to 9.17.2

  Your Open PRs

  1. https://github.com/kagenti/mcp-gateway/pull/412 - "Remove keycloak/kuadrant/cert-manager install from default dev environment"
    - Status: Approved by @guicassolato, ready to merge
    - Recent discussion about OIDC test server dependency on Keycloak
  2. https://github.com/kagenti/mcp-gateway/pull/432 - "Add vision doc"
    - Status: Waiting for review - requested from @maleck13, @esnible, @huang195, @shaneutt
    - No reviews submitted yet (updated 2 days ago)

  Your Drafts

  1. https://github.com/kagenti/mcp-gateway/pull/424 - "Disable writeTimeout to allow long running SSE connections for notifi…"
    - Last updated 6 days ago
  2. https://github.com/kagenti/mcp-gateway/pull/398 - "Break out registration process into more detail"
    - Last updated 9 days ago, has comments from @maleck13

  Priority Issues for https://github.com/kagenti/mcp-gateway/milestone/2 (due 2026-01-26)

  High Priority:
  1. https://github.com/kagenti/mcp-gateway/issues/278 - "CRD name collision with ToolHive" priority/high - Unassigned
  2. https://github.com/kagenti/mcp-gateway/issues/321 - "Operator & OLM Install" priority/high - Unassigned
  3. https://github.com/kagenti/mcp-gateway/issues/389 - "External Service MCP Server bypasses HTTPRoute" priority/high - Unassigned
  4. https://github.com/kagenti/mcp-gateway/issues/24 - "Notifications Support" priority/high - Assigned to you

  Good First Issue:
  5. https://github.com/kagenti/mcp-gateway/issues/382 - "Upgrade Gateway API dependency from v1.3.0 to v1.4.0" good first issue priority/low - Unassigned (note: dependabot PR #431 may address this)

  ---
  Suggested focus order:
  1. Merge your approved PR #412 (dev environment cleanup)
  2. Review PR #423 (virtual server test refactor) - no reviews yet
  3. Review PR #435 (external mcp server docs)
  4. Follow up on PR #432 (vision doc) if no reviews come in
  5. Continue work on your assigned issue #24 (Notifications Support) or pick up an unassigned high-priority issue
```

Example output in this `ai-helpers` repo (where I'm not active):

```
  What to Focus on Next

  PRs Needing Your Review

  No PRs currently need your review.

  (All 3 open PRs are either drafts, authored by bots, or have requested reviews from other specific users)

  Your Assigned PRs with Activity

  You have no assigned PRs.

  Your Open PRs

  You have no open PRs.

  Your Drafts

  You have no draft PRs.

  Open PRs from Others (FYI)

  These PRs are awaiting review from others, not you:

  1. https://github.com/openshift-eng/ai-helpers/pull/213 - "Add autoscale-cluster command to openshift plugin" by @shyadav10
    - Awaiting review from: @Prashanth684, @theobarberbany
    - Updated 4 hours ago
  2. https://github.com/openshift-eng/ai-helpers/pull/212 - "Add JIRA template system and create command enhancements" by @jaypoulz
    - Awaiting review from: @bentito, @bryan-cox
    - Updated 1 day ago
    - Note: Pipeline failure - PLUGINS.md and docs/data.json are out of sync (needs make update)
  3. https://github.com/openshift-eng/ai-helpers/pull/214 - "feat(jira): Add AI-powered activity type categorization command" by @GrimmiMeloni
    - Draft - not ready for review
    - 3 CodeRabbit review comments posted

  Priority Issues

  No open milestones with due dates found.

  Open Issues (unassigned):
  1. https://github.com/openshift-eng/ai-helpers/issues/25 - "Add cleanup command for session plugin"
  2. https://github.com/openshift-eng/ai-helpers/issues/21 - "Using many plugins can create noise due to file creation"
  3. https://github.com/openshift-eng/ai-helpers/issues/19 - "Missing standards on plugin authorship"

  ---You have no PRs requiring immediate attention. Consider picking up one of the open issues above, or reviewing pending PRs if you have domain expertise in those areas.
```

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub plugin with a /github:what-next command to analyze PRs, issues, and milestones and recommend prioritized next work items.
* **Documentation**
  * Added plugin documentation, command reference, README, usage examples, installation/prerequisite notes, and details on the optional contributing-file argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->