### PR TITLE
OCPCLOUD-3252: feat(jira): Add E2E test code generation to generate-test-plan command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "name": "ci",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -176,7 +176,7 @@ A plugin to automate tasks with Jira
 - **`/jira:create-release-note` `<issue-key>`** - Generate bug fix release notes from Jira tickets and linked GitHub PRs
 - **`/jira:create` `<type> [project-key] <summary> [--component <name>] [--version <version>] [--parent <key>]`** - Create Jira issues (story, epic, feature, task, bug, feature-request) with proper formatting
 - **`/jira:generate-feature-doc` `<feature-key>`** - Generate comprehensive feature documentation from Jira feature and all related issues and PRs
-- **`/jira:generate-test-plan` `[JIRA issue key] [GitHub PR URLs]`** - Generate test steps for a JIRA issue
+- **`/jira:generate-test-plan` `[JIRA issue key] [GitHub PR URLs] [--generate-e2e] [--test-dir path] [--skeleton-only]`** - Generate test steps for a JIRA issue
 - **`/jira:grooming` `[project-filter] [time-period] [--component component-name] [--label label-name] [--type issue-type] [--status status] [--story-points]`** - Analyze new bugs and cards added over a time period and generate grooming meeting agenda
 - **`/jira:issues-by-component` `<project-key> [time-period] [--component name] [--assignee username] [--reporter username] [--status status] [--search term] [--search-description]`** - List and analyze JIRA issues organized by component with flexible filtering
 - **`/jira:reconcile-github` `[--github-project <org/repo>] [--jira-project <key>] [--profile <name>] [--porcelain] [--output json|yaml]`** - Reconcile state mismatches between GitHub and Jira issues

