### PR TITLE
feat: add jira:sync-github command

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -161,6 +161,7 @@ A plugin to automate tasks with Jira
 - **`/jira:grooming` `[project-filter] [time-period] [--component component-name] [--label label-name] [--type issue-type] [--status status] [--story-points]`** - Analyze new bugs and cards added over a time period and generate grooming meeting agenda
 - **`/jira:solve`** - Analyze a JIRA issue and create a pull request to solve it.
 - **`/jira:status-rollup` `issue-id [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]`** - Generate a status rollup comment for any JIRA issue based on all child issues and a given date range
+- **`/jira:sync-github` `[--project <key> | --epic <key>] [--repo <org/repo>] [--since <date>] [--include-ignored] [--include-prs]`** - Synchronize issues between JIRA and GitHub with bidirectional support and content sanitization
 - **`/jira:validate-blockers` `[target-version] [component-filter] [--bug issue-key]`** - Validate proposed release blockers using Red Hat OpenShift release blocker criteria
 
 See [plugins/jira/README.md](plugins/jira/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -127,6 +127,12 @@
           "synopsis": "/jira:status-rollup issue-id [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]"
         },
         {
+          "argument_hint": "[--project <key> | --epic <key>] [--repo <org/repo>] [--since <date>] [--include-ignored] [--include-prs]",
+          "description": "Synchronize issues between JIRA and GitHub with bidirectional support and content sanitization",
+          "name": "sync-github",
+          "synopsis": "/jira:sync-github [--project <key> | --epic <key>] [--repo <org/repo>] [--since <date>] [--include-ignored] [--include-prs]"
+        },
+        {
           "argument_hint": "[target-version] [component-filter] [--bug issue-key]",
           "description": "Validate proposed release blockers using Red Hat OpenShift release blocker criteria",
           "name": "validate-blockers",
@@ -202,6 +208,11 @@
           "description": "Jira conventions and bug templates for the OCPBUGS project",
           "id": "ocpbugs",
           "name": "OCPBUGS Jira Conventions"
+        },
+        {
+          "description": "Synchronize issues between JIRA and GitHub with bidirectional support and content sanitization",
+          "id": "sync-github",
+          "name": "JIRA-GitHub Issue Sync"
         }
       ],
       "version": "0.0.1"

