### PR TITLE
Add /github:issue-triage command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -133,6 +133,11 @@
       "name": "workspaces",
       "source": "./plugins/workspaces",
       "description": "Manage isolated git worktree workspaces for multi-repo development"
+    },
+    {
+      "name": "github",
+      "source": "./plugins/github",
+      "description": "GitHub automation and workflow utilities for issue management and triage"
     }
   ]
 }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,6 +11,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Doc](#doc-plugin)
 - [Etcd](#etcd-plugin)
 - [Git](#git-plugin)
+- [Github](#github-plugin)
 - [Hcp](#hcp-plugin)
 - [Hello World](#hello-world-plugin)
 - [Jira](#jira-plugin)
@@ -130,6 +131,15 @@ Git workflow automation and utilities
 - **`/git:summary`** - Show current branch, git status, and recent commits for quick context
 
 See [plugins/git/README.md](plugins/git/README.md) for detailed documentation.
+
+### Github Plugin
+
+GitHub automation and workflow utilities
+
+**Commands:**
+- **`/github:issue-triage` `<owner/repo> [issue-number]`** - Automatically triage and label GitHub issues using AI analysis
+
+See [plugins/github/README.md](plugins/github/README.md) for detailed documentation.
 
 ### Hcp Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1032,6 +1032,22 @@
       "name": "workspaces",
       "skills": [],
       "version": "1.0.0"
+    },
+    {
+      "commands": [
+        {
+          "argument_hint": "<owner/repo> [issue-number]",
+          "description": "Automatically triage and label GitHub issues using AI analysis",
+          "name": "issue-triage",
+          "synopsis": "/github:issue-triage <owner/repo> [issue-number]"
+        }
+      ],
+      "description": "GitHub automation and workflow utilities for issue management and triage",
+      "has_readme": true,
+      "hooks": [],
+      "name": "github",
+      "skills": [],
+      "version": "0.0.1"
     }
   ]
 }

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "github",
+  "description": "GitHub automation and workflow utilities",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,0 +1,210 @@
+# GitHub Plugin
+
+A Claude Code plugin for automating GitHub workflows, with a focus on intelligent issue management and triage.
+
+## Overview
+
+The GitHub plugin provides AI-powered automation for common GitHub repository management tasks. It leverages Claude's natural language understanding to analyze issues, apply appropriate labels, and maintain consistent categorization across your repositories.
+
+## Commands
+
+### `/github:issue-triage`
+
+Automatically triage and label GitHub issues using AI-powered content analysis.
+
+**Usage:**
+```
+/github:issue-triage <owner/repo> [issue-number]
+```
+
+**Arguments:**
+- `owner/repo` (required): Repository in format `owner/repo` (e.g., `openshift-eng/ai-helpers`)
+- `issue-number` (optional): Specific issue number to triage. If omitted, triages all open unlabeled issues.
+
+**Examples:**
+```
+# Triage a specific issue
+/github:issue-triage openshift-eng/ai-helpers 184
+
+# Triage all unlabeled issues
+/github:issue-triage kubernetes/kubernetes
+
+# Triage issue in personal repo
+/github:issue-triage username/my-project 42
+```
+
+**Features:**
+- Analyzes issue title and description for technical content
+- Identifies issue type (bug, enhancement, question, documentation, etc.)
+- Detects affected components and areas
+- Applies labels based on repository's existing label set
+- Provides detailed reasoning for label selections
+- Handles batch triage for multiple issues
+- Conservative approach to avoid misclassification
+
+**Prerequisites:**
+- GitHub CLI (`gh`) installed and authenticated
+- Write access to the target repository
+
+**Output:**
+The command provides a summary table showing:
+- Issues triaged
+- Labels applied to each issue
+- Reasoning for label selection
+- Any warnings or issues requiring manual review
+
+## Installation
+
+### From Marketplace
+
+```bash
+# Add the marketplace
+/plugin marketplace add openshift-eng/ai-helpers
+
+# Install the github plugin
+/plugin install github@ai-helpers
+```
+
+### Manual Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/openshift-eng/ai-helpers.git
+
+# Link to Claude Code commands directory
+mkdir -p ~/.claude/commands
+ln -s "$(pwd)/ai-helpers" ~/.claude/commands/ai-helpers
+```
+
+## Prerequisites
+
+This plugin requires:
+
+1. **GitHub CLI (gh)**
+   - Install from: https://cli.github.com/
+   - Authenticate: `gh auth login`
+   - Verify: `gh auth status`
+
+2. **Repository Permissions**
+   - Write access to repositories you want to triage
+   - For organization repos, ensure proper team permissions
+
+## How It Works
+
+The issue triage command follows this workflow:
+
+1. **Fetch Issue Data**: Retrieves issue details using GitHub CLI
+2. **Fetch Repository Labels**: Gets all available labels from the repository
+3. **AI Analysis**: Analyzes issue content to understand:
+   - Issue type and intent
+   - Technical areas and components affected
+   - Clarity and completeness
+4. **Label Selection**: Chooses appropriate labels based on:
+   - Repository's existing label taxonomy
+   - Objective criteria from issue content
+   - Best practices for categorization
+5. **Apply Labels**: Updates the issue with selected labels
+6. **Report Results**: Provides detailed summary of changes
+
+## Label Selection Criteria
+
+The AI uses the following criteria when selecting labels:
+
+- **Type Labels**: `bug`, `enhancement`, `question`, `documentation`
+- **Area/Component Labels**: Repository-specific labels for different modules or areas
+- **Status Labels**: `needs-triage`, `needs-info`, `good-first-issue`
+- **Platform Labels**: OS or environment-specific labels when relevant
+- **Special Flags**: `duplicate`, `wontfix`, `stale` when appropriate
+
+**Important Constraints:**
+- Only uses labels that exist in the repository
+- Avoids priority labels (p0, p1, p2) unless explicitly required
+- Does not post comments on issues
+- Applies 2-5 labels per issue for optimal categorization
+- Uses `needs-info` for vague or unclear issues
+
+## Use Cases
+
+### Daily Triage for Active Repositories
+
+```bash
+# Triage all new unlabeled issues
+/github:issue-triage my-org/my-project
+```
+
+Run this daily to keep up with new issues in active repositories.
+
+### Pre-Planning Triage
+
+```bash
+# Triage specific issues before sprint planning
+/github:issue-triage my-org/my-project 101
+/github:issue-triage my-org/my-project 102
+/github:issue-triage my-org/my-project 103
+```
+
+Prepare issues for team review by ensuring they're properly labeled.
+
+### Bulk Cleanup
+
+```bash
+# Clean up unlabeled backlog
+/github:issue-triage legacy-org/legacy-project
+```
+
+Apply consistent labels to older issues that were never triaged.
+
+## Best Practices
+
+1. **Review AI Decisions**: While the AI is objective, always review applied labels for accuracy
+2. **Customize Repository Labels**: Maintain a clear, well-organized label structure in your repository
+3. **Use Descriptive Labels**: Ensure repository labels have clear names and descriptions
+4. **Batch Triage Carefully**: For large backlogs, triage in smaller batches to review results
+5. **Combine with Manual Review**: Use AI triage as a first pass, then refine manually
+6. **Regular Cadence**: Run triage regularly to avoid backlog buildup
+
+## Limitations
+
+- Maximum 100 issues processed per batch to avoid rate limiting
+- Requires GitHub API access and appropriate permissions
+- Label selection limited to repository's existing labels
+- Cannot create new labels automatically
+- Does not modify issue assignees, milestones, or other properties
+
+## Troubleshooting
+
+### "gh: command not found"
+Install GitHub CLI from https://cli.github.com/
+
+### "authentication required"
+Run `gh auth login` to authenticate with GitHub
+
+### "permission denied"
+Ensure you have write access to the repository
+
+### "rate limit exceeded"
+Wait a few minutes before retrying, or reduce batch size
+
+### "label not found"
+The command only uses existing labels; check your repository's label list
+
+## Contributing
+
+Contributions are welcome! To add new commands or improve existing ones:
+
+1. Fork the repository
+2. Create a feature branch
+3. Add or modify commands in `plugins/github/commands/`
+4. Update this README
+5. Run `make lint` to validate
+6. Submit a pull request
+
+## Support
+
+- **Issues**: https://github.com/openshift-eng/ai-helpers/issues
+- **Documentation**: https://github.com/openshift-eng/ai-helpers
+- **Claude Code Docs**: https://docs.claude.com/
+
+## License
+
+See the main repository for license information.

--- a/plugins/github/commands/issue-triage.md
+++ b/plugins/github/commands/issue-triage.md
@@ -1,0 +1,177 @@
+---
+description: Automatically triage and label GitHub issues using AI analysis
+argument-hint: "<owner/repo> [issue-number]"
+---
+
+## Name
+github:issue-triage
+
+## Synopsis
+```
+/github:issue-triage <owner/repo> [issue-number]
+```
+
+## Description
+The `github:issue-triage` command automates the process of triaging and labeling GitHub issues using AI-powered content analysis. It analyzes issue titles, descriptions, and context to intelligently select and apply appropriate labels from the repository's existing label set.
+
+When provided with a repository and optional issue number, the command:
+- Fetches issue details and repository labels using GitHub CLI
+- Analyzes issue content to understand the type, scope, and technical areas involved
+- Selects relevant labels based on objective criteria
+- Applies labels to the issue(s) automatically
+- Provides a summary of changes made
+
+This command is designed to reduce manual triage overhead and ensure consistent labeling across issues.
+
+## Implementation
+
+### Prerequisites
+1. **GitHub CLI (gh) Installation**
+   - Check if installed: `which gh`
+   - If not installed, install from: https://cli.github.com/
+   - Verify authentication: `gh auth status`
+   - If not authenticated, run: `gh auth login`
+
+2. **Repository Access**
+   - User must have write access to the repository to apply labels
+   - For organization repositories, ensure proper permissions are granted
+
+### Workflow Steps
+
+1. **Validate Arguments**
+   - Ensure repository is provided in `owner/repo` format
+   - Validate issue number format if provided (must be numeric)
+   - Verify repository exists and is accessible
+
+2. **Fetch Repository Labels**
+   ```bash
+   gh label list --repo $1 --json name,description --limit 1000
+   ```
+   - Retrieve all available labels from the repository
+   - Store label names and descriptions for reference during analysis
+
+3. **Determine Issues to Triage**
+   - If issue number provided (`$2`): Triage only that specific issue
+   - If no issue number: Fetch all open issues without any labels
+   ```bash
+   # Single issue
+   gh issue view $2 --repo $1 --json number,title,body,labels
+
+   # All unlabeled issues
+   gh issue list --repo $1 --state open --limit 100 --json number,title,body,labels \
+     | jq '.[] | select(.labels | length == 0)'
+   ```
+
+4. **Analyze Each Issue**
+   For each issue to be triaged:
+
+   a. **Content Analysis**
+      - Examine issue title for keywords and intent
+      - Parse issue body/description for technical details
+      - Identify issue type (bug report, feature request, question, documentation, etc.)
+      - Determine affected components or areas
+      - Assess clarity and completeness of the issue
+
+   b. **Label Selection Criteria**
+      Apply labels based on:
+      - **Type labels**: `bug`, `enhancement`, `question`, `documentation`, etc.
+      - **Area/Component labels**: Specific to repository structure (e.g., `area/cli`, `component/api`)
+      - **Status labels**: `needs-triage`, `needs-info`, `good-first-issue`, etc.
+      - **Platform labels**: OS-specific or environment-specific labels if mentioned
+      - **Special flags**: `duplicate` (if similar issues exist), `stale`, etc.
+
+   c. **Label Selection Rules**
+      - **ONLY use labels that exist in the repository's label list**
+      - Be specific but comprehensive in label selection
+      - **AVOID priority labels** (e.g., `p0`, `p1`, `p2`, `priority/critical`) unless explicitly part of triage criteria
+      - Prefer 2-5 labels per issue for optimal categorization
+      - If issue content is too vague or unclear, apply `needs-info` or `needs-triage` label
+      - Do not apply labels if none are objectively appropriate
+
+5. **Apply Labels**
+   ```bash
+   gh issue edit $issue_number --repo $1 --add-label "label1,label2,label3"
+   ```
+   - Apply all selected labels in a single command
+   - Handle errors gracefully (e.g., label doesn't exist, permission denied)
+
+6. **Report Results**
+   - Provide a summary table showing:
+     - Issue number and title
+     - Labels applied
+     - Reasoning for label selection
+   - Include any errors or warnings encountered
+   - Suggest manual review for ambiguous cases
+
+### Error Handling
+
+- **GitHub CLI not installed**: Provide installation instructions
+- **Not authenticated**: Guide user to run `gh auth login`
+- **Repository not found**: Verify repository name format
+- **Permission denied**: Check if user has write access to repository
+- **Issue not found**: Verify issue number exists
+- **Label doesn't exist**: Skip invalid labels and warn user
+- **API rate limiting**: Inform user and suggest retry timing
+
+### Constraints
+
+- **No commenting**: The command applies labels only; it does not post comments on issues
+- **Objective labeling**: Labels are selected based on objective analysis, not subjective priority
+- **Batch limits**: Process maximum 100 issues at once to avoid rate limiting
+- **Timeout**: Set reasonable timeout for API calls (e.g., 30 seconds per issue)
+
+## Return Value
+
+- **Format**: Markdown table summarizing triage results
+
+Example output:
+```
+Issue Triage Summary for owner/repo
+====================================
+
+✓ Successfully triaged 5 issues
+
+| Issue | Title | Labels Applied | Reasoning |
+|-------|-------|---------------|-----------|
+| #123 | Login fails on Safari | bug, area/auth, browser/safari | Bug report affecting authentication in Safari browser |
+| #124 | Add dark mode support | enhancement, area/ui | Feature request for UI enhancement |
+| #125 | How to configure X? | question, area/config | Configuration question |
+| #126 | Fix typo in README | documentation, good-first-issue | Simple documentation fix suitable for new contributors |
+| #127 | API returns 500 error | bug, area/api, needs-info | Bug report lacking reproduction steps |
+
+⚠ Issues needing manual review:
+- #127: Insufficient information to fully categorize; applied 'needs-info'
+```
+
+## Examples
+
+1. **Triage a specific issue**:
+   ```
+   /github:issue-triage openshift-eng/ai-helpers 184
+   ```
+   Analyzes issue #184 in the openshift-eng/ai-helpers repository and applies appropriate labels.
+
+2. **Triage all unlabeled issues in a repository**:
+   ```
+   /github:issue-triage kubernetes/kubernetes
+   ```
+   Finds all open issues without labels in kubernetes/kubernetes and triages them in batch.
+
+3. **Triage issues in a personal repository**:
+   ```
+   /github:issue-triage username/my-project 42
+   ```
+   Triages issue #42 in a personal repository.
+
+## Arguments
+
+- `$1` (required): Repository in `owner/repo` format (e.g., `openshift-eng/ai-helpers`)
+- `$2` (optional): Specific issue number to triage (e.g., `184`). If omitted, triages all open unlabeled issues.
+
+## Notes
+
+- This command is inspired by automated issue triage workflows used in large open-source projects
+- The AI analysis is designed to be conservative and objective to avoid misclassification
+- For repositories with custom labeling schemes, the command adapts to available labels
+- Regular use of this command helps maintain consistent issue categorization
+- Consider running this command periodically (e.g., daily) for active repositories


### PR DESCRIPTION
Adds new GitHub plugin with AI-powered issue triage command that automatically analyzes and labels GitHub issues based on content.

Features:
- Analyzes issue titles and descriptions to determine type (bug, feature, question, etc.)
- Selects appropriate labels from repository's existing label set
- Applies labels using GitHub CLI
- Supports single issue and batch triage modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub plugin with issue-triage command for automated GitHub issue analysis and management
  * Uses AI analysis to intelligently identify and apply relevant labels to GitHub issues
  * Supports triaging individual or multiple issues with constraints on label count and selection

* **Documentation**
  * Published comprehensive GitHub plugin documentation including installation instructions, command reference, usage examples, prerequisites, and troubleshooting guides

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->