### PR TITLE
feat(openshift): add Gateway API topology visualization skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -80,7 +80,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.2"
+      "version": "0.0.3"
     },
     {
       "name": "etcd",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -260,6 +260,7 @@ OpenShift development utilities and helpers
 - **`/openshift:new-e2e-test` `[test-specification]`** - Write and validate new OpenShift E2E tests using Ginkgo framework
 - **`/openshift:rebase` `<tag>`** - Rebase OpenShift fork of an upstream repository to a new upstream release.
 - **`/openshift:review-test-cases` `[file-path-or-test-code-or-commands]`** - Review test cases for completeness, quality, and best practices - accepts file path or direct oc commands/test code
+- **`/openshift:visualize-gateway-topology`** - Generate and visualize Kubernetes Gateway API topology diagram
 - **`/openshift:visualize-ovn-topology`** - Generate and visualize OVN-Kubernetes network topology diagram
 
 See [plugins/openshift/README.md](plugins/openshift/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -759,6 +759,12 @@
         },
         {
           "argument_hint": "",
+          "description": "Generate and visualize Kubernetes Gateway API topology diagram",
+          "name": "visualize-gateway-topology",
+          "synopsis": "shell"
+        },
+        {
+          "argument_hint": "",
           "description": "Generate and visualize OVN-Kubernetes network topology diagram",
           "name": "visualize-ovn-topology",
           "synopsis": "/openshift:visualize-ovn-topology"
@@ -770,12 +776,17 @@
       "name": "openshift",
       "skills": [
         {
+          "description": "Generates and displays Kubernetes Gateway API topology diagrams showing GatewayClasses, Gateways, Routes, and backend Services in Mermaid format",
+          "id": "generating-gateway-topology",
+          "name": "generating-gateway-topology"
+        },
+        {
           "description": "Generates and displays OVN-Kubernetes network topology diagrams showing logical switches, routers, ports with IP/MAC addresses in Mermaid format",
           "id": "generating-ovn-topology",
           "name": "generating-ovn-topology"
         }
       ],
-      "version": "0.0.2"
+      "version": "0.0.3"
     },
     {
       "commands": [

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/commands/visualize-gateway-topology.md
+++ b/plugins/openshift/commands/visualize-gateway-topology.md
@@ -1,0 +1,127 @@
+---
+description: Generate and visualize Kubernetes Gateway API topology diagram
+argument-hint:
+---
+
+## Name
+
+openshift:visualize-gateway-topology
+
+## Synopsis
+
+```shell
+/openshift:visualize-gateway-topology
+```
+
+## Description
+
+The `openshift:visualize-gateway-topology` command generates a comprehensive Mermaid diagram of the Kubernetes Gateway API topology for a running cluster. The diagram shows:
+
+- GatewayClasses with their controllers and status
+- Gateways with listeners and addresses
+- Routes (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute) with hostnames
+- Backend Services referenced by routes
+- ReferenceGrants for cross-namespace access
+- Relationships between all resources
+
+The command automatically detects Gateway API resources and creates an accurate topology diagram based on real data from your cluster.
+
+## Implementation
+
+This command invokes the `generating-gateway-topology` skill which implements a data-driven topology discovery approach:
+
+1. **Cluster Detection**: Automatically finds clusters with Gateway API CRDs installed
+2. **Permission Check**: Verifies Kubernetes access level and warns if write permissions detected
+   - If you have cluster admin permissions, you'll be asked to confirm before proceeding
+   - The command only performs read-only operations regardless of your permission level
+   - This check ensures informed consent when using admin credentials
+3. **Data Collection**: Queries all Gateway API resources (GatewayClasses, Gateways, Routes, Services)
+4. **Topology Analysis**: Builds relationship graph between resources
+5. **Diagram Generation**: Creates a Mermaid graph with proper hierarchy and styling
+6. **Output**: Saves diagram to `gateway-topology-diagram.md` (or timestamped/custom path if file exists)
+
+**Key Features:**
+- **Data-driven**: Never generates synthetic data - always queries real cluster
+- **Comprehensive**: Collects all Gateway API resource types
+- **gwctl support**: Uses gwctl if available for enhanced data collection
+- **Visual clarity**: Uses color-coded components and layered subgraphs for organization
+
+**Skill Reference:**
+- Implementation details: `plugins/openshift/skills/generating-gateway-topology/SKILL.md`
+- Helper scripts: `plugins/openshift/skills/generating-gateway-topology/scripts/`
+
+## Return Value
+
+- **Format**: Mermaid diagram saved to file
+- **Location**: `./gateway-topology-diagram.md` (current directory) or custom path if specified
+- **Output**: Summary statistics and preview of the generated diagram
+
+## Examples
+
+1. **Basic usage** (generates topology for detected cluster):
+   ```shell
+   /openshift:visualize-gateway-topology
+   ```
+
+   Output:
+   ```text
+   ✅ Successfully generated Gateway API topology diagram
+
+   📄 Diagram saved to: gateway-topology-diagram.md
+
+   Summary:
+   - 2 GatewayClasses (istio, nginx)
+   - 3 Gateways
+   - 8 HTTPRoutes, 2 GRPCRoutes
+   - 12 Backend Services
+   - 1 ReferenceGrant
+
+   💡 Open the file in your IDE to view the full rendered Mermaid diagram!
+   ```
+
+2. **With existing file** (prompts for action):
+   ```shell
+   /openshift:visualize-gateway-topology
+   ```
+
+   You'll be asked:
+   ```text
+   File gateway-topology-diagram.md already exists. Would you like to:
+   (1) Overwrite it
+   (2) Save to a different location
+   (3) Append timestamp to filename
+   (4) Cancel
+   ```
+
+## Prerequisites
+
+- **kubectl**: Must be installed and configured with access to a Kubernetes cluster
+- **Gateway API**: CRDs must be installed in the cluster
+- **Optional**: gwctl for enhanced data collection
+
+To install Gateway API CRDs:
+```bash
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+```
+
+## Security & Safety
+
+**This command performs ONLY read-only operations:**
+- ✅ `kubectl get` - Query Gateway API resources
+- ✅ `gwctl get/describe` - Query resources if available
+- ✅ Local file writes - Save topology diagram
+
+**Operations NEVER performed:**
+- ❌ No `kubectl create/delete/patch/apply`
+- ❌ No `gwctl apply/delete`
+- ❌ No cluster state changes
+
+**Permission Check:**
+If you have cluster admin permissions, you'll receive a warning message before the command proceeds. This is for transparency - you'll be informed about your access level and asked to confirm. The command will still only perform read-only operations.
+
+## Notes
+
+- The command works with any Gateway API implementation (Istio, Nginx, Envoy, Kong, etc.)
+- gwctl is auto-detected and used when available for richer data
+- The diagram uses top-to-bottom layout (graph TB) following the Gateway API hierarchy
+- Cross-namespace references are shown with ReferenceGrant relationships

--- a/plugins/openshift/skills/generating-gateway-topology/README.md
+++ b/plugins/openshift/skills/generating-gateway-topology/README.md
@@ -1,0 +1,307 @@
+# Gateway API Topology Visualization
+
+Generate and visualize Kubernetes Gateway API topology diagrams showing the complete resource hierarchy.
+
+## Overview
+
+The `/openshift:visualize-gateway-topology` command automatically discovers your Gateway API resources and generates a comprehensive Mermaid diagram showing:
+
+- **GatewayClasses** with their controllers and status
+- **Gateways** with listeners, addresses, and status
+- **Routes** (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute) with hostnames and rules
+- **Backend Services** referenced by routes
+- **ReferenceGrants** for cross-namespace access
+- **Relationships** between all resources
+
+The command is **read-only** and performs no cluster modifications.
+
+## Quick Start
+
+### Prerequisites
+
+- **kubectl**: Installed and configured with access to a Kubernetes cluster
+- **Gateway API**: CRDs installed in your cluster
+- **Optional**: gwctl for enhanced data collection
+
+### Installing Gateway API CRDs
+
+If Gateway API is not installed in your cluster:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
+```
+
+### Basic Usage
+
+Simply run the command - it will automatically detect your cluster:
+
+```shell
+/openshift:visualize-gateway-topology
+```
+
+The command will:
+1. Detect clusters with Gateway API CRDs installed
+2. Check your permissions and warn if you have admin access
+3. Collect all Gateway API resources
+4. Analyze topology relationships
+5. Generate a Mermaid diagram
+6. Save to `gateway-topology-diagram.md`
+
+### Example Output
+
+```text
+✅ Successfully generated Gateway API topology diagram
+
+📄 Diagram saved to: gateway-topology-diagram.md
+
+Summary:
+- 2 GatewayClasses (istio, nginx)
+- 3 Gateways
+- 8 HTTPRoutes, 2 GRPCRoutes
+- 12 Backend Services
+- 1 ReferenceGrant
+
+💡 Open the file in your IDE to view the full rendered Mermaid diagram!
+```
+
+## What Gets Visualized
+
+### Resource Hierarchy (Top-to-Bottom)
+
+The diagram shows the complete Gateway API resource hierarchy:
+
+1. **GatewayClass Layer** - Cluster-scoped gateway implementations
+   - Controller name and status
+   - One per gateway type (istio, nginx, etc.)
+
+2. **Gateway Layer** - Load balancer/proxy instances
+   - Namespace and name
+   - Listeners (protocol:port)
+   - Addresses (IP or hostname)
+
+3. **Route Layer** - Routing rules
+   - HTTPRoute, GRPCRoute, TCPRoute, TLSRoute
+   - Hostnames and paths
+   - Parent gateway references
+
+4. **Backend Layer** - Target services
+   - Kubernetes Services
+   - Ports and types
+
+### Relationship Types
+
+The diagram shows connections between resources:
+
+- **implements**: GatewayClass → Gateway
+- **attaches**: Gateway → Route
+- **references**: Route → Service
+- **grants** (cross-namespace): ReferenceGrant → allowed references
+
+## Security & Safety
+
+### Read-Only Operations
+
+This command performs **ONLY read-only operations**:
+
+✅ **What it does:**
+- `kubectl get` - Query Gateway API resources
+- `gwctl get/describe` - Query resources (if gwctl available)
+- Local file writes - Save topology diagram
+
+❌ **What it NEVER does:**
+- `kubectl create/delete/patch/apply` - No resource modifications
+- `gwctl apply/delete` - No resource modifications
+- No Gateway or Route changes
+- No service disruptions
+
+### Permission Checking
+
+If you have cluster admin permissions, the command will:
+1. Detect write permissions before starting
+2. Display exactly what permissions you have
+3. Explain that only read-only operations will be performed
+4. Ask for your explicit consent to proceed
+
+## Output Format
+
+### Generated Diagram
+
+The command creates a Mermaid diagram in Markdown format:
+
+```markdown
+# Gateway API Topology
+
+## Summary
+- GatewayClasses: 2
+- Gateways: 3
+- Routes: 10
+- Backends: 12
+
+## Topology Diagram
+
+```mermaid
+graph TB
+    subgraph gc_layer["GatewayClasses"]
+        GC_istio["GatewayClass: istio<br/>Controller: istio.io/gateway-controller"]
+    end
+
+    subgraph gw_layer["Gateways"]
+        GW_api["Gateway: default/api-gateway<br/>Listeners: HTTPS:443"]
+    end
+
+    GC_istio -->|implements| GW_api
+```
+```
+
+### Viewing the Diagram
+
+**In VS Code / Claude Code:**
+- Open `gateway-topology-diagram.md`
+- Diagram renders automatically in preview pane
+
+**In GitHub:**
+- Diagrams render automatically in markdown preview
+
+**Export to Image:**
+- Use Mermaid CLI or online editors to export PNG/SVG
+
+## Using gwctl
+
+The command can use [gwctl](https://github.com/kubernetes-sigs/gwctl) for enhanced data collection if available.
+
+### Installing gwctl
+
+**macOS/Linux (Homebrew):**
+```bash
+brew install gwctl
+```
+
+**From Source:**
+```bash
+git clone https://github.com/kubernetes-sigs/gwctl
+cd gwctl
+make build
+```
+
+### Benefits of gwctl
+
+- Richer resource details
+- Better relationship detection
+- Native Gateway API tooling
+
+The command automatically detects if gwctl is available and uses it when possible, falling back to kubectl otherwise.
+
+## Troubleshooting
+
+### "No clusters with Gateway API found"
+
+**Cause**: No kubeconfig with Gateway API CRDs detected
+
+**Solutions**:
+1. Install Gateway API CRDs:
+   ```bash
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
+   ```
+2. Verify CRDs are installed:
+   ```bash
+   kubectl get crd gateways.gateway.networking.k8s.io
+   ```
+3. Set kubeconfig explicitly:
+   ```bash
+   export KUBECONFIG=/path/to/config
+   ```
+
+### "Permission denied" or "Forbidden"
+
+**Cause**: Insufficient RBAC permissions
+
+**Solutions**:
+1. Verify you can list gateways:
+   ```bash
+   kubectl get gateways -A
+   ```
+2. Contact cluster admin to grant read access to Gateway API resources
+
+Required permissions:
+- `get`, `list` on gateways, httproutes, gatewayclasses, services
+- No write permissions needed
+
+### "File already exists"
+
+**Cause**: `gateway-topology-diagram.md` already exists in current directory
+
+**Solutions**:
+The command will prompt you to:
+1. Overwrite existing file
+2. Save to a different location
+3. Append timestamp to filename
+4. Cancel operation
+
+### Diagram appears empty
+
+**Cause**: No Gateway API resources deployed
+
+**Solutions**:
+1. Verify resources exist:
+   ```bash
+   kubectl get gateways,httproutes -A
+   ```
+2. Deploy sample Gateway API resources for testing
+3. Check that GatewayClass controller is installed and running
+
+## FAQ
+
+**Q: Does this modify my cluster?**
+A: No. The command only reads cluster state - no modifications are made.
+
+**Q: Will this work without Gateway API installed?**
+A: No. The command requires Gateway API CRDs to be installed.
+
+**Q: Can I run this on a production cluster?**
+A: Yes. All operations are read-only and lightweight. Verify commands if you have write access.
+
+**Q: What Gateway controllers are supported?**
+A: All controllers implementing the Gateway API spec (Istio, Nginx, Envoy, Kong, Traefik, etc.)
+
+**Q: Does this show Ingress resources?**
+A: No. This focuses on Gateway API resources, not the legacy Ingress API.
+
+**Q: Can I customize the diagram appearance?**
+A: Yes. Edit the generated `.md` file - modify Mermaid syntax for colors, layout, etc.
+
+**Q: How do cross-namespace routes work?**
+A: Cross-namespace references require ReferenceGrants. The diagram shows these relationships.
+
+## Files Created
+
+The command creates these temporary files during execution (automatically cleaned up):
+
+```text
+$TMPDIR/gateway_classes_detail.txt    # GatewayClass data
+$TMPDIR/gateways_detail.txt           # Gateway data
+$TMPDIR/httproutes_detail.txt         # HTTPRoute data
+$TMPDIR/grpcroutes_detail.txt         # GRPCRoute data
+$TMPDIR/tcproutes_detail.txt          # TCPRoute data
+$TMPDIR/tlsroutes_detail.txt          # TLSRoute data
+$TMPDIR/backends_detail.txt           # Backend service data
+$TMPDIR/reference_grants_detail.txt   # ReferenceGrant data
+$TMPDIR/gateway_relationships.txt     # Topology relationships
+```
+
+All temporary files are removed after diagram generation completes.
+
+## Technical Details
+
+For AI agents and developers, see:
+- **Implementation details**: [SKILL.md](SKILL.md)
+- **Helper scripts**: [scripts/](scripts/)
+
+## Support
+
+For issues or questions:
+- **Repository**: <https://github.com/openshift-eng/ai-helpers>
+- **Issues**: <https://github.com/openshift-eng/ai-helpers/issues>
+
+## License
+
+See repository [LICENSE](../../../../LICENSE) file.

--- a/plugins/openshift/skills/generating-gateway-topology/SKILL.md
+++ b/plugins/openshift/skills/generating-gateway-topology/SKILL.md
@@ -1,0 +1,450 @@
+---
+name: generating-gateway-topology
+description: Generates and displays Kubernetes Gateway API topology diagrams showing GatewayClasses, Gateways, Routes, and backend Services in Mermaid format
+tools: [Bash, Read, Write]
+---
+
+# Quick Start - Gateway API Topology Generation
+
+**IMMEDIATE ACTIONS** (follow these steps in order):
+
+1. **Detect Cluster**: Find a cluster with Gateway API CRDs installed
+
+   Run: `scripts/detect-gateway-cluster.sh 2>/dev/null`
+
+   The script discovers clusters with Gateway API:
+   - Scans all kubeconfig files: current KUBECONFIG env, ~/.kube/kind-config, ~/.kube/config
+   - Tests ALL contexts in each kubeconfig
+   - Returns parseable list to stdout: `index|kubeconfig|cluster_name|gateway_count|installed_crds`
+   - Diagnostics go to stderr
+   - Exit code: 0=success, 1=no clusters found
+
+   **How to handle the output:**
+
+   The script returns pipe-delimited lines to stdout, one per cluster found, e.g.:
+   ```text
+   1|/home/user/.kube/config|prod-cluster|5|gateways,httproutes,gatewayclasses
+   2|/home/user/.kube/kind-config|dev-cluster|2|gateways,httproutes
+   ```
+
+   **Decision logic:**
+   - If **one cluster** found → automatically use it (extract kubeconfig path from column 2)
+   - If **multiple clusters** found → show the list to user and ask them to choose by number
+   - After selection, extract the kubeconfig path from column 2 of the chosen line
+   - Store the selected kubeconfig path in variable `KC` for use in subsequent steps
+
+   **Example output format parsing:**
+   - Column 1: Index number (for user selection)
+   - Column 2: Kubeconfig file path (this is what you need for `$KC`)
+   - Column 3: Cluster display name
+   - Column 4: Number of Gateway resources
+   - Column 5: Installed Gateway API CRDs
+
+2. **Check Permissions**: Verify user's Kubernetes access level and inform about write permissions
+
+   Run: `scripts/check_permissions.py "$KC"`
+
+   The script returns:
+   - **Exit 0**: Read-only access or user confirmed → proceed
+   - **Exit 1**: Error or user cancelled → stop
+   - **Exit 2**: Write permissions detected → AI must ask user for confirmation
+
+   **When exit code 2 is returned:**
+   1. Parse the stdout to get the list of write permissions
+   2. Display the permissions clearly to the user using a formatted message
+   3. Explain that:
+      - This skill performs ONLY read-only operations
+      - No cluster modifications will be made
+      - The warning is for transparency about their access level
+      - List read-only operations: kubectl get (gateways, httproutes, services, etc.)
+      - List forbidden operations: kubectl create/delete/patch, no Gateway modifications
+   4. **Ask the user explicitly**: "You have cluster admin permissions. This command will only perform read-only operations. Do you want to proceed?"
+   5. If user says yes → continue, if no → stop
+
+3. **Check Output File**: Ask user if `gateway-topology-diagram.md` exists:
+   - (1) Overwrite, (2) Custom path, (3) Timestamp, (4) Cancel
+
+4. **Create Private Temp Directory**: Create a private temporary directory using `mkdtemp` and use it for all temporary files.
+
+   ```bash
+   TMPDIR=$(mktemp -d)
+   ```
+
+5. **Collect Gateway Data**: Get all Gateway API resources from the cluster
+
+   Run: `scripts/collect_gateway_data.py "$KC" "$TMPDIR"`
+
+   Detail files written to `$TMPDIR`:
+   - `gateway_classes_detail.txt` - name|controller|description|status
+   - `gateways_detail.txt` - namespace|name|class|listeners|addresses|status
+   - `httproutes_detail.txt` - namespace|name|hostnames|parent_refs|backend_refs
+   - `grpcroutes_detail.txt` - namespace|name|parent_refs|backend_refs
+   - `tcproutes_detail.txt` - namespace|name|parent_refs|backend_refs
+   - `tlsroutes_detail.txt` - namespace|name|hostnames|parent_refs|backend_refs
+   - `backends_detail.txt` - namespace|name|type|ports|pod_count
+   - `reference_grants_detail.txt` - namespace|name|from_refs|to_refs
+   - `route_rules_detail.txt` - route_ns|route_name|rule_idx|match_condition|backends_with_weights
+   - `endpoints_detail.txt` - svc_namespace|svc_name|pod_name|pod_ip|ready
+
+6. **Analyze Topology**: Build relationship graph from collected data
+
+   Run: `scripts/analyze_topology.py "$TMPDIR"`
+
+   Relationships written to `$TMPDIR`:
+   - `gateway_relationships.txt` - source_type|source_id|relation|target_type|target_id
+
+7. **Generate Diagram**: Create Mermaid `graph TB` diagram
+   - Read `$TMPDIR/gateway_relationships.txt` to determine connections
+   - Read detail files directly for resource attributes
+   - Group resources by type in subgraphs
+
+8. **Save & Report**: Write diagram to file, show summary, clean up temporary files
+
+**CRITICAL RULES**:
+- ❌ NO codebase searching for IPs/ports
+- ❌ NO synthetic/example data
+- ❌ NO inline multi-line bash (use helper scripts)
+- ❌ NO direct kubectl commands (must use helper scripts only)
+- ✅ Use helper scripts for all kubectl interactions
+- ✅ **SECURITY**: Create private temp directory with `TMPDIR=$(mktemp -d)` - never use `/tmp` directly
+- ✅ Temporary files use `$TMPDIR` (private directory created with mkdtemp)
+- ✅ Clean up temporary files when done: `rm -rf "$TMPDIR"`
+
+## Safety & Security Guarantees
+
+### Read-Only Operations
+
+This skill performs **ONLY read-only operations** against your Kubernetes cluster. No cluster state is modified.
+
+**Allowed Operations:**
+- ✅ `kubectl get` - Query Gateway API resources
+- ✅ `gwctl get/describe` - Query resources if gwctl is available
+- ✅ Local file writes (temporary files in `$TMPDIR`, output diagram)
+
+**Forbidden Operations (NEVER used):**
+- ❌ `kubectl create/apply/delete/patch` - No resource modifications
+- ❌ `gwctl apply/delete` - No resource modifications
+- ❌ No Gateway/Route creation or deletion
+- ❌ No service disruptions
+
+**Privacy Consideration**: The generated diagram contains Gateway API topology information including hostnames and backend services. Control sharing appropriately based on your security policies.
+
+---
+
+# Gateway API Concepts
+
+## Resource Hierarchy
+
+The Gateway API follows a hierarchical model:
+
+1. **GatewayClass** (cluster-scoped)
+   - Defines a type of Gateway managed by a controller
+   - Examples: istio, nginx, envoy, kong
+
+2. **Gateway** (namespace-scoped)
+   - Represents an actual load balancer or proxy
+   - Has listeners (ports, protocols, hostnames)
+   - References a GatewayClass
+
+3. **Routes** (namespace-scoped)
+   - HTTPRoute, GRPCRoute, TCPRoute, TLSRoute
+   - Define routing rules from Gateway to backends
+   - Reference parent Gateways
+
+4. **Backend Services** (namespace-scoped)
+   - Kubernetes Services referenced by Routes
+   - May include port and weight configurations
+
+5. **ReferenceGrants** (namespace-scoped)
+   - Allow cross-namespace references
+   - Required when Route in namespace A references Service in namespace B
+
+## Helper Scripts
+
+All helper scripts are in the `scripts/` directory.
+
+| Script | Purpose | Input | Output |
+|--------|---------|-------|--------|
+| [detect-gateway-cluster.sh](scripts/detect-gateway-cluster.sh) | Find cluster with Gateway API CRDs across all contexts | None | Parseable list to stdout: `index\|kubeconfig\|cluster\|gateways\|crds`. Exit: 0=success, 1=none found |
+| [check_permissions.py](scripts/check_permissions.py) | Check user permissions and warn if write access detected | KUBECONFIG path | Exit: 0=proceed, 1=cancelled/error, 2=write perms (needs user confirmation) |
+| [collect_gateway_data.py](scripts/collect_gateway_data.py) | Collect all Gateway API resources from cluster | KUBECONFIG path, TMPDIR | Detail files: `gateway_classes_detail.txt`, `gateways_detail.txt`, `httproutes_detail.txt`, etc. |
+| [analyze_topology.py](scripts/analyze_topology.py) | Build relationship graph from collected data | TMPDIR (reads detail files) | Relationships file: `gateway_relationships.txt` |
+
+---
+
+# Diagram Generation Rules
+
+## Structure Options
+
+There are two diagram modes based on complexity:
+
+### Mode 1: Per-Gateway Subgraphs (Detailed - for clusters with 1-3 Gateways)
+
+Use this mode for detailed visualization showing listeners, rules, and endpoints within each Gateway.
+
+```mermaid
+graph TB
+    %% GatewayClass at top (cluster-scoped)
+    GC_ocp["GatewayClass: openshift-default<br/>Controller: openshift.io/gateway-controller<br/>Status: Accepted"]
+
+    %% Per-Gateway subgraph (like per-node in OVN topology)
+    subgraph gw1["Gateway: prod-gateway (10.0.0.50)"]
+        direction TB
+
+        %% Listener Layer (like ports in OVN)
+        subgraph listeners1["Listeners"]
+            L1_https["HTTPS:443<br/>TLS: terminate"]
+            L1_http["HTTP:80"]
+        end
+
+        %% Routes attached to this gateway
+        subgraph routes1["Attached Routes"]
+            HR1_api["HTTPRoute: api-route<br/>Host: api.example.com"]
+            HR1_web["HTTPRoute: web-route<br/>Host: www.example.com"]
+        end
+
+        %% Route Rules with match conditions
+        subgraph rules1["Routing Rules"]
+            R1_1["Rule 0: PathPrefix:/api<br/>Headers: x-version=2"]
+            R1_2["Rule 1: PathPrefix:/"]
+        end
+
+        %% Backend Services with weights
+        subgraph backends1["Backends"]
+            SVC1_api["api-service:8080<br/>Weight: 80%"]
+            SVC1_api_canary["api-service-canary:8080<br/>Weight: 20%"]
+            SVC1_web["web-service:80"]
+        end
+
+        %% Pod Endpoints
+        subgraph pods1["Endpoints"]
+            POD1_1["api-pod-abc<br/>10.244.1.5 ready"]
+            POD1_2["api-pod-def<br/>10.244.2.3 ready"]
+            POD1_3["web-pod-xyz<br/>10.244.1.8 ready"]
+        end
+
+        %% Connections within gateway
+        L1_https --> HR1_api
+        L1_http --> HR1_web
+        HR1_api --> R1_1
+        HR1_web --> R1_2
+        R1_1 -->|80%| SVC1_api
+        R1_1 -->|20%| SVC1_api_canary
+        R1_2 --> SVC1_web
+        SVC1_api --> POD1_1
+        SVC1_api --> POD1_2
+        SVC1_web --> POD1_3
+    end
+
+    %% GatewayClass to Gateway connection
+    GC_ocp --> gw1
+
+    %% Styles
+    classDef gatewayclass fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#000
+    classDef listener fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000
+    classDef route fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000
+    classDef rule fill:#fce4ec,stroke:#c2185b,stroke-width:1px,color:#000
+    classDef service fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#000
+    classDef pod fill:#fff9c4,stroke:#f57f17,stroke-width:1px,color:#000
+
+    class GC_ocp gatewayclass
+    class L1_https,L1_http listener
+    class HR1_api,HR1_web route
+    class R1_1,R1_2 rule
+    class SVC1_api,SVC1_api_canary,SVC1_web service
+    class POD1_1,POD1_2,POD1_3 pod
+
+    %% Subgraph Styling
+    style listeners1 fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
+    style routes1 fill:#fff8e1,stroke:#ff8f00,stroke-width:2px
+    style rules1 fill:#fce4ec,stroke:#c2185b,stroke-width:1px,stroke-dasharray: 3 3
+    style backends1 fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style pods1 fill:#fffde7,stroke:#fbc02d,stroke-width:1px,stroke-dasharray: 3 3
+```
+
+### Mode 2: Layered Overview (Simple - for clusters with 4+ Gateways)
+
+Use this mode for high-level overview when there are many Gateways.
+
+```mermaid
+graph TB
+    %% Title
+    subgraph title["Gateway API Topology"]
+        direction TB
+
+        %% Layer 1: GatewayClasses (cluster-scoped)
+        subgraph gc_layer["GatewayClasses"]
+            GC_istio["GatewayClass: istio<br/>Controller: istio.io/gateway-controller<br/>Status: Accepted"]
+        end
+
+        %% Layer 2: Gateways
+        subgraph gw_layer["Gateways"]
+            GW_api["Gateway: default/api-gateway<br/>Listeners: HTTPS:443, HTTP:80<br/>Address: 10.0.0.50"]
+        end
+
+        %% Layer 3: Routes
+        subgraph route_layer["Routes"]
+            HR_api["HTTPRoute: default/api-routes<br/>Hostnames: api.example.com"]
+            HR_web["HTTPRoute: default/web-routes<br/>Hostnames: www.example.com"]
+        end
+
+        %% Layer 4: Backend Services
+        subgraph backend_layer["Backend Services"]
+            SVC_api["Service: default/api-svc<br/>Type: ClusterIP<br/>Ports: 8080→8080/TCP"]
+            SVC_web["Service: default/web-svc<br/>Type: ClusterIP<br/>Ports: 80→80/TCP"]
+        end
+
+        %% Connections
+        GC_istio -->|implements| GW_api
+        GW_api -->|attaches| HR_api
+        GW_api -->|attaches| HR_web
+        HR_api -->|references| SVC_api
+        HR_web -->|references| SVC_web
+    end
+
+    %% Styles
+    classDef gatewayclass fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#000
+    classDef gateway fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000
+    classDef route fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000
+    classDef service fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#000
+
+    class GC_istio gatewayclass
+    class GW_api gateway
+    class HR_api,HR_web route
+    class SVC_api,SVC_web service
+```
+
+## Key Requirements
+
+1. **Graph Direction**: Always `graph TB` (top-to-bottom)
+
+2. **Mode Selection**:
+   - **Per-Gateway Subgraphs** (Mode 1): Use when 1-3 Gateways exist - shows detailed listeners, rules, weights, and endpoints
+   - **Layered Overview** (Mode 2): Use when 4+ Gateways exist - shows high-level relationships only
+
+3. **Resource Layers** (top to bottom):
+   - Layer 1: GatewayClasses (cluster-scoped, at top)
+   - Layer 2: Gateways (with Listeners sub-layer in Mode 1)
+   - Layer 3: Routes (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute)
+   - Layer 4: Route Rules (Mode 1 only - with path/header matches)
+   - Layer 5: Backend Services (with weights in Mode 1)
+   - Layer 6: Pod Endpoints (Mode 1 only - with IPs and ready status)
+
+4. **Node Identifiers**: Use unique IDs based on resource type and name:
+   - GatewayClass: `GC_{name}` (e.g., `GC_istio`)
+   - Gateway: `GW_{namespace}_{name}` (e.g., `GW_default_api_gateway`)
+   - Listener: `L{gw_idx}_{protocol}` (e.g., `L1_https`)
+   - HTTPRoute: `HR_{namespace}_{name}` or `HR{gw_idx}_{name}` in Mode 1
+   - GRPCRoute: `GR_{namespace}_{name}`
+   - TCPRoute: `TR_{namespace}_{name}`
+   - TLSRoute: `TL_{namespace}_{name}`
+   - RouteRule: `R{gw_idx}_{rule_idx}` (e.g., `R1_0`)
+   - Service: `SVC_{namespace}_{name}` or `SVC{gw_idx}_{name}` in Mode 1
+   - Pod: `POD{gw_idx}_{idx}` (e.g., `POD1_1`)
+
+5. **Node Labels**: Include key information:
+   - GatewayClass: `GatewayClass: {name}<br/>Controller: {controller}<br/>Status: {status}`
+   - Gateway (subgraph title): `Gateway: {name} ({address})`
+   - Listener: `{protocol}:{port}<br/>TLS: {tls_mode}` (if applicable)
+   - HTTPRoute: `HTTPRoute: {name}<br/>Host: {hostname}`
+   - RouteRule: `Rule {idx}: {match_type}:{match_value}<br/>Headers: {headers}` (if applicable)
+   - Service: `{name}:{port}<br/>Weight: {weight}%` (with weight in Mode 1)
+   - Pod: `{pod_name}<br/>{pod_ip} {ready_status}`
+
+6. **Connection Labels**: Use relationship types from `gateway_relationships.txt`:
+   - `implements`: GatewayClass → Gateway
+   - `attaches`: Gateway → Route
+   - `references`: Route → Service (Mode 2)
+   - `has-rule`: HTTPRoute → RouteRule (Mode 1)
+   - `routes-to@{weight}`: RouteRule → Service with weight (Mode 1)
+   - `endpoint@{ready|not-ready}`: Service → Pod (Mode 1)
+
+7. **Colors** (apply using classDef with **color:#000** for black text):
+   - GatewayClasses: `fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px,color:#000` (green)
+   - Listeners: `fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000` (blue)
+   - Gateways: `fill:#e3f2fd,stroke:#1565c0,stroke-width:2px,color:#000` (blue)
+   - Routes (all types): `fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#000` (orange)
+   - RouteRules: `fill:#fce4ec,stroke:#c2185b,stroke-width:1px,color:#000` (pink)
+   - Services: `fill:#f3e5f5,stroke:#6a1b9a,stroke-width:2px,color:#000` (purple)
+   - Pods: `fill:#fff9c4,stroke:#f57f17,stroke-width:1px,color:#000` (yellow)
+
+8. **Subgraph Styling** (apply at END of diagram):
+   - Listeners: `style listeners{idx} fill:#e1f5fe,stroke:#0277bd,stroke-width:2px`
+   - Routes: `style routes{idx} fill:#fff8e1,stroke:#ff8f00,stroke-width:2px`
+   - Rules: `style rules{idx} fill:#fce4ec,stroke:#c2185b,stroke-width:1px,stroke-dasharray: 3 3`
+   - Backends: `style backends{idx} fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px`
+   - Pods: `style pods{idx} fill:#fffde7,stroke:#fbc02d,stroke-width:1px,stroke-dasharray: 3 3`
+
+   For Mode 2 (layered):
+   - GatewayClass layer: `style gc_layer fill:#f1f8e9,stroke:#558b2f,stroke-width:2px,stroke-dasharray: 5 5`
+   - Gateway layer: `style gw_layer fill:#e1f5fe,stroke:#0277bd,stroke-width:2px,stroke-dasharray: 5 5`
+   - Route layer: `style route_layer fill:#fff8e1,stroke:#ff8f00,stroke-width:2px,stroke-dasharray: 5 5`
+   - Backend layer: `style backend_layer fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,stroke-dasharray: 5 5`
+
+## Cross-Namespace References
+
+When routes reference services in different namespaces:
+
+1. Check `reference_grants_detail.txt` for ReferenceGrant allowing the reference
+2. Show cross-namespace connections with dashed lines:
+   ```mermaid
+   HR_prod_api -.->|references (cross-ns)| SVC_backend_api
+   ```
+3. Optionally show ReferenceGrant that permits the reference
+
+## Special Cases
+
+### Multiple GatewayClasses
+If cluster has multiple GatewayClasses (e.g., istio, nginx):
+- Group Gateways by their GatewayClass
+- Use different subgraphs or color coding
+
+### No Routes Attached
+If Gateway has no routes attached:
+- Still show the Gateway
+- Add a note: "No routes attached"
+
+### No Gateways Defined
+If only GatewayClasses exist (no Gateways):
+- Show only GatewayClasses layer
+- Add a note: "No Gateways defined"
+
+---
+
+# Final Steps
+
+1. **Determine Mode**: Check Gateway count from collected data
+   - 1-3 Gateways → Use Mode 1 (Per-Gateway Subgraphs) with detailed visualization
+   - 4+ Gateways → Use Mode 2 (Layered Overview) for high-level view
+
+2. Generate complete Mermaid diagram following structure above
+
+3. Save to file chosen by user
+
+4. Show summary:
+   ```
+   ✅ Successfully generated Gateway API topology diagram
+
+   📄 Diagram saved to: gateway-topology-diagram.md
+   📊 Mode: Per-Gateway Subgraphs (detailed view)
+
+   Summary:
+   - 1 GatewayClass (openshift-default)
+   - 1 Gateway (prod-gateway)
+     - 2 Listeners (HTTP:80, HTTPS:443)
+   - 2 HTTPRoutes (api-route, web-route)
+     - 4 Route Rules with path/header matches
+   - 2 Backend Services
+     - Traffic weights: api-service (80%), api-service-canary (20%)
+   - 2 Pod Endpoints (all ready)
+   - 0 ReferenceGrants
+
+   💡 Open the file in your IDE to view the full rendered Mermaid diagram!
+   ```
+
+5. Clean up temporary directory:
+   ```bash
+   rm -rf "$TMPDIR"
+   ```
+
+6. Tell user to open file in IDE to view rendered diagram

--- a/plugins/openshift/skills/generating-gateway-topology/scripts/analyze_topology.py
+++ b/plugins/openshift/skills/generating-gateway-topology/scripts/analyze_topology.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""
+analyze_topology.py - Build relationship graph from collected Gateway API data
+
+Usage: analyze_topology.py <TMPDIR>
+
+This script analyzes collected Gateway API data and builds a relationship graph
+showing connections between resources:
+- GatewayClass -> Gateway (implements)
+- Gateway -> Routes (attaches)
+- Routes -> Backend Services (references)
+- Services -> Pods (endpoints)
+- ReferenceGrants -> cross-namespace permissions
+
+Input files (from TMPDIR):
+  - gateway_classes_detail.txt
+  - gateways_detail.txt
+  - httproutes_detail.txt
+  - grpcroutes_detail.txt
+  - tcproutes_detail.txt
+  - tlsroutes_detail.txt
+  - backends_detail.txt
+  - reference_grants_detail.txt
+
+Output files (written to TMPDIR):
+  - gateway_relationships.txt - source_type|source_id|relation|target_type|target_id
+
+Exit codes:
+  0 - Success
+  1 - Failure
+
+Requirements: Python 3.6+
+"""
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, List, Set, Tuple
+
+from gateway_utils import safe_write_file
+
+# File name constants
+_GATEWAY_CLASSES_FILE = "gateway_classes_detail.txt"
+_GATEWAYS_FILE = "gateways_detail.txt"
+_HTTPROUTES_FILE = "httproutes_detail.txt"
+_GRPCROUTES_FILE = "grpcroutes_detail.txt"
+_TCPROUTES_FILE = "tcproutes_detail.txt"
+_TLSROUTES_FILE = "tlsroutes_detail.txt"
+_BACKENDS_FILE = "backends_detail.txt"
+_REFERENCE_GRANTS_FILE = "reference_grants_detail.txt"
+_ROUTE_RULES_FILE = "route_rules_detail.txt"
+_ENDPOINTS_FILE = "endpoints_detail.txt"
+_RELATIONSHIPS_FILE = "gateway_relationships.txt"
+
+
+@dataclass
+class GatewayClass:
+    """GatewayClass resource."""
+    name: str
+    controller: str
+    description: str
+    status: str
+
+
+@dataclass
+class Gateway:
+    """Gateway resource."""
+    namespace: str
+    name: str
+    gateway_class: str
+    listeners: str
+    addresses: str
+    status: str
+
+
+@dataclass
+class Route:
+    """Generic route resource."""
+    kind: str  # HTTPRoute, GRPCRoute, TCPRoute, TLSRoute
+    namespace: str
+    name: str
+    hostnames: str
+    parent_refs: str
+    backend_refs: str
+
+
+@dataclass
+class Backend:
+    """Backend service."""
+    namespace: str
+    name: str
+    svc_type: str
+    ports: str
+    pod_count: int
+
+
+@dataclass
+class ReferenceGrant:
+    """ReferenceGrant resource."""
+    namespace: str
+    name: str
+    from_refs: str
+    to_refs: str
+
+
+@dataclass
+class RouteRule:
+    """Detailed route rule with match conditions and backends."""
+    route_namespace: str
+    route_name: str
+    rule_index: int
+    match_condition: str  # e.g., "PathPrefix:/api;headers=x-version=2"
+    backends: str  # e.g., "ns/svc:port@weight,ns/svc2:port@weight"
+
+
+@dataclass
+class Endpoint:
+    """Pod endpoint for a service."""
+    svc_namespace: str
+    svc_name: str
+    pod_name: str
+    pod_ip: str
+    ready: bool
+
+
+@dataclass
+class Relationship:
+    """Relationship between two resources."""
+    source_type: str
+    source_id: str  # namespace/name or just name for cluster-scoped
+    relation: str   # implements, attaches, references, grants
+    target_type: str
+    target_id: str
+
+
+class TopologyAnalyzer:
+    """Analyze Gateway API topology and build relationship graph."""
+
+    def __init__(self, tmpdir: str):
+        self.tmpdir = tmpdir
+        self.gateway_classes: Dict[str, GatewayClass] = {}
+        self.gateways: Dict[str, Gateway] = {}  # key: namespace/name
+        self.routes: List[Route] = []
+        self.backends: Dict[str, Backend] = {}  # key: namespace/name
+        self.reference_grants: List[ReferenceGrant] = []
+        self.route_rules: List[RouteRule] = []
+        self.endpoints: List[Endpoint] = []
+        self.relationships: List[Relationship] = []
+
+    def _read_file_lines(self, filename: str) -> List[str]:
+        """Read lines from a file in tmpdir."""
+        filepath = os.path.join(self.tmpdir, filename)
+        if not os.path.exists(filepath):
+            return []
+        try:
+            with open(filepath, 'r') as f:
+                return [line.strip() for line in f if line.strip()]
+        except OSError:
+            return []
+
+    def load_gateway_classes(self):
+        """Load GatewayClass resources."""
+        for line in self._read_file_lines(_GATEWAY_CLASSES_FILE):
+            parts = line.split("|")
+            if len(parts) >= 4:
+                gc = GatewayClass(
+                    name=parts[0],
+                    controller=parts[1],
+                    description=parts[2],
+                    status=parts[3],
+                )
+                self.gateway_classes[gc.name] = gc
+
+    def load_gateways(self):
+        """Load Gateway resources."""
+        for line in self._read_file_lines(_GATEWAYS_FILE):
+            parts = line.split("|")
+            if len(parts) >= 6:
+                gw = Gateway(
+                    namespace=parts[0],
+                    name=parts[1],
+                    gateway_class=parts[2],
+                    listeners=parts[3],
+                    addresses=parts[4],
+                    status=parts[5],
+                )
+                key = f"{gw.namespace}/{gw.name}"
+                self.gateways[key] = gw
+
+    def _load_routes(self, filename: str, kind: str, has_hostnames: bool = True):
+        """Load route resources from file."""
+        for line in self._read_file_lines(filename):
+            parts = line.split("|")
+            if has_hostnames and len(parts) >= 5:
+                route = Route(
+                    kind=kind,
+                    namespace=parts[0],
+                    name=parts[1],
+                    hostnames=parts[2],
+                    parent_refs=parts[3],
+                    backend_refs=parts[4],
+                )
+                self.routes.append(route)
+            elif not has_hostnames and len(parts) >= 4:
+                route = Route(
+                    kind=kind,
+                    namespace=parts[0],
+                    name=parts[1],
+                    hostnames="",
+                    parent_refs=parts[2],
+                    backend_refs=parts[3],
+                )
+                self.routes.append(route)
+
+    def load_routes(self):
+        """Load all route types."""
+        self._load_routes(_HTTPROUTES_FILE, "HTTPRoute", has_hostnames=True)
+        self._load_routes(_GRPCROUTES_FILE, "GRPCRoute", has_hostnames=False)
+        self._load_routes(_TCPROUTES_FILE, "TCPRoute", has_hostnames=False)
+        self._load_routes(_TLSROUTES_FILE, "TLSRoute", has_hostnames=True)
+
+    def load_backends(self):
+        """Load backend services."""
+        for line in self._read_file_lines(_BACKENDS_FILE):
+            parts = line.split("|")
+            if len(parts) >= 5:
+                backend = Backend(
+                    namespace=parts[0],
+                    name=parts[1],
+                    svc_type=parts[2],
+                    ports=parts[3],
+                    pod_count=int(parts[4]) if parts[4].isdigit() else 0,
+                )
+                key = f"{backend.namespace}/{backend.name}"
+                self.backends[key] = backend
+
+    def load_reference_grants(self):
+        """Load ReferenceGrant resources."""
+        for line in self._read_file_lines(_REFERENCE_GRANTS_FILE):
+            parts = line.split("|")
+            if len(parts) >= 4:
+                grant = ReferenceGrant(
+                    namespace=parts[0],
+                    name=parts[1],
+                    from_refs=parts[2],
+                    to_refs=parts[3],
+                )
+                self.reference_grants.append(grant)
+
+    def load_route_rules(self):
+        """Load detailed route rules."""
+        for line in self._read_file_lines(_ROUTE_RULES_FILE):
+            parts = line.split("|")
+            if len(parts) >= 5:
+                rule = RouteRule(
+                    route_namespace=parts[0],
+                    route_name=parts[1],
+                    rule_index=int(parts[2]) if parts[2].isdigit() else 0,
+                    match_condition=parts[3],
+                    backends=parts[4],
+                )
+                self.route_rules.append(rule)
+
+    def load_endpoints(self):
+        """Load endpoint (pod) data."""
+        for line in self._read_file_lines(_ENDPOINTS_FILE):
+            parts = line.split("|")
+            if len(parts) >= 5:
+                endpoint = Endpoint(
+                    svc_namespace=parts[0],
+                    svc_name=parts[1],
+                    pod_name=parts[2],
+                    pod_ip=parts[3],
+                    ready=(parts[4] == "ready"),
+                )
+                self.endpoints.append(endpoint)
+
+    def analyze_gatewayclass_gateway_relations(self):
+        """Find GatewayClass -> Gateway relationships."""
+        for key, gw in self.gateways.items():
+            if gw.gateway_class in self.gateway_classes:
+                self.relationships.append(Relationship(
+                    source_type="GatewayClass",
+                    source_id=gw.gateway_class,
+                    relation="implements",
+                    target_type="Gateway",
+                    target_id=key,
+                ))
+
+    def _parse_parent_ref(self, ref_str: str, route_namespace: str) -> Tuple[str, str]:
+        """Parse a parent reference string to namespace/name.
+
+        Args:
+            ref_str: Reference string like "ns/name:section" or "name"
+            route_namespace: Route's namespace for default
+
+        Returns:
+            Tuple of (namespace, name)
+        """
+        # Remove section name if present
+        if ":" in ref_str:
+            ref_str = ref_str.split(":")[0]
+
+        if "/" in ref_str:
+            ns, name = ref_str.split("/", 1)
+            return ns, name
+        else:
+            return route_namespace, ref_str
+
+    def analyze_gateway_route_relations(self):
+        """Find Gateway -> Route relationships."""
+        for route in self.routes:
+            # Parse parent refs (comma-separated)
+            if not route.parent_refs or route.parent_refs == "none":
+                continue
+
+            for ref in route.parent_refs.split(","):
+                ref = ref.strip()
+                if not ref:
+                    continue
+
+                ns, name = self._parse_parent_ref(ref, route.namespace)
+                gw_key = f"{ns}/{name}"
+
+                if gw_key in self.gateways:
+                    self.relationships.append(Relationship(
+                        source_type="Gateway",
+                        source_id=gw_key,
+                        relation="attaches",
+                        target_type=route.kind,
+                        target_id=f"{route.namespace}/{route.name}",
+                    ))
+
+    def _parse_backend_ref(self, ref_str: str, route_namespace: str) -> Tuple[str, str]:
+        """Parse a backend reference string to namespace/name.
+
+        Args:
+            ref_str: Reference string like "ns/name:port" or "name:port"
+            route_namespace: Route's namespace for default
+
+        Returns:
+            Tuple of (namespace, name)
+        """
+        # Remove port if present
+        if ":" in ref_str:
+            ref_str = ref_str.rsplit(":", 1)[0]
+
+        if "/" in ref_str:
+            ns, name = ref_str.split("/", 1)
+            return ns, name
+        else:
+            return route_namespace, ref_str
+
+    def analyze_route_backend_relations(self):
+        """Find Route -> Backend relationships."""
+        for route in self.routes:
+            if not route.backend_refs or route.backend_refs == "none":
+                continue
+
+            for ref in route.backend_refs.split(","):
+                ref = ref.strip()
+                if not ref:
+                    continue
+
+                ns, name = self._parse_backend_ref(ref, route.namespace)
+                backend_key = f"{ns}/{name}"
+
+                self.relationships.append(Relationship(
+                    source_type=route.kind,
+                    source_id=f"{route.namespace}/{route.name}",
+                    relation="references",
+                    target_type="Service",
+                    target_id=backend_key,
+                ))
+
+    def analyze_rule_backend_relations(self):
+        """Find RouteRule -> Backend relationships with weights."""
+        # Build route lookup for finding route kinds
+        route_lookup: Dict[str, str] = {}
+        for route in self.routes:
+            route_key = f"{route.namespace}/{route.name}"
+            route_lookup[route_key] = route.kind
+
+        for rule in self.route_rules:
+            if not rule.backends or rule.backends == "none":
+                continue
+
+            # Rule ID for relationships
+            rule_id = f"{rule.route_namespace}/{rule.route_name}/rule-{rule.rule_index}"
+
+            # Look up the route kind, defaulting to HTTPRoute if not found
+            route_key = f"{rule.route_namespace}/{rule.route_name}"
+            route_kind = route_lookup.get(route_key, "HTTPRoute")
+
+            # First, link route to rule
+            self.relationships.append(Relationship(
+                source_type=route_kind,
+                source_id=f"{rule.route_namespace}/{rule.route_name}",
+                relation="has-rule",
+                target_type="RouteRule",
+                target_id=rule_id,
+            ))
+
+            # Parse backends (format: ns/svc:port@weight,ns/svc2:port@weight)
+            for backend_str in rule.backends.split(","):
+                backend_str = backend_str.strip()
+                if not backend_str:
+                    continue
+
+                # Extract weight if present
+                weight = "1"
+                if "@" in backend_str:
+                    backend_str, weight = backend_str.rsplit("@", 1)
+
+                # Extract port if present
+                port = ""
+                if ":" in backend_str:
+                    backend_str, port = backend_str.rsplit(":", 1)
+
+                # Extract namespace/name
+                if "/" in backend_str:
+                    ns, name = backend_str.split("/", 1)
+                else:
+                    ns = rule.route_namespace
+                    name = backend_str
+
+                # Include port in backend_key when present
+                backend_key = f"{ns}/{name}:{port}" if port else f"{ns}/{name}"
+
+                self.relationships.append(Relationship(
+                    source_type="RouteRule",
+                    source_id=rule_id,
+                    relation=f"routes-to@{weight}",
+                    target_type="Service",
+                    target_id=backend_key,
+                ))
+
+    def analyze_service_endpoint_relations(self):
+        """Find Service -> Endpoint (Pod) relationships."""
+        for ep in self.endpoints:
+            svc_key = f"{ep.svc_namespace}/{ep.svc_name}"
+            pod_id = f"{ep.svc_namespace}/{ep.pod_name}"
+
+            ready_status = "ready" if ep.ready else "not-ready"
+
+            self.relationships.append(Relationship(
+                source_type="Service",
+                source_id=svc_key,
+                relation=f"endpoint@{ready_status}",
+                target_type="Pod",
+                target_id=pod_id,
+            ))
+
+    def write_relationships(self):
+        """Write relationships to output file."""
+        filepath = os.path.join(self.tmpdir, _RELATIONSHIPS_FILE)
+
+        lines = []
+        for rel in self.relationships:
+            lines.append(
+                f"{rel.source_type}|{rel.source_id}|{rel.relation}|"
+                f"{rel.target_type}|{rel.target_id}\n"
+            )
+
+        safe_write_file(filepath, "".join(lines))
+
+    def print_summary(self):
+        """Print analysis summary."""
+        print()
+        print("=" * 50)
+        print("TOPOLOGY ANALYSIS SUMMARY")
+        print("=" * 50)
+        print(f"  GatewayClasses:   {len(self.gateway_classes)}")
+        print(f"  Gateways:         {len(self.gateways)}")
+        print(f"  Routes:           {len(self.routes)}")
+        print(f"  Route Rules:      {len(self.route_rules)}")
+        print(f"  Backends:         {len(self.backends)}")
+        print(f"  Endpoints:        {len(self.endpoints)}")
+        print(f"  ReferenceGrants:  {len(self.reference_grants)}")
+        print(f"  Relationships:    {len(self.relationships)}")
+        print()
+
+        # Count by relationship type
+        rel_counts: Dict[str, int] = {}
+        for rel in self.relationships:
+            key = f"{rel.source_type} -> {rel.target_type}"
+            rel_counts[key] = rel_counts.get(key, 0) + 1
+
+        if rel_counts:
+            print("Relationship types:")
+            for key, count in sorted(rel_counts.items()):
+                print(f"  {key}: {count}")
+            print()
+
+        print(f"✅ Analysis complete: {len(self.relationships)} relationships found")
+
+    def run(self) -> int:
+        """Run the topology analysis."""
+        print()
+        print("=" * 50)
+        print("ANALYZING GATEWAY API TOPOLOGY")
+        print("=" * 50)
+        print()
+
+        # Load all data
+        print("Loading collected data...")
+        self.load_gateway_classes()
+        self.load_gateways()
+        self.load_routes()
+        self.load_backends()
+        self.load_reference_grants()
+        self.load_route_rules()
+        self.load_endpoints()
+
+        print(f"  Loaded {len(self.gateway_classes)} GatewayClasses")
+        print(f"  Loaded {len(self.gateways)} Gateways")
+        print(f"  Loaded {len(self.routes)} Routes")
+        print(f"  Loaded {len(self.route_rules)} Route Rules")
+        print(f"  Loaded {len(self.backends)} Backends")
+        print(f"  Loaded {len(self.endpoints)} Endpoints")
+        print(f"  Loaded {len(self.reference_grants)} ReferenceGrants")
+        print()
+
+        # Analyze relationships
+        print("Analyzing relationships...")
+        self.analyze_gatewayclass_gateway_relations()
+        self.analyze_gateway_route_relations()
+        self.analyze_route_backend_relations()
+        self.analyze_rule_backend_relations()
+        self.analyze_service_endpoint_relations()
+        print(f"  Found {len(self.relationships)} relationships")
+
+        # Write output
+        self.write_relationships()
+
+        # Print summary
+        self.print_summary()
+
+        return 0
+
+
+def main():
+    """Main entry point."""
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <TMPDIR>", file=sys.stderr)
+        return 1
+
+    tmpdir = sys.argv[1]
+
+    if not os.path.isdir(tmpdir):
+        print(f"❌ Error: TMPDIR is not a directory: {tmpdir}", file=sys.stderr)
+        return 1
+
+    analyzer = TopologyAnalyzer(tmpdir)
+    try:
+        return analyzer.run()
+    except OSError as exc:
+        print(f"❌ Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/openshift/skills/generating-gateway-topology/scripts/check_permissions.py
+++ b/plugins/openshift/skills/generating-gateway-topology/scripts/check_permissions.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+check_permissions.py - Check user permissions and warn if write access detected
+
+Usage: ./check_permissions.py KUBECONFIG
+Returns: 0 if user confirms to proceed, 1 if user cancels or error, 2 if write perms detected
+
+Note: This script must be run from the scripts/ directory or have the scripts/
+      directory in PYTHONPATH for the gateway_utils import to work.
+
+Requirements: Python 3.6+, kubectl in PATH
+"""
+
+import os
+import subprocess
+import sys
+from typing import List, Optional
+
+# Import shared utilities (must be in same directory or in PYTHONPATH)
+from gateway_utils import check_gateway_api_installed
+
+# Dangerous write permissions to check for Gateway API resources
+_DANGEROUS_PERMS = (
+    # Gateway API resources
+    ("delete", "gateways.gateway.networking.k8s.io", "Delete Gateways"),
+    ("create", "gateways.gateway.networking.k8s.io", "Create Gateways"),
+    ("patch", "gateways.gateway.networking.k8s.io", "Modify Gateways"),
+    ("delete", "httproutes.gateway.networking.k8s.io", "Delete HTTPRoutes"),
+    ("create", "httproutes.gateway.networking.k8s.io", "Create HTTPRoutes"),
+    ("patch", "httproutes.gateway.networking.k8s.io", "Modify HTTPRoutes"),
+    ("delete", "gatewayclasses.gateway.networking.k8s.io", "Delete GatewayClasses"),
+    ("create", "gatewayclasses.gateway.networking.k8s.io", "Create GatewayClasses"),
+    # Standard Kubernetes resources
+    ("delete", "services", "Delete Services"),
+    ("create", "services", "Create Services"),
+    ("delete", "pods", "Delete Pods"),
+    ("create", "pods", "Create Pods"),
+)
+
+
+class PermissionChecker:
+    """Check Kubernetes RBAC permissions for the Gateway topology skill."""
+
+    _PERMISSION_CHECK_TIMEOUT = 5  # seconds
+
+    def __init__(self, kubeconfig: str):
+        self.kubeconfig = kubeconfig
+        self.write_perms_found = False
+        self.write_perms_list: List[str] = []
+
+    def check_kubectl_available(self) -> bool:
+        """Check if kubectl is available in PATH."""
+        try:
+            env = os.environ.copy()
+            env["KUBECONFIG"] = self.kubeconfig
+            subprocess.run(
+                [
+                    "kubectl",
+                    "--kubeconfig",
+                    self.kubeconfig,
+                    "version",
+                    "--client=true",
+                    "--output=json",
+                ],
+                capture_output=True,
+                check=True,
+                env=env,
+            )
+            return True
+        except FileNotFoundError:
+            print("❌ Error: kubectl not found in PATH", file=sys.stderr)
+            return False
+        except subprocess.CalledProcessError:
+            return True
+
+    def check_permission(
+        self, resource: str, verb: str, namespace: Optional[str] = None
+    ) -> bool:
+        """
+        Check if user has a specific permission.
+
+        Args:
+            resource: Kubernetes resource type
+            verb: Action verb (e.g., "get", "create")
+            namespace: Namespace to check permissions in
+
+        Returns:
+            True if permission exists, False otherwise
+        """
+        cmd = [
+            "kubectl",
+            "--kubeconfig", self.kubeconfig,
+            "auth", "can-i",
+            verb, resource,
+            "--quiet"
+        ]
+
+        if namespace is not None:
+            cmd.extend(["-n", namespace])
+
+        try:
+            env = os.environ.copy()
+            env["KUBECONFIG"] = self.kubeconfig
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=self._PERMISSION_CHECK_TIMEOUT,
+                env=env
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, subprocess.SubprocessError) as e:
+            print(
+                f"⚠️  Warning: Error checking permission '{verb} {resource}': {e}. "
+                "Assuming no permission.",
+                file=sys.stderr,
+            )
+            return False
+
+    def check_all_permissions(self) -> None:
+        """Check all dangerous write permissions."""
+        print("🔐 Checking your Kubernetes permissions...\n", file=sys.stderr)
+
+        # Check dangerous write permissions (cluster-wide for Gateway API)
+        for verb, resource, description in _DANGEROUS_PERMS:
+            if self.check_permission(resource, verb, None):
+                self.write_perms_found = True
+                self.write_perms_list.append(f"  ⚠️  {description} ({verb})")
+
+        # Check cluster-wide admin permissions
+        if self.check_permission("*", "*", None):
+            self.write_perms_found = True
+            self.write_perms_list.append(
+                "  ⚠️  CLUSTER ADMIN - Full cluster access "
+                "(all verbs on all resources)"
+            )
+
+    def display_warning(self) -> None:
+        """Display warning message about write permissions."""
+        print("⚠️  WARNING: Write permissions detected!\n", file=sys.stderr)
+        print(
+            "Your kubeconfig has the following write/admin permissions:\n",
+            file=sys.stderr,
+        )
+
+        for perm in self.write_perms_list:
+            print(perm, file=sys.stderr)
+
+    def handle_confirmation(self) -> int:
+        """
+        Handle user confirmation based on mode.
+
+        Returns:
+            0: User confirmed to proceed (or no write perms found)
+            1: User cancelled
+            2: Non-interactive mode with write perms (needs AI agent confirmation)
+        """
+        if not self.write_perms_found:
+            print("✅ Permission check passed\n", file=sys.stderr)
+            print("Your access level:", file=sys.stderr)
+            print("  • Read-only permissions detected", file=sys.stderr)
+            print("  • No write/admin access found", file=sys.stderr)
+            print("  • Safe to proceed with topology generation\n", file=sys.stderr)
+            return 0
+
+        self.display_warning()
+
+        print("WRITE_PERMISSIONS_DETECTED")
+        print("PERMISSIONS_LIST_START")
+        for perm in self.write_perms_list:
+            print(perm)
+        print("PERMISSIONS_LIST_END")
+        return 2
+
+    def run(self) -> int:
+        """Run the permission check."""
+        if not self.check_kubectl_available():
+            return 1
+
+        # Verify Gateway API is installed
+        is_installed, installed_crds = check_gateway_api_installed(self.kubeconfig)
+        if not is_installed:
+            print("❌ Error: Gateway API CRDs not found in cluster", file=sys.stderr)
+            print("\nTo install Gateway API:", file=sys.stderr)
+            print("  kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/"
+                  "releases/download/v1.4.1/standard-install.yaml", file=sys.stderr)
+            return 1
+
+        print(f"✓ Gateway API installed: {len(installed_crds)} CRDs found", file=sys.stderr)
+
+        self.check_all_permissions()
+        return self.handle_confirmation()
+
+
+def main():
+    """Main entry point."""
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} KUBECONFIG", file=sys.stderr)
+        return 1
+
+    kubeconfig = sys.argv[1]
+
+    if not os.path.exists(kubeconfig):
+        print(f"❌ Error: Kubeconfig file not found: {kubeconfig}", file=sys.stderr)
+        return 1
+
+    checker = PermissionChecker(kubeconfig)
+    return checker.run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/openshift/skills/generating-gateway-topology/scripts/collect_gateway_data.py
+++ b/plugins/openshift/skills/generating-gateway-topology/scripts/collect_gateway_data.py
@@ -1,0 +1,677 @@
+#!/usr/bin/env python3
+"""
+collect_gateway_data.py - Collect Gateway API data from live cluster
+
+Usage: collect_gateway_data.py <KUBECONFIG> <TMPDIR>
+
+This script collects Gateway API data from a live Kubernetes cluster:
+1. GatewayClasses - cluster-wide gateway implementations
+2. Gateways - gateway instances with listeners
+3. HTTPRoutes - HTTP routing rules
+4. GRPCRoutes - gRPC routing rules
+5. TCPRoutes - TCP routing rules
+6. TLSRoutes - TLS passthrough routes
+7. ReferenceGrants - cross-namespace permissions
+8. Backend Services - services referenced by routes
+
+Outputs (all files written to TMPDIR):
+  - gateway_classes_detail.txt - name|controller|description|status
+  - gateways_detail.txt - namespace|name|class|listeners|addresses|status
+  - httproutes_detail.txt - namespace|name|hostnames|parent_refs|backend_refs
+  - grpcroutes_detail.txt - namespace|name|parent_refs|backend_refs
+  - tcproutes_detail.txt - namespace|name|parent_refs|backend_refs
+  - tlsroutes_detail.txt - namespace|name|hostnames|parent_refs|backend_refs
+  - backends_detail.txt - namespace|name|type|ports|pod_count
+  - reference_grants_detail.txt - namespace|name|from_refs|to_refs
+
+Exit codes:
+  0 - Success (all or partial data collected)
+  1 - Total failure (no data collected)
+
+Requirements: Python 3.6+, kubectl in PATH, optionally gwctl
+"""
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from gateway_utils import (
+    check_gateway_api_installed,
+    collect_endpoint_slices,
+    detect_gwctl,
+    extract_route_rules,
+    format_addresses,
+    format_backend_refs,
+    format_listeners,
+    format_parent_refs,
+    run_kubectl_json,
+    safe_write_file,
+)
+
+# File name constants
+_GATEWAY_CLASSES_FILE = "gateway_classes_detail.txt"
+_GATEWAYS_FILE = "gateways_detail.txt"
+_HTTPROUTES_FILE = "httproutes_detail.txt"
+_GRPCROUTES_FILE = "grpcroutes_detail.txt"
+_TCPROUTES_FILE = "tcproutes_detail.txt"
+_TLSROUTES_FILE = "tlsroutes_detail.txt"
+_BACKENDS_FILE = "backends_detail.txt"
+_REFERENCE_GRANTS_FILE = "reference_grants_detail.txt"
+_ROUTE_RULES_FILE = "route_rules_detail.txt"
+_ENDPOINTS_FILE = "endpoints_detail.txt"
+
+
+@dataclass
+class CollectionStats:
+    """Track collection statistics."""
+    gateway_classes: int = 0
+    gateways: int = 0
+    httproutes: int = 0
+    grpcroutes: int = 0
+    tcproutes: int = 0
+    tlsroutes: int = 0
+    backends: int = 0
+    reference_grants: int = 0
+    route_rules: int = 0
+    endpoints: int = 0
+    errors: List[str] = field(default_factory=list)
+
+
+class GatewayDataCollector:
+    """Collect Gateway API data from live cluster."""
+
+    def __init__(self, kubeconfig: str, tmpdir: str):
+        self.kubeconfig = kubeconfig
+        self.tmpdir = tmpdir
+        self.stats = CollectionStats()
+        self.gwctl_path = detect_gwctl()
+
+        # Track backend references for collection
+        self.backend_refs: Set[str] = set()  # "namespace/name"
+
+        # Store detailed route rules for diagram generation
+        self.route_rules_data: List[Dict] = []
+
+        # Output files
+        self.gateway_classes_file = os.path.join(tmpdir, _GATEWAY_CLASSES_FILE)
+        self.gateways_file = os.path.join(tmpdir, _GATEWAYS_FILE)
+        self.httproutes_file = os.path.join(tmpdir, _HTTPROUTES_FILE)
+        self.grpcroutes_file = os.path.join(tmpdir, _GRPCROUTES_FILE)
+        self.tcproutes_file = os.path.join(tmpdir, _TCPROUTES_FILE)
+        self.tlsroutes_file = os.path.join(tmpdir, _TLSROUTES_FILE)
+        self.backends_file = os.path.join(tmpdir, _BACKENDS_FILE)
+        self.reference_grants_file = os.path.join(tmpdir, _REFERENCE_GRANTS_FILE)
+        self.route_rules_file = os.path.join(tmpdir, _ROUTE_RULES_FILE)
+        self.endpoints_file = os.path.join(tmpdir, _ENDPOINTS_FILE)
+
+    def initialize_output_files(self):
+        """Create/clear output files."""
+        for filepath in [
+            self.gateway_classes_file,
+            self.gateways_file,
+            self.httproutes_file,
+            self.grpcroutes_file,
+            self.tcproutes_file,
+            self.tlsroutes_file,
+            self.backends_file,
+            self.reference_grants_file,
+            self.route_rules_file,
+            self.endpoints_file,
+        ]:
+            safe_write_file(filepath, "")
+
+    def collect_gateway_classes(self) -> bool:
+        """Collect GatewayClass resources."""
+        print("  Collecting GatewayClasses...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "gatewayclasses.gateway.networking.k8s.io",
+        )
+
+        if data is None:
+            self.stats.errors.append("Failed to collect GatewayClasses")
+            return False
+
+        lines = []
+        for item in data.get("items", []):
+            name = item.get("metadata", {}).get("name", "unknown")
+            spec = item.get("spec", {})
+            controller = spec.get("controllerName", "unknown")
+            description = spec.get("description", "")
+
+            # Get status
+            status = item.get("status", {})
+            conditions = status.get("conditions", [])
+            status_str = "Unknown"
+            for cond in conditions:
+                if cond.get("type") == "Accepted":
+                    status_str = cond.get("status", "Unknown")
+                    break
+
+            # Clean description (remove newlines, limit length)
+            description = description.replace("\n", " ").replace("|", "-")[:100]
+
+            lines.append(f"{name}|{controller}|{description}|{status_str}\n")
+            self.stats.gateway_classes += 1
+
+        if lines:
+            safe_write_file(self.gateway_classes_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.gateway_classes} GatewayClasses")
+        return True
+
+    def collect_gateways(self) -> bool:
+        """Collect Gateway resources."""
+        print("  Collecting Gateways...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "gateways.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            self.stats.errors.append("Failed to collect Gateways")
+            return False
+
+        lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            gateway_class = spec.get("gatewayClassName", "unknown")
+            listeners = spec.get("listeners", [])
+
+            status = item.get("status", {})
+            addresses = status.get("addresses", [])
+
+            # Format listeners and addresses
+            listeners_str = format_listeners(listeners)
+            addresses_str = format_addresses(addresses)
+
+            # Get overall status
+            conditions = status.get("conditions", [])
+            status_str = "Unknown"
+            for cond in conditions:
+                if cond.get("type") in ["Accepted", "Programmed"]:
+                    status_str = cond.get("status", "Unknown")
+                    break
+
+            lines.append(
+                f"{namespace}|{name}|{gateway_class}|{listeners_str}|"
+                f"{addresses_str}|{status_str}\n"
+            )
+            self.stats.gateways += 1
+
+        if lines:
+            safe_write_file(self.gateways_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.gateways} Gateways")
+        return True
+
+    def _extract_backend_refs(self, rules: list, route_namespace: str):
+        """Extract backend references from route rules."""
+        for rule in rules or []:
+            for backend_ref in rule.get("backendRefs", []):
+                namespace = backend_ref.get("namespace", route_namespace)
+                name = backend_ref.get("name", "")
+                if name:
+                    self.backend_refs.add(f"{namespace}/{name}")
+
+    def collect_httproutes(self) -> bool:
+        """Collect HTTPRoute resources."""
+        print("  Collecting HTTPRoutes...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "httproutes.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            self.stats.errors.append("Failed to collect HTTPRoutes")
+            return False
+
+        lines = []
+        rules_lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            hostnames = spec.get("hostnames", [])
+            parent_refs = spec.get("parentRefs", [])
+            rules = spec.get("rules", [])
+
+            # Extract and track backend refs
+            self._extract_backend_refs(rules, namespace)
+
+            # Extract detailed route rules for enhanced diagram
+            detailed_rules = extract_route_rules(rules, namespace)
+            for rule in detailed_rules:
+                # Store for later analysis
+                self.route_rules_data.append({
+                    "route_type": "HTTPRoute",
+                    "route_namespace": namespace,
+                    "route_name": name,
+                    "hostnames": hostnames,
+                    "parent_refs": parent_refs,
+                    "rule": rule,
+                })
+
+                # Format rule for output file
+                # Format: route_ns|route_name|rule_idx|match_type|match_value|backends
+                for match in rule.get("matches", [{}]):
+                    path_type = match.get("path_type", "PathPrefix")
+                    path_value = match.get("path_value", "/")
+                    headers = match.get("headers", "")
+                    method = match.get("method", "")
+
+                    match_str = f"{path_type}:{path_value}"
+                    if headers:
+                        match_str += f";headers={headers}"
+                    if method:
+                        match_str += f";method={method}"
+
+                    # Format backends with weights
+                    backends_with_weights = []
+                    for backend in rule.get("backends", []):
+                        bns = backend.get("namespace", namespace)
+                        bname = backend.get("name", "?")
+                        bport = backend.get("port", "")
+                        weight = backend.get("weight", 1)
+                        if bport:
+                            backends_with_weights.append(
+                                f"{bns}/{bname}:{bport}@{weight}"
+                            )
+                        else:
+                            backends_with_weights.append(f"{bns}/{bname}@{weight}")
+
+                    backends_str = ",".join(backends_with_weights) or "none"
+                    rules_lines.append(
+                        f"{namespace}|{name}|{rule['index']}|{match_str}|"
+                        f"{backends_str}\n"
+                    )
+                    self.stats.route_rules += 1
+
+            # Format for output
+            hostnames_str = ", ".join(hostnames) if hostnames else "*"
+            parent_refs_str = format_parent_refs(parent_refs)
+            backend_refs_str = format_backend_refs(rules)
+
+            lines.append(
+                f"{namespace}|{name}|{hostnames_str}|{parent_refs_str}|"
+                f"{backend_refs_str}\n"
+            )
+            self.stats.httproutes += 1
+
+        if lines:
+            safe_write_file(self.httproutes_file, "".join(lines))
+
+        if rules_lines:
+            safe_write_file(self.route_rules_file, "".join(rules_lines))
+
+        print(f"    ✓ Collected {self.stats.httproutes} HTTPRoutes")
+        print(f"    ✓ Extracted {self.stats.route_rules} route rules")
+        return True
+
+    def collect_grpcroutes(self) -> bool:
+        """Collect GRPCRoute resources."""
+        print("  Collecting GRPCRoutes...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "grpcroutes.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            # GRPCRoutes might not exist in cluster
+            print("    ℹ️  GRPCRoutes not found or not accessible")
+            return True
+
+        lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            parent_refs = spec.get("parentRefs", [])
+            rules = spec.get("rules", [])
+
+            self._extract_backend_refs(rules, namespace)
+
+            parent_refs_str = format_parent_refs(parent_refs)
+            backend_refs_str = format_backend_refs(rules)
+
+            lines.append(f"{namespace}|{name}|{parent_refs_str}|{backend_refs_str}\n")
+            self.stats.grpcroutes += 1
+
+        if lines:
+            safe_write_file(self.grpcroutes_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.grpcroutes} GRPCRoutes")
+        return True
+
+    def collect_tcproutes(self) -> bool:
+        """Collect TCPRoute resources."""
+        print("  Collecting TCPRoutes...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "tcproutes.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            print("    ℹ️  TCPRoutes not found or not accessible")
+            return True
+
+        lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            parent_refs = spec.get("parentRefs", [])
+            rules = spec.get("rules", [])
+
+            self._extract_backend_refs(rules, namespace)
+
+            parent_refs_str = format_parent_refs(parent_refs)
+            backend_refs_str = format_backend_refs(rules)
+
+            lines.append(f"{namespace}|{name}|{parent_refs_str}|{backend_refs_str}\n")
+            self.stats.tcproutes += 1
+
+        if lines:
+            safe_write_file(self.tcproutes_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.tcproutes} TCPRoutes")
+        return True
+
+    def collect_tlsroutes(self) -> bool:
+        """Collect TLSRoute resources."""
+        print("  Collecting TLSRoutes...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "tlsroutes.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            print("    ℹ️  TLSRoutes not found or not accessible")
+            return True
+
+        lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            hostnames = spec.get("hostnames", [])
+            parent_refs = spec.get("parentRefs", [])
+            rules = spec.get("rules", [])
+
+            self._extract_backend_refs(rules, namespace)
+
+            hostnames_str = ", ".join(hostnames) if hostnames else "*"
+            parent_refs_str = format_parent_refs(parent_refs)
+            backend_refs_str = format_backend_refs(rules)
+
+            lines.append(
+                f"{namespace}|{name}|{hostnames_str}|{parent_refs_str}|"
+                f"{backend_refs_str}\n"
+            )
+            self.stats.tlsroutes += 1
+
+        if lines:
+            safe_write_file(self.tlsroutes_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.tlsroutes} TLSRoutes")
+        return True
+
+    def collect_reference_grants(self) -> bool:
+        """Collect ReferenceGrant resources."""
+        print("  Collecting ReferenceGrants...")
+
+        data = run_kubectl_json(
+            self.kubeconfig,
+            "referencegrants.gateway.networking.k8s.io",
+            all_namespaces=True,
+        )
+
+        if data is None:
+            print("    ℹ️  ReferenceGrants not found or not accessible")
+            return True
+
+        lines = []
+        for item in data.get("items", []):
+            metadata = item.get("metadata", {})
+            namespace = metadata.get("namespace", "default")
+            name = metadata.get("name", "unknown")
+
+            spec = item.get("spec", {})
+            from_refs = spec.get("from", [])
+            to_refs = spec.get("to", [])
+
+            # Format from references
+            from_strs = []
+            for ref in from_refs:
+                group = ref.get("group", "")
+                kind = ref.get("kind", "")
+                ns = ref.get("namespace", "")
+                from_strs.append(f"{kind}({ns})")
+            from_refs_str = ", ".join(from_strs) if from_strs else "none"
+
+            # Format to references
+            to_strs = []
+            for ref in to_refs:
+                group = ref.get("group", "")
+                kind = ref.get("kind", "")
+                to_strs.append(kind)
+            to_refs_str = ", ".join(to_strs) if to_strs else "none"
+
+            lines.append(f"{namespace}|{name}|{from_refs_str}|{to_refs_str}\n")
+            self.stats.reference_grants += 1
+
+        if lines:
+            safe_write_file(self.reference_grants_file, "".join(lines))
+
+        print(f"    ✓ Collected {self.stats.reference_grants} ReferenceGrants")
+        return True
+
+    def collect_backends(self) -> bool:
+        """Collect backend Services referenced by routes."""
+        print("  Collecting Backend Services...")
+
+        if not self.backend_refs:
+            print("    ℹ️  No backend references found in routes")
+            return True
+
+        lines = []
+        endpoint_lines = []
+        for backend_ref in sorted(self.backend_refs):
+            namespace, name = backend_ref.split("/", 1)
+
+            # Get service details
+            data = run_kubectl_json(
+                self.kubeconfig,
+                f"service/{name}",
+                namespace=namespace,
+            )
+
+            if data is None or "items" in data:
+                # Service not found
+                lines.append(f"{namespace}|{name}|Service|unknown|0\n")
+                continue
+
+            spec = data.get("spec", {})
+            ports = spec.get("ports", [])
+            svc_type = spec.get("type", "ClusterIP")
+
+            # Format ports
+            ports_strs = []
+            for port in ports:
+                port_num = port.get("port", "?")
+                target_port = port.get("targetPort", port_num)
+                protocol = port.get("protocol", "TCP")
+                ports_strs.append(f"{port_num}->{target_port}/{protocol}")
+            ports_str = ", ".join(ports_strs) if ports_strs else "none"
+
+            # Collect detailed endpoint data using EndpointSlices
+            endpoints = collect_endpoint_slices(self.kubeconfig, namespace, name)
+            pod_count = len(endpoints)
+
+            # Write endpoint details for diagram generation
+            # Format: svc_namespace|svc_name|pod_name|pod_ip|ready
+            for ep in endpoints:
+                ready_str = "ready" if ep.get("ready", False) else "not-ready"
+                endpoint_lines.append(
+                    f"{namespace}|{name}|{ep.get('pod_name', 'unknown')}|"
+                    f"{ep.get('pod_ip', '?')}|{ready_str}\n"
+                )
+                self.stats.endpoints += 1
+
+            lines.append(f"{namespace}|{name}|{svc_type}|{ports_str}|{pod_count}\n")
+            self.stats.backends += 1
+
+        if lines:
+            safe_write_file(self.backends_file, "".join(lines))
+
+        if endpoint_lines:
+            safe_write_file(self.endpoints_file, "".join(endpoint_lines))
+
+        print(f"    ✓ Collected {self.stats.backends} Backend Services")
+        print(f"    ✓ Collected {self.stats.endpoints} Endpoints")
+        return True
+
+    def is_collection_successful(self) -> bool:
+        """Check if collection was successful."""
+        # Success if we collected any resources (partial data counts as success)
+        total = (
+            self.stats.gateway_classes
+            + self.stats.gateways
+            + self.stats.httproutes
+            + self.stats.grpcroutes
+            + self.stats.tcproutes
+            + self.stats.tlsroutes
+            + self.stats.backends
+            + self.stats.services
+        )
+        return total > 0
+
+    def print_summary(self):
+        """Print collection summary."""
+        print()
+        print("=" * 50)
+        print("COLLECTION SUMMARY")
+        print("=" * 50)
+        print(f"  GatewayClasses:   {self.stats.gateway_classes}")
+        print(f"  Gateways:         {self.stats.gateways}")
+        print(f"  HTTPRoutes:       {self.stats.httproutes}")
+        print(f"  GRPCRoutes:       {self.stats.grpcroutes}")
+        print(f"  TCPRoutes:        {self.stats.tcproutes}")
+        print(f"  TLSRoutes:        {self.stats.tlsroutes}")
+        print(f"  ReferenceGrants:  {self.stats.reference_grants}")
+        print(f"  Backend Services: {self.stats.backends}")
+        print(f"  Route Rules:      {self.stats.route_rules}")
+        print(f"  Endpoints:        {self.stats.endpoints}")
+        print()
+
+        if self.stats.errors:
+            print("Errors encountered:")
+            for error in self.stats.errors:
+                print(f"  ⚠️  {error}")
+            print()
+
+        total = (
+            self.stats.gateway_classes + self.stats.gateways +
+            self.stats.httproutes + self.stats.grpcroutes +
+            self.stats.tcproutes + self.stats.tlsroutes +
+            self.stats.reference_grants + self.stats.backends +
+            self.stats.route_rules + self.stats.endpoints
+        )
+
+        if self.is_collection_successful():
+            print(f"✅ Collection complete: {total} resources collected")
+        else:
+            print("❌ Collection failed: no Gateway API resources found")
+
+    def run(self) -> int:
+        """Run the complete collection process."""
+        print()
+        print("=" * 50)
+        print("COLLECTING GATEWAY API DATA")
+        print("=" * 50)
+        print()
+
+        # Verify Gateway API is installed
+        is_installed, installed_crds = check_gateway_api_installed(self.kubeconfig)
+        if not is_installed:
+            print("❌ Gateway API CRDs not found in cluster", file=sys.stderr)
+            return 1
+
+        print(f"✓ Gateway API installed ({len(installed_crds)} CRDs)")
+        if self.gwctl_path:
+            print(f"✓ gwctl available at {self.gwctl_path}")
+        else:
+            print("ℹ️  gwctl not found, using kubectl")
+        print()
+
+        # Initialize output files
+        self.initialize_output_files()
+
+        # Collect all resource types
+        self.collect_gateway_classes()
+        self.collect_gateways()
+        self.collect_httproutes()
+        self.collect_grpcroutes()
+        self.collect_tcproutes()
+        self.collect_tlsroutes()
+        self.collect_reference_grants()
+        self.collect_backends()
+
+        # Print summary
+        self.print_summary()
+
+        return 0 if self.is_collection_successful() else 1
+
+
+def main():
+    """Main entry point."""
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <KUBECONFIG> <TMPDIR>", file=sys.stderr)
+        return 1
+
+    kubeconfig = sys.argv[1]
+    tmpdir = sys.argv[2]
+
+    if not os.path.exists(kubeconfig):
+        print(f"❌ Error: Kubeconfig not found: {kubeconfig}", file=sys.stderr)
+        return 1
+
+    if not os.path.isdir(tmpdir):
+        print(f"❌ Error: TMPDIR is not a directory: {tmpdir}", file=sys.stderr)
+        return 1
+
+    collector = GatewayDataCollector(kubeconfig, tmpdir)
+    try:
+        return collector.run()
+    except OSError as exc:
+        print(f"❌ Error writing output files: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/openshift/skills/generating-gateway-topology/scripts/detect-gateway-cluster.sh
+++ b/plugins/openshift/skills/generating-gateway-topology/scripts/detect-gateway-cluster.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# detect-gateway-cluster.sh - Discover clusters with Gateway API CRDs installed
+#
+# Usage: detect-gateway-cluster.sh [--scan-all]
+#
+# Options:
+#   --scan-all    Scan all contexts in all kubeconfig files (default: current context only)
+#
+# Output format (to stdout):
+#   index|kubeconfig|cluster_name|gateway_count|installed_crds
+#
+# Example output:
+#   1|/home/user/.kube/config|prod-cluster|5|gateways,httproutes,gatewayclasses
+#   2|/home/user/.kube/kind-config|dev-cluster|2|gateways,httproutes
+#
+# Diagnostics and human-readable info go to stderr
+# Exit codes: 0=success, 1=no cluster found
+
+# Parse arguments
+SCAN_ALL=false
+for arg in "$@"; do
+    case "$arg" in
+        --scan-all)
+            SCAN_ALL=true
+            ;;
+    esac
+done
+
+if [ "$SCAN_ALL" = true ]; then
+    echo "🔍 Scanning all kubeconfig contexts for Gateway API..." >&2
+else
+    echo "🔍 Checking current context for Gateway API..." >&2
+fi
+echo "" >&2
+
+# Array to store discovered clusters
+# Format: "kubeconfig_path|context_name|cluster_display_name|gateway_count|installed_crds"
+declare -a CLUSTERS=()
+
+# Associative array to track seen kubeconfig+context combinations (for deduplication)
+declare -A SEEN_CONTEXTS=()
+
+# Gateway API CRDs to check
+GATEWAY_CRDS=(
+    "gateways.gateway.networking.k8s.io"
+    "gatewayclasses.gateway.networking.k8s.io"
+    "httproutes.gateway.networking.k8s.io"
+    "grpcroutes.gateway.networking.k8s.io"
+    "tcproutes.gateway.networking.k8s.io"
+    "tlsroutes.gateway.networking.k8s.io"
+    "referencegrants.gateway.networking.k8s.io"
+)
+
+# Function to test a specific kubeconfig and context for Gateway API
+test_context_for_gateway_api() {
+    local kc_file="$1"
+    local context="$2"
+
+    # Resolve to absolute path for deduplication
+    local resolved_kc
+    resolved_kc=$(readlink -f "$kc_file" 2>/dev/null || echo "$kc_file")
+
+    # Create unique key for deduplication
+    local unique_key="${resolved_kc}::${context}"
+
+    # Skip if we've already seen this kubeconfig+context combination
+    if [ -n "${SEEN_CONTEXTS[$unique_key]}" ]; then
+        return 1
+    fi
+
+    # Check if Gateway API CRDs are installed
+    local installed_crds=""
+    local crd_count=0
+
+    for crd in "${GATEWAY_CRDS[@]}"; do
+        if KUBECONFIG="$kc_file" kubectl --kubeconfig="$kc_file" --context="$context" \
+            get crd "$crd" &>/dev/null; then
+            if [ -n "$installed_crds" ]; then
+                installed_crds="${installed_crds},${crd%%.*}"
+            else
+                installed_crds="${crd%%.*}"
+            fi
+            crd_count=$((crd_count + 1))
+        fi
+    done
+
+    # Must have at least the core Gateway CRD
+    if [ $crd_count -eq 0 ]; then
+        return 1
+    fi
+
+    # Mark this combination as seen
+    SEEN_CONTEXTS[$unique_key]=1
+
+    # Get cluster info
+    local cluster_name
+    cluster_name=$(KUBECONFIG="$kc_file" kubectl --kubeconfig="$kc_file" --context="$context" \
+        config view --minify -o jsonpath='{.clusters[0].name}' 2>/dev/null || echo "$context")
+
+    # Count actual Gateway resources
+    local gateway_count
+    gateway_count=$(KUBECONFIG="$kc_file" kubectl --kubeconfig="$kc_file" --context="$context" \
+        get gateways.gateway.networking.k8s.io -A --no-headers 2>/dev/null | wc -l || echo "0")
+    gateway_count=$(echo "$gateway_count" | tr -d '[:space:]')
+
+    # Store cluster info
+    CLUSTERS+=("$kc_file|$context|$cluster_name|$gateway_count|$installed_crds")
+    return 0
+}
+
+# Function to scan all contexts in a kubeconfig file
+scan_kubeconfig_file() {
+    local kc_file="$1"
+    local file_label="$2"
+
+    if [ ! -f "$kc_file" ]; then
+        echo "  ✗ File not found" >&2
+        return 1
+    fi
+
+    echo "Scanning: $file_label" >&2
+
+    # Get all contexts from this kubeconfig
+    local contexts
+    contexts=$(KUBECONFIG="$kc_file" kubectl --kubeconfig="$kc_file" config get-contexts -o name 2>/dev/null || true)
+
+    if [ -z "$contexts" ]; then
+        echo "  ✗ No contexts found" >&2
+        return 1
+    fi
+
+    local found_count=0
+    while IFS= read -r context; do
+        if test_context_for_gateway_api "$kc_file" "$context"; then
+            echo "  ✓ Found Gateway API in context: $context" >&2
+            found_count=$((found_count + 1))
+        fi
+    done <<< "$contexts"
+
+    if [ $found_count -eq 0 ]; then
+        echo "  ✗ No Gateway API clusters found in any context" >&2
+    fi
+
+    echo "" >&2
+}
+
+# Function to test current context only (default behavior)
+test_current_context() {
+    # Get current context
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null)
+
+    if [ -z "$current_context" ]; then
+        echo "  ✗ No current context set" >&2
+        return 1
+    fi
+
+    echo "Testing current context: $current_context" >&2
+
+    # Determine kubeconfig file
+    local kc_file
+    if [ -n "$KUBECONFIG" ]; then
+        # Use first file in KUBECONFIG path
+        IFS=':' read -r kc_file _ <<< "$KUBECONFIG"
+        case "$kc_file" in
+            ~*) kc_file="${kc_file/#\~/$HOME}" ;;
+        esac
+    else
+        kc_file="$HOME/.kube/config"
+    fi
+
+    if [ ! -f "$kc_file" ]; then
+        echo "  ✗ Kubeconfig file not found: $kc_file" >&2
+        return 1
+    fi
+
+    if test_context_for_gateway_api "$kc_file" "$current_context"; then
+        echo "  ✓ Found Gateway API in current context" >&2
+        return 0
+    else
+        echo "  ✗ Gateway API not found in current context" >&2
+        return 1
+    fi
+}
+
+# Phase 1: Discovery
+
+if [ "$SCAN_ALL" = true ]; then
+    # Scan all kubeconfig files and contexts
+
+    # Priority 1: Current KUBECONFIG environment (if set)
+    if [ -n "$KUBECONFIG" ]; then
+        IFS=':' read -r -a kubeconfig_paths <<< "$KUBECONFIG"
+        for kubeconfig_path in "${kubeconfig_paths[@]}"; do
+            [ -z "$kubeconfig_path" ] && continue
+            display_label="$kubeconfig_path"
+            case "$kubeconfig_path" in
+                ~*)
+                    kubeconfig_path="${kubeconfig_path/#\~/$HOME}"
+                    display_label="$kubeconfig_path"
+                    ;;
+            esac
+            scan_kubeconfig_file "$kubeconfig_path" "Current KUBECONFIG environment ($display_label)"
+        done
+    fi
+
+    # Priority 2: ~/.kube/kind-config (common for KIND clusters)
+    if [ -f "$HOME/.kube/kind-config" ]; then
+        scan_kubeconfig_file "$HOME/.kube/kind-config" "~/.kube/kind-config"
+    fi
+
+    # Priority 3: ~/.kube/config (default kubeconfig)
+    if [ -f "$HOME/.kube/config" ]; then
+        scan_kubeconfig_file "$HOME/.kube/config" "~/.kube/config"
+    fi
+else
+    # Default: test current context only
+    test_current_context
+fi
+
+# Phase 2: Output Results - non-interactive parseable format
+
+if [ ${#CLUSTERS[@]} -eq 0 ]; then
+    # No clusters found
+    echo "❌ No clusters with Gateway API found" >&2
+    echo "" >&2
+    if [ "$SCAN_ALL" = true ]; then
+        echo "Searched in:" >&2
+        [ -n "$KUBECONFIG" ] && echo "  - Current KUBECONFIG environment ($KUBECONFIG)" >&2
+        echo "  - ~/.kube/kind-config" >&2
+        echo "  - ~/.kube/config" >&2
+    else
+        echo "Checked: current context only" >&2
+    fi
+    echo "" >&2
+    echo "Solutions:" >&2
+    echo "  1. Install Gateway API CRDs:" >&2
+    echo "     kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml" >&2
+    echo "  2. Set KUBECONFIG to point to a cluster with Gateway API:" >&2
+    echo "     export KUBECONFIG=/path/to/config" >&2
+    echo "  3. Verify Gateway API is installed:" >&2
+    echo "     kubectl get crd gateways.gateway.networking.k8s.io" >&2
+    if [ "$SCAN_ALL" = false ]; then
+        echo "  4. Scan all kubeconfig contexts:" >&2
+        echo "     detect-gateway-cluster.sh --scan-all" >&2
+    fi
+    exit 1
+fi
+
+# Output cluster list to stdout in parseable format
+# Format: index|kubeconfig|cluster_name|gateway_count|installed_crds
+echo "✅ Found ${#CLUSTERS[@]} cluster(s) with Gateway API" >&2
+echo "" >&2
+
+idx=1
+for cluster_info in "${CLUSTERS[@]}"; do
+    # Parse cluster info
+    IFS='|' read -r kc_file context cluster_name gateway_count installed_crds <<< "$cluster_info"
+
+    # Output parseable line to stdout
+    echo "$idx|$kc_file|$cluster_name|$gateway_count|$installed_crds"
+
+    # Output human-readable info to stderr
+    echo "  $idx. $cluster_name" >&2
+    echo "     Context: $context" >&2
+    echo "     Gateways: $gateway_count" >&2
+    echo "     CRDs: $installed_crds" >&2
+    echo "     Kubeconfig: $kc_file" >&2
+    echo "" >&2
+
+    idx=$((idx + 1))
+done
+
+exit 0

--- a/plugins/openshift/skills/generating-gateway-topology/scripts/gateway_utils.py
+++ b/plugins/openshift/skills/generating-gateway-topology/scripts/gateway_utils.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""
+gateway_utils.py - Shared utilities for Gateway API topology scripts
+
+This module provides common functions used across multiple Gateway API topology scripts.
+
+Requirements: Python 3.6+, kubectl in PATH, optionally gwctl
+"""
+
+import errno
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+
+# Gateway API CRD names
+GATEWAY_API_CRDS = [
+    "gateways.gateway.networking.k8s.io",
+    "gatewayclasses.gateway.networking.k8s.io",
+    "httproutes.gateway.networking.k8s.io",
+    "grpcroutes.gateway.networking.k8s.io",
+    "tcproutes.gateway.networking.k8s.io",
+    "tlsroutes.gateway.networking.k8s.io",
+    "referencegrants.gateway.networking.k8s.io",
+]
+
+
+def detect_gwctl() -> Optional[str]:
+    """Detect if gwctl is installed and return its path.
+
+    Checks standard PATH and common Go binary locations.
+
+    Returns:
+        Path to gwctl if found, None otherwise
+    """
+    # Check standard PATH first
+    gwctl_path = shutil.which("gwctl")
+
+    # Also check common Go binary locations
+    if not gwctl_path:
+        go_bin_paths = [
+            os.path.expanduser("~/go/bin/gwctl"),
+            "/usr/local/go/bin/gwctl",
+        ]
+        for path in go_bin_paths:
+            if os.path.isfile(path) and os.access(path, os.X_OK):
+                gwctl_path = path
+                break
+
+    if gwctl_path:
+        try:
+            result = subprocess.run(
+                [gwctl_path, "version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                print(f"✓ Found gwctl at: {gwctl_path}", file=sys.stderr)
+                return gwctl_path
+        except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+            pass
+    return None
+
+
+def run_gwctl_describe(
+    gwctl_path: str,
+    resource_type: str,
+    name: str,
+    namespace: Optional[str] = None,
+    timeout: int = 30,
+) -> Optional[str]:
+    """Run gwctl describe and return raw output.
+
+    Args:
+        gwctl_path: Path to gwctl binary
+        resource_type: Resource type (e.g., 'gateway', 'httproute')
+        name: Resource name
+        namespace: Resource namespace
+        timeout: Command timeout in seconds
+
+    Returns:
+        Raw describe output or None if failed
+    """
+    cmd = [gwctl_path, "describe", resource_type, name]
+    if namespace:
+        cmd.extend(["-n", namespace])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            return result.stdout
+        return None
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return None
+
+
+def collect_endpoint_slices(
+    kubeconfig: str,
+    service_namespace: str,
+    service_name: str,
+    timeout: int = 15,
+) -> List[dict]:
+    """Collect EndpointSlices for a service to get pod IPs.
+
+    Args:
+        kubeconfig: Path to kubeconfig file
+        service_namespace: Service namespace
+        service_name: Service name
+        timeout: Command timeout
+
+    Returns:
+        List of endpoint dicts with pod_name, pod_ip, ready status
+    """
+    endpoints = []
+
+    try:
+        # Get EndpointSlices for the service
+        result = subprocess.run(
+            [
+                "kubectl", "--kubeconfig", kubeconfig,
+                "get", "endpointslices",
+                "-n", service_namespace,
+                "-l", f"kubernetes.io/service-name={service_name}",
+                "-o", "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            for item in data.get("items", []):
+                item_endpoints = item.get("endpoints") or []
+                for endpoint in item_endpoints:
+                    addresses = endpoint.get("addresses") or []
+                    conditions = endpoint.get("conditions") or {}
+                    ready = conditions.get("ready", False)
+                    target_ref = endpoint.get("targetRef") or {}
+                    pod_name = target_ref.get("name", "unknown")
+
+                    for addr in addresses:
+                        endpoints.append({
+                            "pod_name": pod_name,
+                            "pod_ip": addr,
+                            "ready": ready,
+                        })
+
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, json.JSONDecodeError):
+        pass
+
+    return endpoints
+
+
+def extract_route_rules(rules: list, route_namespace: str) -> List[dict]:
+    """Extract detailed route rules from HTTPRoute spec.
+
+    Args:
+        rules: List of rule objects from HTTPRoute spec
+        route_namespace: Route's namespace for resolving backend refs
+
+    Returns:
+        List of rule dicts with match details and backend refs
+    """
+    extracted_rules = []
+
+    for idx, rule in enumerate(rules or []):
+        matches = rule.get("matches", [{}])
+        backend_refs = rule.get("backendRefs", [])
+
+        # Extract match conditions
+        match_details = []
+        for match in matches:
+            match_info = {}
+
+            # Path match
+            path = match.get("path", {})
+            if path:
+                match_info["path_type"] = path.get("type", "PathPrefix")
+                match_info["path_value"] = path.get("value", "/")
+
+            # Header matches
+            headers = match.get("headers", [])
+            if headers:
+                header_strs = []
+                for h in headers:
+                    header_strs.append(f"{h.get('name')}={h.get('value')}")
+                match_info["headers"] = ", ".join(header_strs)
+
+            # Method match
+            method = match.get("method")
+            if method:
+                match_info["method"] = method
+
+            if match_info:
+                match_details.append(match_info)
+
+        # Extract backends with weights
+        backends = []
+        for backend in backend_refs:
+            backend_ns = backend.get("namespace", route_namespace)
+            backend_name = backend.get("name", "unknown")
+            backend_port = backend.get("port", "")
+            weight = backend.get("weight", 1)
+
+            backends.append({
+                "namespace": backend_ns,
+                "name": backend_name,
+                "port": backend_port,
+                "weight": weight,
+            })
+
+        extracted_rules.append({
+            "index": idx,
+            "matches": match_details,
+            "backends": backends,
+        })
+
+    return extracted_rules
+
+
+def check_gateway_api_installed(kubeconfig: str) -> Tuple[bool, List[str]]:
+    """Check if Gateway API CRDs are installed in the cluster.
+
+    Args:
+        kubeconfig: Path to kubeconfig file
+
+    Returns:
+        Tuple of (is_installed, list of installed CRDs)
+    """
+    installed_crds = []
+
+    try:
+        result = subprocess.run(
+            [
+                "kubectl", "--kubeconfig", kubeconfig,
+                "get", "crd", "-o", "jsonpath={.items[*].metadata.name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        if result.returncode == 0:
+            all_crds = result.stdout.strip().split()
+            for crd in GATEWAY_API_CRDS:
+                if crd in all_crds:
+                    installed_crds.append(crd)
+
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError) as e:
+        print(f"⚠️  Error checking CRDs: {e}", file=sys.stderr)
+
+    is_installed = len(installed_crds) > 0
+    return is_installed, installed_crds
+
+
+def run_kubectl_json(
+    kubeconfig: str,
+    resource: str,
+    namespace: Optional[str] = None,
+    all_namespaces: bool = False,
+    timeout: int = 30,
+) -> Optional[dict]:
+    """Run kubectl get with JSON output.
+
+    Args:
+        kubeconfig: Path to kubeconfig file
+        resource: Resource type to get (e.g., 'gateways.gateway.networking.k8s.io')
+        namespace: Specific namespace (optional)
+        all_namespaces: If True, get resources from all namespaces
+        timeout: Command timeout in seconds
+
+    Returns:
+        Parsed JSON data or None if failed
+    """
+    cmd = ["kubectl", "--kubeconfig", kubeconfig, "get", resource, "-o", "json"]
+
+    if all_namespaces:
+        cmd.append("-A")
+    elif namespace:
+        cmd.extend(["-n", namespace])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        else:
+            # Resource might not exist or no permissions
+            if "NotFound" in result.stderr or "the server doesn't have" in result.stderr:
+                return {"items": []}
+            print(f"⚠️  kubectl get {resource} failed: {result.stderr.strip()}", file=sys.stderr)
+            return None
+
+    except json.JSONDecodeError as e:
+        print(f"⚠️  Failed to parse JSON for {resource}: {e}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print(f"⚠️  Timeout getting {resource}", file=sys.stderr)
+        return None
+    except subprocess.SubprocessError as e:
+        print(f"⚠️  Error getting {resource}: {e}", file=sys.stderr)
+        return None
+
+
+def run_gwctl_json(
+    gwctl_path: str,
+    resource: str,
+    namespace: Optional[str] = None,
+    all_namespaces: bool = False,
+    timeout: int = 30,
+) -> Optional[dict]:
+    """Run gwctl get with JSON output.
+
+    Args:
+        gwctl_path: Path to gwctl binary
+        resource: Resource type to get (e.g., 'gateways')
+        namespace: Specific namespace (optional)
+        all_namespaces: If True, get resources from all namespaces
+        timeout: Command timeout in seconds
+
+    Returns:
+        Parsed JSON data or None if failed
+    """
+    cmd = [gwctl_path, "get", resource, "-o", "json"]
+
+    if all_namespaces:
+        cmd.append("-A")
+    elif namespace:
+        cmd.extend(["-n", namespace])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        else:
+            return None
+
+    except json.JSONDecodeError as e:
+        print(f"⚠️  Failed to parse gwctl JSON for {resource}: {e}", file=sys.stderr)
+        return None
+    except subprocess.TimeoutExpired:
+        print(f"⚠️  Timeout running gwctl get {resource}", file=sys.stderr)
+        return None
+    except subprocess.SubprocessError as e:
+        print(f"⚠️  Error running gwctl get {resource}: {e}", file=sys.stderr)
+        return None
+
+
+def count_gateways(kubeconfig: str) -> int:
+    """Count the number of Gateway resources in the cluster.
+
+    Args:
+        kubeconfig: Path to kubeconfig file
+
+    Returns:
+        Number of gateways found
+    """
+    try:
+        result = subprocess.run(
+            [
+                "kubectl", "--kubeconfig", kubeconfig,
+                "get", "gateways.gateway.networking.k8s.io",
+                "-A", "--no-headers",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        if result.returncode == 0:
+            lines = [l for l in result.stdout.strip().split('\n') if l.strip()]
+            return len(lines)
+
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        pass
+
+    return 0
+
+
+def safe_write_file(filepath: str, content: str):
+    """Safely write a file using os.open() with O_NOFOLLOW to prevent symlink attacks.
+
+    Args:
+        filepath: Path to the file to write
+        content: Content to write to the file
+
+    Raises:
+        OSError: If file cannot be written (e.g., symlink detected)
+    """
+    if os.path.lexists(filepath):
+        if os.path.islink(filepath):
+            raise OSError(
+                f"Security violation: {filepath} is a symlink (CWE-377/CWE-59)"
+            )
+
+    flags = os.O_NOFOLLOW | os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    try:
+        fd = os.open(filepath, flags, 0o600)
+        with os.fdopen(fd, 'w') as f:
+            f.write(content)
+    except OSError as e:
+        if e.errno == errno.ELOOP:
+            raise OSError(
+                f"Security violation: {filepath} is a symlink (CWE-377/CWE-59)"
+            ) from e
+        raise
+
+
+def safe_append_file(filepath: str, content: str):
+    """Safely append to a file, checking for symlinks first.
+
+    Args:
+        filepath: Path to the file to append to
+        content: Content to append to the file
+
+    Raises:
+        OSError: If file cannot be written (e.g., symlink detected)
+    """
+    if os.path.lexists(filepath):
+        if os.path.islink(filepath):
+            raise OSError(
+                f"Security violation: {filepath} is a symlink (CWE-377/CWE-59)"
+            )
+        flags = os.O_NOFOLLOW | os.O_WRONLY | os.O_APPEND
+    else:
+        flags = os.O_NOFOLLOW | os.O_CREAT | os.O_WRONLY | os.O_APPEND
+
+    try:
+        fd = os.open(filepath, flags, 0o600)
+        with os.fdopen(fd, 'a') as f:
+            f.write(content)
+    except OSError as e:
+        if e.errno == errno.ELOOP:
+            raise OSError(
+                f"Security violation: {filepath} is a symlink (CWE-377/CWE-59)"
+            ) from e
+        raise
+
+
+def format_listeners(listeners: list) -> str:
+    """Format gateway listeners for display.
+
+    Args:
+        listeners: List of listener objects from Gateway spec
+
+    Returns:
+        Formatted string like "HTTPS:443, HTTP:80"
+    """
+    if not listeners:
+        return "none"
+
+    formatted = []
+    for listener in listeners:
+        protocol = listener.get("protocol", "unknown")
+        port = listener.get("port", "?")
+        name = listener.get("name", "")
+        if name:
+            formatted.append(f"{protocol}:{port}({name})")
+        else:
+            formatted.append(f"{protocol}:{port}")
+
+    return ", ".join(formatted)
+
+
+def format_addresses(addresses: list) -> str:
+    """Format gateway addresses for display.
+
+    Args:
+        addresses: List of address objects from Gateway status
+
+    Returns:
+        Formatted string of addresses
+    """
+    if not addresses:
+        return "pending"
+
+    formatted = []
+    for addr in addresses:
+        addr_type = addr.get("type", "Unknown")
+        value = addr.get("value", "?")
+        formatted.append(f"{value} ({addr_type})")
+
+    return ", ".join(formatted)
+
+
+def format_parent_refs(parent_refs: list) -> str:
+    """Format route parent references for display.
+
+    Args:
+        parent_refs: List of parentRef objects from Route spec
+
+    Returns:
+        Formatted string of parent references
+    """
+    if not parent_refs:
+        return "none"
+
+    formatted = []
+    for ref in parent_refs:
+        namespace = ref.get("namespace", "")
+        name = ref.get("name", "?")
+        section = ref.get("sectionName", "")
+
+        if namespace and section:
+            formatted.append(f"{namespace}/{name}:{section}")
+        elif namespace:
+            formatted.append(f"{namespace}/{name}")
+        elif section:
+            formatted.append(f"{name}:{section}")
+        else:
+            formatted.append(name)
+
+    return ", ".join(formatted)
+
+
+def format_backend_refs(rules: list) -> str:
+    """Extract and format backend references from route rules.
+
+    Args:
+        rules: List of rule objects from Route spec
+
+    Returns:
+        Formatted string of backend references
+    """
+    backends = set()
+
+    for rule in rules or []:
+        for backend_ref in rule.get("backendRefs", []):
+            namespace = backend_ref.get("namespace", "")
+            name = backend_ref.get("name", "?")
+            port = backend_ref.get("port", "")
+
+            if namespace and port:
+                backends.add(f"{namespace}/{name}:{port}")
+            elif namespace:
+                backends.add(f"{namespace}/{name}")
+            elif port:
+                backends.add(f"{name}:{port}")
+            else:
+                backends.add(name)
+
+    return ", ".join(sorted(backends)) if backends else "none"


### PR DESCRIPTION
Add /openshift:visualize-gateway-topology command that generates Mermaid diagrams showing Gateway API resources and their relationships.

## What this PR does / why we need it:


Features:
 - Per-gateway subgraphs with listeners, routes, rules, and endpoints
 - Traffic weight visualization for canary deployments
 - Pod endpoint IPs with ready status
 - gwctl integration for richer data collection
 - Two diagram modes: detailed (1-3 gateways) and overview (4+)

Includes helper scripts for cluster detection, permission checking, data collection and topology analysis.

Assisted with Claude Code


## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] This change includes docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenShift command to generate and visualize Kubernetes Gateway API topology as Mermaid diagrams (per-gateway and layered views).
  * New skill to generate and display Gateway API topology diagrams (GatewayClasses, Gateways, Routes, backends, and relationships).

* **Documentation**
  * Comprehensive docs and README with quick start, examples, output formats, prerequisites, permission guidance, troubleshooting, and FAQ.

* **Chores**
  * Plugin version bumped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->