### PR TITLE
Add okd-build plugin for automating OKD operator compilation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -151,7 +151,8 @@
     {
       "name": "okd-build",
       "source": "./plugins/okd-build",
-      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)"
+      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)",
+      "version": "0.0.1"
     },
     {
       "name": "origin",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -149,6 +149,11 @@
       "version": "0.1.0"
     },
     {
+      "name": "okd-build",
+      "source": "./plugins/okd-build",
+      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)"
+    },
+    {
       "name": "origin",
       "source": "./plugins/origin",
       "description": "Helpers for openshift/origin development.",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -20,7 +20,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Must Gather](#must-gather-plugin)
 - [Node](#node-plugin)
 - [Node Tuning](#node-tuning-plugin)
-- [Okd Build](#okd-build-plugin)
+- [OKD Build](#okd-build-plugin)
 - [Olm](#olm-plugin)
 - [Olm Team](#olm-team-plugin)
 - [Openshift](#openshift-plugin)
@@ -253,7 +253,7 @@ Automatically create and apply tuned profile
 
 See [plugins/node-tuning/README.md](plugins/node-tuning/README.md) for detailed documentation.
 
-### Okd Build Plugin
+### OKD Build Plugin
 
 Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -20,7 +20,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Must Gather](#must-gather-plugin)
 - [Node](#node-plugin)
 - [Node Tuning](#node-tuning-plugin)
-- [OKD Build](#okd-build-plugin)
+- [Okd Build](#okd-build-plugin)
 - [Olm](#olm-plugin)
 - [Olm Team](#olm-team-plugin)
 - [Openshift](#openshift-plugin)
@@ -253,12 +253,12 @@ Automatically create and apply tuned profile
 
 See [plugins/node-tuning/README.md](plugins/node-tuning/README.md) for detailed documentation.
 
-### OKD Build Plugin
+### Okd Build Plugin
 
 Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)
 
 **Commands:**
-- **`/okd-build:build-operators` `[--fix] [--registry=<registry>] [--base-release=<release-image>] [--bash]`** - Automate compilation of OpenShift operators from source to target OKD SCOS
+- **`/okd-build:build-operators` `[--registry=<registry>] [--base-release=<release-image>] [--bash]`** - Automate compilation of OpenShift operators from source to target OKD SCOS
 
 See [plugins/okd-build/README.md](plugins/okd-build/README.md) for detailed documentation.
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -258,7 +258,7 @@ See [plugins/node-tuning/README.md](plugins/node-tuning/README.md) for detailed 
 Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)
 
 **Commands:**
-- **`/okd-build:build-operators` `[--fix] [--registry=<registry>] [--base-release=<release-image>]`** - Automate compilation of OpenShift operators from source to target OKD SCOS
+- **`/okd-build:build-operators` `[--fix] [--registry=<registry>] [--base-release=<release-image>] [--bash]`** - Automate compilation of OpenShift operators from source to target OKD SCOS
 
 See [plugins/okd-build/README.md](plugins/okd-build/README.md) for detailed documentation.
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -20,6 +20,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Must Gather](#must-gather-plugin)
 - [Node](#node-plugin)
 - [Node Tuning](#node-tuning-plugin)
+- [Okd Build](#okd-build-plugin)
 - [Olm](#olm-plugin)
 - [Olm Team](#olm-team-plugin)
 - [Openshift](#openshift-plugin)
@@ -251,6 +252,15 @@ Automatically create and apply tuned profile
 - **`/node-tuning:generate-tuned-profile` `[profile-name] [--summary ...] [--sysctl ...] [options]`** - Generate a Tuned (tuned.openshift.io/v1) profile manifest for the Node Tuning Operator
 
 See [plugins/node-tuning/README.md](plugins/node-tuning/README.md) for detailed documentation.
+
+### Okd Build Plugin
+
+Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)
+
+**Commands:**
+- **`/okd-build:build-operators` `[--fix] [--registry=<registry>] [--base-release=<release-image>]`** - Automate compilation of OpenShift operators from source to target OKD SCOS
+
+See [plugins/okd-build/README.md](plugins/okd-build/README.md) for detailed documentation.
 
 ### Olm Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1602,6 +1602,22 @@
         }
       ],
       "version": "0.0.1"
+    },
+    {
+      "commands": [
+        {
+          "argument_hint": "[--fix] [--registry=<registry>] [--base-release=<release-image>]",
+          "description": "Automate compilation of OpenShift operators from source to target OKD SCOS",
+          "name": "build-operators",
+          "synopsis": "/okd-build:build-operators [--fix] [--registry=<registry>] [--base-release=<release-image>]"
+        }
+      ],
+      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)",
+      "has_readme": true,
+      "hooks": [],
+      "name": "okd-build",
+      "skills": [],
+      "version": "0.0.1"
     }
   ]
 }

--- a/docs/data.json
+++ b/docs/data.json
@@ -1397,6 +1397,22 @@
     {
       "commands": [
         {
+          "argument_hint": "[--registry=<registry>] [--base-release=<release-image>] [--bash]",
+          "description": "Automate compilation of OpenShift operators from source to target OKD SCOS",
+          "name": "build-operators",
+          "synopsis": "/okd-build:build-operators [--registry=<registry>] [--base-release=<release-image>] [--bash]"
+        }
+      ],
+      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)",
+      "has_readme": true,
+      "hooks": [],
+      "name": "okd-build",
+      "skills": [],
+      "version": "0.0.1"
+    },
+    {
+      "commands": [
+        {
           "argument_hint": "[--url PR_URL] [<pr>] [--depth quick|full]",
           "description": "Expert review tool for PRs that add or modify Two Node (Fencing or Arbiter) tests under test/extended/two_node/ in openshift/origin.",
           "name": "two-node-origin-pr-helper",
@@ -1601,22 +1617,6 @@
           "name": "OTE Migration Workflow"
         }
       ],
-      "version": "0.0.1"
-    },
-    {
-      "commands": [
-        {
-          "argument_hint": "[--fix] [--registry=<registry>] [--base-release=<release-image>]",
-          "description": "Automate compilation of OpenShift operators from source to target OKD SCOS",
-          "name": "build-operators",
-          "synopsis": "/okd-build:build-operators [--fix] [--registry=<registry>] [--base-release=<release-image>]"
-        }
-      ],
-      "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)",
-      "has_readme": true,
-      "hooks": [],
-      "name": "okd-build",
-      "skills": [],
       "version": "0.0.1"
     }
   ]

--- a/plugins/okd-build/.claude-plugin/plugin.json
+++ b/plugins/okd-build/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "okd-build",
+  "description": "Automate compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS)",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/okd-build/README.md
+++ b/plugins/okd-build/README.md
@@ -1,0 +1,209 @@
+# OKD Build Plugin
+
+Automate the compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS).
+
+## Overview
+
+The OKD Build plugin streamlines the process of building OpenShift operators for OKD SCOS releases. It handles the entire workflow from source discovery to release payload creation, including:
+
+- Automatic operator discovery in your workspace
+- Dockerfile transformation for SCOS compatibility
+- Container image building with Podman
+- Custom release payload orchestration
+
+## Installation
+
+### From Marketplace
+
+```bash
+# Add the marketplace
+/plugin marketplace add openshift-eng/ai-helpers
+
+# Install the plugin
+/plugin install okd-build@ai-helpers
+```
+
+### Manual Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/openshift-eng/ai-helpers.git ~/.claude/commands/ai-helpers
+
+# The plugin will be available after restarting Claude Code
+```
+
+## Commands
+
+### `/okd-build:build-operators`
+
+Discovers, builds, and orchestrates OpenShift operators for OKD SCOS.
+
+**Syntax:**
+```
+/okd-build:build-operators [--fix] [--registry=<registry>] [--base-release=<release-image>]
+```
+
+**Options:**
+- `--fix`: Automatically attempt to fix common build errors
+- `--registry=<registry>`: Target registry for images (default: `quay.io/${USER}`)
+- `--base-release=<release-image>`: Base OKD release image (default: `quay.io/okd/scos-release:4.21.0-okd-scos.ec.3`)
+
+**Examples:**
+
+1. Basic usage (build all operators):
+   ```
+   /okd-build:build-operators
+   ```
+
+2. Build with automatic error fixing:
+   ```
+   /okd-build:build-operators --fix
+   ```
+
+3. Build and push to custom registry:
+   ```
+   /okd-build:build-operators --registry=quay.io/myuser
+   ```
+
+4. Build with custom base release:
+   ```
+   /okd-build:build-operators --base-release=quay.io/okd/scos-release:4.22.0-okd-scos.ec.1
+   ```
+
+5. Build with all options:
+   ```
+   /okd-build:build-operators --fix --registry=quay.io/myuser --base-release=quay.io/okd/scos-release:4.22.0-okd-scos.ec.1
+   ```
+
+## Workflow
+
+### 1. Discovery Phase
+The command scans your workspace for operator directories and identifies the appropriate Dockerfiles:
+- Checks root directory for `Dockerfile`
+- Searches common locations: `openshift/`, `build/`, `images/`
+- Selects most recent Dockerfile if multiple exist
+
+### 2. SCOS Transformation
+Automatically converts Dockerfiles for SCOS compatibility:
+- Replaces RHEL base images with SCOS equivalents
+- Adds SCOS build arguments when applicable
+- Example transformation:
+  ```dockerfile
+  # Before
+  FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+
+  # After
+  FROM registry.ci.openshift.org/origin/scos-4.21:base-stream9
+  ```
+
+### 3. Build Execution
+Builds each operator using Podman:
+- Constructs appropriate build commands
+- Handles SCOS-specific build flags
+- Optionally attempts to fix build errors with `--fix`
+
+### 4. Release Orchestration
+Generates a custom OKD release payload:
+- Uses base release (configurable via `--base-release`, default: `quay.io/okd/scos-release:4.21.0-okd-scos.ec.3`)
+- Maps operator images to release components
+- Provides ready-to-execute `oc adm release new` command
+
+## Prerequisites
+
+### Required Tools
+
+1. **Podman** - Container build engine
+   ```bash
+   # Check installation
+   which podman
+
+   # Install: https://podman.io/getting-started/installation
+   ```
+
+2. **oc CLI** - OpenShift command-line interface (for release orchestration)
+   ```bash
+   # Check installation
+   which oc
+
+   # Install: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html
+   ```
+
+3. **Registry Authentication**
+   ```bash
+   # Login to your container registry
+   podman login quay.io
+   ```
+
+## Use Cases
+
+### Building Multiple Operators
+If you have a workspace with multiple operator repositories:
+
+```bash
+workspace/
+├── cluster-monitoring-operator/
+├── cluster-ingress-operator/
+└── cluster-network-operator/
+```
+
+Simply run `/okd-build:build-operators` from the workspace directory, and the command will discover and build all operators.
+
+### Creating Custom OKD Releases
+After building operators, you can create a custom OKD release that includes your modified operators. The command generates the complete `oc adm release new` command for you.
+
+### Testing Operator Changes
+When developing operator changes for OKD:
+1. Make your code changes
+2. Run `/okd-build:build-operators --fix` to build and test
+3. Use the generated release command to deploy to a test cluster
+
+## Troubleshooting
+
+### Build Failures
+- **Missing dependencies**: Use `--fix` flag to attempt automatic resolution
+- **Architecture mismatches**: Ensure you're building for the correct architecture
+- **Registry access**: Verify registry authentication with `podman login`
+
+### Dockerfile Not Found
+The command searches common locations. If your Dockerfile is in an unusual location:
+1. Create a symlink: `ln -s path/to/Dockerfile Dockerfile`
+2. Or move the Dockerfile to a standard location
+
+### SCOS Compatibility
+Not all operators may support SCOS builds. The command checks for SCOS support by examining:
+- `Makefile` for SCOS tags
+- `OWNERS` file
+- Repository documentation
+
+## Advanced Usage
+
+### Targeting Specific OKD Versions
+To target a different OKD version, use the `--base-release` flag with your desired release:
+```bash
+/okd-build:build-operators --base-release=quay.io/okd/scos-release:4.22.0-okd-scos.ec.1
+```
+
+Note: You may also need to update the base image transformations in Dockerfiles if targeting versions other than 4.21 (e.g., `ocp/4.22:base-rhel9` → `origin/scos-4.22:base-stream9`)
+
+### Custom Build Arguments
+If you need additional build arguments beyond `--build-arg TAGS=scos`, you can:
+- Modify the Dockerfile before running the command
+- Or extend the command implementation to accept custom build args
+
+## Contributing
+
+To contribute improvements to this plugin:
+
+1. Fork the repository: https://github.com/openshift-eng/ai-helpers
+2. Make your changes following the plugin conventions in `CLAUDE.md`
+3. Test with `/okd-build:build-operators`
+4. Submit a pull request
+
+## Support
+
+- **Issues**: https://github.com/openshift-eng/ai-helpers/issues
+- **Documentation**: https://github.com/openshift-eng/ai-helpers
+
+## License
+
+This plugin is part of the ai-helpers project. See the repository LICENSE for details.

--- a/plugins/okd-build/README.md
+++ b/plugins/okd-build/README.md
@@ -91,15 +91,19 @@ The command scans your workspace for operator directories and identifies the app
 
 ### 2. SCOS Transformation
 Automatically converts Dockerfiles for SCOS compatibility:
-- Replaces RHEL base images with SCOS equivalents
-- Adds SCOS build arguments when applicable
+- **ONLY replaces base image lines** matching `FROM registry.ci.openshift.org/ocp/X.XX:base-rhel[89]`
+- **Does NOT replace builder or golang images**
 - Example transformation:
   ```dockerfile
   # Before
-  FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+  FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+  # ... build steps ...
+  FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 
   # After
-  FROM registry.ci.openshift.org/origin/scos-4.21:base-stream9
+  FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder  # NOT CHANGED
+  # ... build steps ...
+  FROM registry.ci.openshift.org/origin/scos-4.19:base-stream9  # CHANGED
   ```
 
 ### 3. Build Execution

--- a/plugins/okd-build/commands/build-operators.md
+++ b/plugins/okd-build/commands/build-operators.md
@@ -1,0 +1,248 @@
+---
+description: Automate compilation of OpenShift operators from source to target OKD SCOS
+argument-hint: [--fix] [--registry=<registry>] [--base-release=<release-image>]
+---
+
+## Name
+okd-build:build-operators
+
+## Synopsis
+```
+/okd-build:build-operators [--fix] [--registry=<registry>] [--base-release=<release-image>]
+```
+
+## Description
+The `okd-build:build-operators` command automates the compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS). It discovers operator directories, transforms Dockerfiles for SCOS compatibility, builds container images using Podman, and orchestrates the creation of a custom OKD release payload.
+
+This command streamlines the process of building multiple operators in a workspace by:
+- Automatically discovering operator directories and their Dockerfiles
+- Converting base images from RHEL to SCOS variants
+- Building operators with appropriate SCOS tags
+- Optionally creating a custom release payload using `oc adm release new`
+
+## Implementation
+
+### Phase 1: Discovery & Selection
+
+1. **Scan workspace for operator directories**
+   - List all subdirectories in the current working directory
+   - For each directory, identify if it contains an operator project:
+     - Check for presence of common operator files (e.g., `Makefile`, `go.mod`, `OWNERS`)
+     - Look for Kubernetes manifests in `manifests/` or `deploy/` directories
+
+2. **Locate Dockerfiles**
+   - For each operator directory, find the appropriate Dockerfile using this priority:
+     1. Check for `Dockerfile` in the root directory
+     2. If not found, search in common subdirectories:
+        - `openshift/Dockerfile`
+        - `build/Dockerfile`
+        - `images/Dockerfile`
+     3. If multiple Dockerfiles exist, select the one with the most recent modification time (`mtime`)
+   - Use bash commands: `find`, `stat`, `sort` to determine the most recent file
+
+3. **Display discovery results**
+   - Present a list of discovered operators and their Dockerfiles to the user
+   - Ask for confirmation before proceeding
+
+### Phase 2: SCOS Transformation
+
+1. **Analyze Dockerfile content**
+   - Read the selected Dockerfile for each operator
+   - Identify base image references
+
+2. **Replace base images**
+   - Find and replace any OpenShift base image with SCOS equivalent:
+     - Pattern: `FROM registry.ci.openshift.org/ocp/4.21:base-rhel9`
+     - Replacement: `FROM registry.ci.openshift.org/origin/scos-4.21:base-stream9`
+     - Also handle variants like `base-rhel8`, `builder`, etc.
+   - Use the Edit tool to perform the replacement
+
+3. **Determine SCOS build arguments**
+   - Check if the operator supports SCOS builds:
+     - Examine `Makefile` for `TAGS` or `scos` references
+     - Check `OWNERS` file or repository documentation
+   - If SCOS is supported, prepare build arg: `--build-arg TAGS=scos`
+
+### Phase 3: Build Execution (Podman)
+
+1. **Prepare build command**
+   - Extract operator name from directory name
+   - Construct Podman build command:
+     ```bash
+     podman build -t test-[OPERATOR-NAME]:latest -f [DOCKERFILE_PATH] [BUILD_ARGS] [CONTEXT_DIR]
+     ```
+   - Include `--build-arg TAGS=scos` if applicable
+
+2. **Execute builds**
+   - Run the Podman build command for each operator
+   - Capture stdout and stderr for analysis
+   - Display build progress to the user
+
+3. **Error handling**
+   - If build fails, analyze error logs:
+     - Check for missing dependencies (e.g., Go modules, system packages)
+     - Check for architecture mismatches (e.g., ARM vs x86)
+     - Check for network issues (registry access)
+   - If `--fix` flag is present:
+     - Attempt common fixes:
+       - Add missing dependencies to Dockerfile
+       - Adjust build architecture flags
+       - Update Go module requirements
+     - Retry the build once
+   - If build still fails or `--fix` is not present, report error to user and continue with next operator
+
+4. **Tag and push images** (optional)
+   - If `--registry` is provided:
+     - Determine user's registry namespace (from `--registry` or default to `quay.io/${USER}`)
+     - Tag images: `podman tag test-[OPERATOR-NAME]:latest [REGISTRY]/[OPERATOR-NAME]:latest`
+     - Push images: `podman push [REGISTRY]/[OPERATOR-NAME]:latest`
+     - Capture image digests for release orchestration
+
+### Phase 4: Release Orchestration
+
+1. **Verify prerequisites**
+   - Check if `oc` CLI is installed and available
+   - Verify all operator images were successfully pushed to registry
+   - Collect image digests from push operation
+
+2. **Map operators to release components**
+   - For each built operator, determine its component name in the release:
+     - Extract component name from operator metadata (e.g., `manifests/` directory)
+     - Map operator name to standard OpenShift component names
+     - Common mappings:
+       - `cluster-monitoring-operator` → `cluster-monitoring-operator`
+       - `cluster-ingress-operator` → `cluster-ingress-operator`
+       - etc.
+
+3. **Generate oc adm release command**
+   - Determine base release image:
+     - Use `--base-release` flag value if provided
+     - Default: `quay.io/okd/scos-release:4.21.0-okd-scos.ec.3`
+   - Construct command:
+     ```bash
+     oc adm release new \
+       --from-release=[BASE_RELEASE_IMAGE] \
+       [OPERATOR_NAME]=[IMAGE_DIGEST] \
+       [OPERATOR_NAME2]=[IMAGE_DIGEST2] \
+       ... \
+       --to-image=quay.io/${USER}/openshift-release:4.21-custom \
+       --keep-manifest-list \
+       --allow-missing-images
+     ```
+
+4. **Execute or display command**
+   - Display the generated command to the user
+   - Ask if they want to execute it
+   - If confirmed, execute and monitor progress
+   - Provide the final release image reference
+
+## Return Value
+
+- **Format**: Summary report with build status and optional release command
+
+The command outputs:
+
+1. **Discovery Summary**:
+   - List of discovered operators
+   - Selected Dockerfiles for each operator
+
+2. **Build Results**:
+   - Status for each operator (Success/Failed)
+   - Image references for successful builds
+   - Error messages for failed builds
+
+3. **Release Command** (if applicable):
+   - Complete `oc adm release new` command
+   - Target release image reference
+
+Example output:
+```
+Discovered Operators:
+  1. cluster-monitoring-operator → openshift/Dockerfile
+  2. cluster-ingress-operator → Dockerfile
+  3. cluster-network-operator → build/Dockerfile
+
+Build Results:
+  ✓ cluster-monitoring-operator: quay.io/user/cluster-monitoring-operator:latest (sha256:abc123...)
+  ✓ cluster-ingress-operator: quay.io/user/cluster-ingress-operator:latest (sha256:def456...)
+  ✗ cluster-network-operator: Build failed - missing dependency
+
+Release Command:
+oc adm release new \
+  --from-release=quay.io/okd/scos-release:4.21.0-okd-scos.ec.3 \
+  cluster-monitoring-operator=quay.io/user/cluster-monitoring-operator@sha256:abc123... \
+  cluster-ingress-operator=quay.io/user/cluster-ingress-operator@sha256:def456... \
+  --to-image=quay.io/user/openshift-release:4.21-custom \
+  --keep-manifest-list \
+  --allow-missing-images
+```
+
+## Examples
+
+1. **Build all operators in workspace**:
+   ```
+   /okd-build:build-operators
+   ```
+   Discovers and builds all operators in current directory subdirectories.
+
+2. **Build with automatic error fixing**:
+   ```
+   /okd-build:build-operators --fix
+   ```
+   Attempts to automatically resolve common build errors.
+
+3. **Build and push to custom registry**:
+   ```
+   /okd-build:build-operators --registry=quay.io/myuser
+   ```
+   Builds operators and pushes to specified registry.
+
+4. **Build with custom base release**:
+   ```
+   /okd-build:build-operators --base-release=quay.io/okd/scos-release:4.22.0-okd-scos.ec.1
+   ```
+   Uses a specific OKD release as the base for the custom release payload.
+
+5. **Build with fixing and custom registry**:
+   ```
+   /okd-build:build-operators --fix --registry=quay.io/myuser
+   ```
+   Combines automatic error fixing with custom registry.
+
+6. **Build with all options**:
+   ```
+   /okd-build:build-operators --fix --registry=quay.io/myuser --base-release=quay.io/okd/scos-release:4.22.0-okd-scos.ec.1
+   ```
+   Uses all available options for maximum flexibility.
+
+## Arguments
+
+- `--fix` (Optional): Boolean flag. When present, automatically attempts to fix common build errors such as missing dependencies or architecture mismatches. Will retry failed builds once after applying fixes.
+
+- `--registry` (Optional): String. Target registry for pushing built images. Format: `registry.example.com/namespace`. Default: `quay.io/${USER}` where `${USER}` is the current system user.
+
+- `--base-release` (Optional): String. Base OKD release image to use for creating the custom release payload. This should be a fully qualified image reference. Default: `quay.io/okd/scos-release:4.21.0-okd-scos.ec.3`. Examples:
+  - `quay.io/okd/scos-release:4.21.0-okd-scos.ec.3`
+  - `quay.io/okd/scos-release:4.22.0-okd-scos.ec.1`
+  - Custom release images from your registry
+
+## Prerequisites
+
+1. **Podman**: Container build tool
+   - Check if installed: `which podman`
+   - Installation: https://podman.io/getting-started/installation
+
+2. **oc CLI** (for release orchestration): OpenShift CLI
+   - Check if installed: `which oc`
+   - Installation: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html
+
+3. **Registry Authentication**: Credentials for target registry
+   - Login: `podman login quay.io`
+
+## Notes
+
+- The command operates on subdirectories of the current working directory
+- Each subdirectory is treated as a potential operator project
+- SCOS transformation specifically targets OKD 4.21 base images
+- Failed builds do not stop the overall process - the command continues with remaining operators
+- The `--allow-missing-images` flag in the release command permits partial operator updates

--- a/plugins/okd-build/commands/build-operators.md
+++ b/plugins/okd-build/commands/build-operators.md
@@ -1,6 +1,6 @@
 ---
 description: Automate compilation of OpenShift operators from source to target OKD SCOS
-argument-hint: [--registry=<registry>] [--base-release=<release-image>] [--bash]
+argument-hint: "[--registry=<registry>] [--base-release=<release-image>] [--bash]"
 ---
 
 ## Name
@@ -52,11 +52,30 @@ This command streamlines the process of building multiple operators in a workspa
    - Identify base image references
 
 2. **Replace base images**
-   - Find and replace any OpenShift base image with SCOS equivalent:
-     - Pattern: `FROM registry.ci.openshift.org/ocp/4.21:base-rhel9`
-     - Replacement: `FROM registry.ci.openshift.org/origin/scos-4.21:base-stream9`
-     - Also handle variants like `base-rhel8`, `builder`, etc.
+   - **ONLY replace base image lines** matching the pattern `FROM registry.ci.openshift.org/ocp/X.XX:base-rhel[89]`
+   - **DO NOT replace** builder images (e.g., `FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-...`)
+   - **DO NOT replace** golang images
+   - Replacement pattern:
+     - Pattern: `FROM registry.ci.openshift.org/ocp/4.XX:base-rhel9`
+     - Replacement: `FROM registry.ci.openshift.org/origin/scos-4.XX:base-stream9`
+   - Also handle RHEL 8 variants:
+     - Pattern: `FROM registry.ci.openshift.org/ocp/4.XX:base-rhel8`
+     - Replacement: `FROM registry.ci.openshift.org/origin/scos-4.XX:base-stream8`
    - Use the Edit tool to perform the replacement
+   - Example Dockerfile (before):
+     ```dockerfile
+     FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+     # ... build steps ...
+     FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+     # ... final image steps ...
+     ```
+   - Example Dockerfile (after):
+     ```dockerfile
+     FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder  # NOT CHANGED
+     # ... build steps ...
+     FROM registry.ci.openshift.org/origin/scos-4.19:base-stream9  # CHANGED
+     # ... final image steps ...
+     ```
 
 3. **Prepare SCOS build arguments**
    - All operators will be built with SCOS tags


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds a new Claude code plugin that automates the compilation of OpenShift operators from source to target OKD (Stream CoreOS - SCOS). You clone all the operators that you need to compile for OKD and claude handles the rest for you
### Key features
  - /okd-build:build-operators command with flags:
    - --fix: Automatically attempt to fix common build errors
    - --registry=<registry>: Target registry for images (default: quay.io/${USER})
    - --base-release=<release-image>: Base OKD release to build from (default: quay.io/okd/scos-release:4.21.0-okd-scos.ec.3)
    - --bash: Generate executable bash script instead of running builds directly
## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an okd-build plugin with a build-operators command (options for --registry and --base-release) and a --bash script-generation mode.

* **Documentation**
  * Added full plugin docs: README and a comprehensive command reference covering workflow, prerequisites, examples, troubleshooting, and advanced usage.

* **Catalog**
  * Added a new marketplace/catalog entry for the okd-build plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->