### PR TITLE
feat(jira): add workload command to analyze sprint assignments

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -210,6 +210,7 @@ A plugin to automate tasks with Jira
 - **`/jira:status-rollup` `issue-id [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]`** - Generate a status rollup comment for any JIRA issue based on all child issues and a given date range
 - **`/jira:update-weekly-status` `[project-key] [--component name] [--label label-name] [user-filters...]`** - Update weekly status summaries for Jira issues with component and user filtering
 - **`/jira:validate-blockers` `[target-version] [component-filter] [--bug issue-key]`** - Validate proposed release blockers using Red Hat OpenShift release blocker criteria
+- **`/jira:workload` `<assignee> <sprint-name>`** - Retrieve and analyze an associate's workload for a given sprint
 
 See [plugins/jira/README.md](plugins/jira/README.md) for detailed documentation.
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -185,6 +185,12 @@
           "description": "Validate proposed release blockers using Red Hat OpenShift release blocker criteria",
           "name": "validate-blockers",
           "synopsis": "/jira:validate-blockers [target-version] [component-filter] [--bug issue-key]"
+        },
+        {
+          "argument_hint": "<assignee> <sprint-name>",
+          "description": "Retrieve and analyze an associate's workload for a given sprint",
+          "name": "workload",
+          "synopsis": "/jira:workload <assignee> <sprint-name>"
         }
       ],
       "description": "A plugin to automate tasks with Jira",
@@ -276,6 +282,11 @@
           "description": "Shared engine for analyzing Jira issue activity and generating status summaries",
           "id": "status-analysis",
           "name": "Jira Status Analysis Engine"
+	},
+	{
+          "description": "Analyze sprint workload using JIRA MCP server integration",
+          "id": "workload",
+          "name": "Workload Analysis with MCP"
         }
       ],
       "version": "0.3.6"

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -12,6 +12,7 @@ Comprehensive Jira integration for Claude Code, providing AI-powered tools to an
 - 🧪 **Test Generation** - Generate comprehensive test steps for JIRA issues by analyzing related PRs
 - ✨ **Issue Creation** - Create well-formed stories, epics, features, tasks, bugs, and feature requests with guided workflows
 - 📝 **Release Note Generation** - Automatically generate bug fix release notes from Jira and linked GitHub PRs
+- 📈 **Workload Analysis** - Retrieve and analyze an associate's workload for a given sprint
 - 🤖 **Automated Workflows** - From issue analysis to PR creation, fully automated
 - 💬 **Smart Comment Analysis** - Extracts blockers, risks, and key insights from comments
 
