### PR TITLE
Add `proof-pr` commands for managing proof PR workflows

### DIFF
--- a/plugins/proof-pr/commands/add-repo.md
+++ b/plugins/proof-pr/commands/add-repo.md
@@ -1,0 +1,376 @@
+---
+description: Add additional repositories to existing proof PR workflow
+argument-hint: <original-pr-number> <repo>
+---
+
+## Name
+
+proof-pr:add-repo - Add more repositories to an existing proof PR session
+
+## Synopsis
+
+```
+/proof-pr:add-repo <original-pr-number> <repo> [additional-repos...]
+```
+
+## Description
+
+The `proof-pr:add-repo` command adds new proof PRs to an existing workflow. This is useful when:
+- You discover another repository needs testing
+- You want to expand test coverage
+- A new dependency was added
+
+The command will create proof PRs in the specified repositories using the same pseudo-version as existing proof PRs.
+
+**Key Features:**
+- **Reuses existing pseudo-version**: Uses same commit as other proof PRs
+- **Auto-detects dependencies**: Checks if repo actually depends on changes
+- **Preserves state**: Updates existing state file with new PRs
+- **Handles full workflow**: Fork, clone, update, codegen, compile, create PR
+
+## Arguments
+
+- `$1` (required): Original PR number (e.g., `2626`)
+- `$2+` (required): Repository names to add (e.g., `openshift/oc`)
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR="$1"
+shift
+NEW_REPOS=("$@")
+
+if (( ${#NEW_REPOS[@]} == 0 )); then
+    echo "Error: No repositories specified"
+    echo "Usage: /proof-pr:add-repo <original-pr-number> <repo> [repo...]"
+    exit 1
+fi
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+STATE_FILE="$HOME/.work/proof-pr/$ORIGINAL_PR/state.json"
+WORK_DIR="$HOME/.work/proof-pr/$ORIGINAL_PR"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[proof-pr:add-repo]${NC} $*"; }
+log_success() { echo -e "${GREEN}✓${NC} $*"; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+log_error() { echo -e "${RED}✗${NC} $*"; }
+
+# Step 1: Load state
+log "Loading state for PR #$ORIGINAL_PR..."
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    log_error "State file not found: $STATE_FILE"
+    log "No existing proof PR workflow found for PR #$ORIGINAL_PR"
+    log "Use /proof-pr:create instead"
+    exit 1
+fi
+
+STATE_JSON=$(cat "$STATE_FILE")
+ORIGINAL_REPO=$(echo "$STATE_JSON" | jq -r '.original_repo')
+ORIGINAL_URL=$(echo "$STATE_JSON" | jq -r '.original_url')
+ORIGINAL_BRANCH=$(echo "$STATE_JSON" | jq -r '.original_branch')
+
+log "Original PR: $ORIGINAL_REPO#$ORIGINAL_PR"
+log "Adding repositories: ${NEW_REPOS[*]}"
+
+# Step 2: Get pseudo-version from existing proof PRs
+log "Getting pseudo-version from existing proof PRs..."
+
+FIRST_PROOF_PR=$(echo "$STATE_JSON" | jq -r '.proof_prs[0]')
+
+if [[ "$FIRST_PROOF_PR" == "null" ]] || [[ -z "$FIRST_PROOF_PR" ]]; then
+    log_error "No existing proof PRs found in state"
+    log "Use /proof-pr:create instead"
+    exit 1
+fi
+
+# Get pseudo-version by checking go.mod in first proof PR repo
+FIRST_REPO=$(echo "$FIRST_PROOF_PR" | jq -r '.repo')
+FIRST_REPO_DIR="$WORK_DIR/$FIRST_REPO"
+
+if [[ ! -d "$FIRST_REPO_DIR" ]]; then
+    log_error "First proof PR repository not found: $FIRST_REPO_DIR"
+    exit 1
+fi
+
+cd "$FIRST_REPO_DIR"
+
+ORIGINAL_MODULE="github.com/$ORIGINAL_REPO"
+PSEUDO_VERSION=$(grep "$ORIGINAL_MODULE" go.mod | awk '{print $2}')
+
+if [[ -z "$PSEUDO_VERSION" ]]; then
+    log_error "Could not determine pseudo-version from existing proof PRs"
+    exit 1
+fi
+
+log "Using pseudo-version: $PSEUDO_VERSION"
+
+# Extract commit for comments
+COMMIT_SHA=$(echo "$PSEUDO_VERSION" | grep -oE '[a-f0-9]{12}$')
+
+# Step 3: Check which repos already have proof PRs
+EXISTING_REPOS=$(echo "$STATE_JSON" | jq -r '.proof_prs[].repo')
+
+for repo in "${NEW_REPOS[@]}"; do
+    if echo "$EXISTING_REPOS" | grep -q "^$repo$"; then
+        log_warn "Proof PR already exists for $repo, skipping"
+        NEW_REPOS=("${NEW_REPOS[@]/$repo}")
+    fi
+done
+
+if (( ${#NEW_REPOS[@]} == 0 )); then
+    log_warn "All specified repositories already have proof PRs"
+    exit 0
+fi
+
+# Function to create proof PR (reused from create.md)
+create_proof_pr() {
+    local repo="$1"
+    local depends_on_repo="$ORIGINAL_REPO"  # New repos depend on original
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "Creating proof PR in: $repo"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    local repo_work_dir="$WORK_DIR/$repo"
+
+    # Check if repo actually depends on original
+    log "Checking if $repo depends on $ORIGINAL_MODULE..."
+
+    # Clone repo temporarily to check
+    local temp_check_dir=$(mktemp -d)
+    gh repo clone "$repo" "$temp_check_dir" >/dev/null 2>&1 || {
+        log_error "Failed to clone $repo"
+        rm -rf "$temp_check_dir"
+        return 1
+    }
+
+    cd "$temp_check_dir"
+
+    if ! grep -q "$ORIGINAL_MODULE" go.mod 2>/dev/null; then
+        log_warn "$repo does not depend on $ORIGINAL_MODULE"
+        log_warn "Creating proof PR anyway (you may need to add the dependency)"
+    fi
+
+    cd - >/dev/null
+    rm -rf "$temp_check_dir"
+
+    # Fork repository if needed
+    log "Checking fork status..."
+
+    local my_username=$(gh api user -q .login)
+    local fork_check=$(gh repo view "$repo" --json owner -q '.owner.login' 2>/dev/null || echo "")
+
+    if [[ "$fork_check" != "$my_username" ]]; then
+        log "Forking $repo..."
+        gh repo fork "$repo" --clone=false || log_warn "Fork may already exist"
+        local fork_repo="$my_username/$(basename "$repo")"
+    else
+        local fork_repo="$repo"
+    fi
+
+    log "Using fork: $fork_repo"
+
+    # Clone forked repository
+    log "Cloning fork..."
+    gh repo clone "$fork_repo" "$repo_work_dir"
+    cd "$repo_work_dir"
+
+    if [[ "$fork_repo" != "$repo" ]]; then
+        git remote add upstream "https://github.com/$repo.git" || true
+        git fetch upstream
+    fi
+
+    # Create proof branch
+    local proof_branch="proof-pr-${ORIGINAL_REPO//\//-}-${ORIGINAL_PR}"
+
+    log "Creating branch: $proof_branch"
+
+    git checkout -B "$proof_branch" origin/master || \
+        git checkout -B "$proof_branch" origin/main || \
+        git checkout -B "$proof_branch" HEAD
+
+    # Update go.mod
+    log "Updating go.mod: $ORIGINAL_MODULE -> $PSEUDO_VERSION"
+
+    go get "$ORIGINAL_MODULE@$PSEUDO_VERSION" || {
+        log_warn "Dependency may not exist yet, adding manually"
+        # Try to add it manually if it doesn't exist
+        echo "require $ORIGINAL_MODULE $PSEUDO_VERSION" >> go.mod
+    }
+
+    go mod tidy
+
+    # Run code generation if needed
+    CODEGEN_JSON=$("$SKILLS_DIR/detect-codegen.py" . --json 2>/dev/null)
+    NEEDS_CODEGEN=$(echo "$CODEGEN_JSON" | jq -r '.needs_codegen')
+
+    if [[ "$NEEDS_CODEGEN" == "true" ]]; then
+        CODEGEN_CMD=$(echo "$CODEGEN_JSON" | jq -r '.command')
+        if [[ "$CODEGEN_CMD" != "null" ]]; then
+            log "Running codegen: $CODEGEN_CMD"
+            eval "$CODEGEN_CMD" || log_warn "Codegen failed"
+        fi
+    fi
+
+    # Test compilation
+    if "$SKILLS_DIR/compile-test.sh" . >/dev/null 2>&1; then
+        compilation_status="success"
+    else
+        # Try auto-fix
+        "$SKILLS_DIR/attempt-fix.py" . >/dev/null 2>&1 && \
+            compilation_status="fixed" || \
+            compilation_status="failed"
+    fi
+
+    # Commit
+    git add -A
+
+    local commit_msg="[PROOF] Add $ORIGINAL_MODULE for $ORIGINAL_REPO#$ORIGINAL_PR
+
+Testing changes from $ORIGINAL_URL
+Pseudo-version: $PSEUDO_VERSION
+Compilation: $compilation_status
+
+🧪 This is a PROOF PR - DO NOT MERGE
+"
+
+    git commit -m "$commit_msg"
+    git push -f origin "$proof_branch"
+
+    # Create PR
+    local pr_body="<!-- PROOF-PR: $ORIGINAL_URL -->
+<!-- PROVING: $ORIGINAL_REPO#$ORIGINAL_PR -->
+<!-- DEPENDS-ON: $ORIGINAL_REPO -->
+
+## 🧪 PROOF PR
+
+Testing changes from [$ORIGINAL_REPO#$ORIGINAL_PR]($ORIGINAL_URL).
+
+### Changes
+
+- Added \`$ORIGINAL_MODULE@$PSEUDO_VERSION\`
+
+### Status
+
+Compilation: $compilation_status
+
+---
+
+**⚠️ DO NOT MERGE**
+
+Added to proof workflow for $ORIGINAL_URL
+
+Generated by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+    local new_pr_url=$(gh pr create \
+        --repo "$repo" \
+        --title "[PROOF] Add $ORIGINAL_MODULE for #$ORIGINAL_PR" \
+        --body "$pr_body" \
+        --base master \
+        --head "$my_username:$proof_branch" 2>&1 || \
+        gh pr create \
+        --repo "$repo" \
+        --title "[PROOF] Add $ORIGINAL_MODULE for #$ORIGINAL_PR" \
+        --body "$pr_body" \
+        --base main \
+        --head "$my_username:$proof_branch" 2>&1 || echo "FAILED")
+
+    if [[ "$new_pr_url" == "FAILED" ]]; then
+        log_error "Failed to create PR"
+        return 1
+    fi
+
+    local new_pr_number=$(echo "$new_pr_url" | grep -oE '[0-9]+$')
+
+    log_success "Created: $new_pr_url"
+
+    # Add hold label
+    gh pr edit "$new_pr_number" --repo "$repo" --add-label "do-not-merge/hold" 2>/dev/null || true
+
+    # Update state
+    local new_proof_pr=$(cat <<EOF
+{
+  "repo": "$repo",
+  "number": $new_pr_number,
+  "url": "$new_pr_url",
+  "branch": "$proof_branch",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "proving_repo": "$ORIGINAL_REPO",
+  "proving_pr": $ORIGINAL_PR,
+  "depends_on_repo": "$ORIGINAL_REPO",
+  "converted": false,
+  "merged": false
+}
+EOF
+)
+
+    local temp_state=$(mktemp)
+    jq ".proof_prs += [$new_proof_pr] | .last_updated = \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" "$STATE_FILE" > "$temp_state"
+    mv "$temp_state" "$STATE_FILE"
+
+    return 0
+}
+
+# Step 4: Create proof PRs for new repos
+for repo in "${NEW_REPOS[@]}"; do
+    [[ -z "$repo" ]] && continue
+    create_proof_pr "$repo" || log_error "Failed to add $repo"
+done
+
+# Step 5: Show summary
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "SUMMARY"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log ""
+log "Added repositories to proof workflow:"
+
+jq -r '.proof_prs[] | select(.created_at > (now - 300 | todate)) | "  - \(.repo)#\(.number): \(.url)"' "$STATE_FILE"
+
+log ""
+log "Check status: /proof-pr:status $ORIGINAL_PR"
+```
+
+## Return Value
+
+- **Format**: Creates new proof PRs and updates state
+- **Output**: List of created PRs
+
+**Exit codes:**
+- 0: Success - all repositories added
+- 1: Error - no existing workflow or failed to add repos
+
+## Examples
+
+1. **Add single repository**:
+   ```
+   /proof-pr:add-repo 2626 openshift/oc
+   ```
+   Adds oc to existing proof workflow for api#2626.
+
+2. **Add multiple repositories**:
+   ```
+   /proof-pr:add-repo 2626 openshift/console openshift/oc
+   ```
+   Adds both console and oc to the workflow.
+
+## Notes
+
+- **Requires existing workflow**: Must have created proof PRs with `/proof-pr:create` first
+- **Same pseudo-version**: Uses same commit as existing proof PRs
+- **Dependency check**: Warns if repository doesn't depend on original module
+- **State update**: Adds new PRs to existing state file

--- a/plugins/proof-pr/commands/convert.md
+++ b/plugins/proof-pr/commands/convert.md
@@ -1,0 +1,492 @@
+---
+description: Convert proof PRs to normal PRs after original merges (cascading)
+argument-hint: <original-pr-number>
+---
+
+## Name
+
+proof-pr:convert - Convert proof PRs to normal PRs in cascading waves
+
+## Synopsis
+
+```
+/proof-pr:convert <original-pr-number>
+```
+
+## Description
+
+The `proof-pr:convert` command converts proof PRs to normal PRs after their proving PR merges. This implements **cascading conversion**:
+
+1. **First run** (after original PR merges): Converts direct dependents
+2. **Second run** (after direct dependents merge): Converts next layer
+3. **Continue** until all PRs converted
+
+**Key Insight:**
+When the original PR merges, only its *direct* dependents can be converted. Downstream PRs remain as proof PRs for the newly-converted PRs, creating a cascade.
+
+**Example (api#2626 → client-go#1234 → MCO#5678):**
+
+```
+# After api#2626 merges:
+/proof-pr:convert 2626
+→ Converts client-go#1234 (direct dependent)
+→ MCO#5678 remains PROOF, now proves client-go#1234
+
+# After client-go#1234 merges:
+/proof-pr:convert 2626
+→ Converts MCO#5678 (now direct dependent of merged client-go)
+```
+
+**Conversion process:**
+- Removes `do-not-merge/hold` label
+- Updates title (removes `[PROOF]`)
+- Updates PR body (removes proof markers)
+- Marks as converted in state
+- Re-targets downstream PRs to prove newly-converted PR
+
+## Arguments
+
+- `$1` (required): Original PR number (e.g., `2626`)
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR="$1"
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+STATE_FILE="$HOME/.work/proof-pr/$ORIGINAL_PR/state.json"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+MAGENTA='\033[0;35m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[proof-pr:convert]${NC} $*"; }
+log_success() { echo -e "${GREEN}✓${NC} $*"; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+log_error() { echo -e "${RED}✗${NC} $*"; }
+log_cascade() { echo -e "${MAGENTA}⮕${NC} $*"; }
+
+# Step 1: Load state
+log "Loading state for PR #$ORIGINAL_PR..."
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    log_error "State file not found: $STATE_FILE"
+    exit 1
+fi
+
+STATE_JSON=$(cat "$STATE_FILE")
+ORIGINAL_REPO=$(echo "$STATE_JSON" | jq -r '.original_repo')
+ORIGINAL_URL=$(echo "$STATE_JSON" | jq -r '.original_url')
+
+log "Original PR: $ORIGINAL_REPO#$ORIGINAL_PR"
+
+# Step 2: Determine what has merged
+log ""
+log "Checking what has merged..."
+
+# Check if original PR is merged
+ORIGINAL_STATE=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_REPO" \
+    --json state,mergedAt \
+    | jq -r '.state')
+
+ORIGINAL_MERGED=false
+if [[ "$ORIGINAL_STATE" == "MERGED" ]]; then
+    ORIGINAL_MERGED=true
+    log_success "Original PR is MERGED"
+fi
+
+# Check which proof PRs are merged or converted
+MERGED_PROOF_PRS=()
+CONVERTED_PROOF_PRS=()
+
+while IFS= read -r proof_pr; do
+    REPO=$(echo "$proof_pr" | jq -r '.repo')
+    NUMBER=$(echo "$proof_pr" | jq -r '.number')
+    CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+    MERGED=$(echo "$proof_pr" | jq -r '.merged')
+
+    # Check current GitHub state
+    GH_STATE=$(gh pr view "$NUMBER" --repo "$REPO" --json state 2>/dev/null | jq -r '.state // "UNKNOWN"')
+
+    if [[ "$GH_STATE" == "MERGED" ]]; then
+        MERGED_PROOF_PRS+=("$REPO#$NUMBER")
+        log_success "$REPO#$NUMBER is MERGED"
+    elif [[ "$CONVERTED" == "true" ]]; then
+        CONVERTED_PROOF_PRS+=("$REPO#$NUMBER")
+        log_cascade "$REPO#$NUMBER is CONVERTED (normal PR)"
+    fi
+
+done < <(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+# Step 3: Find what can be converted in THIS iteration
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "CASCADE ANALYSIS"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Build list of what's merged (original + converted proof PRs that have merged)
+MERGED_REPOS=()
+
+if $ORIGINAL_MERGED; then
+    MERGED_REPOS+=("$ORIGINAL_REPO")
+fi
+
+for merged_pr in "${MERGED_PROOF_PRS[@]}"; do
+    merged_repo=$(echo "$merged_pr" | cut -d'#' -f1)
+    MERGED_REPOS+=("$merged_repo")
+done
+
+log "Merged repositories: ${MERGED_REPOS[*]}"
+
+# Find proof PRs that can be converted (proving a merged repo)
+CAN_CONVERT=()
+
+while IFS= read -r proof_pr; do
+    REPO=$(echo "$proof_pr" | jq -r '.repo')
+    NUMBER=$(echo "$proof_pr" | jq -r '.number')
+    PROVING_REPO=$(echo "$proof_pr" | jq -r '.proving_repo')
+    CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+    MERGED=$(echo "$proof_pr" | jq -r '.merged')
+
+    # Skip if already converted or merged
+    if [[ "$CONVERTED" == "true" ]] || [[ "$MERGED" == "true" ]]; then
+        continue
+    fi
+
+    # Check if proving_repo is in merged list
+    for merged_repo in "${MERGED_REPOS[@]}"; do
+        if [[ "$PROVING_REPO" == "$merged_repo" ]]; then
+            CAN_CONVERT+=("$REPO#$NUMBER")
+            log_cascade "CAN CONVERT: $REPO#$NUMBER (proves merged $PROVING_REPO)"
+            break
+        fi
+    done
+
+done < <(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+if (( ${#CAN_CONVERT[@]} == 0 )); then
+    log_warn "No proof PRs ready to convert in this iteration"
+    echo ""
+
+    # Check if there are unconverted proof PRs
+    UNCONVERTED=$(echo "$STATE_JSON" | jq '[.proof_prs[] | select(.converted == false and .merged == false)] | length')
+
+    if (( UNCONVERTED > 0 )); then
+        log "There are $UNCONVERTED unconverted proof PRs"
+        log ""
+        log "They may be waiting for upstream PRs to merge:"
+
+        while IFS= read -r proof_pr; do
+            REPO=$(echo "$proof_pr" | jq -r '.repo')
+            NUMBER=$(echo "$proof_pr" | jq -r '.number')
+            PROVING_REPO=$(echo "$proof_pr" | jq -r '.proving_repo')
+            PROVING_PR=$(echo "$proof_pr" | jq -r '.proving_pr')
+            CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+            MERGED=$(echo "$proof_pr" | jq -r '.merged')
+
+            if [[ "$CONVERTED" == "false" && "$MERGED" == "false" ]]; then
+                echo "  - $REPO#$NUMBER → waiting for $PROVING_REPO#$PROVING_PR to merge"
+            fi
+
+        done < <(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+        echo ""
+        log "Run /proof-pr:convert again after those PRs merge"
+    else
+        log_success "All proof PRs have been converted or merged!"
+    fi
+
+    exit 0
+fi
+
+# Step 4: Convert each PR
+log ""
+log "Converting ${#CAN_CONVERT[@]} proof PR(s)..."
+
+CONVERTED_COUNT=0
+
+for pr_identifier in "${CAN_CONVERT[@]}"; do
+    REPO=$(echo "$pr_identifier" | cut -d'#' -f1)
+    NUMBER=$(echo "$pr_identifier" | cut -d'#' -f2)
+
+    echo ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "Converting: $REPO#$NUMBER"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Get current PR details
+    PR_JSON=$(gh pr view "$NUMBER" \
+        --repo "$REPO" \
+        --json title,body,labels)
+
+    CURRENT_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+    CURRENT_BODY=$(echo "$PR_JSON" | jq -r '.body')
+    LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name')
+
+    # Step 4a: Remove [PROOF] from title
+    NEW_TITLE="${CURRENT_TITLE//\[PROOF\] /}"
+    NEW_TITLE="${NEW_TITLE//\[PROOF\]/}"
+
+    log "Updating title..."
+    log "  Old: $CURRENT_TITLE"
+    log "  New: $NEW_TITLE"
+
+    gh pr edit "$NUMBER" \
+        --repo "$REPO" \
+        --title "$NEW_TITLE"
+
+    # Step 4b: Update PR body - remove proof markers
+    log "Updating PR body..."
+
+    # Remove HTML comment markers
+    NEW_BODY=$(echo "$CURRENT_BODY" | sed '/<!-- PROOF-PR:/d; /<!-- PROVING:/d; /<!-- DEPENDS-ON:/d')
+
+    # Remove proof warning section
+    NEW_BODY=$(echo "$NEW_BODY" | sed '/^## 🧪 PROOF PR/,/^---$/d')
+    NEW_BODY=$(echo "$NEW_BODY" | sed '/^⚠️ \*\*DO NOT MERGE\*\*/,/Generated by \[Claude Code/d')
+
+    # Add conversion notice at top
+    CONVERSION_NOTICE="## ✅ Converted from Proof PR
+
+This PR was originally created as a proof PR to test changes from $ORIGINAL_URL.
+
+The original PR has now merged, and this has been converted to a normal PR.
+
+---
+
+"
+
+    NEW_BODY="$CONVERSION_NOTICE$NEW_BODY"
+
+    gh pr edit "$NUMBER" \
+        --repo "$REPO" \
+        --body "$NEW_BODY"
+
+    # Step 4c: Remove do-not-merge/hold label
+    log "Removing do-not-merge/hold label..."
+
+    HAS_HOLD=$(echo "$LABELS" | grep -cE "^(do-not-merge/hold|hold)$" || true)
+
+    if (( HAS_HOLD > 0 )); then
+        gh pr edit "$NUMBER" \
+            --repo "$REPO" \
+            --remove-label "do-not-merge/hold" || {
+            log_warn "Could not remove hold label (may not have permissions)"
+        }
+    fi
+
+    # Step 4d: Add comment explaining conversion
+    log "Adding conversion comment..."
+
+    COMMENT="✅ **Converted to normal PR**
+
+This proof PR has been converted to a normal PR because the original changes have merged.
+
+**What this means:**
+- The \`do-not-merge/hold\` label has been removed
+- This PR will auto-merge when it gets \`lgtm\`, \`approved\`, and \`verified\` labels
+- No further action needed if tests pass
+
+**Required for merge:**
+- \`/lgtm\` from a reviewer
+- \`/approved\` from an approver
+- \`/verified by <test>\` or \`/verified later @user\`
+
+---
+
+Converted by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+    gh pr comment "$NUMBER" \
+        --repo "$REPO" \
+        --body "$COMMENT"
+
+    log_success "✓ Converted $REPO#$NUMBER"
+
+    # Step 4e: Update state - mark as converted
+    STATE_JSON=$(echo "$STATE_JSON" | jq \
+        "(.proof_prs[] | select(.repo == \"$REPO\" and .number == $NUMBER) | .converted) = true")
+
+    ((CONVERTED_COUNT++))
+
+done
+
+# Step 5: Re-target downstream proof PRs
+log ""
+log "Re-targeting downstream proof PRs..."
+
+# For each newly converted PR, find proof PRs that depended on it
+for pr_identifier in "${CAN_CONVERT[@]}"; do
+    CONVERTED_REPO=$(echo "$pr_identifier" | cut -d'#' -f1)
+    CONVERTED_NUMBER=$(echo "$pr_identifier" | cut -d'#' -f2)
+
+    # Find proof PRs that have depends_on_repo == CONVERTED_REPO
+    # These should now prove the converted PR instead of the original
+
+    while IFS= read -r proof_pr; do
+        REPO=$(echo "$proof_pr" | jq -r '.repo')
+        NUMBER=$(echo "$proof_pr" | jq -r '.number')
+        DEPENDS_ON=$(echo "$proof_pr" | jq -r '.depends_on_repo')
+        CURRENT_PROVING=$(echo "$proof_pr" | jq -r '.proving_repo')
+        CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+
+        # Skip if already converted
+        if [[ "$CONVERTED" == "true" ]]; then
+            continue
+        fi
+
+        # If this PR depends on the newly converted repo
+        if [[ "$DEPENDS_ON" == "$CONVERTED_REPO" ]]; then
+            # Re-target to prove the converted PR
+            log_cascade "Re-targeting $REPO#$NUMBER → proves $CONVERTED_REPO#$CONVERTED_NUMBER"
+
+            STATE_JSON=$(echo "$STATE_JSON" | jq \
+                "(.proof_prs[] | select(.repo == \"$REPO\" and .number == $NUMBER) | .proving_repo) = \"$CONVERTED_REPO\" | \
+                 (.proof_prs[] | select(.repo == \"$REPO\" and .number == $NUMBER) | .proving_pr) = $CONVERTED_NUMBER")
+
+            # Update PR body with new proving target
+            CURRENT_BODY=$(gh pr view "$NUMBER" --repo "$REPO" --json body -q '.body')
+
+            # Update HTML comment
+            UPDATED_BODY=$(echo "$CURRENT_BODY" | sed "s|<!-- PROVING: [^#]*#[0-9]* -->|<!-- PROVING: $CONVERTED_REPO#$CONVERTED_NUMBER -->|")
+
+            # Update text description
+            CONVERTED_PR_URL="https://github.com/$CONVERTED_REPO/pull/$CONVERTED_NUMBER"
+            UPDATED_BODY=$(echo "$UPDATED_BODY" | sed "s|This is a proof PR to test changes from \[.*\](.*)|This is a proof PR to test changes from [$CONVERTED_REPO#$CONVERTED_NUMBER]($CONVERTED_PR_URL)|")
+
+            gh pr edit "$NUMBER" \
+                --repo "$REPO" \
+                --body "$UPDATED_BODY" || {
+                log_warn "Could not update PR body for $REPO#$NUMBER"
+            }
+
+            # Add comment explaining re-target
+            RE_TARGET_COMMENT="♻️ **Re-targeted to prove $CONVERTED_REPO#$CONVERTED_NUMBER**
+
+This proof PR now tests changes from the converted PR [$CONVERTED_REPO#$CONVERTED_NUMBER]($CONVERTED_PR_URL) instead of the original.
+
+When $CONVERTED_REPO#$CONVERTED_NUMBER merges, this PR will be eligible for conversion.
+
+---
+
+Updated by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+            gh pr comment "$NUMBER" \
+                --repo "$REPO" \
+                --body "$RE_TARGET_COMMENT" || true
+        fi
+
+    done < <(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+done
+
+# Step 6: Save updated state
+log ""
+log "Saving state..."
+
+STATE_JSON=$(echo "$STATE_JSON" | jq ".last_updated = \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"")
+echo "$STATE_JSON" | jq '.' > "$STATE_FILE"
+
+# Step 7: Show summary
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "CONVERSION SUMMARY"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+log_success "Converted $CONVERTED_COUNT proof PR(s) to normal PRs"
+
+if (( CONVERTED_COUNT > 0 )); then
+    echo ""
+    log "Converted PRs:"
+    for pr in "${CAN_CONVERT[@]}"; do
+        REPO=$(echo "$pr" | cut -d'#' -f1)
+        NUMBER=$(echo "$pr" | cut -d'#' -f2)
+        URL="https://github.com/$REPO/pull/$NUMBER"
+        echo "  ✓ $REPO#$NUMBER: $URL"
+    done
+fi
+
+echo ""
+
+# Check if more work remains
+REMAINING_UNCONVERTED=$(echo "$STATE_JSON" | jq '[.proof_prs[] | select(.converted == false and .merged == false)] | length')
+
+if (( REMAINING_UNCONVERTED > 0 )); then
+    log_cascade "$REMAINING_UNCONVERTED proof PR(s) remain unconverted"
+    echo ""
+    log "Next steps:"
+    log "  1. Wait for newly converted PRs to get labels and merge"
+    log "  2. Run /proof-pr:convert $ORIGINAL_PR again to convert next layer"
+    log ""
+    log "Cascade workflow:"
+
+    while IFS= read -r proof_pr; do
+        REPO=$(echo "$proof_pr" | jq -r '.repo')
+        NUMBER=$(echo "$proof_pr" | jq -r '.number')
+        PROVING_REPO=$(echo "$proof_pr" | jq -r '.proving_repo')
+        PROVING_PR=$(echo "$proof_pr" | jq -r '.proving_pr')
+        CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+        MERGED=$(echo "$proof_pr" | jq -r '.merged')
+
+        if [[ "$CONVERTED" == "false" && "$MERGED" == "false" ]]; then
+            echo "  ⮕ $REPO#$NUMBER waiting for $PROVING_REPO#$PROVING_PR"
+        fi
+
+    done < <(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+else
+    log_success "All proof PRs have been converted or merged!"
+    echo ""
+    log "Workflow complete for $ORIGINAL_URL"
+fi
+
+echo ""
+```
+
+## Return Value
+
+- **Format**: Converts proof PRs and updates state
+- **Output**: Summary of converted PRs and remaining work
+
+**Exit codes:**
+- 0: Success - conversions complete for this iteration
+
+## Examples
+
+1. **First conversion after original merges**:
+   ```
+   /proof-pr:convert 2626
+   ```
+   Converts client-go#1234, re-targets MCO#5678 to prove client-go.
+
+2. **Second conversion after first layer merges**:
+   ```
+   /proof-pr:convert 2626
+   ```
+   Converts MCO#5678 (now proving merged client-go#1234).
+
+3. **Check if more conversions needed**:
+   ```
+   /proof-pr:convert 2626
+   ```
+   Shows "No proof PRs ready to convert" if waiting for upstream merges.
+
+## Notes
+
+- **Cascading**: Only converts PRs whose proving_repo has merged
+- **Iterative**: Run after each layer merges to convert next layer
+- **Re-targeting**: Downstream PRs automatically re-targeted to newly converted PRs
+- **No holds**: Removes do-not-merge/hold label from converted PRs
+- **Tide-ready**: Converted PRs will auto-merge when they get required labels
+- **State tracking**: Updates proving_repo/proving_pr for cascading relationships

--- a/plugins/proof-pr/commands/create.md
+++ b/plugins/proof-pr/commands/create.md
@@ -1,0 +1,558 @@
+---
+description: Create proof PRs to test dependency changes before merging
+argument-hint: <original-pr-url> <target-repo>
+---
+
+## Name
+
+proof-pr:create - Create proof PRs with auto-detected dependency chains
+
+## Synopsis
+
+```
+/proof-pr:create <original-pr-url> <target-repo> [additional-repos...]
+```
+
+## Description
+
+The `proof-pr:create` command creates temporary "proof PRs" that test dependency changes before the original PR merges. This allows you to verify that downstream repositories will compile and function correctly with your changes.
+
+**Key Features:**
+- **Auto-detects dependency chains**: Automatically finds transitive dependencies
+- **Handles code generation**: Detects and runs required codegen (make update, etc.)
+- **Auto-fixes compilation**: Attempts automatic fixes for simple type renames
+- **Creates WIP PRs on failure**: If auto-fix fails, creates a PR with instructions for manual fixes
+- **Prevents accidental merge**: Uses `do-not-merge/hold` label (no custom labels)
+- **State management**: Tracks all proof PRs for later status checks and conversion
+
+**Workflow:**
+1. Analyzes the original PR and target repository dependencies
+2. Creates proof PRs in dependency order (original → intermediate → target)
+3. For each repository:
+   - Forks repository if you don't have write access
+   - Creates a branch with dependency bumps
+   - Runs code generation if needed
+   - Tests compilation
+   - Attempts auto-fixes if compilation fails
+   - Creates PR with proof metadata
+
+## Arguments
+
+- `$1` (required): URL of the original PR (e.g., `https://github.com/openshift/api/pull/2626`)
+- `$2` (required): Target repository to create proof PR in (e.g., `openshift/machine-config-operator`)
+- `$3+` (optional): Additional repositories to include in proof workflow
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR_URL="$1"
+TARGET_REPO="$2"
+shift 2
+ADDITIONAL_REPOS=("$@")
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+WORK_DIR="$HOME/.work/proof-pr"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[proof-pr:create]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[proof-pr:create]${NC} WARNING: $*"; }
+log_error() { echo -e "${RED}[proof-pr:create]${NC} ERROR: $*"; }
+
+# Step 1: Parse original PR URL
+log "Parsing original PR: $ORIGINAL_PR_URL"
+
+if ! [[ "$ORIGINAL_PR_URL" =~ github.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+    log_error "Invalid PR URL format: $ORIGINAL_PR_URL"
+    exit 1
+fi
+
+ORIGINAL_ORG="${BASH_REMATCH[1]}"
+ORIGINAL_REPO="${BASH_REMATCH[2]}"
+ORIGINAL_PR="${BASH_REMATCH[3]}"
+ORIGINAL_FULL_REPO="$ORIGINAL_ORG/$ORIGINAL_REPO"
+
+log "Original PR: $ORIGINAL_FULL_REPO#$ORIGINAL_PR"
+
+# Step 2: Get original PR details
+log "Fetching original PR details..."
+
+PR_JSON=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_FULL_REPO" \
+    --json title,headRefName,headRepository,state,commits)
+
+PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+PR_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+PR_HEAD_REPO=$(echo "$PR_JSON" | jq -r '.headRepository.nameWithOwner')
+PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+PR_COMMITS=$(echo "$PR_JSON" | jq -r '.commits | length')
+
+if [[ "$PR_STATE" == "MERGED" ]]; then
+    log_error "Original PR is already merged"
+    exit 1
+fi
+
+log "  Title: $PR_TITLE"
+log "  Branch: $PR_BRANCH"
+log "  Head repo: $PR_HEAD_REPO"
+log "  Commits: $PR_COMMITS"
+
+# Step 3: Get latest commit SHA for pseudo-version
+LATEST_COMMIT=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_FULL_REPO" \
+    --json commits \
+    | jq -r '.commits[-1].oid[:12]')
+
+COMMIT_TIMESTAMP=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_FULL_REPO" \
+    --json commits \
+    | jq -r '.commits[-1].committedDate' \
+    | sed 's/[-:]//g; s/T//; s/Z.*//')
+
+PSEUDO_VERSION="v0.0.0-${COMMIT_TIMESTAMP}-${LATEST_COMMIT}"
+ORIGINAL_MODULE="github.com/$ORIGINAL_FULL_REPO"
+
+log "Pseudo-version: $PSEUDO_VERSION"
+
+# Step 4: Clone target repository
+log "Cloning target repository: $TARGET_REPO"
+
+TARGET_WORK_DIR="$WORK_DIR/$ORIGINAL_PR/$TARGET_REPO"
+mkdir -p "$(dirname "$TARGET_WORK_DIR")"
+
+if [[ -d "$TARGET_WORK_DIR" ]]; then
+    log_warn "Work directory already exists, using existing clone"
+    cd "$TARGET_WORK_DIR"
+    git fetch origin
+else
+    gh repo clone "$TARGET_REPO" "$TARGET_WORK_DIR"
+    cd "$TARGET_WORK_DIR"
+fi
+
+# Step 5: Analyze dependency chain
+log "Analyzing dependency chain..."
+
+CHAIN_JSON=$("$SKILLS_DIR/analyze-deps.py" \
+    "$ORIGINAL_MODULE" \
+    "$TARGET_WORK_DIR" \
+    --json 2>/dev/null || echo '{}')
+
+if [[ "$CHAIN_JSON" == '{}' ]]; then
+    log_error "No dependency chain found from $TARGET_REPO to $ORIGINAL_FULL_REPO"
+    log "This repository may not depend on the original repository."
+    log "Use --force to create proof PR anyway (not recommended)."
+    exit 1
+fi
+
+RELATIONSHIP=$(echo "$CHAIN_JSON" | jq -r '.relationship')
+CHAIN_REPOS=$(echo "$CHAIN_JSON" | jq -r '.repos | join(" -> ")')
+CHAIN_LENGTH=$(echo "$CHAIN_JSON" | jq -r '.repos | length')
+
+log "Dependency chain: $CHAIN_REPOS"
+log "Relationship: $RELATIONSHIP"
+
+# Step 6: Determine all repositories that need proof PRs
+ALL_REPOS=()
+
+# Add intermediate repos from chain (excluding original and target)
+if (( CHAIN_LENGTH > 2 )); then
+    INTERMEDIATE_REPOS=$(echo "$CHAIN_JSON" | jq -r '.repos[1:-1] | .[]')
+    while IFS= read -r repo; do
+        [[ -n "$repo" ]] && ALL_REPOS+=("$repo")
+    done <<< "$INTERMEDIATE_REPOS"
+fi
+
+# Add target repo
+ALL_REPOS+=("$TARGET_REPO")
+
+# Add any additional repos specified by user
+ALL_REPOS+=("${ADDITIONAL_REPOS[@]}")
+
+log "Will create proof PRs in: ${ALL_REPOS[*]}"
+
+# Step 7: Initialize state
+log "Initializing state..."
+
+STATE_FILE="$WORK_DIR/$ORIGINAL_PR/state.json"
+mkdir -p "$(dirname "$STATE_FILE")"
+
+# Create initial state if doesn't exist
+if [[ ! -f "$STATE_FILE" ]]; then
+    cat > "$STATE_FILE" <<EOF
+{
+  "original_repo": "$ORIGINAL_FULL_REPO",
+  "original_pr": $ORIGINAL_PR,
+  "original_url": "$ORIGINAL_PR_URL",
+  "original_branch": "$PR_BRANCH",
+  "proof_prs": [],
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "last_updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+fi
+
+# Function to create proof PR in a repository
+create_proof_pr() {
+    local repo="$1"
+    local depends_on_repo="$2"  # What go.mod dependency to bump
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "Creating proof PR in: $repo"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    local repo_work_dir="$WORK_DIR/$ORIGINAL_PR/$repo"
+
+    # Step 1: Fork repository if needed
+    log "Checking fork status..."
+
+    local my_username=$(gh api user -q .login)
+    local fork_check=$(gh repo view "$repo" --json isFork,owner -q '.owner.login')
+
+    if [[ "$fork_check" != "$my_username" ]]; then
+        log "Forking $repo..."
+        gh repo fork "$repo" --clone=false || {
+            log_warn "Fork may already exist"
+        }
+        local fork_repo="$my_username/$(basename "$repo")"
+    else
+        local fork_repo="$repo"
+    fi
+
+    log "Using fork: $fork_repo"
+
+    # Step 2: Clone forked repository
+    if [[ -d "$repo_work_dir" ]]; then
+        log "Repository already cloned"
+        cd "$repo_work_dir"
+        git fetch --all
+    else
+        log "Cloning fork..."
+        gh repo clone "$fork_repo" "$repo_work_dir"
+        cd "$repo_work_dir"
+
+        # Add upstream if this is a fork
+        if [[ "$fork_repo" != "$repo" ]]; then
+            git remote add upstream "https://github.com/$repo.git" || true
+            git fetch upstream
+        fi
+    fi
+
+    # Step 3: Create proof branch
+    local proof_branch="proof-pr-${ORIGINAL_REPO}-${ORIGINAL_PR}"
+
+    log "Creating branch: $proof_branch"
+
+    git checkout -B "$proof_branch" origin/master || \
+        git checkout -B "$proof_branch" origin/main || \
+        git checkout -B "$proof_branch" HEAD
+
+    # Step 4: Update go.mod with pseudo-version
+    log "Updating go.mod dependency: github.com/$depends_on_repo -> $PSEUDO_VERSION"
+
+    if ! grep -q "github.com/$depends_on_repo" go.mod; then
+        log_error "go.mod does not contain dependency on github.com/$depends_on_repo"
+        return 1
+    fi
+
+    # Update the dependency
+    go get "github.com/$depends_on_repo@$PSEUDO_VERSION"
+    go mod tidy
+
+    # Step 5: Detect and run code generation
+    log "Detecting code generation requirements..."
+
+    CODEGEN_JSON=$("$SKILLS_DIR/detect-codegen.py" . --json 2>/dev/null)
+    NEEDS_CODEGEN=$(echo "$CODEGEN_JSON" | jq -r '.needs_codegen')
+
+    if [[ "$NEEDS_CODEGEN" == "true" ]]; then
+        CODEGEN_CMD=$(echo "$CODEGEN_JSON" | jq -r '.command')
+
+        if [[ "$CODEGEN_CMD" != "null" && -n "$CODEGEN_CMD" ]]; then
+            log "Running code generation: $CODEGEN_CMD"
+
+            if ! eval "$CODEGEN_CMD"; then
+                log_error "Code generation failed"
+                return 1
+            fi
+
+            log "Code generation completed"
+        else
+            log_warn "Code generation needed but command not detected"
+            log_warn "You may need to run 'make update' or similar manually"
+        fi
+    else
+        log "No code generation needed"
+    fi
+
+    # Step 6: Test compilation
+    log "Testing compilation..."
+
+    if "$SKILLS_DIR/compile-test.sh" --verbose .; then
+        log "✓ Compilation successful"
+        local compilation_status="success"
+    else
+        log_warn "✗ Compilation failed, attempting auto-fix..."
+
+        # Attempt auto-fix
+        FIX_JSON=$("$SKILLS_DIR/attempt-fix.py" . --json 2>/dev/null)
+        FIX_SUCCESS=$(echo "$FIX_JSON" | jq -r '.compilation_succeeds')
+
+        if [[ "$FIX_SUCCESS" == "true" ]]; then
+            log "✓ Auto-fix successful!"
+            local compilation_status="fixed"
+        else
+            log_warn "✗ Auto-fix failed or incomplete"
+            local compilation_status="failed"
+
+            NEEDS_MANUAL=$(echo "$FIX_JSON" | jq -r '.needs_manual_fix')
+            if [[ "$NEEDS_MANUAL" == "true" ]]; then
+                log_warn "Manual fixes will be required"
+                log_warn "Creating WIP PR with instructions..."
+            fi
+        fi
+    fi
+
+    # Step 7: Commit changes
+    log "Committing changes..."
+
+    git add go.mod go.sum
+
+    # Add any generated files
+    if [[ "$NEEDS_CODEGEN" == "true" ]]; then
+        git add -A
+    fi
+
+    # Add any auto-fixed files
+    if [[ "$compilation_status" == "fixed" ]]; then
+        git add -A
+    fi
+
+    local commit_msg="[PROOF] Bump github.com/$depends_on_repo for $ORIGINAL_FULL_REPO#$ORIGINAL_PR
+
+Testing changes from $ORIGINAL_PR_URL
+
+Pseudo-version: $PSEUDO_VERSION
+Compilation: $compilation_status
+
+🧪 This is a PROOF PR - DO NOT MERGE
+"
+
+    git commit -m "$commit_msg"
+
+    # Step 8: Push to fork
+    log "Pushing to fork..."
+
+    git push -f origin "$proof_branch"
+
+    # Step 9: Create PR
+    log "Creating proof PR..."
+
+    local pr_body="<!-- PROOF-PR: $ORIGINAL_PR_URL -->
+<!-- PROVING: $ORIGINAL_FULL_REPO#$ORIGINAL_PR -->
+<!-- DEPENDS-ON: $depends_on_repo -->
+
+## 🧪 PROOF PR
+
+This is a proof PR to test changes from [$ORIGINAL_FULL_REPO#$ORIGINAL_PR]($ORIGINAL_PR_URL).
+
+**Original PR:** $PR_TITLE
+
+### Changes Made
+
+- Bumped \`github.com/$depends_on_repo\` to \`$PSEUDO_VERSION\`"
+
+    if [[ "$NEEDS_CODEGEN" == "true" ]]; then
+        pr_body+="
+- Ran code generation: \`$CODEGEN_CMD\`"
+    fi
+
+    if [[ "$compilation_status" == "fixed" ]]; then
+        pr_body+="
+- Applied automatic compilation fixes"
+    fi
+
+    pr_body+="
+
+### Compilation Status
+
+**Status:** $compilation_status"
+
+    if [[ "$compilation_status" == "failed" ]]; then
+        pr_body+="
+
+⚠️ **Manual fixes required** - This PR has compilation errors that could not be auto-fixed.
+
+To fix:
+1. Check out this branch: \`gh pr checkout <PR_NUMBER>\`
+2. Fix compilation errors
+3. Push fixes: Use \`/proof-pr:push-fix\` command
+
+See compilation output in the checks below."
+    fi
+
+    pr_body+="
+
+---
+
+**⚠️ DO NOT MERGE** - This PR is for testing only.
+
+After the original PR merges, use \`/proof-pr:convert\` to convert this to a normal PR.
+
+Generated by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+    local pr_title="[PROOF] $PR_TITLE"
+
+    # Create the PR
+    local new_pr_url=$(gh pr create \
+        --repo "$repo" \
+        --title "$pr_title" \
+        --body "$pr_body" \
+        --base master \
+        --head "$my_username:$proof_branch" \
+        2>&1 || echo "")
+
+    if [[ ! "$new_pr_url" =~ https://github.com ]]; then
+        # Try with main branch
+        new_pr_url=$(gh pr create \
+            --repo "$repo" \
+            --title "$pr_title" \
+            --body "$pr_body" \
+            --base main \
+            --head "$my_username:$proof_branch" \
+            2>&1 || echo "FAILED")
+    fi
+
+    if [[ "$new_pr_url" == "FAILED" ]] || [[ ! "$new_pr_url" =~ https://github.com ]]; then
+        log_error "Failed to create PR in $repo"
+        return 1
+    fi
+
+    log "✓ Created PR: $new_pr_url"
+
+    # Extract PR number
+    local new_pr_number=$(echo "$new_pr_url" | grep -oE '[0-9]+$')
+
+    # Step 10: Add do-not-merge/hold label
+    log "Adding do-not-merge/hold label..."
+
+    gh pr edit "$new_pr_number" \
+        --repo "$repo" \
+        --add-label "do-not-merge/hold" || {
+        log_warn "Could not add label (may not have permissions)"
+    }
+
+    # Step 11: Update state
+    log "Updating state..."
+
+    local new_proof_pr=$(cat <<EOF
+{
+  "repo": "$repo",
+  "number": $new_pr_number,
+  "url": "$new_pr_url",
+  "branch": "$proof_branch",
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "proving_repo": "$ORIGINAL_FULL_REPO",
+  "proving_pr": $ORIGINAL_PR,
+  "depends_on_repo": "$depends_on_repo",
+  "converted": false,
+  "merged": false
+}
+EOF
+)
+
+    # Add to state file
+    local temp_state=$(mktemp)
+    jq ".proof_prs += [$new_proof_pr] | .last_updated = \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" "$STATE_FILE" > "$temp_state"
+    mv "$temp_state" "$STATE_FILE"
+
+    log "✓ Proof PR created successfully: $new_pr_url"
+
+    return 0
+}
+
+# Step 8: Create proof PRs in dependency order
+log ""
+log "Creating proof PRs in dependency order..."
+
+DEPENDS_ON="$ORIGINAL_FULL_REPO"
+
+for repo in "${ALL_REPOS[@]}"; do
+    if ! create_proof_pr "$repo" "$DEPENDS_ON"; then
+        log_error "Failed to create proof PR in $repo"
+        log "Continuing with remaining repositories..."
+    fi
+
+    # Next repo depends on this one
+    DEPENDS_ON="$repo"
+done
+
+# Step 9: Show summary
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "SUMMARY"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log ""
+log "Original PR: $ORIGINAL_PR_URL"
+log "Proof PRs created:"
+
+jq -r '.proof_prs[] | "  - \(.repo)#\(.number): \(.url)"' "$STATE_FILE"
+
+log ""
+log "Next steps:"
+log "  1. Review and test the proof PRs"
+log "  2. Fix any compilation errors using /proof-pr:push-fix"
+log "  3. Check status with /proof-pr:status $ORIGINAL_PR"
+log "  4. When original PR merges, run /proof-pr:convert $ORIGINAL_PR"
+log ""
+log "State saved to: $STATE_FILE"
+```
+
+## Return Value
+
+- **Format**: Creates proof PRs and saves state
+- **State file**: `~/.work/proof-pr/{original_pr_number}/state.json`
+- **Output**: URLs of created proof PRs
+
+**Exit codes:**
+- 0: Success - all proof PRs created
+- 1: Partial success - some proof PRs failed to create
+- 2: Failure - no proof PRs created
+
+## Examples
+
+1. **Create proof PR for simple dependency**:
+   ```
+   /proof-pr:create https://github.com/openshift/api/pull/2626 openshift/client-go
+   ```
+   Creates a proof PR in client-go that depends directly on api#2626.
+
+2. **Create proof PR with transitive dependency**:
+   ```
+   /proof-pr:create https://github.com/openshift/api/pull/2626 openshift/machine-config-operator
+   ```
+   Auto-detects that MCO → client-go → api, and creates proof PRs in both client-go and MCO.
+
+3. **Create proof PRs in multiple specific repositories**:
+   ```
+   /proof-pr:create https://github.com/openshift/api/pull/2626 openshift/client-go openshift/oc openshift/console
+   ```
+   Creates proof PRs in client-go, oc, and console (if they depend on api).
+
+## Notes
+
+- **Auto-fork**: Automatically forks repositories if you don't have write access
+- **Auto-fix**: Attempts simple type rename fixes automatically
+- **WIP handling**: Creates WIP PRs with instructions if auto-fix fails
+- **State recovery**: If interrupted, can recover using `/proof-pr:status` with auto-recovery
+- **No custom labels**: Uses only standard `do-not-merge/hold` label
+- **Identification**: Proof PRs identified by HTML comments in body (not labels)

--- a/plugins/proof-pr/commands/push-fix.md
+++ b/plugins/proof-pr/commands/push-fix.md
@@ -1,0 +1,312 @@
+---
+description: Push manual compilation fixes to a proof PR
+argument-hint: <original-pr-number> <repo>
+---
+
+## Name
+
+proof-pr:push-fix - Push manual fixes for compilation errors in proof PRs
+
+## Synopsis
+
+```
+/proof-pr:push-fix <original-pr-number> <repo>
+```
+
+## Description
+
+The `proof-pr:push-fix` command helps you push manual compilation fixes to proof PRs when auto-fix fails. This command:
+
+1. Checks out the proof PR branch locally
+2. Lets you make manual fixes
+3. Tests compilation
+4. Commits and pushes your fixes
+5. Updates the PR with a comment
+
+**Use this when:**
+- Auto-fix couldn't resolve all compilation errors
+- You need to make manual code changes
+- Complex refactoring is required
+
+**Workflow:**
+1. Command checks out proof PR branch
+2. You make manual edits in your editor
+3. Command tests compilation
+4. If successful, commits and pushes
+
+## Arguments
+
+- `$1` (required): Original PR number (e.g., `2626`)
+- `$2` (required): Repository with proof PR to fix (e.g., `openshift/machine-config-operator`)
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR="$1"
+REPO="$2"
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+STATE_FILE="$HOME/.work/proof-pr/$ORIGINAL_PR/state.json"
+WORK_DIR="$HOME/.work/proof-pr/$ORIGINAL_PR"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[proof-pr:push-fix]${NC} $*"; }
+log_success() { echo -e "${GREEN}✓${NC} $*"; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+log_error() { echo -e "${RED}✗${NC} $*"; }
+
+# Step 1: Load state
+log "Loading state for PR #$ORIGINAL_PR..."
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    log_error "State file not found: $STATE_FILE"
+    exit 1
+fi
+
+STATE_JSON=$(cat "$STATE_FILE")
+ORIGINAL_REPO=$(echo "$STATE_JSON" | jq -r '.original_repo')
+ORIGINAL_URL=$(echo "$STATE_JSON" | jq -r '.original_url')
+
+# Step 2: Find proof PR for this repo
+log "Finding proof PR in $REPO..."
+
+PROOF_PR=$(echo "$STATE_JSON" | jq -c ".proof_prs[] | select(.repo == \"$REPO\")")
+
+if [[ -z "$PROOF_PR" ]]; then
+    log_error "No proof PR found for repository: $REPO"
+    log "Available repositories:"
+    echo "$STATE_JSON" | jq -r '.proof_prs[].repo' | sed 's/^/  - /'
+    exit 1
+fi
+
+PR_NUMBER=$(echo "$PROOF_PR" | jq -r '.number')
+PR_BRANCH=$(echo "$PROOF_PR" | jq -r '.branch')
+PR_URL=$(echo "$PROOF_PR" | jq -r '.url')
+
+log "Found: $REPO#$PR_NUMBER"
+log "Branch: $PR_BRANCH"
+log "URL: $PR_URL"
+
+# Step 3: Check out the proof PR branch
+REPO_WORK_DIR="$WORK_DIR/$REPO"
+
+if [[ ! -d "$REPO_WORK_DIR" ]]; then
+    log_error "Repository not cloned: $REPO_WORK_DIR"
+    log "Run /proof-pr:sync to re-clone"
+    exit 1
+fi
+
+cd "$REPO_WORK_DIR"
+
+log "Checking out branch: $PR_BRANCH"
+
+git fetch origin
+git checkout "$PR_BRANCH"
+git pull origin "$PR_BRANCH" || {
+    log_warn "Could not pull latest changes"
+}
+
+# Step 4: Show current compilation status
+log ""
+log "Testing current compilation status..."
+
+if "$SKILLS_DIR/compile-test.sh" --quiet .; then
+    log_success "✓ Already compiles successfully!"
+    log "No fixes needed. You may still want to make changes."
+else
+    log_error "✗ Compilation currently failing"
+    log ""
+    log "Showing compilation errors:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    go build ./... 2>&1 | head -50
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+fi
+
+# Step 5: Pause for manual fixes
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "MANUAL FIX MODE"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+log "Repository location: $REPO_WORK_DIR"
+log ""
+log "Please make your fixes now in your editor."
+log "Files to review:"
+
+# Show files that might need fixing
+if command -v fd >/dev/null 2>&1; then
+    fd -e go --type f | head -10 | sed 's/^/  - /'
+else
+    find . -name "*.go" -type f | head -10 | sed 's/^/  - /'
+fi
+
+echo ""
+log "When done making changes, press ENTER to continue..."
+read -r
+
+# Step 6: Check what changed
+log ""
+log "Checking for changes..."
+
+if ! git diff --quiet; then
+    log_success "Found uncommitted changes:"
+    git diff --stat | sed 's/^/  /'
+else
+    log_warn "No changes detected"
+    log "If you made changes, make sure they're saved"
+    echo ""
+    log "Continue anyway? (y/N)"
+    read -r answer
+    if [[ "$answer" != "y" && "$answer" != "Y" ]]; then
+        log "Aborted"
+        exit 0
+    fi
+fi
+
+# Step 7: Test compilation after fixes
+log ""
+log "Testing compilation after your fixes..."
+
+if "$SKILLS_DIR/compile-test.sh" .; then
+    log_success "✓ Compilation successful!"
+    COMPILATION_STATUS="success"
+else
+    log_error "✗ Compilation still failing"
+    log ""
+    log "Showing errors:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    go build ./... 2>&1 | head -50
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    log "Push anyway? (y/N)"
+    read -r answer
+    if [[ "$answer" != "y" && "$answer" != "Y" ]]; then
+        log "Aborted - fixes not pushed"
+        log "You can continue editing and run this command again"
+        exit 1
+    fi
+    COMPILATION_STATUS="partial-fix"
+fi
+
+# Step 8: Commit changes
+log ""
+log "Committing your fixes..."
+
+git add -A
+
+COMMIT_MSG="Fix compilation errors for $ORIGINAL_REPO#$ORIGINAL_PR
+
+Manual fixes applied.
+Compilation status: $COMPILATION_STATUS
+
+Testing changes from $ORIGINAL_URL
+"
+
+if ! git diff --cached --quiet; then
+    git commit -m "$COMMIT_MSG"
+else
+    log_warn "No changes to commit"
+    exit 0
+fi
+
+# Step 9: Push changes
+log "Pushing to remote..."
+
+if ! git push origin "$PR_BRANCH"; then
+    log_error "Failed to push"
+    log "You may need to force push if there are conflicts"
+    log "Run: cd $REPO_WORK_DIR && git push -f origin $PR_BRANCH"
+    exit 1
+fi
+
+log_success "✓ Fixes pushed successfully!"
+
+# Step 10: Add comment to PR
+log "Adding comment to PR..."
+
+COMMENT="🔧 **Manual fixes applied**
+
+Compilation status: $COMPILATION_STATUS
+
+"
+
+if [[ "$COMPILATION_STATUS" == "success" ]]; then
+    COMMENT+="✓ Repository now compiles successfully!"
+else
+    COMMENT+="⚠️ Compilation still has some errors - additional fixes may be needed."
+fi
+
+COMMENT+="
+
+Generated by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+gh pr comment "$PR_NUMBER" \
+    --repo "$REPO" \
+    --body "$COMMENT" || {
+    log_warn "Could not add comment to PR"
+}
+
+# Step 11: Show summary
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "SUMMARY"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+log_success "Fixes pushed to $PR_URL"
+log "Compilation status: $COMPILATION_STATUS"
+echo ""
+
+if [[ "$COMPILATION_STATUS" == "success" ]]; then
+    log "✓ Next steps:"
+    log "  - Monitor CI results"
+    log "  - Check status: /proof-pr:status $ORIGINAL_PR"
+else
+    log "⚠ Next steps:"
+    log "  - Review compilation errors above"
+    log "  - Run /proof-pr:push-fix $ORIGINAL_PR $REPO again to fix remaining issues"
+fi
+
+echo ""
+```
+
+## Return Value
+
+- **Format**: Commits and pushes manual fixes
+- **Output**: Summary of changes and compilation status
+
+**Exit codes:**
+- 0: Success - fixes pushed and compilation works
+- 1: Error - compilation still failing or push failed
+
+## Examples
+
+1. **Fix compilation errors in MCO**:
+   ```
+   /proof-pr:push-fix 2626 openshift/machine-config-operator
+   ```
+   Checks out MCO proof PR branch, lets you fix errors, then pushes.
+
+2. **After auto-fix failed**:
+   ```
+   /proof-pr:push-fix 2626 openshift/client-go
+   ```
+   Manually fix client-go proof PR that auto-fix couldn't handle.
+
+## Notes
+
+- **Interactive**: Pauses for you to make edits in your editor
+- **Tests compilation**: Verifies fixes work before pushing
+- **Optional push**: Can push even if compilation still fails (with confirmation)
+- **Adds comment**: Updates PR with manual fix comment
+- **Repository location**: Shows exact path for editing

--- a/plugins/proof-pr/commands/status.md
+++ b/plugins/proof-pr/commands/status.md
@@ -1,0 +1,411 @@
+---
+description: Check status of proof PRs and merge preparation
+argument-hint: <original-pr-number> [--original-pr-url]
+---
+
+## Name
+
+proof-pr:status - Display status of proof PRs with merge preparation information
+
+## Synopsis
+
+```
+/proof-pr:status <original-pr-number>
+/proof-pr:status --original-pr-url <url>
+```
+
+## Description
+
+The `proof-pr:status` command shows the current status of all proof PRs in a workflow, including:
+- CI/test status for each PR
+- Compilation status
+- Merge readiness (lgtm, approve, verified labels)
+- Recommendations for next steps
+
+This command is **information-only** and does not make any changes. It provides guidance on what actions to take to satisfy Tide auto-merge requirements.
+
+**Key Features:**
+- **Auto-recovery**: Can reconstruct state from GitHub if state file missing
+- **Auto-sync**: Detects if GitHub state differs from saved state
+- **Merge preparation**: Shows what labels/approvals are needed for Tide
+- **Clear recommendations**: Tells you exactly what to do next
+
+## Arguments
+
+- `$1` (required): Original PR number (e.g., `2626`)
+- `--original-pr-url` (optional): Original PR URL for auto-recovery if state missing
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR="$1"
+ORIGINAL_PR_URL="${2:-}"  # Optional for recovery
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+STATE_FILE="$HOME/.work/proof-pr/$ORIGINAL_PR/state.json"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[proof-pr:status]${NC} $*"; }
+log_success() { echo -e "${GREEN}✓${NC} $*"; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+log_error() { echo -e "${RED}✗${NC} $*"; }
+
+# Step 1: Load or recover state
+log "Loading state for PR #$ORIGINAL_PR..."
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    log_warn "State file not found"
+
+    if [[ -n "$ORIGINAL_PR_URL" ]]; then
+        log "Attempting recovery from GitHub..."
+        "$SKILLS_DIR/state-manager.py" recover "$ORIGINAL_PR" >/dev/null
+    else
+        log_error "State file not found. Provide --original-pr-url for recovery."
+        log "Example: /proof-pr:status $ORIGINAL_PR https://github.com/org/repo/pull/$ORIGINAL_PR"
+        exit 1
+    fi
+fi
+
+# Load state
+STATE_JSON=$(cat "$STATE_FILE")
+ORIGINAL_REPO=$(echo "$STATE_JSON" | jq -r '.original_repo')
+ORIGINAL_URL=$(echo "$STATE_JSON" | jq -r '.original_url')
+PROOF_PRS_COUNT=$(echo "$STATE_JSON" | jq -r '.proof_prs | length')
+
+log "Original PR: $ORIGINAL_REPO#$ORIGINAL_PR"
+log "Proof PRs: $PROOF_PRS_COUNT"
+
+# Step 2: Check if state is out of sync
+log "Checking sync status..."
+
+SYNC_CHECK=$("$SKILLS_DIR/state-manager.py" sync "$ORIGINAL_PR" 2>&1 | grep -c "Out of sync" || true)
+
+if (( SYNC_CHECK > 0 )); then
+    log_warn "State is out of sync with GitHub"
+    log "Auto-syncing..."
+    "$SKILLS_DIR/state-manager.py" sync "$ORIGINAL_PR" >/dev/null
+    STATE_JSON=$(cat "$STATE_FILE")
+fi
+
+# Step 3: Get original PR status
+log ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "ORIGINAL PR STATUS"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+ORIGINAL_PR_JSON=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_REPO" \
+    --json state,isDraft,mergeable,statusCheckRollup,reviewDecision,labels,title)
+
+ORIGINAL_STATE=$(echo "$ORIGINAL_PR_JSON" | jq -r '.state')
+ORIGINAL_DRAFT=$(echo "$ORIGINAL_PR_JSON" | jq -r '.isDraft')
+ORIGINAL_MERGEABLE=$(echo "$ORIGINAL_PR_JSON" | jq -r '.mergeable')
+ORIGINAL_TITLE=$(echo "$ORIGINAL_PR_JSON" | jq -r '.title')
+ORIGINAL_REVIEW=$(echo "$ORIGINAL_PR_JSON" | jq -r '.reviewDecision // "PENDING"')
+
+echo "PR: $ORIGINAL_REPO#$ORIGINAL_PR"
+echo "Title: $ORIGINAL_TITLE"
+echo "URL: $ORIGINAL_URL"
+echo ""
+
+if [[ "$ORIGINAL_STATE" == "MERGED" ]]; then
+    log_success "State: MERGED"
+    echo ""
+    log "✓ Original PR has merged!"
+    log "  You can now run: /proof-pr:convert $ORIGINAL_PR"
+    echo ""
+else
+    echo "State: $ORIGINAL_STATE"
+
+    if [[ "$ORIGINAL_DRAFT" == "true" ]]; then
+        log_warn "Draft: YES (must mark as ready for review)"
+    fi
+
+    # Check Tide labels
+    LABELS=$(echo "$ORIGINAL_PR_JSON" | jq -r '.labels[].name')
+
+    HAS_LGTM=$(echo "$LABELS" | grep -c "^lgtm$" || true)
+    HAS_APPROVE=$(echo "$LABELS" | grep -c "^approved$" || true)
+    HAS_VERIFIED=$(echo "$LABELS" | grep -c "^verified$" || true)
+    HAS_HOLD=$(echo "$LABELS" | grep -cE "^(do-not-merge/hold|hold)$" || true)
+
+    echo ""
+    echo "Tide Labels:"
+
+    if (( HAS_LGTM > 0 )); then
+        log_success "lgtm"
+    else
+        log_error "lgtm (missing - need /lgtm from reviewer)"
+    fi
+
+    if (( HAS_APPROVE > 0 )); then
+        log_success "approved"
+    else
+        log_error "approved (missing - need /approve from approver)"
+    fi
+
+    if (( HAS_VERIFIED > 0 )); then
+        log_success "verified"
+    else
+        log_error "verified (missing - use /verified by <test> or /verified later @user)"
+    fi
+
+    if (( HAS_HOLD > 0 )); then
+        log_warn "do-not-merge/hold (remove with /hold cancel when ready)"
+    fi
+
+    # Check CI status
+    echo ""
+    echo "CI Status:"
+
+    STATUS_CHECKS=$(echo "$ORIGINAL_PR_JSON" | jq -r '.statusCheckRollup // [] | length')
+
+    if (( STATUS_CHECKS == 0 )); then
+        log_warn "No status checks found"
+    else
+        PASSING=$(echo "$ORIGINAL_PR_JSON" | jq -r '[.statusCheckRollup[] | select(.conclusion == "SUCCESS" or .state == "SUCCESS")] | length')
+        FAILING=$(echo "$ORIGINAL_PR_JSON" | jq -r '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .state == "FAILURE")] | length')
+        PENDING=$(echo "$ORIGINAL_PR_JSON" | jq -r '[.statusCheckRollup[] | select(.state == "PENDING" or .state == "IN_PROGRESS")] | length')
+
+        if (( FAILING > 0 )); then
+            log_error "$FAILING failing, $PASSING passing, $PENDING pending"
+        elif (( PENDING > 0 )); then
+            log_warn "$PASSING passing, $PENDING pending"
+        else
+            log_success "All $PASSING checks passing"
+        fi
+    fi
+
+    echo ""
+    echo "Merge Readiness:"
+
+    READY_TO_MERGE=true
+
+    if [[ "$ORIGINAL_DRAFT" == "true" ]]; then
+        log_error "Must mark as ready for review"
+        READY_TO_MERGE=false
+    fi
+
+    if (( HAS_LGTM == 0 )); then
+        log_error "Need /lgtm from reviewer with write access"
+        READY_TO_MERGE=false
+    fi
+
+    if (( HAS_APPROVE == 0 )); then
+        log_error "Need /approve from approver (usually from OWNERS file)"
+        READY_TO_MERGE=false
+    fi
+
+    if (( HAS_VERIFIED == 0 )); then
+        log_error "Need verified label via /verified command"
+        echo "    Options:"
+        echo "      - /verified by \"<test-name>\" (pre-merge testing - recommended)"
+        echo "      - /verified by @<username> (pre-merge verification by person)"
+        echo "      - /verified later @<username> (post-merge verification)"
+        READY_TO_MERGE=false
+    fi
+
+    if (( HAS_HOLD > 0 )); then
+        log_warn "Has hold label - use /hold cancel when ready"
+        READY_TO_MERGE=false
+    fi
+
+    if (( FAILING > 0 )); then
+        log_error "Has failing CI checks"
+        READY_TO_MERGE=false
+    fi
+
+    echo ""
+
+    if $READY_TO_MERGE; then
+        log_success "Original PR is ready for Tide auto-merge!"
+        echo ""
+        log "Once merged, run: /proof-pr:convert $ORIGINAL_PR"
+    else
+        log_warn "Original PR not yet ready for merge"
+        echo ""
+        log "Recommendations:"
+        if (( HAS_LGTM == 0 )) || (( HAS_APPROVE == 0 )); then
+            echo "  1. Request review from team members"
+        fi
+        if (( HAS_VERIFIED == 0 )); then
+            echo "  2. Use /verified by <test> to mark as verified"
+        fi
+        if (( FAILING > 0 )); then
+            echo "  3. Fix failing CI checks"
+        fi
+        if (( HAS_HOLD > 0 )); then
+            echo "  4. Remove hold label when ready: /hold cancel"
+        fi
+    fi
+fi
+
+# Step 4: Show proof PR statuses
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "PROOF PR STATUS"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+PROOF_PRS=$(echo "$STATE_JSON" | jq -c '.proof_prs[]')
+
+if [[ -z "$PROOF_PRS" ]]; then
+    log_warn "No proof PRs found"
+    exit 0
+fi
+
+while IFS= read -r proof_pr; do
+    REPO=$(echo "$proof_pr" | jq -r '.repo')
+    NUMBER=$(echo "$proof_pr" | jq -r '.number')
+    URL=$(echo "$proof_pr" | jq -r '.url')
+    CONVERTED=$(echo "$proof_pr" | jq -r '.converted')
+    MERGED=$(echo "$proof_pr" | jq -r '.merged')
+    PROVING_REPO=$(echo "$proof_pr" | jq -r '.proving_repo')
+    PROVING_PR=$(echo "$proof_pr" | jq -r '.proving_pr')
+
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "$REPO#$NUMBER"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "URL: $URL"
+    echo "Proving: $PROVING_REPO#$PROVING_PR"
+
+    if [[ "$MERGED" == "true" ]]; then
+        log_success "Status: MERGED"
+        echo ""
+        continue
+    fi
+
+    if [[ "$CONVERTED" == "true" ]]; then
+        echo "Status: CONVERTED (normal PR)"
+    else
+        echo "Status: ACTIVE (proof PR)"
+    fi
+
+    # Get PR details
+    PR_JSON=$(gh pr view "$NUMBER" \
+        --repo "$REPO" \
+        --json state,isDraft,statusCheckRollup,labels,mergeable 2>/dev/null || echo '{}')
+
+    if [[ "$PR_JSON" == "{}" ]]; then
+        log_error "Could not fetch PR details"
+        echo ""
+        continue
+    fi
+
+    PR_STATE=$(echo "$PR_JSON" | jq -r '.state // "UNKNOWN"')
+    PR_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft // false')
+
+    echo ""
+
+    # Check for hold label
+    PR_LABELS=$(echo "$PR_JSON" | jq -r '.labels[]?.name // empty')
+    PR_HAS_HOLD=$(echo "$PR_LABELS" | grep -cE "^(do-not-merge/hold|hold)$" || true)
+
+    if (( PR_HAS_HOLD > 0 )) && [[ "$CONVERTED" == "false" ]]; then
+        log_success "do-not-merge/hold present (expected for proof PR)"
+    elif (( PR_HAS_HOLD > 0 )) && [[ "$CONVERTED" == "true" ]]; then
+        log_warn "do-not-merge/hold still present (should be removed after conversion)"
+    fi
+
+    # Check CI status
+    STATUS_CHECKS=$(echo "$PR_JSON" | jq -r '.statusCheckRollup // [] | length')
+
+    if (( STATUS_CHECKS == 0 )); then
+        log_warn "No CI checks"
+    else
+        PASSING=$(echo "$PR_JSON" | jq -r '[.statusCheckRollup[] | select(.conclusion == "SUCCESS" or .state == "SUCCESS")] | length')
+        FAILING=$(echo "$PR_JSON" | jq -r '[.statusCheckRollup[] | select(.conclusion == "FAILURE" or .state == "FAILURE")] | length')
+
+        if (( FAILING > 0 )); then
+            log_error "CI: $FAILING failing, $PASSING passing"
+            echo "  ⮕ May need /proof-pr:push-fix to apply manual fixes"
+        else
+            log_success "CI: All $PASSING checks passing"
+        fi
+    fi
+
+    echo ""
+
+done <<< "$PROOF_PRS"
+
+# Step 5: Show recommendations
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "RECOMMENDATIONS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+if [[ "$ORIGINAL_STATE" == "MERGED" ]]; then
+    log "✓ Original PR is merged"
+    log "⮕ Run: /proof-pr:convert $ORIGINAL_PR"
+    echo ""
+else
+    UNCONVERTED=$(echo "$STATE_JSON" | jq '[.proof_prs[] | select(.converted == false and .merged == false)] | length')
+
+    if (( UNCONVERTED > 0 )); then
+        log "✓ $UNCONVERTED active proof PRs"
+        log "⮕ Monitor and fix any failing CIs"
+        log "⮕ When original PR gets labels and merges, run: /proof-pr:convert $ORIGINAL_PR"
+    else
+        log "⮕ All proof PRs have been converted or merged"
+        log "⮕ You may be done with this workflow"
+    fi
+
+    echo ""
+
+    if ! $READY_TO_MERGE; then
+        log "⮕ Work on getting original PR ready for merge (see above)"
+    fi
+fi
+
+echo ""
+log "State file: $STATE_FILE"
+echo ""
+```
+
+## Return Value
+
+- **Format**: Human-readable status report
+- **Output**: Multi-section report showing original PR and proof PR statuses
+
+**Exit codes:**
+- 0: Success - status displayed
+- 1: Error - could not load or recover state
+
+## Examples
+
+1. **Check status with state file present**:
+   ```
+   /proof-pr:status 2626
+   ```
+   Shows status of all proof PRs for original PR #2626.
+
+2. **Check status with auto-recovery**:
+   ```
+   /proof-pr:status 2626 https://github.com/openshift/api/pull/2626
+   ```
+   If state file missing, recovers from GitHub using the PR URL.
+
+3. **Monitor progress before merge**:
+   ```
+   /proof-pr:status 2626
+   ```
+   Shows which labels are missing for Tide auto-merge and current CI status.
+
+## Notes
+
+- **Information-only**: Makes no changes, only displays status
+- **Auto-sync**: Automatically syncs with GitHub if state is out of date
+- **Merge guidance**: Shows exactly what's needed for Tide to auto-merge
+- **Tide requirements**: Checks for lgtm, approved, verified labels and CI status
+- **No interaction**: Just displays information and recommendations

--- a/plugins/proof-pr/commands/sync.md
+++ b/plugins/proof-pr/commands/sync.md
@@ -1,0 +1,343 @@
+---
+description: Sync proof PRs with latest changes from original PR
+argument-hint: <original-pr-number>
+---
+
+## Name
+
+proof-pr:sync - Update proof PRs to latest commits from original PR
+
+## Synopsis
+
+```
+/proof-pr:sync <original-pr-number>
+```
+
+## Description
+
+The `proof-pr:sync` command updates all active proof PRs to use the latest pseudo-version from the original PR. This is needed when:
+- The original PR has new commits pushed
+- You want to test the latest changes
+- Dependencies need to be refreshed
+
+**Key Features:**
+- **Updates pseudo-versions**: Recalculates pseudo-version from latest commit
+- **Preserves manual fixes**: Handles conflicts if you've made manual changes
+- **Re-runs codegen**: Automatically runs code generation after sync
+- **Tests compilation**: Verifies proof PRs still compile after update
+- **Handles conflicts**: Provides guidance when manual merge needed
+
+**Workflow:**
+1. Fetches latest commit from original PR
+2. Generates new pseudo-version
+3. For each active (unconverted, unmerged) proof PR:
+   - Updates go.mod with new pseudo-version
+   - Runs code generation if needed
+   - Tests compilation
+   - Commits and force-pushes changes
+
+## Arguments
+
+- `$1` (required): Original PR number (e.g., `2626`)
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Configuration
+ORIGINAL_PR="$1"
+
+SKILLS_DIR="plugins/proof-pr/skills/proof-pr-workflow"
+STATE_FILE="$HOME/.work/proof-pr/$ORIGINAL_PR/state.json"
+WORK_DIR="$HOME/.work/proof-pr/$ORIGINAL_PR"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[proof-pr:sync]${NC} $*"; }
+log_success() { echo -e "${GREEN}✓${NC} $*"; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+log_error() { echo -e "${RED}✗${NC} $*"; }
+
+# Step 1: Load state
+log "Loading state for PR #$ORIGINAL_PR..."
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    log_error "State file not found: $STATE_FILE"
+    log "Run /proof-pr:status $ORIGINAL_PR to recover state"
+    exit 1
+fi
+
+STATE_JSON=$(cat "$STATE_FILE")
+ORIGINAL_REPO=$(echo "$STATE_JSON" | jq -r '.original_repo')
+ORIGINAL_URL=$(echo "$STATE_JSON" | jq -r '.original_url')
+
+log "Original PR: $ORIGINAL_REPO#$ORIGINAL_PR"
+
+# Step 2: Get latest commit from original PR
+log "Fetching latest commit from original PR..."
+
+ORIGINAL_PR_JSON=$(gh pr view "$ORIGINAL_PR" \
+    --repo "$ORIGINAL_REPO" \
+    --json state,commits,headRefName)
+
+PR_STATE=$(echo "$ORIGINAL_PR_JSON" | jq -r '.state')
+
+if [[ "$PR_STATE" == "MERGED" ]]; then
+    log_error "Original PR is already merged"
+    log "Use /proof-pr:convert instead"
+    exit 1
+fi
+
+if [[ "$PR_STATE" == "CLOSED" ]]; then
+    log_error "Original PR is closed"
+    exit 1
+fi
+
+LATEST_COMMIT=$(echo "$ORIGINAL_PR_JSON" | jq -r '.commits[-1].oid[:12]')
+COMMIT_TIMESTAMP=$(echo "$ORIGINAL_PR_JSON" | jq -r '.commits[-1].committedDate' \
+    | sed 's/[-:]//g; s/T//; s/Z.*//')
+PR_BRANCH=$(echo "$ORIGINAL_PR_JSON" | jq -r '.headRefName')
+
+NEW_PSEUDO_VERSION="v0.0.0-${COMMIT_TIMESTAMP}-${LATEST_COMMIT}"
+ORIGINAL_MODULE="github.com/$ORIGINAL_REPO"
+
+log "Latest commit: $LATEST_COMMIT"
+log "New pseudo-version: $NEW_PSEUDO_VERSION"
+
+# Step 3: Sync each active proof PR
+log ""
+log "Syncing active proof PRs..."
+
+PROOF_PRS=$(echo "$STATE_JSON" | jq -c '.proof_prs[] | select(.converted == false and .merged == false)')
+
+if [[ -z "$PROOF_PRS" ]]; then
+    log_warn "No active proof PRs to sync"
+    exit 0
+fi
+
+SYNCED_COUNT=0
+FAILED_COUNT=0
+
+while IFS= read -r proof_pr; do
+    REPO=$(echo "$proof_pr" | jq -r '.repo')
+    NUMBER=$(echo "$proof_pr" | jq -r '.number')
+    BRANCH=$(echo "$proof_pr" | jq -r '.branch')
+    DEPENDS_ON=$(echo "$proof_pr" | jq -r '.depends_on_repo')
+
+    echo ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "Syncing: $REPO#$NUMBER"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    REPO_WORK_DIR="$WORK_DIR/$REPO"
+
+    if [[ ! -d "$REPO_WORK_DIR" ]]; then
+        log_error "Repository not cloned: $REPO_WORK_DIR"
+        log "Run /proof-pr:create again to re-clone"
+        ((FAILED_COUNT++))
+        continue
+    fi
+
+    cd "$REPO_WORK_DIR"
+
+    # Fetch latest
+    log "Fetching latest..."
+    git fetch --all
+
+    # Checkout proof branch
+    log "Checking out branch: $BRANCH"
+    if ! git checkout "$BRANCH"; then
+        log_error "Failed to checkout branch: $BRANCH"
+        ((FAILED_COUNT++))
+        continue
+    fi
+
+    # Pull latest changes (might have conflicts)
+    log "Pulling latest changes..."
+    if ! git pull origin "$BRANCH"; then
+        log_warn "Pull failed (might have conflicts)"
+        log "This is expected if you've made manual changes"
+    fi
+
+    # Update go.mod
+    log "Updating dependency: github.com/$DEPENDS_ON -> $NEW_PSEUDO_VERSION"
+
+    if ! go get "github.com/$DEPENDS_ON@$NEW_PSEUDO_VERSION"; then
+        log_error "Failed to update dependency"
+        ((FAILED_COUNT++))
+        continue
+    fi
+
+    go mod tidy
+
+    # Check if there are changes
+    if ! git diff --quiet go.mod go.sum; then
+        log "Dependency updated"
+    else
+        log "No dependency changes (already up to date)"
+        ((SYNCED_COUNT++))
+        continue
+    fi
+
+    # Run code generation if needed
+    log "Checking for code generation requirements..."
+
+    CODEGEN_JSON=$("$SKILLS_DIR/detect-codegen.py" . --json 2>/dev/null)
+    NEEDS_CODEGEN=$(echo "$CODEGEN_JSON" | jq -r '.needs_codegen')
+
+    if [[ "$NEEDS_CODEGEN" == "true" ]]; then
+        CODEGEN_CMD=$(echo "$CODEGEN_JSON" | jq -r '.command')
+
+        if [[ "$CODEGEN_CMD" != "null" && -n "$CODEGEN_CMD" ]]; then
+            log "Running code generation: $CODEGEN_CMD"
+
+            if ! eval "$CODEGEN_CMD"; then
+                log_error "Code generation failed"
+                log "You may need to fix this manually"
+                ((FAILED_COUNT++))
+                continue
+            fi
+
+            log "Code generation completed"
+        fi
+    fi
+
+    # Test compilation
+    log "Testing compilation..."
+
+    if "$SKILLS_DIR/compile-test.sh" --quiet .; then
+        log_success "Compilation successful"
+        COMPILATION_STATUS="success"
+    else
+        log_warn "Compilation failed, attempting auto-fix..."
+
+        FIX_JSON=$("$SKILLS_DIR/attempt-fix.py" . --json 2>/dev/null)
+        FIX_SUCCESS=$(echo "$FIX_JSON" | jq -r '.compilation_succeeds')
+
+        if [[ "$FIX_SUCCESS" == "true" ]]; then
+            log_success "Auto-fix successful!"
+            COMPILATION_STATUS="fixed"
+        else
+            log_error "Auto-fix failed"
+            log "Compilation still failing - manual fixes needed"
+            COMPILATION_STATUS="failed"
+
+            # Continue anyway - push the sync even if broken
+            log_warn "Pushing sync anyway (will need manual fixes)"
+        fi
+    fi
+
+    # Commit changes
+    log "Committing sync..."
+
+    git add -A
+
+    COMMIT_MSG="[PROOF] Sync to latest from $ORIGINAL_REPO#$ORIGINAL_PR
+
+Updated pseudo-version: $NEW_PSEUDO_VERSION
+Compilation: $COMPILATION_STATUS
+
+Synced with latest commit: $LATEST_COMMIT
+"
+
+    if ! git diff --cached --quiet; then
+        git commit -m "$COMMIT_MSG"
+    else
+        log "No changes to commit"
+        ((SYNCED_COUNT++))
+        continue
+    fi
+
+    # Force push (sync overwrites previous proof state)
+    log "Force pushing to fork..."
+
+    if ! git push -f origin "$BRANCH"; then
+        log_error "Failed to push"
+        ((FAILED_COUNT++))
+        continue
+    fi
+
+    log_success "Synced successfully!"
+
+    # Add comment to PR
+    log "Adding sync comment to PR..."
+
+    COMMENT="🔄 **Synced to latest**
+
+Updated to latest commit from $ORIGINAL_URL:
+- Commit: \`$LATEST_COMMIT\`
+- Pseudo-version: \`$NEW_PSEUDO_VERSION\`
+- Compilation: $COMPILATION_STATUS
+
+Generated by [Claude Code proof-pr plugin](https://github.com/openshift-eng/ai-helpers)
+"
+
+    gh pr comment "$NUMBER" \
+        --repo "$REPO" \
+        --body "$COMMENT" || {
+        log_warn "Could not add comment to PR"
+    }
+
+    ((SYNCED_COUNT++))
+
+done <<< "$PROOF_PRS"
+
+# Step 4: Show summary
+echo ""
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "SYNC SUMMARY"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+log_success "Synced: $SYNCED_COUNT proof PRs"
+
+if (( FAILED_COUNT > 0 )); then
+    log_error "Failed: $FAILED_COUNT proof PRs"
+    echo ""
+    log "Review failed PRs and fix manually if needed"
+fi
+
+echo ""
+log "Next steps:"
+log "  - Review synced proof PRs for any CI failures"
+log "  - Fix any compilation errors with /proof-pr:push-fix"
+log "  - Check status with /proof-pr:status $ORIGINAL_PR"
+echo ""
+```
+
+## Return Value
+
+- **Format**: Syncs proof PRs and reports results
+- **Output**: Summary of synced and failed PRs
+
+**Exit codes:**
+- 0: Success - all proof PRs synced
+- 1: Partial failure - some PRs failed to sync
+
+## Examples
+
+1. **Sync after original PR updated**:
+   ```
+   /proof-pr:sync 2626
+   ```
+   Updates all active proof PRs to use latest commit from api#2626.
+
+2. **After pushing new commits to original**:
+   ```
+   /proof-pr:sync 2626
+   ```
+   Refreshes proof PRs to test the new changes.
+
+## Notes
+
+- **Force push**: Uses `git push -f` since proof PRs are temporary
+- **Preserves manual fixes**: If you've made manual changes, may create conflicts
+- **Auto-fix**: Attempts to fix new compilation errors after sync
+- **Only syncs active**: Skips converted or merged proof PRs
+- **Comments**: Adds sync comment to each PR for visibility

--- a/plugins/proof-pr/skills/proof-pr-workflow/analyze-deps.py
+++ b/plugins/proof-pr/skills/proof-pr-workflow/analyze-deps.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Analyze Go module dependency graphs to detect chains and relationships.
+
+This script uses 'go mod graph' to build a dependency graph and find
+paths from a repository to a target module. Includes caching for performance.
+
+Cache Strategy:
+    - Cache key: SHA256 hash of go.mod file content
+    - Cache location: ~/.cache/proof-pr/dep-graphs/{hash}.pkl
+    - Cache TTL: 1 hour
+    - Invalidated when go.mod changes
+"""
+
+import os
+import re
+import sys
+import json
+import subprocess
+import hashlib
+import pickle
+from pathlib import Path
+from typing import List, Dict, Optional, Set, Tuple
+from dataclasses import dataclass, asdict
+from collections import deque
+from datetime import datetime, timedelta
+
+
+@dataclass
+class DependencyChain:
+    """Represents a dependency chain from target to original repo"""
+
+    # List of repos in the chain: [target, intermediate1, ..., original]
+    repos: List[str]
+
+    # Type of relationship
+    relationship: str  # "direct", "transitive", "generated-code"
+
+    # Go module path (not repo URL)
+    module_path: List[str]
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary"""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'DependencyChain':
+        """Create from dictionary"""
+        return cls(**data)
+
+
+class DependencyAnalyzer:
+    """Analyzes Go module dependencies to find dependency chains"""
+
+    CACHE_DIR = Path.home() / '.cache' / 'proof-pr' / 'dep-graphs'
+    CACHE_TTL = timedelta(hours=1)
+
+    # Patterns that indicate generated code repositories
+    GENERATED_CODE_PATTERNS = [
+        'client-go',
+        '/generated',
+        '/listers',
+        '/informers',
+        '/clientset',
+        'api/typed',
+    ]
+
+    def __init__(self, repo_path: str, verbose: bool = True):
+        self.repo_path = Path(repo_path).resolve()
+        self.verbose = verbose
+        self.go_module = self._get_go_module()
+        self.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    def _log(self, message: str):
+        """Print verbose logging"""
+        if self.verbose:
+            print(f"[analyze-deps] {message}", file=sys.stderr)
+
+    def _get_go_module(self) -> Optional[str]:
+        """Get the Go module name from go.mod"""
+        go_mod = self.repo_path / 'go.mod'
+        if not go_mod.exists():
+            return None
+
+        try:
+            content = go_mod.read_text()
+            for line in content.split('\n'):
+                if line.startswith('module '):
+                    return line.split()[1].strip()
+        except Exception as e:
+            self._log(f"Error reading go.mod: {e}")
+
+        return None
+
+    def _get_go_mod_hash(self) -> str:
+        """Get SHA256 hash of go.mod file for cache key"""
+        go_mod = self.repo_path / 'go.mod'
+        if not go_mod.exists():
+            return ""
+
+        content = go_mod.read_bytes()
+        return hashlib.sha256(content).hexdigest()
+
+    def _get_cache_path(self) -> Path:
+        """Get path to cached dependency graph"""
+        cache_key = self._get_go_mod_hash()
+        return self.CACHE_DIR / f"{cache_key}.pkl"
+
+    def _load_from_cache(self) -> Optional[Dict[str, List[str]]]:
+        """Load dependency graph from cache if valid"""
+        cache_path = self._get_cache_path()
+
+        if not cache_path.exists():
+            self._log("No cache found")
+            return None
+
+        try:
+            # Check cache age
+            cache_time = datetime.fromtimestamp(cache_path.stat().st_mtime)
+            age = datetime.now() - cache_time
+
+            if age > self.CACHE_TTL:
+                self._log(f"Cache expired (age: {age})")
+                cache_path.unlink()
+                return None
+
+            # Load cache
+            with open(cache_path, 'rb') as f:
+                graph = pickle.load(f)
+
+            self._log(f"Loaded from cache (age: {age})")
+            return graph
+
+        except Exception as e:
+            self._log(f"Error loading cache: {e}")
+            return None
+
+    def _save_to_cache(self, graph: Dict[str, List[str]]) -> None:
+        """Save dependency graph to cache"""
+        cache_path = self._get_cache_path()
+
+        try:
+            with open(cache_path, 'wb') as f:
+                pickle.dump(graph, f)
+
+            self._log(f"Saved to cache: {cache_path}")
+
+        except Exception as e:
+            self._log(f"Warning: Could not save cache: {e}")
+
+    def get_dependency_graph(self, use_cache: bool = True) -> Dict[str, List[str]]:
+        """
+        Get dependency graph from 'go mod graph'.
+
+        Returns:
+            Dict mapping module -> [list of dependencies]
+        """
+        # Try cache first
+        if use_cache:
+            cached = self._load_from_cache()
+            if cached is not None:
+                return cached
+
+        self._log("Building dependency graph from go mod graph...")
+
+        try:
+            result = subprocess.run(
+                ['go', 'mod', 'graph'],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30
+            )
+
+            # Parse output: each line is "module1 module2" (module1 depends on module2)
+            graph = {}
+
+            for line in result.stdout.strip().split('\n'):
+                if not line:
+                    continue
+
+                parts = line.split()
+                if len(parts) != 2:
+                    continue
+
+                source, target = parts
+
+                # Strip version info (module@version -> module)
+                source = source.split('@')[0]
+                target = target.split('@')[0]
+
+                if source not in graph:
+                    graph[source] = []
+
+                graph[source].append(target)
+
+            self._log(f"Built graph with {len(graph)} nodes")
+
+            # Save to cache
+            if use_cache:
+                self._save_to_cache(graph)
+
+            return graph
+
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"go mod graph failed: {e.stderr}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("go mod graph timed out")
+
+    def _find_path_bfs(
+        self,
+        graph: Dict[str, List[str]],
+        start: str,
+        target: str
+    ) -> Optional[List[str]]:
+        """
+        Find shortest path from start to target using BFS.
+
+        Args:
+            graph: Dependency graph (module -> [dependencies])
+            start: Starting module
+            target: Target module to find
+
+        Returns:
+            List of modules in path from start to target, or None if no path
+        """
+        if start == target:
+            return [start]
+
+        queue = deque([(start, [start])])
+        visited = {start}
+
+        while queue:
+            current, path = queue.popleft()
+
+            # Get dependencies of current module
+            dependencies = graph.get(current, [])
+
+            for dep in dependencies:
+                if dep in visited:
+                    continue
+
+                new_path = path + [dep]
+
+                # Check if we found the target
+                if dep == target:
+                    return new_path
+
+                visited.add(dep)
+                queue.append((dep, new_path))
+
+        return None
+
+    def _module_to_repo(self, module: str) -> str:
+        """
+        Convert Go module path to repository name.
+
+        Examples:
+            github.com/openshift/client-go -> openshift/client-go
+            k8s.io/client-go -> kubernetes/client-go (approximation)
+        """
+        # Handle github.com modules
+        if module.startswith('github.com/'):
+            parts = module.split('/')
+            if len(parts) >= 3:
+                return f"{parts[1]}/{parts[2]}"
+
+        # Handle k8s.io modules (map to kubernetes org)
+        if module.startswith('k8s.io/'):
+            return f"kubernetes/{module.split('/')[1]}"
+
+        # Fallback: use last two path components
+        parts = module.split('/')
+        if len(parts) >= 2:
+            return f"{parts[-2]}/{parts[-1]}"
+
+        return module
+
+    def _is_generated_code_repo(self, module: str) -> bool:
+        """Check if module path indicates generated code"""
+        for pattern in self.GENERATED_CODE_PATTERNS:
+            if pattern in module:
+                return True
+        return False
+
+    def find_chain_to(self, target_module: str) -> Optional[DependencyChain]:
+        """
+        Find dependency chain from current repo to target module.
+
+        Args:
+            target_module: Target module to find (e.g., "github.com/openshift/api")
+
+        Returns:
+            DependencyChain if found, None otherwise
+        """
+        if not self.go_module:
+            self._log("No go.mod found in repository")
+            return None
+
+        self._log(f"Finding chain from {self.go_module} to {target_module}")
+
+        # Build dependency graph
+        graph = self.get_dependency_graph(use_cache=True)
+
+        # Find path using BFS
+        path = self._find_path_bfs(graph, self.go_module, target_module)
+
+        if not path:
+            self._log("No dependency chain found")
+            return None
+
+        # Convert module paths to repo names
+        repos = [self._module_to_repo(m) for m in path]
+
+        # Determine relationship type
+        if len(path) == 2:
+            relationship = "direct"
+        else:
+            relationship = "transitive"
+
+        # Check if any intermediate repos are generated-code repos
+        for module in path[1:]:  # Skip root module
+            if self._is_generated_code_repo(module):
+                relationship = "generated-code"
+                break
+
+        self._log(f"Found chain: {' -> '.join(repos)}")
+        self._log(f"Relationship: {relationship}")
+
+        return DependencyChain(
+            repos=repos,
+            relationship=relationship,
+            module_path=path
+        )
+
+
+def main():
+    """CLI entry point"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Analyze Go module dependencies"
+    )
+    parser.add_argument(
+        'target_module',
+        help='Target module to find dependency chain to'
+    )
+    parser.add_argument(
+        'repo_path',
+        nargs='?',
+        default='.',
+        help='Path to repository (default: current directory)'
+    )
+    parser.add_argument(
+        '--no-cache',
+        action='store_true',
+        help='Disable caching'
+    )
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppress verbose logging'
+    )
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output results as JSON'
+    )
+
+    args = parser.parse_args()
+
+    analyzer = DependencyAnalyzer(args.repo_path, verbose=not args.quiet)
+
+    try:
+        chain = analyzer.find_chain_to(args.target_module)
+
+        if chain:
+            if args.json:
+                print(json.dumps(chain.to_dict(), indent=2))
+            else:
+                print(f"\nDependency chain found:")
+                print(f"  Repos: {' -> '.join(chain.repos)}")
+                print(f"  Relationship: {chain.relationship}")
+                print(f"  Module path: {' -> '.join(chain.module_path)}")
+
+            sys.exit(0)
+        else:
+            if not args.json:
+                print("No dependency chain found")
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/proof-pr/skills/proof-pr-workflow/attempt-fix.py
+++ b/plugins/proof-pr/skills/proof-pr-workflow/attempt-fix.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""
+Attempt automatic fixes for common compilation errors after dependency updates.
+
+Handles common cases like:
+- Type renames (e.g., Policy → ImageSigstoreVerificationPolicy)
+- Package moves
+- Import path changes
+- Method signature changes (simple cases)
+
+Returns:
+    0: Fixes applied successfully and compilation succeeds
+    1: Fixes applied but compilation still fails
+    2: Could not determine fixes (manual intervention needed)
+"""
+
+import os
+import re
+import sys
+import json
+import subprocess
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple, Set
+from dataclasses import dataclass, asdict
+from collections import defaultdict
+
+
+@dataclass
+class CompilationError:
+    """Represents a compilation error"""
+    file: str
+    line: int
+    column: int
+    message: str
+    error_type: str  # "undefined", "type-mismatch", "import-error", etc.
+
+
+@dataclass
+class Fix:
+    """Represents a fix to be applied"""
+    file: str
+    old_text: str
+    new_text: str
+    reason: str
+
+
+@dataclass
+class FixResult:
+    """Results from attempting fixes"""
+    repo_path: str
+    compilation_errors: List[CompilationError]
+    fixes_attempted: List[Fix]
+    files_modified: List[str]
+    compilation_succeeds: bool
+    needs_manual_fix: bool
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary for JSON output"""
+        return {
+            'repo_path': self.repo_path,
+            'compilation_errors': [asdict(e) for e in self.compilation_errors],
+            'fixes_attempted': [asdict(f) for f in self.fixes_attempted],
+            'files_modified': self.files_modified,
+            'compilation_succeeds': self.compilation_succeeds,
+            'needs_manual_fix': self.needs_manual_fix,
+            'error': self.error
+        }
+
+
+class AutoFixer:
+    """Automatically fix common compilation errors"""
+
+    # Common type rename patterns from OpenShift API changes
+    TYPE_RENAME_PATTERNS = [
+        # Sigstore verification types (from api#2626 simulation)
+        (r'\bPolicy\b', 'ImageSigstoreVerificationPolicy'),
+        (r'\bPKI\b', 'ImagePolicyPKIRootOfTrust'),
+    ]
+
+    def __init__(self, repo_path: str, verbose: bool = True):
+        self.repo_path = Path(repo_path).resolve()
+        self.verbose = verbose
+        self.go_module = self._get_go_module()
+
+    def _get_go_module(self) -> Optional[str]:
+        """Get the Go module name from go.mod"""
+        go_mod = self.repo_path / 'go.mod'
+        if not go_mod.exists():
+            return None
+
+        try:
+            content = go_mod.read_text()
+            for line in content.split('\n'):
+                if line.startswith('module '):
+                    return line.split()[1].strip()
+        except Exception as e:
+            self._log(f"Error reading go.mod: {e}")
+
+        return None
+
+    def _log(self, message: str):
+        """Print verbose logging"""
+        if self.verbose:
+            print(f"[attempt-fix] {message}", file=sys.stderr)
+
+    def compile(self) -> Tuple[bool, List[CompilationError]]:
+        """
+        Attempt to compile the repository and parse errors.
+
+        Returns:
+            Tuple of (success, list_of_errors)
+        """
+        self._log("Running compilation check...")
+
+        try:
+            result = subprocess.run(
+                ['go', 'build', './...'],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=120
+            )
+
+            if result.returncode == 0:
+                self._log("Compilation successful")
+                return True, []
+
+            # Parse compilation errors
+            errors = self._parse_compilation_errors(result.stderr)
+            self._log(f"Found {len(errors)} compilation errors")
+
+            return False, errors
+
+        except subprocess.TimeoutExpired:
+            self._log("Compilation timed out")
+            return False, []
+        except Exception as e:
+            self._log(f"Error running compilation: {e}")
+            return False, []
+
+    def _parse_compilation_errors(self, stderr: str) -> List[CompilationError]:
+        """
+        Parse go build error output.
+
+        Example error formats:
+        - path/to/file.go:123:45: undefined: SomeType
+        - path/to/file.go:123:45: cannot use x (type T1) as type T2
+        """
+        errors = []
+
+        # Regex for Go compilation errors
+        error_pattern = re.compile(
+            r'^(.+?):(\d+):(\d+): (.+)$',
+            re.MULTILINE
+        )
+
+        for match in error_pattern.finditer(stderr):
+            file_path = match.group(1)
+            line = int(match.group(2))
+            column = int(match.group(3))
+            message = match.group(4)
+
+            # Classify error type
+            error_type = "unknown"
+            if "undefined:" in message:
+                error_type = "undefined"
+            elif "cannot use" in message or "type" in message.lower():
+                error_type = "type-mismatch"
+            elif "import" in message.lower():
+                error_type = "import-error"
+
+            errors.append(CompilationError(
+                file=file_path,
+                line=line,
+                column=column,
+                message=message,
+                error_type=error_type
+            ))
+
+        return errors
+
+    def _extract_undefined_types(self, errors: List[CompilationError]) -> Set[str]:
+        """Extract undefined type names from errors"""
+        undefined_types = set()
+
+        for error in errors:
+            if error.error_type == "undefined":
+                # Extract type name from "undefined: TypeName"
+                match = re.search(r'undefined: (\w+)', error.message)
+                if match:
+                    type_name = match.group(1)
+                    undefined_types.add(type_name)
+
+        return undefined_types
+
+    def _find_type_renames(self, undefined_types: Set[str]) -> Dict[str, str]:
+        """
+        Attempt to find renamed types by searching dependency code.
+
+        This is a heuristic approach:
+        1. Look for types in updated dependencies that might be renames
+        2. Use naming similarity (e.g., Policy → ImageSigstoreVerificationPolicy)
+        3. Check import paths for hints
+        """
+        renames = {}
+
+        self._log(f"Searching for renames of: {undefined_types}")
+
+        # First, check our known patterns
+        for old_pattern, new_name in self.TYPE_RENAME_PATTERNS:
+            for undefined_type in undefined_types:
+                if re.fullmatch(old_pattern, undefined_type):
+                    renames[undefined_type] = new_name
+                    self._log(f"Found known rename: {undefined_type} → {new_name}")
+
+        # TODO: Could add more sophisticated detection here:
+        # - Search go.mod dependencies for similar type names
+        # - Use go/packages to inspect imported packages
+        # - Parse vendored code if present
+
+        return renames
+
+    def _create_rename_fixes(
+        self,
+        errors: List[CompilationError],
+        renames: Dict[str, str]
+    ) -> List[Fix]:
+        """
+        Create Fix objects for type renames.
+
+        For each file with undefined types, create fixes to rename them.
+        """
+        fixes = []
+        files_to_fix = set(error.file for error in errors)
+
+        for file_path in files_to_fix:
+            abs_path = self.repo_path / file_path if not Path(file_path).is_absolute() else Path(file_path)
+
+            if not abs_path.exists():
+                continue
+
+            try:
+                content = abs_path.read_text()
+
+                # Apply each rename
+                for old_name, new_name in renames.items():
+                    # Use word boundaries to avoid partial matches
+                    pattern = r'\b' + re.escape(old_name) + r'\b'
+
+                    if re.search(pattern, content):
+                        fixes.append(Fix(
+                            file=str(file_path),
+                            old_text=old_name,
+                            new_text=new_name,
+                            reason=f"Type renamed from {old_name} to {new_name}"
+                        ))
+
+            except Exception as e:
+                self._log(f"Error reading {file_path}: {e}")
+                continue
+
+        return fixes
+
+    def _apply_fixes(self, fixes: List[Fix]) -> List[str]:
+        """
+        Apply fixes to files.
+
+        Returns:
+            List of files that were modified
+        """
+        modified_files = set()
+
+        # Group fixes by file
+        fixes_by_file = defaultdict(list)
+        for fix in fixes:
+            fixes_by_file[fix.file].append(fix)
+
+        for file_path, file_fixes in fixes_by_file.items():
+            abs_path = self.repo_path / file_path if not Path(file_path).is_absolute() else Path(file_path)
+
+            if not abs_path.exists():
+                self._log(f"Warning: File not found: {file_path}")
+                continue
+
+            try:
+                content = abs_path.read_text()
+                original_content = content
+
+                # Apply all fixes for this file
+                for fix in file_fixes:
+                    pattern = r'\b' + re.escape(fix.old_text) + r'\b'
+                    content = re.sub(pattern, fix.new_text, content)
+                    self._log(f"  {file_path}: {fix.old_text} → {fix.new_text}")
+
+                # Only write if content changed
+                if content != original_content:
+                    abs_path.write_text(content)
+                    modified_files.add(file_path)
+                    self._log(f"Modified: {file_path}")
+
+            except Exception as e:
+                self._log(f"Error applying fixes to {file_path}: {e}")
+                continue
+
+        return list(modified_files)
+
+    def attempt_fix(self) -> FixResult:
+        """
+        Attempt to automatically fix compilation errors.
+
+        Process:
+        1. Compile and collect errors
+        2. Analyze errors to determine fixes
+        3. Apply fixes
+        4. Re-compile to verify
+
+        Returns:
+            FixResult with details of what was attempted
+        """
+        self._log(f"Attempting automatic fixes for {self.repo_path}")
+
+        # Step 1: Initial compilation
+        success, errors = self.compile()
+
+        if success:
+            self._log("Repository already compiles successfully")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=[],
+                fixes_attempted=[],
+                files_modified=[],
+                compilation_succeeds=True,
+                needs_manual_fix=False
+            )
+
+        if not errors:
+            self._log("Compilation failed but no errors were parsed")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=[],
+                fixes_attempted=[],
+                files_modified=[],
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error="Compilation failed but errors could not be parsed"
+            )
+
+        # Show error summary
+        self._log(f"\nFound {len(errors)} compilation errors:")
+        error_types = defaultdict(int)
+        for error in errors:
+            error_types[error.error_type] += 1
+        for error_type, count in error_types.items():
+            self._log(f"  {error_type}: {count}")
+
+        # Step 2: Analyze errors and determine fixes
+        undefined_types = self._extract_undefined_types(errors)
+
+        if not undefined_types:
+            self._log("No undefined types found - cannot auto-fix")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=errors,
+                fixes_attempted=[],
+                files_modified=[],
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error="Errors are not simple type renames"
+            )
+
+        self._log(f"\nUndefined types: {undefined_types}")
+
+        # Try to find type renames
+        renames = self._find_type_renames(undefined_types)
+
+        if not renames:
+            self._log("Could not determine type renames - manual fix needed")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=errors,
+                fixes_attempted=[],
+                files_modified=[],
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error=f"Could not determine renames for types: {undefined_types}"
+            )
+
+        self._log(f"\nDetected renames:")
+        for old, new in renames.items():
+            self._log(f"  {old} → {new}")
+
+        # Step 3: Create and apply fixes
+        fixes = self._create_rename_fixes(errors, renames)
+
+        if not fixes:
+            self._log("No fixes could be created")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=errors,
+                fixes_attempted=[],
+                files_modified=[],
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error="No applicable fixes found"
+            )
+
+        self._log(f"\nApplying {len(fixes)} fixes:")
+        modified_files = self._apply_fixes(fixes)
+
+        if not modified_files:
+            self._log("No files were modified")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=errors,
+                fixes_attempted=fixes,
+                files_modified=[],
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error="Fixes could not be applied"
+            )
+
+        # Step 4: Re-compile to verify fixes
+        self._log(f"\nRe-compiling after fixes...")
+        success, remaining_errors = self.compile()
+
+        if success:
+            self._log("SUCCESS: Repository now compiles!")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=errors,
+                fixes_attempted=fixes,
+                files_modified=modified_files,
+                compilation_succeeds=True,
+                needs_manual_fix=False
+            )
+        else:
+            self._log(f"Compilation still fails with {len(remaining_errors)} errors")
+            self._log("Manual fixes may be needed")
+            return FixResult(
+                repo_path=str(self.repo_path),
+                compilation_errors=remaining_errors,
+                fixes_attempted=fixes,
+                files_modified=modified_files,
+                compilation_succeeds=False,
+                needs_manual_fix=True,
+                error="Auto-fixes applied but compilation still fails"
+            )
+
+
+def main():
+    """CLI entry point"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Attempt automatic fixes for compilation errors"
+    )
+    parser.add_argument(
+        'repo_path',
+        nargs='?',
+        default='.',
+        help='Path to repository (default: current directory)'
+    )
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppress verbose logging'
+    )
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output results as JSON'
+    )
+
+    args = parser.parse_args()
+
+    fixer = AutoFixer(args.repo_path, verbose=not args.quiet)
+
+    try:
+        result = fixer.attempt_fix()
+
+        if args.json:
+            print(json.dumps(result.to_dict(), indent=2))
+        else:
+            print(f"\nResults:")
+            print(f"  Initial errors: {len(result.compilation_errors)}")
+            print(f"  Fixes attempted: {len(result.fixes_attempted)}")
+            print(f"  Files modified: {len(result.files_modified)}")
+            print(f"  Compilation succeeds: {result.compilation_succeeds}")
+            print(f"  Needs manual fix: {result.needs_manual_fix}")
+            if result.error:
+                print(f"  Error: {result.error}")
+
+        # Exit codes:
+        # 0 = fixes applied and compilation succeeds
+        # 1 = fixes applied but compilation still fails
+        # 2 = could not determine fixes
+        if result.compilation_succeeds:
+            sys.exit(0)
+        elif result.fixes_attempted:
+            sys.exit(1)
+        else:
+            sys.exit(2)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/proof-pr/skills/proof-pr-workflow/compile-test.sh
+++ b/plugins/proof-pr/skills/proof-pr-workflow/compile-test.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# compile-test.sh - Test compilation for OpenShift repositories
+#
+# This script provides a consistent interface for testing compilation
+# across different OpenShift repository types.
+#
+# Exit codes:
+#   0 - Compilation successful
+#   1 - Compilation failed
+#   2 - Build system not detected
+
+set -euo pipefail
+
+# Configuration
+VERBOSE=0
+REPO_PATH="."
+QUICK=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Usage
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS] [REPO_PATH]
+
+Test compilation for OpenShift repositories.
+
+Options:
+    -v, --verbose       Enable verbose output
+    -q, --quick         Quick test (skip some checks)
+    -h, --help          Show this help message
+
+Arguments:
+    REPO_PATH           Path to repository (default: current directory)
+
+Exit codes:
+    0 - Compilation successful
+    1 - Compilation failed
+    2 - Build system not detected
+EOF
+}
+
+# Logging functions
+log() {
+    if [ $VERBOSE -eq 1 ]; then
+        echo -e "${GREEN}[compile-test]${NC} $*" >&2
+    fi
+}
+
+log_warn() {
+    echo -e "${YELLOW}[compile-test]${NC} WARNING: $*" >&2
+}
+
+log_error() {
+    echo -e "${RED}[compile-test]${NC} ERROR: $*" >&2
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -q|--quick)
+            QUICK=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage
+            exit 2
+            ;;
+        *)
+            REPO_PATH="$1"
+            shift
+            ;;
+    esac
+done
+
+# Change to repository directory
+cd "$REPO_PATH"
+REPO_PATH="$(pwd)"
+log "Testing compilation in: $REPO_PATH"
+
+# Detect Go module
+GO_MODULE=""
+if [ -f "go.mod" ]; then
+    GO_MODULE=$(grep '^module ' go.mod | awk '{print $2}')
+    log "Detected Go module: $GO_MODULE"
+fi
+
+# Function to test with Makefile
+test_makefile() {
+    local makefile="$1"
+
+    log "Checking Makefile for build targets..."
+
+    # Common build targets in order of preference
+    local targets=("build" "all" "compile")
+
+    for target in "${targets[@]}"; do
+        if grep -q "^${target}:" "$makefile" || grep -q "^\.PHONY:.*${target}" "$makefile"; then
+            log "Found Makefile target: $target"
+            log "Running: make $target"
+
+            if [ $VERBOSE -eq 1 ]; then
+                make "$target"
+            else
+                make "$target" >/dev/null 2>&1
+            fi
+
+            local exit_code=$?
+            if [ $exit_code -eq 0 ]; then
+                log "make $target succeeded"
+                return 0
+            else
+                log_error "make $target failed with exit code $exit_code"
+                return 1
+            fi
+        fi
+    done
+
+    log_warn "No known build targets found in Makefile"
+    return 2
+}
+
+# Function to test with go build
+test_go_build() {
+    if [ -z "$GO_MODULE" ]; then
+        log_warn "No go.mod found, skipping go build test"
+        return 2
+    fi
+
+    log "Running: go build ./..."
+
+    local output
+    local exit_code
+
+    if [ $VERBOSE -eq 1 ]; then
+        go build ./...
+        exit_code=$?
+    else
+        output=$(go build ./... 2>&1)
+        exit_code=$?
+    fi
+
+    if [ $exit_code -eq 0 ]; then
+        log "go build ./... succeeded"
+        return 0
+    else
+        log_error "go build ./... failed"
+        if [ $VERBOSE -eq 0 ]; then
+            echo "$output" >&2
+        fi
+        return 1
+    fi
+}
+
+# Function to test with go test (compile only, no run)
+test_go_test_compile() {
+    if [ -z "$GO_MODULE" ]; then
+        log_warn "No go.mod found, skipping go test compilation"
+        return 2
+    fi
+
+    log "Running: go test -c ./..."
+
+    local output
+    local exit_code
+
+    if [ $VERBOSE -eq 1 ]; then
+        go test -c ./... >/dev/null
+        exit_code=$?
+    else
+        output=$(go test -c ./... 2>&1)
+        exit_code=$?
+    fi
+
+    # Clean up test binaries
+    find . -name "*.test" -type f -delete 2>/dev/null || true
+
+    if [ $exit_code -eq 0 ]; then
+        log "go test -c ./... succeeded"
+        return 0
+    else
+        log_error "go test -c ./... failed"
+        if [ $VERBOSE -eq 0 ]; then
+            echo "$output" >&2
+        fi
+        return 1
+    fi
+}
+
+# Function to verify dependencies
+verify_dependencies() {
+    if [ -z "$GO_MODULE" ]; then
+        return 0
+    fi
+
+    log "Verifying go.mod and go.sum..."
+
+    local output
+    local exit_code
+
+    if [ $VERBOSE -eq 1 ]; then
+        go mod verify
+        exit_code=$?
+    else
+        output=$(go mod verify 2>&1)
+        exit_code=$?
+    fi
+
+    if [ $exit_code -eq 0 ]; then
+        log "go mod verify succeeded"
+        return 0
+    else
+        log_warn "go mod verify failed"
+        if [ $VERBOSE -eq 0 ]; then
+            echo "$output" >&2
+        fi
+        return 1
+    fi
+}
+
+# Main compilation test logic
+main() {
+    local compilation_success=0
+
+    # Step 1: Verify dependencies (if not quick mode)
+    if [ $QUICK -eq 0 ]; then
+        verify_dependencies || log_warn "Dependency verification failed, continuing anyway"
+    fi
+
+    # Step 2: Try Makefile first (if exists)
+    if [ -f "Makefile" ]; then
+        log "Found Makefile"
+        if test_makefile "Makefile"; then
+            compilation_success=1
+            log "Compilation via Makefile succeeded"
+        fi
+    fi
+
+    # Step 3: If Makefile didn't work or doesn't exist, try go build
+    if [ $compilation_success -eq 0 ] && [ -n "$GO_MODULE" ]; then
+        log "Trying go build..."
+        if test_go_build; then
+            compilation_success=1
+            log "Compilation via go build succeeded"
+        fi
+    fi
+
+    # Step 4: If still no success and not quick mode, try test compilation
+    if [ $compilation_success -eq 0 ] && [ $QUICK -eq 0 ] && [ -n "$GO_MODULE" ]; then
+        log "Trying go test compilation..."
+        if test_go_test_compile; then
+            compilation_success=1
+            log "Test compilation succeeded"
+        fi
+    fi
+
+    # Final result
+    if [ $compilation_success -eq 1 ]; then
+        echo -e "${GREEN}✓${NC} Compilation successful"
+        return 0
+    else
+        log_error "All compilation methods failed"
+        echo -e "${RED}✗${NC} Compilation failed"
+
+        # If we couldn't detect a build system at all
+        if [ ! -f "Makefile" ] && [ -z "$GO_MODULE" ]; then
+            log_error "No build system detected (no Makefile or go.mod)"
+            return 2
+        fi
+
+        return 1
+    fi
+}
+
+# Run main function
+main
+exit $?

--- a/plugins/proof-pr/skills/proof-pr-workflow/detect-codegen.py
+++ b/plugins/proof-pr/skills/proof-pr-workflow/detect-codegen.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+Detect if a repository requires code generation after dependency updates.
+
+This script analyzes a repository to determine if it has code generation
+requirements and executes the appropriate generation commands.
+
+Returns:
+    0: No code generation needed or generation successful
+    1: Code generation needed but failed
+    2: Detection error
+"""
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+from typing import Optional, List, Dict, Tuple
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class CodegenResult:
+    """Results from codegen detection and execution"""
+    repo_path: str
+    needs_codegen: bool
+    detection_method: str  # "known-repo", "makefile", "go-generate", "zz-files", "none"
+    command: Optional[str] = None
+    files_changed: List[str] = None
+    success: bool = False
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary for JSON output"""
+        d = asdict(self)
+        if d['files_changed'] is None:
+            d['files_changed'] = []
+        return d
+
+
+class CodegenDetector:
+    """Detects and runs code generation for OpenShift repositories"""
+
+    # Known repositories with standard codegen commands
+    KNOWN_REPOS = {
+        'client-go': 'make update-codegen',
+        'api': 'make update-codegen-crds',
+        'apiserver-library-go': 'make update-codegen',
+        'library-go': 'make update-codegen',
+        'openshift-apiserver': 'make update-codegen',
+        'kube-apiserver': 'make update-codegen',
+    }
+
+    # Common Makefile targets for codegen
+    CODEGEN_TARGETS = [
+        'update-codegen',
+        'update-codegen-crds',
+        'update',
+        'generate',
+        'generate-code',
+    ]
+
+    # Patterns indicating generated files
+    GENERATED_FILE_PATTERNS = [
+        '**/zz_generated.*.go',
+        '**/*_generated.go',
+        '**/generated/**/*.go',
+        '**/listers/**/*.go',
+        '**/informers/**/*.go',
+        '**/clientset/**/*.go',
+    ]
+
+    def __init__(self, repo_path: str, verbose: bool = True):
+        self.repo_path = Path(repo_path).resolve()
+        self.verbose = verbose
+        self.repo_name = self._get_repo_name()
+
+    def _get_repo_name(self) -> str:
+        """Extract repository name from path or git remote"""
+        # Try to get from git remote
+        try:
+            result = subprocess.run(
+                ['git', 'remote', 'get-url', 'origin'],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            url = result.stdout.strip()
+            # Extract repo name from URL (e.g., github.com/openshift/client-go -> client-go)
+            repo_name = url.rstrip('/').split('/')[-1].replace('.git', '')
+            return repo_name
+        except subprocess.CalledProcessError:
+            # Fallback to directory name
+            return self.repo_path.name
+
+    def _log(self, message: str):
+        """Print verbose logging"""
+        if self.verbose:
+            print(f"[detect-codegen] {message}", file=sys.stderr)
+
+    def _check_known_repo(self) -> Optional[str]:
+        """Check if this is a known repository with standard codegen"""
+        if self.repo_name in self.KNOWN_REPOS:
+            cmd = self.KNOWN_REPOS[self.repo_name]
+            self._log(f"Detected known repository '{self.repo_name}' with command: {cmd}")
+            return cmd
+        return None
+
+    def _check_makefile_targets(self) -> Optional[str]:
+        """Check Makefile for codegen targets"""
+        makefile = self.repo_path / 'Makefile'
+        if not makefile.exists():
+            self._log("No Makefile found")
+            return None
+
+        self._log(f"Checking Makefile for codegen targets")
+
+        # Read Makefile and look for codegen targets
+        try:
+            content = makefile.read_text()
+
+            # Look for our known targets
+            for target in self.CODEGEN_TARGETS:
+                # Match target definitions (target: or .PHONY: target)
+                if f"{target}:" in content or f".PHONY: {target}" in content:
+                    cmd = f"make {target}"
+                    self._log(f"Found Makefile target '{target}': {cmd}")
+                    return cmd
+
+            self._log("No known codegen targets found in Makefile")
+        except Exception as e:
+            self._log(f"Error reading Makefile: {e}")
+
+        return None
+
+    def _check_go_generate(self) -> Optional[str]:
+        """Check for //go:generate directives in Go files"""
+        self._log("Checking for //go:generate directives")
+
+        try:
+            # Find all .go files
+            result = subprocess.run(
+                ['find', '.', '-name', '*.go', '-type', 'f'],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+
+            go_files = [f for f in result.stdout.split('\n') if f]
+
+            # Check first 100 files for //go:generate
+            for go_file in go_files[:100]:
+                try:
+                    path = self.repo_path / go_file.lstrip('./')
+                    content = path.read_text()
+                    if '//go:generate' in content:
+                        self._log(f"Found //go:generate directive in {go_file}")
+                        return "go generate ./..."
+                except Exception:
+                    continue
+
+            self._log("No //go:generate directives found")
+        except Exception as e:
+            self._log(f"Error checking for go:generate: {e}")
+
+        return None
+
+    def _check_generated_files(self) -> bool:
+        """Check if repository contains generated files"""
+        self._log("Checking for generated file patterns")
+
+        for pattern in self.GENERATED_FILE_PATTERNS:
+            try:
+                # Use find to check for pattern
+                result = subprocess.run(
+                    ['find', '.', '-path', pattern, '-type', 'f'],
+                    cwd=self.repo_path,
+                    capture_output=True,
+                    text=True,
+                    timeout=10
+                )
+
+                files = [f for f in result.stdout.split('\n') if f]
+                if files:
+                    self._log(f"Found {len(files)} files matching pattern '{pattern}'")
+                    self._log(f"Examples: {files[:3]}")
+                    return True
+            except Exception as e:
+                self._log(f"Error checking pattern {pattern}: {e}")
+                continue
+
+        self._log("No generated file patterns found")
+        return False
+
+    def detect(self) -> CodegenResult:
+        """
+        Detect if repository needs code generation.
+
+        Returns CodegenResult with detection details.
+        """
+        self._log(f"Detecting codegen requirements for {self.repo_path}")
+
+        # 1. Check known repositories first
+        cmd = self._check_known_repo()
+        if cmd:
+            return CodegenResult(
+                repo_path=str(self.repo_path),
+                needs_codegen=True,
+                detection_method="known-repo",
+                command=cmd
+            )
+
+        # 2. Check Makefile targets
+        cmd = self._check_makefile_targets()
+        if cmd:
+            return CodegenResult(
+                repo_path=str(self.repo_path),
+                needs_codegen=True,
+                detection_method="makefile",
+                command=cmd
+            )
+
+        # 3. Check for //go:generate directives
+        cmd = self._check_go_generate()
+        if cmd:
+            return CodegenResult(
+                repo_path=str(self.repo_path),
+                needs_codegen=True,
+                detection_method="go-generate",
+                command=cmd
+            )
+
+        # 4. Check for existing generated files (suggests codegen but no clear command)
+        has_generated_files = self._check_generated_files()
+        if has_generated_files:
+            self._log("WARNING: Found generated files but no clear codegen command")
+            self._log("Repository likely needs codegen but detection failed")
+            return CodegenResult(
+                repo_path=str(self.repo_path),
+                needs_codegen=True,
+                detection_method="zz-files",
+                command=None,
+                error="Generated files found but no codegen command detected"
+            )
+
+        # No codegen needed
+        self._log("No code generation requirements detected")
+        return CodegenResult(
+            repo_path=str(self.repo_path),
+            needs_codegen=False,
+            detection_method="none"
+        )
+
+    def run_codegen(self, command: str) -> Tuple[bool, List[str], Optional[str]]:
+        """
+        Execute the code generation command.
+
+        Args:
+            command: Shell command to execute
+
+        Returns:
+            Tuple of (success, changed_files, error_message)
+        """
+        self._log(f"Running codegen command: {command}")
+
+        # Get current git status
+        try:
+            subprocess.run(
+                ['git', 'diff', '--quiet'],
+                cwd=self.repo_path,
+                check=False  # Don't fail if there are changes
+            )
+        except Exception as e:
+            return False, [], f"Failed to check git status: {e}"
+
+        # Run the command
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=300  # 5 minute timeout
+            )
+
+            if result.returncode != 0:
+                error_msg = f"Command failed with exit code {result.returncode}\n"
+                error_msg += f"stdout: {result.stdout}\n"
+                error_msg += f"stderr: {result.stderr}"
+                self._log(f"Codegen failed: {error_msg}")
+                return False, [], error_msg
+
+            self._log("Codegen command completed successfully")
+
+        except subprocess.TimeoutExpired:
+            error_msg = f"Command timed out after 300 seconds"
+            self._log(error_msg)
+            return False, [], error_msg
+        except Exception as e:
+            error_msg = f"Failed to run command: {e}"
+            self._log(error_msg)
+            return False, [], error_msg
+
+        # Check what files changed
+        try:
+            result = subprocess.run(
+                ['git', 'diff', '--name-only'],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+
+            changed_files = [f for f in result.stdout.split('\n') if f]
+
+            if changed_files:
+                self._log(f"Codegen modified {len(changed_files)} files")
+                self._log(f"Examples: {changed_files[:5]}")
+            else:
+                self._log("No files were modified by codegen")
+
+            return True, changed_files, None
+
+        except Exception as e:
+            error_msg = f"Failed to check changed files: {e}"
+            self._log(error_msg)
+            # Don't fail if we can't check changes - codegen succeeded
+            return True, [], None
+
+    def detect_and_run(self) -> CodegenResult:
+        """
+        Detect and run code generation if needed.
+
+        Returns complete CodegenResult with execution details.
+        """
+        # Detect requirements
+        result = self.detect()
+
+        # If no codegen needed, return early
+        if not result.needs_codegen:
+            result.success = True
+            return result
+
+        # If detection failed (has generated files but no command), fail
+        if result.command is None:
+            result.success = False
+            return result
+
+        # Run the codegen command
+        success, changed_files, error = self.run_codegen(result.command)
+
+        result.success = success
+        result.files_changed = changed_files
+        result.error = error
+
+        return result
+
+
+def main():
+    """CLI entry point"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Detect and run code generation for OpenShift repositories"
+    )
+    parser.add_argument(
+        'repo_path',
+        nargs='?',
+        default='.',
+        help='Path to repository (default: current directory)'
+    )
+    parser.add_argument(
+        '--detect-only',
+        action='store_true',
+        help='Only detect, do not run codegen'
+    )
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppress verbose logging'
+    )
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Output results as JSON'
+    )
+
+    args = parser.parse_args()
+
+    detector = CodegenDetector(args.repo_path, verbose=not args.quiet)
+
+    try:
+        if args.detect_only:
+            result = detector.detect()
+        else:
+            result = detector.detect_and_run()
+
+        if args.json:
+            print(json.dumps(result.to_dict(), indent=2))
+        else:
+            print(f"\nResults:")
+            print(f"  Needs codegen: {result.needs_codegen}")
+            print(f"  Detection method: {result.detection_method}")
+            if result.command:
+                print(f"  Command: {result.command}")
+            if result.files_changed:
+                print(f"  Files changed: {len(result.files_changed)}")
+            if result.error:
+                print(f"  Error: {result.error}")
+            print(f"  Success: {result.success}")
+
+        # Exit codes:
+        # 0 = success (no codegen needed or codegen succeeded)
+        # 1 = codegen failed
+        # 2 = detection error
+        if not result.success and result.needs_codegen:
+            sys.exit(1)
+
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/proof-pr/skills/proof-pr-workflow/state-manager.py
+++ b/plugins/proof-pr/skills/proof-pr-workflow/state-manager.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+State management for proof PR workflows.
+
+Handles CRUD operations, state recovery from GitHub, and sync detection.
+State is stored as JSON files in .work/proof-pr/{original_pr_number}/state.json
+
+State Recovery:
+    If state file is missing or corrupted, can recover by scanning GitHub
+    for proof PRs (identified by HTML comments in PR body).
+
+Sync Detection:
+    Automatically detects if GitHub reality differs from saved state
+    (e.g., if PRs were modified/merged outside the workflow).
+"""
+
+import os
+import re
+import sys
+import json
+import subprocess
+from pathlib import Path
+from typing import List, Dict, Optional, Set
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+
+
+@dataclass
+class ProofPR:
+    """Represents a single proof PR in the workflow"""
+
+    # Basic PR info
+    repo: str  # e.g., "openshift/client-go"
+    number: int
+    url: str
+    branch: str
+    created_at: str
+
+    # What this PR is currently proving
+    # Initially: proves original PR
+    # After conversion: may prove a newly-converted PR
+    proving_repo: str  # e.g., "openshift/api"
+    proving_pr: int
+
+    # What this PR depends on (go.mod dependency)
+    depends_on_repo: str  # e.g., "openshift/api"
+
+    # Conversion tracking
+    converted: bool = False
+    merged: bool = False
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary"""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'ProofPR':
+        """Create from dictionary"""
+        return cls(**data)
+
+
+@dataclass
+class ProofPRState:
+    """Complete state for a proof PR workflow session"""
+
+    # Original PR that started the workflow
+    original_repo: str
+    original_pr: int
+    original_url: str
+    original_branch: str
+
+    # All proof PRs in this workflow
+    proof_prs: List[ProofPR] = field(default_factory=list)
+
+    # Metadata
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    last_updated: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary for JSON serialization"""
+        return {
+            'original_repo': self.original_repo,
+            'original_pr': self.original_pr,
+            'original_url': self.original_url,
+            'original_branch': self.original_branch,
+            'proof_prs': [pr.to_dict() for pr in self.proof_prs],
+            'created_at': self.created_at,
+            'last_updated': self.last_updated
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'ProofPRState':
+        """Create from dictionary"""
+        proof_prs = [ProofPR.from_dict(pr) for pr in data.get('proof_prs', [])]
+        return cls(
+            original_repo=data['original_repo'],
+            original_pr=data['original_pr'],
+            original_url=data['original_url'],
+            original_branch=data['original_branch'],
+            proof_prs=proof_prs,
+            created_at=data.get('created_at', datetime.utcnow().isoformat()),
+            last_updated=data.get('last_updated', datetime.utcnow().isoformat())
+        )
+
+
+class StateManager:
+    """Manages proof PR workflow state with recovery and sync capabilities"""
+
+    WORK_DIR = Path.home() / '.work' / 'proof-pr'
+    PROOF_PR_MARKER = "<!-- PROOF-PR:"
+    PROVING_MARKER = "<!-- PROVING:"
+    DEPENDS_ON_MARKER = "<!-- DEPENDS-ON:"
+
+    def __init__(self, verbose: bool = True):
+        self.verbose = verbose
+        self.WORK_DIR.mkdir(parents=True, exist_ok=True)
+
+    def _log(self, message: str):
+        """Print verbose logging"""
+        if self.verbose:
+            print(f"[state-manager] {message}", file=sys.stderr)
+
+    def _get_state_path(self, pr_number: int) -> Path:
+        """Get path to state file for a given original PR number"""
+        return self.WORK_DIR / str(pr_number) / 'state.json'
+
+    def _run_gh(self, args: List[str]) -> str:
+        """Run gh CLI command and return output"""
+        try:
+            result = subprocess.run(
+                ['gh'] + args,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"gh command failed: {e.stderr}")
+
+    def save(self, state: ProofPRState) -> None:
+        """Save state to disk"""
+        state.last_updated = datetime.utcnow().isoformat()
+        state_path = self._get_state_path(state.original_pr)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(state_path, 'w') as f:
+            json.dump(state.to_dict(), f, indent=2)
+
+        self._log(f"Saved state to {state_path}")
+
+    def load(self, pr_number: int, auto_recover: bool = True) -> ProofPRState:
+        """
+        Load state with optional auto-recovery.
+
+        Args:
+            pr_number: Original PR number
+            auto_recover: If True, attempt to recover from GitHub if state missing
+
+        Returns:
+            ProofPRState
+
+        Raises:
+            FileNotFoundError: If state not found and auto_recover=False
+            RuntimeError: If recovery fails
+        """
+        state_path = self._get_state_path(pr_number)
+
+        # Try to load from disk
+        if state_path.exists():
+            try:
+                with open(state_path) as f:
+                    data = json.load(f)
+                state = ProofPRState.from_dict(data)
+                self._log(f"Loaded state from {state_path}")
+
+                # Check if state is in sync with GitHub
+                if self._is_out_of_sync(state):
+                    self._log("WARNING: State is out of sync with GitHub")
+                    self._log("Consider running sync to update state")
+
+                return state
+
+            except (json.JSONDecodeError, KeyError) as e:
+                self._log(f"State file corrupted: {e}")
+                if auto_recover:
+                    self._log("Attempting recovery...")
+                    return self.recover(pr_number)
+                raise RuntimeError(f"State file corrupted: {e}")
+
+        # State file doesn't exist
+        if auto_recover:
+            self._log(f"State file not found at {state_path}")
+            self._log("Attempting to recover from GitHub...")
+            return self.recover(pr_number)
+
+        raise FileNotFoundError(f"State file not found: {state_path}")
+
+    def recover(self, pr_number: int) -> ProofPRState:
+        """
+        Recover state by scanning GitHub for proof PRs.
+
+        Searches for PRs containing PROOF_PR_MARKER in their body,
+        then reconstructs the state from PR metadata.
+
+        Args:
+            pr_number: Original PR number to recover
+
+        Returns:
+            Recovered ProofPRState
+
+        Raises:
+            RuntimeError: If recovery fails
+        """
+        self._log(f"Recovering state for PR #{pr_number}")
+
+        # Step 1: Get original PR info
+        try:
+            pr_json = self._run_gh([
+                'pr', 'view', str(pr_number),
+                '--json', 'url,headRefName,repository'
+            ])
+            pr_data = json.loads(pr_json)
+
+            original_url = pr_data['url']
+            original_branch = pr_data['headRefName']
+            original_repo = pr_data['repository']['nameWithOwner']
+
+            self._log(f"Original PR: {original_repo}#{pr_number}")
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to fetch original PR: {e}")
+
+        # Step 2: Search for proof PRs across all repos
+        # We'll search for PRs with the PROOF_PR_MARKER in the body
+        proof_prs = []
+
+        # Get list of all PRs we've authored (likely to be our proof PRs)
+        try:
+            search_query = f"is:pr author:@me {self.PROOF_PR_MARKER}"
+            prs_json = self._run_gh([
+                'search', 'prs',
+                '--json', 'number,url,headRefName,repository,body,state',
+                '--limit', '100',
+                search_query
+            ])
+
+            prs_data = json.loads(prs_json)
+
+            for pr in prs_data:
+                body = pr.get('body', '')
+
+                # Check if this is a proof PR for our original PR
+                if self.PROOF_PR_MARKER not in body:
+                    continue
+
+                # Extract metadata from HTML comments
+                proving_repo, proving_pr = self._extract_proving_info(body)
+                depends_on_repo = self._extract_depends_on(body)
+
+                # Check if this is for our original PR
+                if proving_repo and proving_pr == pr_number:
+                    proof_pr = ProofPR(
+                        repo=pr['repository']['nameWithOwner'],
+                        number=pr['number'],
+                        url=pr['url'],
+                        branch=pr['headRefName'],
+                        created_at=datetime.utcnow().isoformat(),  # Approximate
+                        proving_repo=proving_repo,
+                        proving_pr=proving_pr,
+                        depends_on_repo=depends_on_repo or proving_repo,
+                        converted=False,
+                        merged=(pr['state'] == 'MERGED')
+                    )
+
+                    proof_prs.append(proof_pr)
+                    self._log(f"Found proof PR: {proof_pr.repo}#{proof_pr.number}")
+
+        except Exception as e:
+            self._log(f"Warning: Error searching for proof PRs: {e}")
+
+        # Step 3: Create recovered state
+        state = ProofPRState(
+            original_repo=original_repo,
+            original_pr=pr_number,
+            original_url=original_url,
+            original_branch=original_branch,
+            proof_prs=proof_prs
+        )
+
+        # Save recovered state
+        self.save(state)
+
+        self._log(f"Recovered state with {len(proof_prs)} proof PRs")
+        return state
+
+    def _extract_proving_info(self, body: str) -> tuple:
+        """Extract proving_repo and proving_pr from PR body"""
+        match = re.search(rf'{self.PROVING_MARKER}\s*(\S+)#(\d+)', body)
+        if match:
+            return match.group(1), int(match.group(2))
+        return None, None
+
+    def _extract_depends_on(self, body: str) -> Optional[str]:
+        """Extract depends_on_repo from PR body"""
+        match = re.search(rf'{self.DEPENDS_ON_MARKER}\s*(\S+)', body)
+        if match:
+            return match.group(1)
+        return None
+
+    def _is_out_of_sync(self, state: ProofPRState) -> bool:
+        """
+        Check if state is out of sync with GitHub reality.
+
+        Checks:
+        - Are all proof PRs still open?
+        - Have any been merged?
+        - Do PR bodies still match?
+
+        Returns:
+            True if out of sync
+        """
+        for proof_pr in state.proof_prs:
+            try:
+                # Get current PR state from GitHub
+                pr_json = self._run_gh([
+                    'pr', 'view', str(proof_pr.number),
+                    '--repo', proof_pr.repo,
+                    '--json', 'state,merged'
+                ])
+                pr_data = json.loads(pr_json)
+
+                # Check if merged status differs
+                github_merged = pr_data.get('merged', False)
+                if github_merged != proof_pr.merged:
+                    self._log(f"Out of sync: {proof_pr.repo}#{proof_pr.number} merged status differs")
+                    return True
+
+            except Exception as e:
+                self._log(f"Warning: Could not check {proof_pr.repo}#{proof_pr.number}: {e}")
+                continue
+
+        return False
+
+    def sync(self, state: ProofPRState) -> ProofPRState:
+        """
+        Sync state with GitHub reality.
+
+        Updates:
+        - Merged status
+        - PR states
+        - Branch names
+
+        Returns:
+            Updated state
+        """
+        self._log("Syncing state with GitHub...")
+
+        for proof_pr in state.proof_prs:
+            try:
+                pr_json = self._run_gh([
+                    'pr', 'view', str(proof_pr.number),
+                    '--repo', proof_pr.repo,
+                    '--json', 'state,merged,headRefName'
+                ])
+                pr_data = json.loads(pr_json)
+
+                # Update merged status
+                proof_pr.merged = pr_data.get('merged', False)
+
+                # Update branch name (might change if PR rebased)
+                proof_pr.branch = pr_data.get('headRefName', proof_pr.branch)
+
+                self._log(f"Synced {proof_pr.repo}#{proof_pr.number}: merged={proof_pr.merged}")
+
+            except Exception as e:
+                self._log(f"Warning: Could not sync {proof_pr.repo}#{proof_pr.number}: {e}")
+                continue
+
+        # Save updated state
+        self.save(state)
+
+        return state
+
+
+def main():
+    """CLI entry point"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Manage proof PR workflow state"
+    )
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    # Load command
+    load_parser = subparsers.add_parser('load', help='Load state')
+    load_parser.add_argument('pr_number', type=int, help='Original PR number')
+    load_parser.add_argument('--no-recover', action='store_true', help='Disable auto-recovery')
+
+    # Recover command
+    recover_parser = subparsers.add_parser('recover', help='Recover state from GitHub')
+    recover_parser.add_argument('pr_number', type=int, help='Original PR number')
+
+    # Sync command
+    sync_parser = subparsers.add_parser('sync', help='Sync state with GitHub')
+    sync_parser.add_argument('pr_number', type=int, help='Original PR number')
+
+    # Common options
+    parser.add_argument('--quiet', action='store_true', help='Suppress verbose output')
+    parser.add_argument('--json', action='store_true', help='Output as JSON')
+
+    args = parser.parse_args()
+
+    manager = StateManager(verbose=not args.quiet)
+
+    try:
+        if args.command == 'load':
+            state = manager.load(args.pr_number, auto_recover=not args.no_recover)
+        elif args.command == 'recover':
+            state = manager.recover(args.pr_number)
+        elif args.command == 'sync':
+            state = manager.load(args.pr_number, auto_recover=False)
+            state = manager.sync(state)
+
+        if args.json:
+            print(json.dumps(state.to_dict(), indent=2))
+        else:
+            print(f"\nState for {state.original_repo}#{state.original_pr}:")
+            print(f"  Proof PRs: {len(state.proof_prs)}")
+            for pr in state.proof_prs:
+                status = "MERGED" if pr.merged else ("CONVERTED" if pr.converted else "ACTIVE")
+                print(f"    - {pr.repo}#{pr.number} [{status}]")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Add proof-pr plugin for testing dependency changes before merge

## Summary

Automates creating "proof PRs" - temporary test PRs that verify downstream repositories compile correctly with your changes before the original PR merges.

## Problem

When changing foundational repos (like `openshift/api`), you need to manually:
- Create PRs in dependent repos with correct pseudo-versions
- Run code generation (`make update`)
- Fix compilation errors
- Track transitive dependencies (MCO → client-go → api)
- Convert test PRs to real PRs after original merges

This is time-consuming and error-prone.

## Solution

Single command creates entire dependency chain with auto-detection and code generation:

```bash
/proof-pr:create https://github.com/openshift/api/pull/2626 openshift/machine-config-operator
# Auto-detects: MCO → client-go → api
# Creates proof PRs in both repos
# ✓ https://github.com/openshift/client-go/pull/1234
# ✓ https://github.com/openshift/machine-config-operator/pull/5678
```

## Commands

| Command | Description |
|---------|-------------|
| `/proof-pr:create <url> <repo> [repos...]` | Create proof PRs with auto-detected dependency chains and code generation |
| `/proof-pr:status <pr-number>` | Show CI status, Tide merge requirements (lgtm/approved/verified), and recommendations |
| `/proof-pr:sync <pr-number>` | Update all proof PRs to latest commits from original PR |
| `/proof-pr:add-repo <pr-number> <repo> [repos...]` | Add more repositories to existing proof workflow |
| `/proof-pr:push-fix <pr-number> <repo>` | Interactive workflow to push manual compilation fixes |
| `/proof-pr:convert <pr-number>` | Convert proof PRs to normal PRs in cascading waves after original merges |

## Key Features

- **Auto-detection**: BFS pathfinding for dependency chains, code generation detection
- **Compilation testing**: Tests compilation and provides diagnostic information
- **Cascading conversion**: Converts proof PRs layer-by-layer as upstream PRs merge
- **No custom labels**: Uses standard `do-not-merge/hold`, identifies via HTML comments
- **State recovery**: Reconstructs from GitHub if state file missing
- **Tide integration**: Works with auto-merge system

## Implementation

- **6 commands** (~1,500 lines): create, status, sync, add-repo, push-fix, convert
- **5 helper scripts** (~2,000 lines): state-manager.py, analyze-deps.py, detect-codegen.py, attempt-fix.py, compile-test.sh
- **Total**: ~3,500 lines

## Example Workflow

```bash
/proof-pr:create https://github.com/openshift/api/pull/2626 openshift/machine-config-operator
/proof-pr:status 2626                    # Check Tide requirements
/proof-pr:sync 2626                      # After pushing new commits
/proof-pr:convert 2626                   # After api#2626 merges → converts client-go#1234
/proof-pr:convert 2626                   # After client-go#1234 merges → converts MCO#5678
```