--- a/docs/data.json
+++ b/docs/data.json
@@ -133,7 +133,7 @@
           "synopsis": "/jira:generate-feature-doc <feature-key>"
         },
         {
-          "argument_hint": "[JIRA issue key] [GitHub PR URLs]",
+          "argument_hint": "[JIRA issue key] [GitHub PR URLs] [--generate-e2e] [--test-dir path] [--skeleton-only]",
           "description": "Generate test steps for a JIRA issue",
           "name": "generate-test-plan",
           "synopsis": ""
@@ -278,7 +278,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -9,7 +9,7 @@ Comprehensive Jira integration for Claude Code, providing AI-powered tools to an
 - 📝 **Weekly Status Updates** - Automate weekly status summary updates with intelligent activity analysis and color-coded health indicators
 - 📋 **Backlog Grooming** - Analyze new bugs and cards for grooming meetings
 - 🏷️ **Activity Type Categorization** - AI-powered categorization of JIRA tickets into activity types with confidence scoring
-- 🧪 **Test Generation** - Generate comprehensive test steps for JIRA issues by analyzing related PRs
+- 🧪 **Test Plan Generation** - Generate comprehensive manual test plans and automated E2E test code by analyzing related PRs
 - ✨ **Issue Creation** - Create well-formed stories, epics, features, tasks, bugs, and feature requests with guided workflows
 - 📝 **Release Note Generation** - Automatically generate bug fix release notes from Jira and linked GitHub PRs
 - 🤖 **Automated Workflows** - From issue analysis to PR creation, fully automated
@@ -142,18 +142,36 @@ See [commands/categorize-activity-type.md](commands/categorize-activity-type.md)
 
 ---
 
-### `/jira:generate-test-plan` - Generate Test Steps
+### `/jira:generate-test-plan` - Generate Test Plans and E2E Tests
 
-Generate comprehensive test steps for a JIRA issue by analyzing related pull requests. The command supports auto-discovery of PRs from the JIRA issue or manual specification of specific PRs to analyze.
+Generate comprehensive test plans for JIRA issues by analyzing related pull requests. The command supports auto-discovery of PRs from the JIRA issue or manual specification of specific PRs to analyze. Optionally generates automated E2E test code that matches your project's existing test style.
 
 **Usage:**
 ```bash
-# Auto-discover all PRs from JIRA
+# Generate manual test plan only (auto-discover PRs)
 /jira:generate-test-plan CNTRLPLANE-205
 
-# Test only specific PRs
+# Generate manual test plan for specific PRs
 /jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888
+
+# Generate manual test plan + E2E test code (auto-detect test directory)
+/jira:generate-test-plan CNTRLPLANE-205 --generate-e2e
+
+# Generate E2E tests with specific test directory
+/jira:generate-test-plan CNTRLPLANE-205 --generate-e2e --test-dir test/e2e/
+
+# Generate only test skeleton (structure without implementation)
+/jira:generate-test-plan CNTRLPLANE-205 --generate-e2e --skeleton-only
 ```
+
+**Key Features:**
+- **Automatic PR Discovery** - Scans JIRA for all related PRs or uses specific PR URLs
+- **Comprehensive Test Scenarios** - Maps JIRA acceptance criteria to test scenarios
+- **E2E Test Code Generation** - Generates Ginkgo/Gomega tests matching your project's style
+- **Code Style Analysis** - Analyzes existing tests and replicates patterns, naming, and structure
+- **Smart Directory Detection** - Auto-detects test directories or accepts custom paths
+- **TODO Guidance** - Partial implementation with clear markers for manual completion
+- **Interactive Confirmation** - Asks for confirmation before generating files
 
 See [commands/generate-test-plan.md](commands/generate-test-plan.md) for full documentation.
 

--- a/plugins/jira/commands/generate-test-plan.md
+++ b/plugins/jira/commands/generate-test-plan.md
@@ -1,18 +1,20 @@
 ---
 description: Generate test steps for a JIRA issue
-argument-hint: "[JIRA issue key] [GitHub PR URLs]"
+argument-hint: "[JIRA issue key] [GitHub PR URLs] [--generate-e2e] [--test-dir path] [--skeleton-only]"
 ---
 
 ## Name
 jira:generate-test-plan
 
 ## Synopsis
-/jira:generate-test-plan [JIRA issue key] [GitHub PR URLs]
+/jira:generate-test-plan [JIRA issue key] [GitHub PR URLs] [--generate-e2e] [--test-dir path] [--skeleton-only]
 
 ## Description
-The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a list of PR URLs. It fetches the JIRA issue details, retrieves all related PRs (or uses the provided PR list), analyzes the changes, and generates a comprehensive manual testing guide.
+The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a list of PR URLs. It fetches the JIRA issue details, retrieves all related PRs (or uses the provided PR list), analyzes the changes, and generates:
+1. A comprehensive manual testing guide (always generated)
+2. Automated E2E test code (when `--generate-e2e` flag is used)
 
-**JIRA Issue Test Guide Generator**
+**JIRA Issue Test Guide Generator with Optional E2E Code Generation**
 
 ## Implementation
 
@@ -113,26 +115,209 @@ The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a li
    - **Note skipped PRs** in the test guide with reasoning
    - Focus test scenarios on PRs with actual code changes
 
-8. **Output**: Display the testing guide:
-   - Show the file path where the guide was saved
+8. **E2E Test Generation** (only if `--generate-e2e` flag is present):
+   - **Determine Target Repository**:
+     - **If PRs are provided**: Extract repository from the first PR URL (e.g., `https://github.com/openshift/hypershift/pull/123` -> `openshift/hypershift`)
+     - **If no PRs found**: MUST ask user to confirm or specify the target repository
+     - **NEVER default to current working directory without explicit user confirmation**
+
+   - **Detect Test Directory**:
+     - **If `--test-dir` provided**: Use the specified directory (absolute or relative to target repository)
+     - **Otherwise, auto-detect** by searching for existing E2E test directories in the target repository:
+       - Check for: `test/e2e/`, `tests/e2e/`, `e2e/`, `test/integration/`
+       - If found, use the existing directory
+       - If multiple found, prompt user to select
+       - If none found, default to `test/e2e/` and ask for confirmation
+     - **Always display the full path** where files will be generated and ask for user confirmation before writing files
+
+   - **Analyze Existing Test Style**:
+     - Find all `*_test.go` files in the detected test directory
+     - Analyze the first 2-3 test files to extract code style patterns:
+       - Test framework (Ginkgo, testify, standard testing)
+       - Assertion library (Gomega, assert, require)
+       - Naming conventions (function names, test descriptions)
+       - Structure patterns (BeforeEach/AfterEach, setup/teardown)
+       - Common imports and helper functions
+       - Variable naming and declaration patterns
+       - Context management patterns
+       - Timeout and polling interval constants
+       - Error handling style
+     - Select the most similar existing test file as a template
+     - If no existing tests found, use a default Ginkgo template
+
+   - **Generate E2E Test Code**:
+     - Create test file with name based on JIRA issue: `{feature}_test.go`
+       - Extract feature name from JIRA summary (e.g., "imagetagmirrorset" from "Enable ImageTagMirrorSet configuration")
+       - Convert to snake_case and append `_test.go`
+     - Match the detected code style for all elements:
+       - Use same test framework and assertion style
+       - Follow same naming patterns for test descriptions
+       - Use same variable declaration style (var blocks vs inline)
+       - Match BeforeEach/AfterEach setup patterns
+       - Replicate context management approach
+       - Use same helper function patterns
+       - Match timeout/interval constant usage
+       - Follow same error handling patterns
+     - Generate test cases based on JIRA acceptance criteria:
+       - One test case per acceptance criterion
+       - Use `By()` steps to break down test logic
+       - Add TODO comments for implementation-specific details
+       - Include verification steps with Eventually() for async operations
+     - **Code Generation Strategy**:
+       - If `--skeleton-only` flag: Generate only test structure with all TODO markers
+       - If `--generate-e2e` without skeleton flag (default): Generate partial implementation:
+         - Complete: imports, variable declarations, BeforeEach/AfterEach
+         - Partial: test case structure with key assertions
+         - TODO: Implementation-specific details that require PR analysis
+     - Add appropriate imports based on detected patterns
+     - Include inline comments explaining TODO items
+
+   - **Create Test Directory Structure** (if needed):
+     - If test directory doesn't exist, create it
+     - If helpers directory is used in existing tests, create `helpers/` subdirectory
+     - Maintain consistency with existing project structure
+
+   - **Update Test Plan Document**:
+     - Add "Automated E2E Tests" section to the generated test plan
+     - Reference the generated test file location
+     - Map each test case to corresponding acceptance criteria
+     - Include instructions for running the tests
+     - Add implementation notes with TODO list
+
+9. **User Confirmation** (before writing E2E files):
+   - **CRITICAL**: Before writing any E2E test files, MUST display to the user:
+     - Target repository (from PR or current directory)
+     - Full absolute path where test file will be created
+     - Test directory detected or selected
+   - **Ask for explicit confirmation**:
+     - "Generate E2E test at `/path/to/repo/test/e2e/feature_test.go`? (y/n)"
+     - If user says no, ask for alternative directory
+     - If user provides alternative, validate and confirm again
+   - **Only proceed with file generation after receiving explicit user approval**
+
+10. **Output**: Display the testing guide and E2E code (if generated):
+   - Show the file path where the manual test guide was saved
+   - If E2E tests generated, show the test file path
    - Provide a summary of:
      - JIRA issue being tested
      - Number of PRs included
-     - Number of test scenarios generated
+     - Number of manual test scenarios generated
+     - Number of automated test cases generated (if applicable)
+     - Target repository used (if applicable)
+     - Test directory used (if applicable)
+     - Code style matched (if applicable)
+     - Number of TODO items requiring completion (if applicable)
      - Critical test cases to focus on
    - Highlight any PRs that were skipped and why
-   - Ask if the user would like any modifications to the test guide
+   - If E2E tests generated, provide next steps:
+     - Review generated test code
+     - Complete TODO items
+     - Run tests to verify they work
+   - Ask if the user would like any modifications to the test guide or generated code
 
 ## Examples:
 
+### Manual Test Plan Only (Default Behavior)
+
 1. **Generate test steps for JIRA with auto-discovered PRs**:
-   `/jira:generate-test-plan CNTRLPLANE-205`
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205
+   ```
 
 2. **Generate test steps for JIRA with specific PRs only**:
-   `/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888`
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888
+   ```
 
 3. **Generate test steps for multiple specific PRs**:
-   `/jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888 https://github.com/openshift/hypershift/pull/6889`
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888 https://github.com/openshift/hypershift/pull/6889
+   ```
+
+### E2E Test Generation
+
+4. **Generate test plan + E2E test code (auto-detect test directory)**:
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 --generate-e2e
+   ```
+   Output:
+   - `test-cntrlplane-205.md` - Manual test plan
+   - `test/e2e/imagetagmirrorset_test.go` - E2E test code (auto-detected directory)
+
+5. **Generate E2E tests with specific test directory**:
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 --generate-e2e --test-dir test/e2e/
+   ```
+
+6. **Generate only test skeleton (structure without implementation)**:
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 --generate-e2e --skeleton-only
+   ```
+   Generates test structure with all TODO markers for manual implementation.
+
+7. **Generate E2E tests with specific PRs**:
+   ```bash
+   /jira:generate-test-plan CNTRLPLANE-205 https://github.com/openshift/hypershift/pull/6888 --generate-e2e
+   ```
+
+8. **Complete workflow example with confirmation**:
+   ```bash
+   # Generate test plan + E2E code (with PR provided)
+   $ /jira:generate-test-plan OCPBUGS-12345 https://github.com/openshift/hypershift/pull/6888 --generate-e2e
+
+   # Claude analyzes and prompts:
+   # 🔍 Analyzing JIRA issue OCPBUGS-12345...
+   # ✓ Found 1 PR: https://github.com/openshift/hypershift/pull/6888
+   # ✓ Detected repository: openshift/hypershift
+   # ✓ Detected test directory: test/e2e/
+   # ✓ Code style: Ginkgo v2 + Gomega
+   #
+   # 📝 Ready to generate:
+   #   - Manual test plan: /current/dir/test-ocpbugs-12345.md
+   #   - E2E test code: /path/to/hypershift/test/e2e/bugfix_test.go
+   #
+   # Generate E2E test at /path/to/hypershift/test/e2e/bugfix_test.go? (y/n)
+
+   # User responds: y
+
+   # ✓ Generated test plan: test-ocpbugs-12345.md
+   # ✓ Generated E2E test: /path/to/hypershift/test/e2e/bugfix_test.go
+   #
+   # Next steps:
+   # 1. Review test-ocpbugs-12345.md
+   # 2. Complete TODOs in test/e2e/bugfix_test.go (8 items)
+   # 3. Run: make test-e2e FOCUS="bugfix"
+   ```
+
+9. **Workflow when no PR is found**:
+   ```bash
+   # Generate test plan + E2E code (no PR linked)
+   $ /jira:generate-test-plan OCPCLOUD-3262 --generate-e2e
+
+   # Claude analyzes and prompts:
+   # 🔍 Analyzing JIRA issue OCPCLOUD-3262...
+   # ⚠️  No PRs found linked to this JIRA issue
+   #
+   # Where should I generate the E2E test code?
+   # Options:
+   #   1. Current directory: go/src/github.com/openshift/cluster-capi-operator
+   #   2. Specify a different repository path
+   #   3. Skip E2E generation (manual test plan only)
+   #
+   # Please choose (1/2/3) or provide path:
+
+   # User responds: 1
+
+   # ✓ Detected test directory: e2e/
+   # 📝 Ready to generate E2E test at: go/src/github.com/openshift/cluster-capi-operator/e2e/machineset_vap_test.go
+   #
+   # Confirm? (y/n)
+
+   # User responds: y
+
+   # ✓ Generated test plan: test-ocpcloud-3262.md
+   # ✓ Generated E2E test: e2e/machineset_vap_test.go
+   ```
 
 ## Arguments:
 
@@ -140,8 +325,23 @@ The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a li
 - **$2, $3, ..., $N**: Optional GitHub PR URLs
   - If provided: Only these PRs will be analyzed
   - If omitted: All PRs linked to the JIRA will be discovered and analyzed
+- **--generate-e2e**: Generate automated E2E test code in addition to manual test plan
+  - Analyzes existing test code style and generates matching test code
+  - Creates test file in detected or specified test directory
+  - Generates test cases based on JIRA acceptance criteria
+  - Includes TODO markers for implementation-specific details
+- **--test-dir <path>**: Specify the directory for E2E test generation
+  - Only used when `--generate-e2e` is present
+  - If omitted, auto-detects test directory from project structure
+  - Examples: `test/e2e/`, `tests/integration/`, `e2e/`
+- **--skeleton-only**: Generate only test structure without implementation
+  - Only used when `--generate-e2e` is present
+  - Creates test framework with all TODO markers
+  - Useful when you want to write all implementation details manually
 
 ## Smart Features:
+
+### Manual Test Plan Features
 
 1. **Automatic PR Discovery**:
    - Scans JIRA issue for all related PRs
@@ -170,7 +370,52 @@ The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a li
    - Does NOT include cleanup steps
    - Focuses on test execution and verification
 
-## Example Workflow:
+### E2E Code Generation Features (when --generate-e2e is used)
+
+7. **Intelligent Test Directory Detection**:
+   - Automatically finds existing E2E test directories
+   - Supports common patterns: `test/e2e/`, `tests/e2e/`, `e2e/`, `test/integration/`
+   - Prompts user for confirmation if multiple directories found
+   - Creates directory structure if it doesn't exist
+
+8. **Code Style Analysis and Matching**:
+   - Analyzes existing test files to learn project conventions
+   - Detects test framework (Ginkgo, testify, standard testing)
+   - Matches naming conventions for functions and variables
+   - Replicates setup/teardown patterns (BeforeEach/AfterEach)
+   - Uses same assertion style (Gomega matchers, assert, require)
+   - Follows same context management approach
+   - Matches timeout and polling interval patterns
+   - Preserves import organization and helper function usage
+
+9. **Template-Based Generation**:
+   - Finds the most similar existing test as a template
+   - Extracts reusable patterns and structures
+   - Adapts template to new test requirements
+   - Maintains consistency with existing codebase
+
+10. **Acceptance Criteria Mapping**:
+    - Generates one test case per JIRA acceptance criterion
+    - Maps test scenarios to specific requirements
+    - Ensures complete coverage of acceptance criteria
+    - Links generated tests back to manual test plan
+
+11. **Partial Implementation with TODO Guidance**:
+    - Generates complete test structure and framework
+    - Includes partial implementation where possible
+    - Adds clear TODO markers for manual completion
+    - Provides inline comments explaining what needs to be done
+    - Balances automation with flexibility
+
+12. **Integration with Test Plan**:
+    - Updates manual test plan with E2E test information
+    - Cross-references automated and manual test scenarios
+    - Provides instructions for running generated tests
+    - Documents implementation status and TODO items
+
+## Example Workflows:
+
+### Workflow 1: Manual Test Plan Only
 
 ```bash
 # Auto-discover all PRs from JIRA
@@ -184,3 +429,68 @@ The 'jira:generate-test-plan' command takes a JIRA issue key and optionally a li
 ```
 
 The command will provide a comprehensive manual testing guide that QE or developers can use to thoroughly test the JIRA issue implementation.
+
+### Workflow 2: Manual Test Plan + E2E Test Generation
+
+```bash
+# Generate both manual test plan and E2E test code
+$ /jira:generate-test-plan CNTRLPLANE-205 --generate-e2e
+
+🔍 Analyzing JIRA issue CNTRLPLANE-205...
+✓ Fetched issue: "Enable ImageTagMirrorSet configuration in HostedCluster CRs"
+✓ Found 3 acceptance criteria
+
+🔍 Discovering PRs...
+✓ Found 1 linked PR: https://github.com/openshift/hypershift/pull/6888
+
+📊 Analyzing PR changes...
+✓ Detected changes in: API types, Controller logic
+✓ Platforms affected: AWS, Azure, GCP
+
+🔍 Detecting test directory...
+✓ Found existing tests in: test/e2e/
+✓ Analyzing code style...
+✓ Detected: Ginkgo v2 + Gomega
+✓ Found template: test/e2e/hostedcluster_test.go (90% similarity)
+
+📝 Generating test plan...
+✓ Created: test-cntrlplane-205.md
+
+💻 Generating E2E test code...
+✓ Created: test/e2e/imagetagmirrorset_test.go
+✓ Generated 3 test cases (mapped to acceptance criteria)
+✓ Added 8 TODO items for manual completion
+
+Summary:
+  Manual Test Plan: test-cntrlplane-205.md
+    - 5 manual test scenarios
+    - 2 regression test scenarios
+
+  E2E Test Code: test/e2e/imagetagmirrorset_test.go
+    - 3 automated test cases
+    - 8 TODO items to complete
+    - Framework: Ginkgo v2 + Gomega
+    - Style matched to existing tests
+
+Next steps:
+1. Review test-cntrlplane-205.md for manual test scenarios
+2. Complete TODO items in test/e2e/imagetagmirrorset_test.go:
+   - TODO #1: Add ImageTagMirrorSet configuration (line 45)
+   - TODO #2: Verify configuration is applied (line 52)
+   - TODO #3-8: Implementation-specific validations
+3. Run tests: make test-e2e FOCUS="ImageTagMirrorSet"
+4. Update test plan with E2E test results
+```
+
+### Workflow 3: Skeleton-Only E2E Generation
+
+```bash
+# Generate test structure without implementation details
+$ /jira:generate-test-plan OCPBUGS-12345 --generate-e2e --skeleton-only
+
+✓ Generated test skeleton: test/e2e/bugfix_test.go
+✓ All implementation marked with TODO comments
+✓ Test structure ready for manual coding
+
+# Useful when you want full control over implementation
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Jira plugin docs: renamed to “Test Plan Generation,” added optional E2E test code generation, new flags (--generate-e2e, --test-dir, --skeleton-only), richer examples, Key Features, Smart Comment Analysis, interactive prompts, auto-detection flows, and guidance on skeleton vs. full E2E output.
* **Chores**
  * Bumped Jira plugin version to 0.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->