@@ -276,6 +277,32 @@ Updated: https://redhat.atlassian.net/browse/OCPBUGS-38358
 ```
 
 See [commands/create-release-note.md](commands/create-release-note.md) for full documentation.
+
+### `/jira:workload` - Retrieve Sprint Workload
+
+Retrieve and analyze an associate's workload for a specific sprint. The command provides a comprehensive breakdown of all issues assigned to the associate, including status, priority, story points, and time tracking information.
+
+**Usage:**
+```bash
+# Get workload by username
+/jira:workload jdoe "Sprint 23"
+
+# Get workload by email
+/jira:workload jane.doe@company.com "2025-Q1 Sprint 3"
+
+# Get workload for current sprint
+/jira:workload jsmith "Current Sprint"
+```
+
+**Features:**
+- Groups issues by status (To Do, In Progress, Done, Blocked)
+- Calculates story points and completion metrics
+- Shows priority distribution
+- Identifies blockers and risks
+- Generates actionable insights
+- Exports to Markdown and optionally CSV
+
+See [commands/workload.md](commands/workload.md) for full documentation.
 
 ---
 

--- a/plugins/jira/commands/workload.md
+++ b/plugins/jira/commands/workload.md
@@ -1,0 +1,340 @@
+---
+description: Retrieve and analyze an associate's workload for a given sprint
+argument-hint: <assignee> <sprint-name>
+---
+
+## Name
+jira:workload
+
+## Synopsis
+```
+/jira:workload <assignee> <sprint-name>
+```
+
+## Description
+
+The `jira:workload` command retrieves and analyzes an associate's workload for a specific sprint. It provides a comprehensive breakdown of all issues assigned to the associate within the sprint, including their status, priority, story points, and time tracking information.
+
+This command is particularly useful for:
+- Sprint planning and capacity assessment
+- Identifying overloaded team members
+- Understanding individual contributor workload distribution
+- Tracking progress on assigned work during a sprint
+- Generating reports for 1-on-1s and retrospectives
+
+Key capabilities:
+- Fetches all issues assigned to a user within a specified sprint
+- Groups issues by status (To Do, In Progress, Done, Blocked)
+- Calculates total story points and time estimates
+- Shows priority distribution
+- Identifies blockers and dependencies
+- Generates a formatted report with actionable insights
+
+## MCP Tools Used
+
+This command requires the `mcp-atlassian` MCP server (https://github.com/sooperset/mcp-atlassian) with the following Jira tools enabled:
+
+**Read Operations:**
+- `jira_search` - Search issues using JQL to find workload by assignee and sprint
+- `jira_get_sprint_issues` - Get all issues in a specific sprint
+- `jira_get_agile_boards` - List all agile boards to find sprints
+- `jira_get_sprints_from_board` - List sprints from a board to resolve sprint names
+- `jira_get_user_profile` - Validate user exists (optional)
+
+**Write Operations (optional):**
+- `jira_add_comment` - Post workload report as a comment to a Jira issue
+
+## Implementation
+
+The command executes the following workflow using the JIRA MCP server:
+
+### Step 1: Parse and Validate Arguments
+
+Extract the command arguments:
+- `$1`: assignee (username, email, or display name)
+- `$2`: sprint name (e.g., "Sprint 23", "CORENET Sprint 281")
+
+Both arguments are required for the command to proceed.
+
+### Step 2: Fetch Sprint Issues via MCP
+
+Use the MCP `jira_search` tool to fetch all issues in the specified sprint:
+
+1. **Build the JQL query:**
+   ```
+   sprint="<sprint-name>"
+   ```
+
+2. **Call the `jira_search` tool:**
+   - Set `jql` parameter to the query built above
+   - Set `max_results` to 200 (or higher if needed)
+   - Request comprehensive fields including:
+     - `summary`, `status`, `priority`, `issuetype`
+     - `assignee` (critical for filtering)
+     - `customfield_12310243` (story points for Red Hat Jira)
+     - `timetracking` (original estimate, time spent, remaining)
+     - `labels`, `components`
+     - `created`, `updated`, `resolutiondate`
+     - `parent` (for subtasks)
+
+3. **Verify the response:**
+   - Check that issues were returned
+   - If no issues found, inform the user that the sprint name may be incorrect
+   - Display total number of issues found in the sprint
+
+**Note on Sprint Name Resolution:**
+If the initial search fails, you can help the user find the correct sprint name:
+- Use `jira_get_agile_boards` to list available boards
+- Use `jira_get_sprints_from_board` with a board ID to list sprint names
+- Suggest similar sprint names to the user
+
+### Step 3: Filter Issues by Assignee
+
+From the full sprint results, filter to find issues assigned to the specified user:
+
+1. **Match by assignee fields:**
+   - Compare against `assignee.name` (username)
+   - Compare against `assignee.emailAddress` (email)
+   - Compare against `assignee.displayName` (full name)
+   - Support partial matches for display name
+
+2. **Handle case sensitivity:**
+   - Perform case-insensitive matching for better user experience
+   - Normalize email addresses (lowercase)
+
+3. **Verify matches found:**
+   - If no issues found for the assignee, list all unique assignees in the sprint
+   - Suggest correct assignee names to help the user
+
+### Step 4: Categorize and Analyze Issues
+
+Organize the filtered issues into meaningful categories:
+
+**Status Categorization:**
+- **To Do**: Statuses like "open", "new", "backlog", "to do"
+- **In Progress**: Statuses like "in progress", "wip", "review", "in review", "code review"
+- **Done**: Statuses like "done", "closed", "resolved", "complete"
+- **Blocked**: Statuses like "blocked", "on hold", "waiting"
+- **Other**: Any custom statuses not matching above categories
+
+**Calculate Metrics:**
+- Count issues in each status category
+- Sum story points for each category (use `customfield_12310243` or similar)
+- Calculate completion percentage (done issues / total issues)
+- Analyze priority distribution (P0, P1, P2, P3, etc.)
+- Extract time tracking data if available
+
+**Priority Analysis:**
+- Group by priority level
+- Count issues and sum story points per priority
+- Identify high-priority items that are blocked or still in "To Do"
+
+**Identify Insights:**
+- Issues that have been in progress for a long time (compare `updated` date)
+- High-priority items not yet started
+- Blocked items requiring attention
+- Sprint progress assessment based on completion rate
+- Workload balance (story points vs. capacity)
+
+### Step 5: Generate Workload Report
+
+Create a comprehensive markdown report with the following structure:
+
+```markdown
+# Sprint Workload: {Assignee Display Name} - {Sprint Name}
+
+**Sprint:** {Sprint Name}
+**Assignee:** {Assignee Display Name} ({username})
+**Status as of:** {Current Date}
+
+## Summary
+- **Total Issues:** {count}
+- **Story Points:** {done points} completed / {total points} total ({percentage}%)
+- **Completion Rate:** {done count}/{total count} issues ({percentage}%)
+- **Status:** {On Track | At Risk | Behind}
+
+## Issues by Status
+
+### To Do ({count} issues, {points} points)
+{List issues with: [KEY] [Priority] Summary (story points) - created date}
+
+### In Progress ({count} issues, {points} points)
+{List issues with: [KEY] [Priority] Summary (story points) - started date}
+
+### Blocked ({count} issues, {points} points)
+{List issues with: [KEY] [Priority] Summary (story points) - blocked since date}
+
+### Done ({count} issues, {points} points)
+{List issues with: [KEY] [Priority] Summary (story points) - completed date}
+
+## Priority Breakdown
+- **P0 (Critical):** {count} issues ({points} points)
+- **P1 (High):** {count} issues ({points} points)
+- **P2 (Medium):** {count} issues ({points} points)
+- **P3 (Low):** {count} issues ({points} points)
+
+## Insights
+{Bulleted list of actionable insights based on the data}
+
+## Time Tracking (if available)
+- **Estimated:** {total estimate}
+- **Logged:** {time spent} ({percentage}% of estimate)
+- **Remaining:** {remaining estimate}
+```
+
+### Step 6: Save and Display Report
+
+1. **Setup working directory:**
+   ```bash
+   WORK_DIR="$HOME/.work/jira/workload"
+   mkdir -p "$WORK_DIR"
+   ```
+
+2. **Generate filename:**
+   - Use format: `{assignee-sanitized}-{sprint-sanitized}-{timestamp}.md`
+   - Sanitize names by replacing spaces with hyphens and removing special characters
+
+3. **Write report to file:**
+   - Save the generated markdown to the working directory
+   - Preserve formatting for proper markdown rendering
+
+4. **Display to user:**
+   - Show the complete report in the console
+   - Provide the file path for future reference
+
+### Error Handling
+
+The implementation handles these error cases:
+
+1. **Missing Arguments**:
+   - Display usage message if assignee or sprint name is missing
+   - Example: `Usage: /jira:workload <assignee> <sprint-name>`
+
+2. **MCP Server Not Available**:
+   - Check if the `jira_search` tool is available
+   - If not, inform the user to configure the JIRA MCP server
+   - Provide setup instructions or link to MCP documentation
+
+3. **Sprint Not Found**:
+   - If JQL query returns no results, the sprint name may be incorrect
+   - Suggest using `jira_get_sprints_from_board` to find the correct sprint name
+   - Offer to list available sprints
+
+4. **Assignee Not Found**:
+   - If filtering yields no issues, list all assignees found in the sprint
+   - Suggest the correct assignee name based on similarity
+   - Support case-insensitive matching to help find the user
+
+5. **Missing Story Points**:
+   - Default to 0 story points if the field is not set
+   - Calculate metrics with available data
+   - Note in the report if story points are not being used
+
+6. **Custom Field Variations**:
+   - Different Jira instances use different custom field IDs for story points
+   - Common field names: `customfield_12310243`, `customfield_10016`, `Story Points`
+   - Try multiple field names and use the first one that has values
+
+## Return Value
+
+- **Markdown Report**: Saved to `.work/jira/workload/{assignee}-{sprint-sanitized}-{timestamp}.md`
+- **Console Output**: Complete formatted report displayed in terminal
+
+The report includes:
+- Sprint metadata (name, assignee details)
+- Executive summary with completion metrics
+- Issue breakdown by status with counts and story points
+- Detailed listing of issues in each status category
+- Priority distribution analysis
+- Time tracking summary (if available in Jira)
+- Actionable insights and recommendations based on workload analysis
+
+## Examples
+
+1. **Get workload for a user by username**:
+   ```
+   /jira:workload jdoe "Sprint 23"
+   ```
+   Output: Workload report for user jdoe in Sprint 23
+
+2. **Get workload using email address**:
+   ```
+   /jira:workload jane.doe@company.com "2025-Q1 Sprint 3"
+   ```
+   Output: Workload report for jane.doe@company.com in 2025-Q1 Sprint 3
+
+3. **Get workload for current sprint**:
+   ```
+   /jira:workload jsmith "Current Sprint"
+   ```
+   Output: Workload report for the currently active sprint
+
+**Example Output:**
+
+```markdown
+# Sprint Workload: Jane Doe - Sprint 23
+
+**Sprint:** Sprint 23
+**Assignee:** Jane Doe (jdoe)
+**Status as of:** 2025-01-13
+
+## Summary
+- **Total Issues:** 12
+- **Story Points:** 18 completed / 34 total (53%)
+- **Completion Rate:** 6/12 issues (50%)
+- **Status:** On Track
+
+## Issues by Status
+
+### To Do (3 issues, 8 points)
+- [TEAM-456] [P2] Implement user settings page (5 points)
+- [TEAM-457] [P3] Update API documentation (2 points)
+- [TEAM-458] [P2] Add error handling for edge cases (1 point)
+
+### In Progress (3 issues, 8 points)
+- [TEAM-451] [P0] Fix critical authentication bug (3 points) - Started 2 days ago
+- [TEAM-452] [P1] Refactor database queries (5 points) - Started 5 days ago
+
+### Blocked (0 issues, 0 points)
+- None
+
+### Done (6 issues, 18 points)
+- [TEAM-441] [P1] Implement OAuth2 login (8 points) - Completed 7 days ago
+- [TEAM-442] [P2] Add unit tests for auth service (5 points) - Completed 5 days ago
+- [TEAM-443] [P3] Update dependencies (2 points) - Completed 3 days ago
+- [TEAM-444] [P2] Fix UI rendering bug (3 points) - Completed 2 days ago
+
+## Priority Breakdown
+- **P0 (Critical):** 1 issue (3 points)
+- **P1 (High):** 3 issues (13 points)
+- **P2 (Medium):** 6 issues (15 points)
+- **P3 (Low):** 2 issues (3 points)
+
+## Insights
+- Good progress: 53% of story points completed at sprint midpoint
+- Critical P0 issue (TEAM-451) is being actively worked on
+- No blocked items currently
+- Workload appears balanced with clear priority distribution
+- Recommendation: Focus on completing P0 and P1 items before picking up new work
+
+## Time Tracking
+- **Estimated:** 68h
+- **Logged:** 42h (62% of estimate)
+- **Remaining:** 26h
+
+---
+Report saved to: .work/jira/workload/jane.doe-sprint-23.md
+```
+
+## Arguments
+
+- `<assignee>` (required): The JIRA user to analyze. Can be:
+  - Username (e.g., `jdoe`)
+  - Email address (e.g., `jane.doe@company.com`)
+  - Display name (e.g., `Jane Doe`)
+
+- `<sprint-name>` (required): The sprint to analyze. Examples:
+  - `"Sprint 23"`
+  - `"2025-Q1 Sprint 3"`
+  - `"Current Sprint"` (for active sprint)
+  - Sprint ID number if known (e.g., `12345`)

--- a/plugins/jira/skills/workload/README.md
+++ b/plugins/jira/skills/workload/README.md
@@ -1,0 +1,213 @@
+# Workload Analysis with JIRA MCP
+
+This directory contains guidance and helper resources for the `/jira:workload` command, which analyzes an associate's workload for a given sprint using the JIRA MCP server.
+
+## Overview
+
+The `/jira:workload` command leverages the JIRA MCP server to:
+- Fetch sprint issues using native MCP tools
+- Filter issues by assignee
+- Categorize issues by status, priority, and type
+- Calculate story points and completion metrics
+- Generate actionable insights
+- Create formatted markdown reports
+
+## Usage
+
+```bash
+/jira:workload <assignee> <sprint-name>
+```
+
+**Arguments:**
+- `<assignee>`: Username, email, or display name of the assignee
+- `<sprint-name>`: Name of the sprint (e.g., "Sprint 23", "CORENET Sprint 281")
+
+**Examples:**
+```bash
+/jira:workload jdoe "Sprint 23"
+/jira:workload jane.doe@company.com "CORENET Sprint 281"
+/jira:workload "Jane Doe" "2025-Q1 Sprint 3"
+```
+
+## How It Works
+
+### 1. MCP Integration
+
+The command uses the `mcp-atlassian` MCP server (https://github.com/sooperset/mcp-atlassian) with these tools:
+
+- **`jira_search`**: Search issues using JQL
+- **`jira_get_sprint_issues`**: Get all issues in a sprint
+- **`jira_get_agile_boards`**: List agile boards (for sprint resolution)
+- **`jira_get_sprints_from_board`**: List sprints from a board
+
+### 2. Workflow
+
+1. **Fetch Sprint Issues**: Uses `jira_search` with JQL `sprint="<sprint-name>"`
+2. **Filter by Assignee**: Matches on username, email, or display name
+3. **Categorize**: Groups issues by status (To Do, In Progress, Blocked, Done)
+4. **Calculate Metrics**: Sums story points and calculates completion rates
+5. **Generate Insights**: Analyzes workload patterns and provides recommendations
+6. **Create Report**: Generates a markdown report and saves to `.work/jira/workload/`
+
+### 3. Status Categorization
+
+The command automatically categorizes Jira statuses:
+
+- **To Do**: open, new, backlog, to do, todo
+- **In Progress**: in progress, wip, review, in review, code review
+- **Done**: done, closed, resolved, complete, completed
+- **Blocked**: blocked, on hold, waiting, hold
+- **Other**: Any custom statuses not matching above
+
+### 4. Story Points
+
+The command looks for story points in these custom fields:
+1. `customfield_12310243` (Red Hat Jira)
+2. `customfield_10016` (Common Jira)
+3. `customfield_10002` (Jira Cloud)
+4. Any field containing "story" or "point"
+
+Defaults to 0 if not found.
+
+## Prerequisites
+
+### MCP Server Setup
+
+You must have the JIRA MCP server configured:
+
+1. **Install the MCP server:**
+   ```bash
+   npm install -g @sooperset/mcp-atlassian
+   ```
+
+2. **Configure credentials** in your MCP configuration file (e.g., `~/.cursor/mcp.json`):
+   ```json
+   {
+     "mcpServers": {
+       "mcp-atlassian": {
+         "command": "npx",
+         "args": ["-y", "@sooperset/mcp-atlassian"],
+         "env": {
+           "JIRA_URL": "https://your-jira-instance.atlassian.net",
+           "JIRA_PERSONAL_TOKEN": "your-jira-api-token"
+         }
+       }
+     }
+   }
+   ```
+
+3. **Restart Claude Code** to load the MCP server
+
+### Jira Access
+
+- Access to the Jira project and sprints
+- Valid Jira API token with read permissions
+- Appropriate project permissions
+
+## Report Format
+
+The generated report includes:
+
+```markdown
+# Sprint Workload: {Display Name} - {Sprint Name}
+
+**Sprint:** {Sprint Name}
+**Assignee:** {Display Name} ({username})
+**Status as of:** {Current Date}
+
+## Summary
+- **Total Issues:** {count}
+- **Story Points:** {done} completed / {total} total ({percentage}%)
+- **Completion Rate:** {done}/{total} issues ({percentage}%)
+- **Status:** {On Track | At Risk | Behind | Blocked}
+
+## Issues by Status
+
+### To Do ({count} issues, {points} points)
+{List of issues with key, priority, summary, and story points}
+
+### In Progress ({count} issues, {points} points)
+{List of issues...}
+
+### Blocked ({count} issues, {points} points)
+{List of issues...}
+
+### Done ({count} issues, {points} points)
+{List of issues...}
+
+## Priority Breakdown
+- **P0 (Critical):** {count} issues ({points} points)
+- **P1 (High):** {count} issues ({points} points)
+- **P2 (Medium):** {count} issues ({points} points)
+- **P3 (Low):** {count} issues ({points} points)
+
+## Insights
+{Bulleted list of actionable insights}
+
+## Time Tracking (if available)
+- **Estimated:** {hours}h
+- **Logged:** {hours}h ({percentage}% of estimate)
+- **Remaining:** {hours}h
+```
+
+Reports are saved to: `~/.work/jira/workload/{assignee}-{sprint}-{timestamp}.md`
+
+## Error Handling
+
+The command handles common errors:
+
+- **MCP Server Not Available**: Provides setup instructions
+- **Sprint Not Found**: Suggests using sprint listing tools to find the correct name
+- **Assignee Not Found**: Lists all assignees in the sprint to help identify the correct one
+- **Missing Story Points**: Continues with 0 points and notes this in the report
+- **Custom Field Variations**: Tries multiple common field names
+
+## Insights Generated
+
+The command provides actionable insights such as:
+
+- **Progress Assessment**: "On Track" / "At Risk" / "Behind" based on completion rate
+- **Priority Alerts**: High-priority items not yet started
+- **Stale Work**: Issues in progress for more than 5 days
+- **Blocked Items**: Items requiring attention
+- **Workload Balance**: Distribution of story points across statuses
+- **Recommendations**: Focus areas (e.g., "Complete P0 items before starting new work")
+
+## Troubleshooting
+
+### Can't find assignee
+- Try different formats: username, email, or display name
+- Check the list of available assignees shown in the error message
+- Use case-insensitive matching
+
+### Story points are all 0
+- Verify your Jira instance uses story points
+- Check which custom field your Jira uses (varies by instance)
+- The command will still provide useful metrics based on issue counts
+
+### Sprint not found
+- Verify the sprint name matches exactly (including capitalization)
+- Use quotes around sprint names with spaces
+- Try listing sprints using the MCP tools to find the correct name
+
+### MCP server not responding
+- Verify the MCP server is configured in your settings
+- Check that credentials are correct
+- Restart Claude Code to reload the MCP server
+
+## Additional Resources
+
+- **Command Documentation**: See `../commands/workload.md`
+- **Skill Implementation**: See `SKILL.md` in this directory
+- **MCP Atlassian Server**: https://github.com/sooperset/mcp-atlassian
+- **Jira API Documentation**: https://developer.atlassian.com/cloud/jira/platform/rest/v2/
+
+## Legacy Files
+
+### `generate_workload_report.py`
+
+**Note**: This Python script is legacy code from the pre-MCP implementation. It is no longer used by the `/jira:workload` command, which now uses the JIRA MCP server directly.
+
+The script remains in this directory for reference and potential future use cases, but the MCP-based approach is preferred for all new implementations.
+
+If you need to use the old curl-based approach for any reason, refer to the git history for the previous implementation details.

--- a/plugins/jira/skills/workload/SKILL.md
+++ b/plugins/jira/skills/workload/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: Workload Analysis with MCP
+description: Analyze sprint workload using JIRA MCP server integration
+---
+
+# Workload Analysis with MCP
+
+This skill provides guidance for analyzing an associate's workload for a given sprint using the JIRA MCP server.
+
+## Purpose
+
+This skill helps Claude:
+- Fetch sprint issues using JIRA MCP tools
+- Filter issues by assignee
+- Categorize issues by status, priority, and type
+- Calculate story points and completion metrics
+- Generate comprehensive workload reports in Markdown format
+
+## When to Use This Skill
+
+This skill is automatically invoked by the `/jira:workload` command:
+
+```bash
+/jira:workload <assignee> <sprint-name>
+```
+
+## MCP Tools Required
+
+This skill requires the `mcp-atlassian` MCP server (https://github.com/sooperset/mcp-atlassian) with these tools enabled:
+
+- **`jira_search`**: Search issues using JQL
+- **`jira_get_sprint_issues`**: Get all issues in a sprint (alternative to jira_search)
+- **`jira_get_agile_boards`**: List agile boards (for sprint name resolution)
+- **`jira_get_sprints_from_board`**: List sprints from a board (for sprint name resolution)
+- **`jira_get_user_profile`**: Validate user exists (optional)
+
+## Prerequisites
+
+- JIRA MCP server configured and running locally
+- Credentials configured in MCP server settings
+- Access to the relevant Jira project and sprints
+
+## Implementation Approach
+
+### Step 1: Fetch Sprint Issues
+
+Use the `jira_search` MCP tool with JQL to get all issues in the sprint:
+
+```
+jira_search(
+  jql="sprint=\"<sprint-name>\"",
+  max_results=200,
+  fields=["summary", "status", "priority", "issuetype", "assignee",
+          "customfield_12310243", "timetracking", "labels",
+          "components", "created", "updated", "resolutiondate", "parent"]
+)
+```
+
+**Important fields:**
+- `assignee`: Required for filtering by user
+- `customfield_12310243`: Story points (Red Hat Jira) - may vary by instance
+- `status`, `priority`, `issuetype`: For categorization
+- `timetracking`: Optional time estimates
+
+### Step 2: Filter by Assignee
+
+From the MCP results, filter issues where the assignee matches:
+
+**Matching logic:**
+- Compare against `assignee.name` (username like "jdoe")
+- Compare against `assignee.emailAddress` (email like "jane.doe@company.com")
+- Compare against `assignee.displayName` (full name like "Jane Doe")
+- Use case-insensitive matching
+- Support partial matches for display names
+
+**If no matches found:**
+- Extract all unique assignees from the sprint
+- Display them to the user with usernames and display names
+- Suggest the correct assignee name
+
+### Step 3: Categorize Issues
+
+Group the filtered issues by status using these categories:
+
+**Status Categories:**
+- **To Do**: Statuses like "open", "new", "backlog", "to do", "todo"
+- **In Progress**: Statuses like "in progress", "inprogress", "wip", "review", "in review", "code review"
+- **Done**: Statuses like "done", "closed", "resolved", "complete", "completed"
+- **Blocked**: Statuses like "blocked", "on hold", "waiting", "hold"
+- **Other**: Any custom statuses not matching above
+
+**Priority Mapping:**
+- **P0/Blocker**: Critical issues requiring immediate attention
+- **P1/Critical**: High-priority issues
+- **P2/Major**: Medium-priority issues
+- **P3/Minor**: Low-priority issues
+- **P4/Trivial**: Lowest priority
+
+### Step 4: Calculate Metrics
+
+For each status category, calculate:
+
+1. **Issue Count**: Number of issues in each status
+2. **Story Points**: Sum of story points per status
+   - Try these field names in order:
+     - `customfield_12310243` (Red Hat Jira)
+     - `customfield_10016` (Common Jira)
+     - `customfield_10002` (Jira Cloud)
+     - Look for any field containing "story" or "point"
+   - Default to 0 if not found
+3. **Completion Rate**: (Done issues / Total issues) × 100
+4. **Points Completion**: (Done points / Total points) × 100
+
+### Step 5: Generate Insights
+
+Analyze the data to provide actionable insights:
+
+**Workload Assessment:**
+- **On Track**: ≥50% points complete at sprint midpoint, no blockers
+- **At Risk**: <50% points complete, or 1-2 blocked items
+- **Behind**: <30% points complete, or 3+ blocked items
+- **Blocked**: Multiple blocked items preventing progress
+
+**Key Insights to Include:**
+- High-priority items (P0/P1) that are not started
+- Issues in progress for more than 5 days (check `updated` field)
+- Blocked items requiring attention
+- Balance of story points across statuses
+- Recommendation on focus areas (e.g., "Complete P0 items before starting new work")
+
+### Step 6: Generate Report
+
+Create a markdown report with this structure:
+
+```markdown
+# Sprint Workload: {Display Name} - {Sprint Name}
+
+**Sprint:** {Sprint Name}
+**Assignee:** {Display Name} ({username})
+**Status as of:** {Current Date}
+
+## Summary
+- **Total Issues:** {count}
+- **Story Points:** {done} completed / {total} total ({percentage}%)
+- **Completion Rate:** {done}/{total} issues ({percentage}%)
+- **Status:** {On Track | At Risk | Behind | Blocked}
+
+## Issues by Status
+
+### To Do ({count} issues, {points} points)
+{For each issue: [KEY] [Priority] Summary (points) - created {date}}
+
+### In Progress ({count} issues, {points} points)
+{For each issue: [KEY] [Priority] Summary (points) - started {date}}
+
+### Blocked ({count} issues, {points} points)
+{For each issue: [KEY] [Priority] Summary (points) - blocked since {date}}
+
+### Done ({count} issues, {points} points)
+{For each issue: [KEY] [Priority] Summary (points) - completed {date}}
+
+## Priority Breakdown
+- **P0 (Critical):** {count} issues ({points} points)
+- **P1 (High):** {count} issues ({points} points)
+- **P2 (Medium):** {count} issues ({points} points)
+- **P3 (Low):** {count} issues ({points} points)
+
+## Insights
+{Bulleted list of 3-5 actionable insights}
+
+## Time Tracking (if available)
+- **Estimated:** {hours}h
+- **Logged:** {hours}h ({percentage}% of estimate)
+- **Remaining:** {hours}h
+```
+
+### Step 7: Save and Display
+
+1. Create working directory: `~/.work/jira/workload/`
+2. Generate filename: `{assignee-sanitized}-{sprint-sanitized}-{timestamp}.md`
+3. Write report to file
+4. Display full report to user
+5. Provide file path for reference
+
+## Error Handling
+
+**MCP Server Not Available:**
+```
+Error: JIRA MCP server is not available.
+Please ensure the mcp-atlassian server is configured and running.
+
+Setup instructions:
+1. Install mcp-atlassian: npm install -g @sooperset/mcp-atlassian
+2. Configure in ~/.cursor/mcp.json or similar
+3. Restart Claude Code
+```
+
+**Sprint Not Found:**
+```
+Error: No issues found for sprint "{sprint-name}"
+
+This could mean:
+- The sprint name is incorrect
+- The sprint doesn't exist
+- You don't have access to this sprint
+
+Would you like me to list available sprints?
+```
+
+**Assignee Not Found:**
+```
+Error: No issues found for assignee "{assignee}" in sprint "{sprint-name}"
+
+Available assignees in this sprint:
+- jdoe (Jane Doe, jane.doe@company.com)
+- jsmith (John Smith, john.smith@company.com)
+...
+
+Please verify the assignee name and try again.
+```
+
+**Missing Story Points:**
+- Continue with 0 story points
+- Note in report if story points are not being tracked
+- Still provide valuable insights from issue counts and statuses
+
+## Data Analysis Tips
+
+**Date Calculations:**
+- Use `created` field to determine when work was added
+- Use `updated` field to see recent activity
+- Use `resolutiondate` for completion time
+- Calculate "days in progress" by comparing dates
+
+**Story Points Variations:**
+Different Jira instances use different custom fields. Try:
+1. `customfield_12310243` (Red Hat Jira)
+2. `customfield_10016` (Common configuration)
+3. `customfield_10002` (Jira Cloud)
+4. Search for fields containing "story" or "point" in the field name
+
+**Status Normalization:**
+Convert all status names to lowercase and remove special characters for matching:
+```
+"In Progress" → "inprogress"
+"To-Do" → "todo"
+"On Hold" → "onhold"
+```
+
+## Example MCP Tool Usage
+
+**Searching for sprint issues:**
+```
+Use jira_search tool:
+  jql: sprint="CORENET Sprint 281"
+  max_results: 200
+  fields: summary,status,priority,assignee,customfield_12310243,timetracking
+```
+
+**Listing sprints (if needed):**
+```
+1. Use jira_get_agile_boards tool to get board IDs
+2. Use jira_get_sprints_from_board with board_id
+3. Display sprint names to user
+```
+
+## Troubleshooting
+
+**Problem:** Can't find the assignee
+- **Solution**: Try different formats: username, email, or display name
+- **Debug**: List all assignees in the sprint to help user find the right one
+
+**Problem:** Story points are all 0
+- **Solution**: Check which custom field your Jira uses for story points
+- **Debug**: Inspect the raw MCP response to find the correct field name
+
+**Problem:** Status categorization seems wrong
+- **Solution**: Check the actual status names in your Jira workflow
+- **Adjust**: Add custom status names to the categorization logic
+
+## Additional Documentation
+
+- MCP Atlassian Server: https://github.com/sooperset/mcp-atlassian
+- Jira REST API: https://developer.atlassian.com/cloud/jira/platform/rest/v2/
+- Command Documentation: See `../commands/workload.md`


### PR DESCRIPTION
Add new /jira:workload command that retrieves and analyzes an associate's workload for a specific sprint. The command provides comprehensive breakdown of issues by status, priority, and story points, along with actionable insights.

Features:
- Groups issues by status (To Do, In Progress, Done, Blocked)
- Calculates story points and completion metrics
- Shows priority distribution
- Identifies blockers and risks
- Generates actionable insights
- Exports to Markdown and optionally CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /jira:workload <assignee> <sprint-name> — generates sprint workload analysis with status grouping, story points, completion metrics, priority distribution, time-tracking aggregates, blocker detection, insights, and exportable Markdown/CSV outputs.

* **Documentation**
  * Added comprehensive user docs and usage examples for the workload command, including invocation patterns, expected report structure, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->