--- a/plugins/jira/commands/sync-github.md
+++ b/plugins/jira/commands/sync-github.md
@@ -1,0 +1,379 @@
+---
+description: Synchronize issues between JIRA and GitHub with bidirectional support and content sanitization
+argument-hint: [--project <key> | --epic <key>] [--repo <org/repo>] [--since <date>] [--include-ignored] [--include-prs]
+---
+
+## Name
+jira:sync-github
+
+## Synopsis
+```
+/jira:sync-github [--project <key> | --epic <key>] [--repo <org/repo>] [--since <date>] [--include-ignored] [--include-prs]
+```
+
+## Description
+
+The `jira:sync-github` command synchronizes issues between a JIRA project or epic and a GitHub repository. It identifies issues that exist in one system but not the other, allows selective syncing with user confirmation, and handles content sanitization appropriately for each direction.
+
+**Key Features:**
+
+- **Interactive UI**: Uses arrow-key navigation and multi-select for all user choices
+- **Bidirectional sync**: Sync issues from JIRA to GitHub and vice versa
+- **PR-Aware**: Discovers GitHub PRs, correlates them to JIRA issues, and updates status when merged
+- **Orphan PR Handling**: Creates JIRA issues for merged PRs that have no linked issue
+- **Incremental sync**: Optionally filter to only issues created/updated/closed after a specific date
+- **Smart date filtering**: Automatically suggests date filter for large repositories (>50 items)
+- **Semantic matching**: Identifies issues that exist in both systems based on similarity and existing links
+- **Content sanitization**: Strips company-specific information when syncing JIRA→GitHub
+- **Content cleanup**: Improves professionalism when syncing GitHub→JIRA
+- **Remote linking**: Automatically adds JIRA remote links to synced GitHub issues/PRs
+- **Status sync**: Updates JIRA status when linked GitHub issues are closed or PRs are merged
+- **Persistent memory**: Remembers ignored issues and learned preferences across sessions
+- **Learned preferences**: Suggests previously used projects, epics, and repos in prompts
+- **Select-then-execute**: Each sync direction shows results immediately after selection
+- **Label/Component mapping**: Learns and persists mappings across sessions
+
+**Use Cases:**
+
+1. Keep an open-source GitHub project in sync with internal JIRA tracking
+2. Publish sanitized versions of internal issues to public issue trackers
+3. Import community-reported issues into internal tracking systems
+4. Update JIRA status based on GitHub issue resolution or PR merges
+5. Track orphan PRs by creating JIRA issues for merged work without linked issues
+6. Run incremental syncs to process only recent changes (e.g., weekly sync)
+7. Resume syncing without re-reviewing previously ignored items
+
+## Prerequisites
+
+### Required Tools
+
+This command requires the following tools to be configured:
+
+#### 1. Atlassian MCP Server (for JIRA)
+
+```bash
+# Start the Atlassian MCP server
+podman run -i --rm -p 8080:8080 \
+  -e "JIRA_URL=https://issues.redhat.com" \
+  -e "JIRA_USERNAME" \
+  -e "JIRA_PERSONAL_TOKEN" \
+  -e "JIRA_SSL_VERIFY=true" \
+  ghcr.io/sooperset/mcp-atlassian:latest --transport sse --port 8080 -vv
+
+# Add to Claude Code
+claude mcp add --transport sse atlassian http://localhost:8080/sse
+```
+
+#### 2. GitHub CLI (gh)
+
+```bash
+# Install gh CLI (macOS)
+brew install gh
+
+# Install gh CLI (Fedora/RHEL)
+sudo dnf install gh
+
+# Authenticate with GitHub
+gh auth login
+```
+
+**Required GitHub Scopes:**
+- `repo` - Full control of private repositories (for issue read/write)
+- `public_repo` - Access public repositories (minimum for public repos)
+
+### Verification
+
+- Use `/mcp` within Claude Code to verify the Atlassian MCP server is running
+- Run `gh auth status` to verify GitHub CLI is authenticated
+
+## Implementation
+
+The command operates in five phases. **Invoke the `jira:sync-github` skill** for detailed step-by-step implementation guidance.
+
+### Phase 1: Source Selection (with Learned Preferences)
+- Use `AskUserQuestion` with interactive UI to prompt for JIRA source (project or epic)
+- **Populate options from learned preferences** (recently used projects/epics from state)
+- Use `AskUserQuestion` to prompt for GitHub repository
+- **Suggest repos previously associated with selected project** from state
+- Check repository size and **auto-suggest date filter** if >50 issues+PRs
+- Validate access to both systems
+
+### Phase 2: Data Collection and State Loading
+- **First**, check Claude memory/CLAUDE.md for configured work directory
+- If not found, prompt user with `AskUserQuestion` for work directory location
+- After selection, **tell user how to persist**: run `/memory` and add `jira:sync-github work directory: {path}`
+- Load existing state from `{work_directory}/state.json` (ignored issues, preferences, mappings)
+- Display count of previously ignored items (hidden unless `--include-ignored`)
+- Fetch JIRA issues using MCP `jira_search` with date filter if `--since` provided
+- Fetch GitHub issues using `gh issue list --json ...`
+- **Fetch GitHub PRs** using `gh pr list --json ...` (if `--include-prs` or by default)
+- Extract existing JIRA→GitHub remote links for matching
+- **Extract JIRA key mentions from PR titles, bodies, and branch names**
+- Cache data to `{work_directory}/{timestamp}/`
+
+### Phase 3: Semantic Matching & Gap Analysis
+- Match issues by: existing remote links, JIRA key mentions, title similarity
+- **Correlate PRs to JIRA issues** by: JIRA key mentions, linked GitHub issues, title similarity
+- Categorize as:
+  - **MATCHED**: Issues in both systems
+  - **JIRA-ONLY**: Can sync to GitHub (filtered by ignored list)
+  - **GITHUB-ONLY**: Open issues can sync to JIRA (filtered by ignored list)
+  - **STATUS-SYNC-NEEDED**: Closed GitHub issues with open JIRA
+  - **PR-STATUS-SYNC-NEEDED**: Merged PRs with open JIRA
+  - **ORPHAN-PRS**: Merged PRs with no linked issue (can create JIRA, filtered by ignored list)
+
+### Phase 4: Sync Execution (Interactive Select-Then-Execute)
+
+Each sync direction uses `AskUserQuestion` for multi-select, then immediately executes:
+
+1. **JIRA → GitHub Sync**
+   - Use `AskUserQuestion` with multi-select to choose which JIRA-only issues to sync
+   - For each selected issue: sanitize content, preview, confirm, create GitHub issue
+   - Add remote link comment in JIRA after creation
+   - **Track unselected items as ignored** for future runs
+   - Display results immediately
+
+2. **GitHub → JIRA Sync**
+   - Use `AskUserQuestion` with multi-select to choose which open GitHub-only issues to sync
+   - Note: Closed GitHub issues without a JIRA match are not shown (typically old/irrelevant)
+   - For each selected issue: clean up formatting, preview, confirm, create JIRA issue
+   - **Track unselected items as ignored** for future runs
+   - Display results immediately
+
+3. **Issue Status Sync**
+   - Use `AskUserQuestion` with multi-select to choose which matched issues need status updates
+   - Fetch available transitions from JIRA to show valid target statuses
+   - Use `AskUserQuestion` to select target status (e.g., ON_QA, Verified, Closed)
+   - Execute transitions and display results
+
+4. **PR Status Sync**
+   - Use `AskUserQuestion` with multi-select to choose which merged PRs should update JIRA status
+   - Transition correlated JIRA issues to selected status
+   - **Add remote link from JIRA to PR** if not already linked
+   - Display results immediately
+
+5. **Orphan PR → JIRA Sync**
+   - Use `AskUserQuestion` with multi-select to choose which orphan PRs should create JIRA issues
+   - For each selected PR: build issue from PR content, preview, confirm, create JIRA issue
+   - Add remote link from new JIRA issue to PR
+   - **Track unselected PRs as ignored** for future runs
+   - Display results immediately
+
+### Phase 5: Summary Report and State Persistence
+- Display sync results with success/failure/ignored counts
+- **Save updated state** to `{work_directory}/state.json` (ignored items, preferences, mappings)
+- Save detailed report to `{work_directory}/{timestamp}/report.md`
+- Offer retry for failed items
+
+## Arguments
+
+- **--project** *(optional)*
+  JIRA project key to sync (e.g., `MYPROJECT`).
+  Mutually exclusive with `--epic`.
+
+- **--epic** *(optional)*
+  JIRA epic key to sync (e.g., `MYPROJECT-123`).
+  Syncs the epic and all child issues.
+  Mutually exclusive with `--project`.
+
+- **--repo** *(optional)*
+  GitHub repository in `org/repo` format (e.g., `openshift/origin`).
+
+- **--since** *(optional)*
+  Only sync issues/PRs created, updated, or closed after this date.
+  Accepts formats: `YYYY-MM-DD`, `last-week`, `last-month`, or relative like `7d`, `30d`.
+  Useful for incremental syncs to avoid reprocessing old issues.
+  **Note:** If not provided and the repository has >50 items, you'll be prompted to select a date filter.
+
+- **--include-ignored** *(optional)*
+  Include previously ignored issues and PRs in sync candidates.
+  By default, items you've skipped in previous runs are hidden.
+  Use this flag to reconsider all items.
+
+- **--include-prs** *(optional, default: true)*
+  Fetch and process GitHub pull requests in addition to issues.
+  Enables PR→JIRA status sync and orphan PR handling.
+  PRs are included by default; use `--no-include-prs` to disable.
+
+If arguments are not provided, the command prompts interactively using learned preferences from previous runs.
+
+## Return Value
+
+- **Summary**: Count of issues and PRs synced in each direction
+- **Created Issues**: List of newly created issue keys/URLs
+- **Status Updates**: List of JIRA issues with updated status (from issues and PRs)
+- **PR Links**: List of PRs linked to JIRA issues
+- **Ignored Items**: Count of items added to ignore list
+- **State Updates**: Confirmation that preferences and mappings were saved
+- **Failures**: List of any sync failures with error details
+- **Report File**: Path to detailed sync report
+
+## Examples
+
+1. **Interactive sync (recommended for first use):**
+   ```
+   /jira:sync-github
+   ```
+   Prompts for work directory, project/epic, and repository selection.
+   On subsequent runs, uses learned preferences.
+
+2. **Sync a specific project:**
+   ```
+   /jira:sync-github --project MYPROJECT --repo openshift/my-operator
+   ```
+
+3. **Sync issues under an epic:**
+   ```
+   /jira:sync-github --epic MYPROJECT-100 --repo myorg/myrepo
+   ```
+
+4. **Incremental sync (only recent changes):**
+   ```
+   /jira:sync-github --project MYPROJECT --repo openshift/my-operator --since 2025-12-01
+   ```
+
+5. **Weekly sync (last 7 days):**
+   ```
+   /jira:sync-github --project MYPROJECT --repo openshift/my-operator --since last-week
+   ```
+
+6. **Sync changes from last 30 days:**
+   ```
+   /jira:sync-github --epic MYPROJECT-100 --repo myorg/myrepo --since 30d
+   ```
+
+7. **Review previously ignored items:**
+   ```
+   /jira:sync-github --include-ignored
+   ```
+   Shows all items including those previously skipped.
+
+8. **Sync without PR processing:**
+   ```
+   /jira:sync-github --project MYPROJECT --repo openshift/my-operator --no-include-prs
+   ```
+   Only syncs issues, skips PR correlation and orphan PR handling.
+
+## Error Handling
+
+### GitHub CLI Not Available
+
+**Scenario:** GitHub CLI (gh) not installed or not authenticated.
+
+**Action:**
+```
+GitHub CLI not available or not authenticated.
+
+Please ensure gh is installed and authenticated:
+  # Install (macOS)
+  brew install gh
+
+  # Install (Fedora/RHEL)
+  sudo dnf install gh
+
+  # Authenticate
+  gh auth login
+
+Then try again.
+```
+
+### Atlassian MCP Server Not Available
+
+**Scenario:** Atlassian MCP server not running.
+
+**Action:**
+```
+Atlassian MCP server not available.
+
+Please ensure the server is running and configured.
+Use /mcp in Claude Code to check status.
+```
+
+### Permission Denied
+
+**Scenario:** Cannot create issue in target system.
+
+**Action:**
+- Log the failure
+- Continue with remaining issues
+- Report in summary
+- Suggest checking token permissions
+
+### Rate Limiting
+
+**Scenario:** GitHub or JIRA API rate limit hit.
+
+**Action:**
+- Pause and wait for rate limit reset
+- Inform user of delay
+- Continue when limit resets
+
+### No Issues Found
+
+**Scenario:** Source has no issues to sync.
+
+**Action:**
+```
+No issues found in JIRA project MYPROJECT.
+
+Please verify:
+1. The project key is correct
+2. You have access to the project
+3. The project contains issues
+```
+
+## Security Considerations
+
+### Content Sanitization (JIRA → GitHub)
+
+When syncing to public GitHub repositories, the following is automatically removed:
+
+- Internal URLs (wikis, dashboards, internal tools)
+- Employee names and email addresses
+- Internal project codenames
+- Confidential customer references
+- Credentials, tokens, or secrets
+- Internal component/team names (replaced with generic terms)
+
+**Important:** Always review the sanitized preview before confirming creation.
+
+### Access Control
+
+- GitHub issues are created with your GitHub token's permissions
+- JIRA issues include `security: Red Hat Employee` by default
+- Remote links are only added from JIRA to GitHub (not vice versa)
+
+## State Management
+
+This command maintains persistent state across sessions in `{work_directory}/state.json`:
+
+- **Ignored issues**: Items you've skipped are remembered and hidden in future runs
+- **Recent projects/epics/repos**: Previously used values appear as quick-select options
+- **Project-repo associations**: The command learns which repos you sync with which projects
+- **Label/component mappings**: Mappings you establish are reused in future sessions
+
+**To configure a persistent work directory**, run `/memory` and add:
+
+```
+jira:sync-github work directory: /path/to/your/preferred/location
+```
+
+**To clear ignored items**, manually edit the `state.json` file or run with `--include-ignored` to reconsider all items.
+
+## See Also
+
+- `jira:create` - Create individual JIRA issues
+- `jira:solve` - Analyze and solve JIRA issues
+- `jira:status-rollup` - Generate status rollup reports
+- `jira:extract-prs` - Extract PR links from JIRA issues (used internally)
+
+## Skills Reference
+
+This command invokes the following skill:
+
+- **sync-github** - Detailed implementation guide for the sync workflow
+
+To view skill details:
+```bash
+cat plugins/jira/skills/sync-github/SKILL.md
+```

