### PR TITLE
Add /openshift:sniff-test command to review code for quality issues

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -245,6 +245,7 @@ OpenShift development utilities and helpers
 - **`/openshift:new-e2e-test` `[test-specification]`** - Write and validate new OpenShift E2E tests using Ginkgo framework
 - **`/openshift:rebase` `<tag>`** - Rebase OpenShift fork of an upstream repository to a new upstream release.
 - **`/openshift:review-test-cases` `[file-path-or-test-code-or-commands]`** - Review test cases for completeness, quality, and best practices - accepts file path or direct oc commands/test code
+- **`/openshift:sniff-test` `<file|commit>`** - Review code for quality issues, bad patterns, and code smells.
 - **`/openshift:visualize-ovn-topology`** - Generate and visualize OVN-Kubernetes network topology diagram
 
 See [plugins/openshift/README.md](plugins/openshift/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -723,6 +723,12 @@
           "synopsis": "/openshift:review-test-cases [file-path-or-test-code-or-commands]"
         },
         {
+          "argument_hint": "<file|commit>",
+          "description": "Review code for quality issues, bad patterns, and code smells.",
+          "name": "sniff-test",
+          "synopsis": "/openshift:sniff-test <file|commit>"
+        },
+        {
           "argument_hint": "",
           "description": "Generate and visualize OVN-Kubernetes network topology diagram",
           "name": "visualize-ovn-topology",

--- a/plugins/openshift/commands/sniff-test.md
+++ b/plugins/openshift/commands/sniff-test.md
@@ -1,0 +1,66 @@
+---
+argument-hint: <file|commit>
+description: Review code for quality issues, bad patterns, and code smells.
+---
+
+## Name
+openshift:sniff-test
+
+## Synopsis
+```
+/openshift:sniff-test <file|commit>
+```
+
+## Description
+
+Review code for quality issues, bad patterns, and code smells.
+
+This command accepts a file path or commit hash as an argument to analyze for code quality issues.
+Usage: `/openshift:sniff-test path/to/file.go` or `/openshift:sniff-test commit-hash`
+
+## Implementation
+
+The command will analyze the code for:
+- Bad patterns or anti-patterns
+- Unnecessary or dead code
+- Unreferenced functions or variables
+- Code duplication
+- Functions that should be simplified or refactored
+- API fields missing documentation
+- Hardcoded values that should be constants
+- Unhelpful or misleading comments
+- Missing error handling
+- Performance issues
+- Security vulnerabilities
+- Inconsistent naming conventions
+- Missing unit tests for public functions
+
+Steps:
+1. Determine if the argument is a file path or commit hash
+2. If it's a commit hash, get the list of changed files in that commit
+3. For each file to analyze:
+   - Read the file content
+   - Perform static analysis looking for code smells
+   - Check for Go-specific issues like inefficient patterns
+   - Look for missing documentation on exported types/functions
+   - Identify hardcoded values that could be constants
+   - Check for unused imports, variables, or functions
+   - Look for duplicated code blocks
+   - Analyze function complexity and suggest simplifications
+4. Generate a comprehensive report with:
+   - Summary of issues found
+   - Specific line numbers and explanations
+   - Suggested improvements
+   - Severity levels (critical, major, minor)
+   - Best practice recommendations
+
+For Go files, pay special attention to:
+- Proper error handling patterns
+- Efficient slice/map operations
+- Context usage in functions
+- Interface design
+- Goroutine and channel usage
+- Memory allocation patterns
+- API design and documentation
+
+The analysis should be constructive and educational, explaining why certain patterns are problematic and how to improve them.


### PR DESCRIPTION

This PR introduces a /sniff-test command for claude code to review a file or commit for "code smells", or bad practices that should be addressed. This can be used to find new issues in existing code, or it can be used on your local commits to prevent introducing new issues in a PR.

I originally introduced this for local-storage-operator in https://github.com/openshift/local-storage-operator/pull/571 and it turns out to be fairly useful. @mpatlasov added it to https://github.com/openshift/csi-operator/pull/486 as well. We want to consolidate it here since it seems to be generally useful.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/openshift:sniff-test <file|commit>` command to the OpenShift plugin. Users can now analyze code quality, detect bad patterns, and identify code smells across specified files or commits.

* **Documentation**
  * Updated plugin documentation with details on the new sniff-test command and its usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->