### PR TITLE
  Add jira:sprint-review command for comprehensive sprint review report

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "name": "ci",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -189,6 +189,7 @@ A plugin to automate tasks with Jira
 - **`/jira:reconcile-github` `[--github-project <org/repo>] [--jira-project <key>] [--profile <name>] [--porcelain] [--output json|yaml]`** - Reconcile state mismatches between GitHub and Jira issues
 - **`/jira:setup-gh2jira`** - Install and configure the gh2jira utility with all required tools and credentials
 - **`/jira:solve`** - Analyze a JIRA issue and create a pull request to solve it.
+- **`/jira:sprint-review` `[--project project-name] [--component component-name] [--jql custom-filter] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--output filename]`** - Generate comprehensive sprint review report with custom date range and flexible scope filtering
 - **`/jira:status-rollup` `issue-id [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]`** - Generate a status rollup comment for any JIRA issue based on all child issues and a given date range
 - **`/jira:update-weekly-status` `[project-key] [--component name] [--label label-name] [user-filters...]`** - Update weekly status summaries for Jira issues with component and user filtering
 - **`/jira:validate-blockers` `[target-version] [component-filter] [--bug issue-key]`** - Validate proposed release blockers using Red Hat OpenShift release blocker criteria

--- a/docs/data.json
+++ b/docs/data.json
@@ -169,6 +169,12 @@
           "synopsis": "/jira:solve <jira-issue-id> [remote] [--ci]"
         },
         {
+          "argument_hint": "[--project project-name] [--component component-name] [--jql custom-filter] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--output filename]",
+          "description": "Generate comprehensive sprint review report with custom date range and flexible scope filtering",
+          "name": "sprint-review",
+          "synopsis": "/jira:sprint-review [--project project-name] [--component component-name] [--jql custom-filter] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--output filename]"
+        },
+        {
           "argument_hint": "issue-id [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD]",
           "description": "Generate a status rollup comment for any JIRA issue based on all child issues and a given date range",
           "name": "status-rollup",
@@ -278,7 +284,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -9,6 +9,7 @@ Comprehensive Jira integration for Claude Code, providing AI-powered tools to an
 - 📝 **Weekly Status Updates** - Automate weekly status summary updates with intelligent activity analysis and color-coded health indicators
 - 📋 **Backlog Grooming** - Analyze new bugs and cards for grooming meetings
 - 🏷️ **Activity Type Categorization** - AI-powered categorization of JIRA tickets into activity types with confidence scoring
+- 📈 **Sprint Reviews** - Generate comprehensive sprint review reports with custom date ranges and flexible filtering
 - 🧪 **Test Generation** - Generate comprehensive test steps for JIRA issues by analyzing related PRs
 - ✨ **Issue Creation** - Create well-formed stories, epics, features, tasks, bugs, and feature requests with guided workflows
 - 📝 **Release Note Generation** - Automatically generate bug fix release notes from Jira and linked GitHub PRs
@@ -324,6 +325,60 @@ Automate the process of updating weekly status summaries for Jira issues with in
 - Jira permissions to update Status Summary field
 
 See [commands/update-weekly-status.md](commands/update-weekly-status.md) for full documentation.
+
+---
+
+### `/jira:sprint-review` - Generate Sprint Review Reports
+
+Generate comprehensive sprint review reports for any project or component with custom date ranges. The command analyzes blockers, new work items, closed issues, activity trends, and generates actionable insights with team accomplishments, metrics, and recommendations.
+
+**Usage:**
+```bash
+# Single project sprint review
+/jira:sprint-review --project OCPSTRAT --start-date 2024-12-01 --end-date 2024-12-15
+
+# Project with specific component
+/jira:sprint-review --project OCM --component "Multicluster Networking" --start-date 2024-12-01
+
+# Multiple components
+/jira:sprint-review --project OCPSTRAT --component "Control Plane,Storage" --start-date 2024-12-01 --end-date 2024-12-15
+
+# Custom JQL filter
+/jira:sprint-review --jql "project=OCM AND component='ARO HCP'" --start-date 2024-12-01 --end-date 2024-12-15
+
+# Custom output filename
+/jira:sprint-review --project OCPBUGS --start-date 2024-12-01 --output "q4-sprint-3-review.md"
+```
+
+**What it does:**
+1. Collects user parameters (scope, date range, output settings)
+2. Builds JQL queries for blocker bugs, new work, closed issues, and activity
+3. Executes queries and collects issue data
+4. Analyzes data across multiple dimensions (blockers, completion, activity, metrics)
+5. Generates comprehensive Markdown report with 10 sections
+6. Saves report to current directory
+
+**Report Sections:**
+- **Executive Summary** - Key metrics and sprint health
+- **Blocker Bugs** - Open blocker-priority issues with status
+- **New Work Items** - Issues created during sprint, grouped by type
+- **Closed Issues** - Issues resolved during sprint with details
+- **Activity Summary** - Issues updated during sprint by status
+- **Work Breakdown** - Analysis by type and work area
+- **Key Metrics** - Counts, trends, and velocity statistics
+- **Risks & Concerns** - Blockers and issues requiring attention
+- **Recommendations** - Actionable next steps
+- **Team Accomplishments** - Highlights of completed work
+
+**Key Features:**
+- Flexible scope filtering (project, component, or custom JQL)
+- Custom date range with smart defaults (end date = today)
+- Multi-dimensional analysis and metrics
+- Markdown output for easy sharing
+- Automatic trend identification
+- Risk assessment and recommendations
+
+See [commands/sprint-review.md](commands/sprint-review.md) for full documentation.
 
 ---
 

--- a/plugins/jira/commands/sprint-review.md
+++ b/plugins/jira/commands/sprint-review.md
@@ -1,0 +1,273 @@
+---
+description: Generate comprehensive sprint review report with custom date range and flexible scope filtering
+argument-hint: "[--project project-name] [--component component-name] [--jql custom-filter] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--output filename]"
+---
+
+## Name
+jira:sprint-review
+
+## Synopsis
+```
+/jira:sprint-review [--project project-name] [--component component-name] [--jql custom-filter] [--start-date YYYY-MM-DD] [--end-date YYYY-MM-DD] [--output filename]
+```
+
+## Description
+The `jira:sprint-review` command generates comprehensive sprint review reports for any project or component combination. It analyzes all issue activity within a specified date range and produces detailed insights on blockers, new work, completed issues, activity trends, and team accomplishments.
+
+This command is particularly useful for:
+- End-of-sprint retrospectives and reviews
+- Executive status reports across multiple sprints
+- Team performance analysis and metrics tracking
+- Identifying patterns in issue creation and resolution
+- Planning future sprint capacity based on historical data
+
+Key capabilities:
+- Flexible scope filtering (project, component, or custom JQL)
+- Custom date range specification with smart defaults
+- Multi-dimensional analysis (blockers, new work, closed issues, activity)
+- Automatic work breakdown by type and area
+- Metrics calculation and trend analysis
+- Risk identification and recommendations
+- Markdown output for easy sharing and documentation
+
+## Implementation
+
+The command executes the following workflow:
+
+### 1. Parameter Collection
+
+Prompt the user for the following parameters if not provided:
+
+**Scope Filter** (choose one approach):
+- **Option A**: Project and optional component(s)
+  - Project name (e.g., "OCM", "OCPSTRAT")
+  - Component(s) (e.g., "Multicluster Networking", or multiple: "Control Plane,Storage")
+- **Option B**: Custom JQL filter
+  - Full JQL query (e.g., `project=OCM AND component="ARO HCP"`)
+
+**Date Range**:
+- Start date in YYYY-MM-DD format (required)
+- End date in YYYY-MM-DD format (defaults to today if not provided)
+
+**Output Settings**:
+- Report filename (optional, defaults to `sprint-review-{start-date}-to-{end-date}.md`)
+
+### 2. Build JQL Queries
+
+Construct base filter based on user input:
+
+**If using project + components:**
+```jql
+project="{PROJECT}" AND component in ("{COMPONENT1}", "{COMPONENT2}")
+```
+
+**If using custom JQL:**
+```jql
+{USER_JQL}
+```
+
+Then construct specific queries for data collection:
+
+1. **Blocker bugs:**
+   ```jql
+   {BASE_FILTER} AND priority=Blocker AND resolution is EMPTY
+   ```
+
+2. **New issues created during sprint:**
+   ```jql
+   {BASE_FILTER} AND created >= "{START_DATE}" AND created <= "{END_DATE}"
+   ```
+
+3. **Closed issues during sprint:**
+   ```jql
+   {BASE_FILTER} AND status in (Closed, Done, Resolved) AND resolved >= "{START_DATE}" AND resolved <= "{END_DATE}"
+   ```
+
+4. **Updated issues during sprint:**
+   ```jql
+   {BASE_FILTER} AND updated >= "{START_DATE}" AND updated <= "{END_DATE}"
+   ```
+
+### 3. Data Collection
+
+Execute each JQL query using the `jira issue list` command:
+- Use `--raw` flag for JSON output
+- Use `--paginate 100` to capture all results
+- Validate date formats before execution
+- Handle authentication and API errors gracefully
+
+Extract key fields from each issue:
+- Issue key, summary, type, priority
+- Status, resolution, assignee, reporter
+- Created date, updated date, resolved date
+- Components, labels, story points (if available)
+- Links to related issues
+
+### 4. Data Analysis
+
+**Blocker Analysis:**
+- Identify all open blocker-priority issues
+- Categorize by age, component, and assignee status
+- Flag unassigned or stale blockers
+
+**New Work Analysis:**
+- Group new issues by type (Bug, Story, Task, Epic, etc.)
+- Categorize by purpose (feature, bug fix, tech debt, etc.)
+- Identify trends in issue creation patterns
+
+**Completion Analysis:**
+- Calculate completion rate (closed vs. created)
+- Analyze resolution time distribution
+- Identify high-performing areas and bottlenecks
+
+**Activity Analysis:**
+- Track status transitions during the sprint
+- Identify most active components/assignees
+- Detect issues with excessive churn
+
+**Metrics Calculation:**
+- Total issues: created, closed, in-progress, blocked
+- Story points: planned vs. completed (if available)
+- Velocity trends and capacity utilization
+- Blocker impact and resolution time
+
+### 5. Report Generation
+
+Generate a comprehensive Markdown report with the following sections:
+
+**Report Header:**
+- Sprint date range
+- Scope (project/component filter)
+- Generation timestamp
+- Claude Code attribution
+
+**Main Sections:**
+
+1. **📊 Executive Summary**
+   - Key metrics and highlights
+   - Overall sprint health assessment
+
+2. **🚨 Blocker Bugs**
+   - All open blocker-priority issues
+   - Detailed status and recommended actions
+
+3. **✨ New Work Items**
+   - All issues created during sprint
+   - Grouped by type and purpose
+
+4. **✅ Closed Issues**
+   - All issues resolved/closed during sprint
+   - Completion details and trends
+
+5. **📈 Activity Summary**
+   - Issues updated during sprint
+   - Status transition analysis
+
+6. **🔍 Work Breakdown**
+   - Analysis by issue type
+   - Analysis by work area/component
+
+7. **📉 Key Metrics**
+   - Counts, percentages, and trends
+   - Velocity and capacity metrics
+
+8. **⚠️ Risks & Concerns**
+   - Identified blockers requiring attention
+   - Process or capacity concerns
+
+9. **💡 Recommendations**
+   - Actionable next steps for the team
+   - Suggested process improvements
+
+10. **🎯 Team Accomplishments**
+    - Highlights of completed work
+    - Notable achievements
+
+**Appendix:**
+- Links to all key issues referenced
+- Full JQL queries used for data collection
+
+### 6. Output and Review
+
+- Save report to specified location (current directory by default)
+- Display filename and path to user
+- Provide summary of key findings
+- Offer to open the report or make adjustments
+
+## Usage Examples
+
+1. **Single project sprint review:**
+   ```
+   /jira:sprint-review --project OCPSTRAT --start-date 2024-12-01 --end-date 2024-12-15
+   ```
+
+2. **Project with specific component:**
+   ```
+   /jira:sprint-review --project OCM --component "Multicluster Networking" --start-date 2024-12-01
+   ```
+
+3. **Multiple components:**
+   ```
+   /jira:sprint-review --project OCPSTRAT --component "Control Plane,Storage" --start-date 2024-12-01 --end-date 2024-12-15
+   ```
+
+4. **Custom JQL filter:**
+   ```
+   /jira:sprint-review --jql "project=OCM AND component='ARO HCP'" --start-date 2024-12-01 --end-date 2024-12-15
+   ```
+
+5. **Custom output filename:**
+   ```
+   /jira:sprint-review --project OCPBUGS --start-date 2024-12-01 --output "q4-sprint-3-review.md"
+   ```
+
+6. **End date defaults to today:**
+   ```
+   /jira:sprint-review --project HOSTEDCP --start-date 2024-12-15
+   ```
+
+## Arguments
+
+- **--project** *(optional if --jql provided)*
+  JIRA project key for scope filtering.
+  Example: `OCPSTRAT`, `OCM`, `HOSTEDCP`
+
+- **--component** *(optional)*
+  JIRA component name(s) for filtering (single or comma-separated).
+  Examples:
+    - `--component "Multicluster Networking"`
+    - `--component "Control Plane,Storage"`
+
+- **--jql** *(optional, alternative to --project/--component)*
+  Custom JQL filter for maximum flexibility.
+  Example: `--jql "project=OCM AND component='ARO HCP' AND labels=customer-facing"`
+
+- **--start-date** *(required)*
+  Sprint start date in YYYY-MM-DD format.
+  Example: `--start-date 2024-12-01`
+
+- **--end-date** *(optional)*
+  Sprint end date in YYYY-MM-DD format.
+  Default: Today's date
+  Example: `--end-date 2024-12-15`
+
+- **--output** *(optional)*
+  Custom filename for the generated report.
+  Default: `sprint-review-{start-date}-to-{end-date}.md`
+  Example: `--output "december-sprint-review.md"`
+
+## Return Value
+
+- **Markdown Report**: Comprehensive sprint review document saved to the current directory
+- **Console Summary**: Key findings and metrics displayed to the user
+- **File Path**: Full path to the generated report
+
+**Report Format:**
+```
+Current Directory/
+└── {output-filename}.md  (e.g., sprint-review-2024-12-01-to-2024-12-15.md)
+```
+
+## See Also
+- `jira:grooming` - Backlog grooming meeting agendas
+- `jira:status-rollup` - Status rollup for parent issues


### PR DESCRIPTION
Adds a new `/jira:sprint-review` command to the jira plugin that generates comprehensive sprint review reports with custom date ranges and flexible scope filtering.

## Key Features
- **Flexible scope filtering**: Filter by project + component(s) OR custom JQL query
- **Custom date ranges**: Required start date, optional end date (defaults to today)
- **Comprehensive analysis**: 10 report sections covering blockers, new work, closed issues, activity, metrics, risks, recommendations, and accomplishments
- **JQL query construction**: Automatically builds queries for blockers, new issues, closed issues, and updated issues
- **Markdown output**: Reports saved to current directory for easy sharing 
 
Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /jira:sprint-review command to generate comprehensive sprint review reports with project/component/JQL filtering, customizable date ranges, and optional file output.

* **Documentation**
  * Added detailed usage docs, examples, report sections, and guidance for running and customizing sprint review reports.

* **Chores**
  * Bumped the Jira plugin version to 0.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->