--- a/plugins/jira/skills/sync-github/SKILL.md
+++ b/plugins/jira/skills/sync-github/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: JIRA-GitHub Issue Sync
+description: Synchronize issues between JIRA and GitHub with bidirectional support and content sanitization
+---
+
+# JIRA-GitHub Issue Sync
+
+This skill provides detailed implementation guidance for synchronizing issues between JIRA and GitHub. It handles bidirectional sync with appropriate content transformation for each direction.
+
+**IMPORTANT FOR AI**: This is a **procedural skill** - when invoked, you should directly execute the implementation steps defined in this document. Follow the step-by-step instructions below, making MCP tool calls and using AskUserQuestion as specified.
+
+**CRITICAL**: Do NOT proactively check prerequisites or validate access before starting Phase 1. Begin immediately with Step 1.1 (prompting the user for JIRA source). Prerequisites are only checked when an operation fails - see Error Handling section for recovery steps.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+- Sync issues from a JIRA project or epic to a GitHub repository
+- Import GitHub issues into JIRA for internal tracking
+- Update JIRA status based on linked GitHub issue state
+- Maintain consistency between internal and public issue trackers
+
+**Key Characteristics:**
+- **Bidirectional**: Supports JIRA→GitHub and GitHub→JIRA sync
+- **Incremental**: Optionally filter to only issues changed after a specific date
+- **Sanitized**: Strips company-specific info from JIRA→GitHub sync
+- **Professional**: Cleans up formatting for GitHub→JIRA sync
+- **Interactive**: Confirms each sync operation with preview
+- **Linked**: Adds JIRA remote links to track GitHub issues
+- **Stateful**: Remembers ignored issues and learned preferences across sessions
+
+## State Management
+
+This skill maintains persistent state across sessions to remember user preferences and previously ignored issues.
+
+### State File Location
+
+The state file is stored at the configured work directory path. The default is `.work/jira/sync-github/state.json`.
+
+### State Schema (v1.0)
+
+```json
+{
+  "schema_version": "1.0",
+  "last_updated": "2025-12-11T10:30:00Z",
+  "ignored_issues": {
+    "jira_to_github": {"PROJ-101": {"ignored_at": "...", "reason": "user_skip", "summary": "..."}},
+    "github_to_jira": {"openshift/hypershift#42": {"ignored_at": "...", "reason": "user_skip", "summary": "..."}}
+  },
+  "sync_history": {
+    "jira_to_github": [{"jira_key": "PROJ-100", "github_url": "...", "synced_at": "..."}],
+    "github_to_jira": [{"github_number": 50, "github_repo": "...", "jira_key": "PROJ-102", "synced_at": "..."}]
+  },
+  "preferences": {
+    "recent_projects": ["OCPMCP", "HOSTEDCP"],
+    "recent_epics": ["OCPMCP-33"],
+    "recent_repos": ["openshift/hypershift"],
+    "project_repo_associations": {"OCPMCP": ["openshift/openshift-mcp-server"]},
+    "label_mappings": {"openshift/hypershift": {"jira_to_github": {...}, "github_to_jira": {...}}},
+    "component_mappings": {"OCPMCP": {"github_to_jira": {...}}}
+  }
+}
+```
+
+### State Operations
+
+Load state at start (create empty if not exists), save after each operation, merge ignored issues and preferences with existing data.
+
+## Implementation
+
+### Phase 1: Source Selection
+
+#### Step 1.1: Determine JIRA Source
+
+If `--project` or `--epic` argument provided, use it. Otherwise, prompt user:
+
+```
+AskUserQuestion: "What would you like to sync from JIRA?" (header: "Source")
+Options: "Project..." | "Epic..."
+```
+
+Handle custom responses (e.g., "project MYPROJECT", "MYPROJECT-123") by auto-detecting type.
+
+If key not provided, prompt with options from `state.preferences.recent_projects` or `recent_epics`. After selection, update preferences (add to front, dedupe, keep 5 most recent).
+
+#### Step 1.2: Determine GitHub Repository
+
+If `--repo` argument provided, use it. Otherwise:
+
+```
+Use AskUserQuestion:
+  question: "Which GitHub repository should sync with {project_key}?"
+  header: "Repository"
+  multiSelect: false
+  options: (populated from state.preferences.project_repo_associations[project] first, then recent_repos)
+```
+
+Parse response to extract `org/repo`. Update `recent_repos` and `project_repo_associations` in state.
+
+#### Step 1.3: Determine Date Filter (Optional)
+
+If `--since` argument provided, parse it. Otherwise, check issue count with `gh issue list --repo {org}/{repo} --state all --limit 1 --json totalCount`.
+
+**If count > 50 issues**, prompt:
+
+```
+Use AskUserQuestion:
+  question: "This repository has many issues ({count}). Apply a date filter?"
+  header: "Date Filter"
+  multiSelect: false
+  options:
+    - label: "Last 30 days" (description: "Recommended")
+    - label: "Last 90 days"
+    - label: "Last 7 days"
+    - label: "No filter (sync all)" (description: "Warning: Many items")
+```
+
+**Supported formats:** `YYYY-MM-DD`, `last-week`, `last-month`, `Nd` (e.g., `7d`, `30d`). Store as `since_date`.
+
+#### Step 1.4: Validate Access
+
+**JIRA:** Call `mcp__atlassian__jira_search` (project) or `mcp__atlassian__jira_get_issue` (epic) with minimal fields.
+
+**GitHub:** Run `gh repo view {org}/{repo} --json name`
+
+If JIRA fails, show Atlassian MCP setup (see Error Handling). If gh fails, show gh CLI setup (see Error Handling).
+
+### Phase 2: Data Collection and State Loading
+
+#### Step 2.1: Determine Work Directory
+
+**This must happen BEFORE loading state or fetching data.**
+
+First, check the user's CLAUDE.md (or Claude memory) for a configured work directory:
+- Look for pattern: `jira:sync-github work directory: {path}`
+
+**If not found, prompt the user:**
+
+```
+Use AskUserQuestion:
+  question: "Where should sync-github store its state and reports?"
+  header: "Work Dir"
+  multiSelect: false
+  options:
+    - label: "~/.github-jira-sync" (description: "Persists across repos, recommended")
+    - label: ".work/jira/sync-github" (description: "Project-local directory")
+```
+
+After the user selects (or provides a custom path via "Other"):
+
+1. **Create the directory** if it doesn't exist: `mkdir -p {work_directory}`
+2. **Tell the user how to persist this choice** by displaying:
+
+```
+To remember this location for future sessions, run `/memory` and add:
+  jira:sync-github work directory: {selected_path}
+```
+
+Store the resolved path as `work_directory` for use throughout the session.
+
+#### Step 2.2: Load Existing State
+
+Load from `{work_directory}/state.json` or initialize empty state. Inform user of loaded ignored count and preferences.
+
+#### Step 2.3: Check for --include-ignored Flag
+
+Set `include_ignored = true` if provided (inform user), otherwise `false` (filter ignored issues from prompts).
+
+#### Step 2.4: Fetch JIRA Issues
+
+**JQL query:**
+- Project: `project = {project_key} AND issuetype in (Story, Task, Bug, Epic)`
+- Epic: `issue in childIssuesOf({epic_key})` (also fetch the epic itself)
+
+If `since_date` set, append: `AND (created >= "{since_date}" OR updated >= "{since_date}" OR resolutiondate >= "{since_date}")`
+
+Call `mcp__atlassian__jira_search` with fields: `key,summary,description,status,issuetype,components,labels`. For epic source, also call `mcp__atlassian__jira_get_issue` to get the epic itself.
+
+#### Step 2.5: Extract Existing JIRA→GitHub Links
+
+For each JIRA issue, fetch with `expand: "changelog"` and examine `changelog.histories[].items[]` where `field == "RemoteIssueLink"`. Extract GitHub issue URLs matching `https://github.com/{org}/{repo}/issues/{number}`. Store for matching in Phase 3.
+
+#### Step 2.6: Fetch GitHub Issues
+
+```bash
+gh issue list --repo {org}/{repo} --state all --limit 500 \
+  --json number,title,body,state,labels,createdAt,updatedAt,closedAt,url
+```
+
+If `since_date` set, add `--search "updated:>={since_date}"` or filter results post-fetch by `createdAt`, `updatedAt`, or `closedAt`.
+
+#### Step 2.7: Cache Data
+
+Save fetched data to `{work_directory}/{timestamp}/`: `jira-issues.json`, `github-issues.json`, `existing-links.json`. Allows fast iteration without re-fetching.
+
+### Phase 3: Semantic Matching
+
+#### Step 3.1: Build Issue Match Candidates
+
+Compare each JIRA issue against GitHub issues. **Matching criteria (priority order):**
+1. **Existing remote link** (score: 100) - JIRA has remote link to GitHub issue URL
+2. **JIRA key in GitHub** (score: 50) - Key appears in GitHub title/body
+3. **Title similarity** (score: 30) - 3+ common significant words between JIRA summary and GitHub title
+4. **Body similarity** (score: 20) - 5+ common significant words between JIRA description and GitHub body
+
+Match if score >= 50.
+
+#### Step 3.2: Categorize Issues
+
+Based on matching results, categorize:
+
+- **MATCHED**: Issues in both systems (track JIRA keys ↔ GitHub numbers)
+- **JIRA-ONLY**: JIRA issues with no GitHub match → candidates for sync TO GitHub (filter ignored unless `include_ignored`)
+- **GITHUB-ONLY**: Open GitHub issues with no JIRA match → candidates for sync TO JIRA (filter ignored; skip closed issues)
+- **STATUS-SYNC-NEEDED**: Matched issues where GitHub is closed but JIRA status not in (Done, Closed, Resolved)
+
+### Phase 4: Sync Execution
+
+User selection with immediate execution for each sync direction.
+
+#### Step 4.1: Display Summary
+
+```
+Sync Analysis Complete{" (changes since {since_date})" if since_date}:
+━━━━━━━━━━━━━━━━━━━━━━━
+- Matched: {count} issues
+- JIRA-only: {count} (can sync to GitHub)
+- GitHub-only: {count} open issues (can sync to JIRA)
+- Status updates needed: {count}
+- Previously ignored: {count} hidden (use --include-ignored to show)
+```
+
+---
+
+#### Step 4.2: JIRA → GitHub Sync
+
+Handles **JIRA-ONLY** issues.
+
+##### 4.2.1: Select JIRA Issues
+
+```
+Use AskUserQuestion:
+  question: "Select JIRA issues to create in GitHub:"
+  header: "JIRA→GitHub"
+  multiSelect: true
+  options: (label=JIRA key, description=summary truncated to 50 chars)
+    - For >4 issues, batch into multiple rounds of 4
+    - Include "[Skip all]" option
+```
+
+Track unselected issues in `state.ignored_issues.jira_to_github` for future filtering.
+
+##### 4.2.2: Create GitHub Issues
+
+For each selected JIRA issue:
+
+**Sanitize content:**
+- Remove internal URLs (`.redhat.com`, `.corp.`, `internal`, `wiki.`, `confluence.`) → `[internal link removed]`
+- Remove emails → `[email removed]`
+- Redact credentials (`token:`, `Bearer`, `password=`) → `[REDACTED]`
+- Convert JIRA formatting (`{code}`, `{noformat}`) to Markdown backticks
+- Do NOT include source JIRA key in GitHub issue
+
+**Map components to labels:** If no obvious match, prompt:
+
+```
+Use AskUserQuestion:
+  question: "Map JIRA component '{component_name}' to which GitHub label?"
+  header: "Label"
+  multiSelect: false
+  options: (available GitHub labels, up to 4)
+```
+
+**Preview and confirm** sanitized content before creating. Create with `gh issue create`. Add comment in JIRA linking to new GitHub issue.
+
+##### 4.2.3: Report Results
+
+Display: `✓ PROJ-101 → #89` or `✗ PROJ-103 → Failed: {reason}`
+
+---
+
+#### Step 4.3: GitHub → JIRA Sync
+
+Handles **GITHUB-ONLY** open issues (skip closed).
+
+##### 4.3.1: Select GitHub Issues
+
+```
+Use AskUserQuestion:
+  question: "Select GitHub issues to create in JIRA:"
+  header: "GitHub→JIRA"
+  multiSelect: true
+  options: (label="#{number}", description=title truncated to 50 chars)
+    - For >4 issues, batch into multiple rounds of 4
+```
+
+##### 4.3.2: Create JIRA Issues
+
+For each selected GitHub issue:
+
+**Clean content:**
+- Capitalize title if needed
+- Convert Markdown to JIRA format (`{code}` blocks, `[text|url]` links)
+- Convert `#N` references to `[#N|https://github.com/{org}/{repo}/issues/N]`
+- Clean excessive whitespace
+
+**Determine issue type** from GitHub labels: "bug"→Bug, "enhancement"/"feature"→Story, else→Task
+
+**Map labels to components:** If no obvious match, prompt:
+
+```
+Use AskUserQuestion:
+  question: "Map GitHub label '{label_name}' to which JIRA component?"
+  header: "Component"
+  multiSelect: false
+  options: (available JIRA components, up to 4)
+```
+
+**Link to parent epic:** Find Epic Link field ID via `mcp__atlassian__jira_search_fields` (keyword: "epic") or by inspecting an existing child issue. Include in `additional_fields`.
+
+**Preview and confirm** before creating. Call `mcp__atlassian__jira_create_issue`. Do NOT set labels unless explicitly requested.
+
+##### 4.3.3: Report Results
+
+Display: `✓ #42 → PROJ-150` or `✗ #89 → Failed: {reason}`
+
+---
+
+#### Step 4.4: Status Sync
+
+Handles **STATUS-SYNC-NEEDED** - matched issues where GitHub is closed but JIRA is still open.
+
+##### 4.4.1: Select Issues
+
+```
+Use AskUserQuestion:
+  question: "These JIRA issues are linked to closed GitHub issues. Select which to update:"
+  header: "Status Sync"
+  multiSelect: true
+  options: (label=JIRA key, description="Linked to #{number} (closed) - {title}")
+    - For >4 issues, batch into multiple rounds
+```
+
+##### 4.4.2: Select Target Status
+
+Fetch transitions via `mcp__atlassian__jira_get_transitions`, then:
+
+```
+Use AskUserQuestion:
+  question: "What status should these {N} JIRA issues be updated to?"
+  header: "Target Status"
+  multiSelect: false
+  options: (up to 4 completion-related statuses: Done, Closed, Resolved, ON_QA, etc.)
+```
+
+##### 4.4.3: Execute Transitions
+
+Call `mcp__atlassian__jira_transition_issue` with comment noting the linked GitHub issue. If transition unavailable for specific issue, fetch its transitions and retry or inform user.
+
+##### 4.4.4: Report Results
+
+Display: `✓ PROJ-101 → ON_QA (linked to #45)` or `✗ PROJ-103 → Failed: {reason}`
+
+### Phase 5: Summary Report and State Persistence
+
+#### Step 5.1: Track and Display Results
+
+Track throughout Phase 4: successful syncs, status updates, ignored items, failures.
+
+Display summary:
+```
+Sync Complete
+━━━━━━━━━━━━━
+JIRA → GitHub: ✓ PROJ-101 → #89, ✓ PROJ-102 → #90
+GitHub → JIRA: ✓ #42 → PROJ-150
+Status Updates: ✓ PROJ-104 → Done (linked to #45)
+State: {N} items ignored, preferences saved
+Summary: {sync_count} synced, {status_count} updated, {failure_count} failed
+```
+
+#### Step 5.2: Save State
+
+Save to `{work_directory}/state.json`: ignored issues, sync history, preferences, label/component mappings.
+
+#### Step 5.3: Save Report
+
+Write to `{work_directory}/{timestamp}/report.md` with summary table (Direction | Success | Failed | Ignored), details for each sync direction, and state changes (newly ignored items, learned preferences).
+
+#### Step 5.4: Offer Retry
+
+If failures occurred, ask: "Some items failed. Retry failed items?" If yes, re-attempt only failures.
+
+## Error Handling
+
+### Atlassian MCP Server Not Available
+
+Show setup instructions:
+```
+podman run -i --rm -p 8080:8080 -e "JIRA_URL=https://issues.redhat.com" -e "JIRA_USERNAME" -e "JIRA_PERSONAL_TOKEN" ghcr.io/sooperset/mcp-atlassian:latest --transport sse --port 8080 -vv
+claude mcp add --transport sse atlassian http://localhost:8080/sse
+```
+
+### GitHub CLI Not Available
+
+Check: `which gh`, `gh auth status`. Install: `brew install gh` (macOS) or `sudo dnf install gh` (Fedora). Auth: `gh auth login`
+
+### Rate Limiting
+
+Inform user, wait 60s, retry.
+
+### Partial Failures
+
+Continue processing; log failures; report all in summary.
+
+## Security Considerations
+
+**Sanitization (JIRA→GitHub):** Remove internal URLs, emails, employee names, credentials, codenames, customer info.
+
+**Preview requirement:** NEVER create without user confirmation.
+
+**Token security:** Never log tokens; use env vars; minimal scopes.
+
+## Best Practices
+
+- Use `--since 7d` for incremental syncs
+- Review every sanitized preview before confirming
+- Establish label/component mappings early
+- For large projects, prefer epic-level syncing
+- Use `--include-ignored` periodically to review skipped items
+- Configure work directory in CLAUDE.md for persistence
+
+## Anti-Patterns
+
+- Syncing without preview
+- Syncing credentials/internal URLs
+- Assuming mappings without confirmation
+- Adding JIRA labels without explicit request
+- Running full syncs on large repos without date filtering
+
+## Workflow Summary
+
+1. **Phase 1**: Source selection (project/epic, repo, date filter) via AskUserQuestion prompts
+2. **Phase 2**: Load state, validate access, fetch issues from both systems
+3. **Phase 3**: Semantic matching (remote links, key mentions, title/body similarity)
+4. **Phase 4**: Execute sync:
+   - JIRA → GitHub: Select → sanitize → preview → create → link back
+   - GitHub → JIRA: Select → clean → preview → create
+   - Status sync: Select matched issues with closed GitHub → transition JIRA
+5. **Phase 5**: Save state, display summary, offer retry


### PR DESCRIPTION


## What this PR does / why we need it:

Many of us work with issues in upstream github communities as well as in JIRA, and it can be a lot to keep those two systems in sync. This PR adds a flow where claude interactively goes through both JIRA and a github repo and determines which issues you may want to sync. After confirmation, it goes through and does the sync for you.

Please always check what claude is doing before letting it create the issues for you! This is just meant to speed up the process of keeping these systems relatively in sync.



## Which issue(s) this PR fixes:

## Special notes for your reviewer:

Note: I haven't tested this on repos/JIRA projects with very large issue counts

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [X] This change includes docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JIRA-GitHub Issue Sync command enabling bidirectional synchronization of issues between JIRA and GitHub with automatic content sanitization and status updates.

* **Documentation**
  * Added comprehensive documentation covering the sync-github command, multi-phase implementation workflow, state management, and error handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->