### PR TITLE
feat: add jira-auto-pm plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -201,6 +201,12 @@
       "source": "./plugins/ote-migration",
       "description": "Automate OpenShift Tests Extension (OTE) migration for component repositories",
       "version": "0.0.1"
+    },
+    {
+      "name": "jira-auto-pm",
+      "source": "./plugins/jira-auto-pm",
+      "description": "Automatic JIRA lifecycle tracking for implementation plans",
+      "version": "0.1.0"
     }
   ]
 }

--- a/docs/data.json
+++ b/docs/data.json
@@ -1532,6 +1532,32 @@
         }
       ],
       "version": "0.0.1"
+    },
+    {
+      "commands": [],
+      "description": "Automatic JIRA lifecycle tracking for implementation plans",
+      "has_readme": true,
+      "hooks": [
+        {
+          "description": "JIRA automatic project management hooks",
+          "name": "TaskCompleted",
+          "type": "TaskCompleted"
+        },
+        {
+          "description": "JIRA automatic project management hooks",
+          "name": "SessionStart",
+          "type": "SessionStart"
+        }
+      ],
+      "name": "jira-auto-pm",
+      "skills": [
+        {
+          "description": "Ensures implementation plans reference a JIRA issue key for automatic lifecycle tracking",
+          "id": "jira-auto-pm",
+          "name": "JIRA Auto PM Plan Tracker"
+        }
+      ],
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugins/jira-auto-pm/.claude-plugin/plugin.json
+++ b/plugins/jira-auto-pm/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "jira-auto-pm",
+  "description": "Automatic JIRA lifecycle tracking for implementation plans",
+  "version": "0.1.0",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/jira-auto-pm/README.md
+++ b/plugins/jira-auto-pm/README.md
@@ -1,0 +1,139 @@
+# Jira Auto PM Plugin
+
+Automatically keeps JIRA cards in sync with implementation progress. As you work through tasks, the plugin posts plans, tracks PRs, manages status transitions, and validates card state -- all without manual intervention.
+
+## Features
+
+- **Automatic Plan Posting** - Posts your implementation plan to the JIRA card as a structured comment when work begins
+- **PR Linking** - Links pull requests to the JIRA card as tasks complete
+- **Status Transitions** - Moves cards through workflow states (In Progress, Code Review, Done) based on task progress
+- **State Validation** - Validates card state before every transition and flags misalignment instead of forcing changes
+- **Session Resumability** - Prefixed `[jira-auto-pm]` comments allow reconstructing plan progress from the JIRA card across sessions
+- **JIRA Key Detection** - Automatically finds the relevant JIRA key from conversation context, git branch name, or recent commits
+
+## Prerequisites
+
+- Claude Code installed
+- `jira@ai-helpers` plugin installed (`/plugin install jira@ai-helpers`)
+- Atlassian MCP server configured (see [jira plugin README](../jira/README.md) for setup instructions)
+
+## Installation
+
+Ensure you have the ai-helpers marketplace enabled, via [the instructions here](/README.md).
+
+```bash
+# Install the jira plugin dependency first (if not already installed)
+/plugin install jira@ai-helpers
+
+# Install the plugin
+/plugin install jira-auto-pm@ai-helpers
+```
+
+## How It Works
+
+This plugin has no commands. It operates entirely through hooks, a skill, and a background PM agent that activate automatically during your workflow.
+
+### Skill: Plan-Time JIRA Awareness
+
+When you enter plan mode with a JIRA key in context, the `jira-auto-pm` skill auto-invokes. It detects the JIRA key, fetches card state, and ensures your plan clearly references the JIRA key. The plan will include PR tasks and a final verification task.
+
+### TaskCompleted Hook: PM Agent
+
+Each time a task completes, the hook spawns a lightweight PM agent (Haiku) that:
+
+1. Finds the JIRA key in the task list
+2. Posts the implementation plan to the card (on first task completion)
+3. Links PRs mentioned in completed task descriptions
+4. Transitions the card through workflow states as milestones are reached
+5. Posts a completion summary when all tasks are done
+
+### SessionStart Hook: Dependency Check
+
+On session start, the hook verifies that the `jira` plugin dependency is available and the Atlassian MCP server is configured.
+
+## Lifecycle
+
+```
+Session starts
+  └── SessionStart hook injects jira-auto-pm context
+
+User enters plan mode with JIRA key in context
+  └── jira-auto-pm skill auto-invokes
+      └── Detects JIRA key (from context, branch, or commits)
+      └── Fetches card state
+      └── Ensures plan clearly references JIRA key
+      └── Plan includes: PR tasks, final verification task
+
+User approves plan (context may clear, plan file re-loaded)
+  └── Implementation begins, tasks created from plan
+
+First task completes
+  └── TaskCompleted hook -> PM agent
+      └── Finds JIRA key in task list
+      └── No plan comment on card yet -> posts plan, transitions to "In Progress"
+
+Implementation task completes (with PR URL in description)
+  └── TaskCompleted hook -> PM agent
+      └── Links PR to JIRA card
+      └── Posts progress comment with PR details
+
+Last PR-related task completes
+  └── TaskCompleted hook -> PM agent
+      └── Detects all PR tasks done
+      └── Transitions card to "Code Review"
+
+Final task completes
+  └── TaskCompleted hook -> PM agent
+      └── All tasks done
+      └── Posts completion summary
+      └── Transitions card to "Done"
+
+At ANY step, if card state is misaligned:
+  └── PM agent flags to user with proposed remediation
+  └── Does NOT take the action
+```
+
+## JIRA Key Detection
+
+The plugin detects the relevant JIRA key using the following priority order:
+
+1. **Conversation context** - JIRA key mentioned in the current conversation or task descriptions
+2. **Git branch name** - Parsed from branch names like `PROJ-123-fix-something`
+3. **Recent commits** - Extracted from commit messages referencing JIRA keys
+
+## Comment Format
+
+All comments posted to JIRA cards are prefixed with `[jira-auto-pm]`. This prefix serves two purposes:
+
+- **Identification** - Clearly marks which comments were posted by the plugin
+- **Session resumability** - When resuming work in a new session, the plugin reads these comments to reconstruct what has already been posted and which transitions have occurred
+
+## State Validation
+
+Before every status transition, the PM agent validates that the card is in an expected state. If the card state does not match expectations (for example, the card was manually moved), the agent flags the misalignment to the user with a proposed remediation rather than forcing the transition.
+
+## Troubleshooting
+
+### No JIRA key found
+
+The plugin could not detect a JIRA key from the conversation, branch name, or recent commits. Make sure your plan or task list references a JIRA key (e.g., `PROJ-123`), or that your git branch includes one.
+
+### Transition failures
+
+JIRA workflow transitions may fail if the card is not in the expected status. Check the card's current status in JIRA and verify that the target transition is available. The PM agent will report the specific transition error.
+
+### MCP tools unavailable
+
+If the Atlassian MCP server is not running or not configured, the plugin cannot interact with JIRA. Verify that:
+
+- The MCP server is running (see [jira plugin README](../jira/README.md) for setup)
+- The server is registered with Claude Code (`claude mcp list` to verify)
+- Your JIRA personal access token is valid and not expired
+
+### Plugin dependency not detected
+
+The `jira-auto-pm` plugin requires `jira@ai-helpers`. Install it with `/plugin install jira@ai-helpers` and restart your session.
+
+## License
+
+Apache-2.0

--- a/plugins/jira-auto-pm/agents/project-manager.md
+++ b/plugins/jira-auto-pm/agents/project-manager.md
@@ -1,0 +1,137 @@
+---
+name: project-manager
+description: Manages JIRA lifecycle by reading plan context and card state
+tools: Read, Grep, Glob, TaskList, TaskGet
+mcpServers: atlassian
+model: haiku
+maxTurns: 10
+---
+
+You are a JIRA lifecycle management agent. You are invoked on each `TaskCompleted` event. Your job is to read the current task list and JIRA card state, then decide what JIRA actions to take. Follow the steps below IN ORDER. Stop processing at the first step that takes an action.
+
+## Step 1: Find JIRA Key
+
+Call `TaskList` to read all tasks. Scan every task subject and description for the pattern `[A-Z]+-\d+` (e.g., GCP-123, OCPBUGS-456).
+
+If NO match is found, EXIT immediately with:
+
+```
+JIRA Auto-PM: No JIRA key found — no action taken.
+```
+
+## Step 2: Fetch JIRA Card
+
+Call `mcp__atlassian__jira_get_issue` with the found key. Note the card's current status and existing comments.
+
+## Step 3: Check for Plan Comment
+
+Search card comments for one starting with `[jira-auto-pm]`.
+
+If NO plan comment exists:
+
+1. Derive the plan from the task list (all task subjects as steps).
+2. Get the current branch name by reading the output of `git branch --show-current`.
+3. Post the plan as a comment using `mcp__atlassian__jira_add_comment` with this exact format:
+
+```
+[jira-auto-pm] Implementation Plan
+
+Branch: <branch name>
+
+Steps:
+1. [ ] <task 1 subject>
+2. [ ] <task 2 subject>
+3. [ ] <task 3 subject>
+...
+```
+
+4. Call `mcp__atlassian__jira_get_transitions` to get available transitions.
+5. Find the transition matching "In Progress" (or nearest match such as "Start Progress").
+6. **State validation:** Confirm the card is in a pre-work state ("To Do", "New", "Open", or "Backlog"). If it is NOT in a pre-work state, flag to user (see Flagging section below) and do NOT transition.
+7. If validation passes, call `mcp__atlassian__jira_transition_issue` to move the card to "In Progress".
+8. **STOP here.** Do not process further steps on this invocation.
+
+## Step 4: Check Completed Task for PR URL
+
+The completed task context is available from the hook invocation. Search the completed task description for a URL pattern matching `https://github.com/...` or similar pull request URLs.
+
+If a PR URL is found:
+
+1. Call `mcp__atlassian__jira_create_remote_issue_link` to link the PR to the JIRA card.
+2. Post a progress comment using `mcp__atlassian__jira_add_comment` with this exact format:
+
+```
+[jira-auto-pm] Progress Update
+
+Completed: <task subject>
+PR: <PR URL>
+
+Progress:
+- [x] <completed task 1>
+- [x] <completed task 2>
+- [ ] <remaining task 3>
+```
+
+3. **State validation:** Confirm the card is in "In Progress". If it is NOT, flag to user (see Flagging section below).
+
+## Step 5: Check if All PR-Related Tasks Are Done
+
+Scan the task list for tasks with subjects containing "PR", "pull request", or "merge" (case-insensitive).
+
+If ALL such tasks have status "completed":
+
+1. **State validation:** Confirm the card is currently in "In Progress". If it is NOT, flag to user and do NOT transition.
+2. Call `mcp__atlassian__jira_get_transitions` to get available transitions.
+3. Find the transition matching "Code Review" or "In Review" (nearest match).
+4. Call `mcp__atlassian__jira_transition_issue` to move the card.
+
+## Step 6: Check if All Tasks Are Done
+
+If every task in the task list has status "completed":
+
+1. **State validation:** Confirm the card is currently in "Code Review" or "In Review". If it is NOT, flag to user and do NOT transition.
+2. Post a completion summary comment using `mcp__atlassian__jira_add_comment` with this exact format:
+
+```
+[jira-auto-pm] Implementation Complete
+
+All steps completed.
+- [x] <task 1>
+- [x] <task 2>
+- [x] <task 3>
+
+Card transitioned to: Done
+```
+
+3. Call `mcp__atlassian__jira_get_transitions` to get available transitions.
+4. Find the transition matching "Done" or "Closed" (nearest match).
+5. Call `mcp__atlassian__jira_transition_issue` to move the card.
+
+## Flagging to User
+
+When the card status does not match the expected state for a given action, output a warning and do NOT proceed with the transition:
+
+> WARNING: JIRA card <ISSUE-KEY> is in status '<current status>' but we expected '<expected status>'. The plan comment may be missing or the card was manually updated. Proposed fix: <specific remediation>. Please confirm before I proceed.
+
+Examples of specific remediation suggestions:
+- "Transition the card to 'In Progress' before continuing."
+- "Verify the card was intentionally moved and re-run if needed."
+- "Manually set the card to 'Code Review' to align with the current task state."
+
+## Output Format
+
+After each action, output a summary in this format:
+
+```
+JIRA Auto-PM: <ISSUE-KEY>
+- Current status: <status>
+- Action taken: <description>
+- Next expected status: <status>
+```
+
+## Error Handling
+
+- **MCP call failure:** If any `mcp__atlassian__*` call fails, output the error message and stop processing. Do not retry automatically.
+- **Missing transition:** If the expected transition name is not found in the available transitions list, output all available transition names and ask the user which one to use.
+- **Inaccessible issue:** If `jira_get_issue` returns an error (permissions, issue not found), output: `JIRA Auto-PM: Unable to access <ISSUE-KEY> — <error detail>. Verify the issue key and your JIRA permissions.`
+- **Multiple JIRA keys found:** If more than one JIRA key is detected in the task list, use the first one found and note: `JIRA Auto-PM: Multiple JIRA keys detected. Using <ISSUE-KEY>. Other keys found: <list>.`

--- a/plugins/jira-auto-pm/hooks/hooks.json
+++ b/plugins/jira-auto-pm/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "description": "JIRA automatic project management hooks",
+  "hooks": {
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "You are a JIRA project management agent. A task was just completed. Context: $ARGUMENTS\n\nFollow these steps exactly:\n\n1. EXTRACT CONTEXT: Parse $ARGUMENTS for task_id, task_subject, task_description.\n\n2. FIND JIRA KEY: Call TaskList to get all tasks. Scan every task subject and description for a JIRA key matching pattern [A-Z]+-\\d+ (e.g. PROJ-123). If no JIRA key found anywhere, exit silently with no output.\n\n3. FETCH CARD STATE: Call mcp__atlassian__jira_get_issue with the discovered issue_key. Note the current status and check existing comments.\n\n4. CHECK FOR PLAN COMMENT: Search comments for one containing the marker \"[jira-auto-pm]\".\n\n5. IF NO PLAN COMMENT EXISTS:\n   a. Derive an implementation plan from the task list (summarize each task as a checklist item).\n   b. Get the current git branch name.\n   c. Post a comment via mcp__atlassian__jira_add_comment with body: \"[jira-auto-pm] Implementation Plan\\n\\nBranch: <branch-name>\\n\\nSteps:\\n1. [ ] <task1>\\n2. [ ] <task2>\\n...\" (one line per task).\n   d. Validate the card is in a pre-work state (To Do, New, Open, or Backlog). If not, output WARNING with current status and expected states, do NOT transition.\n   e. If valid: call mcp__atlassian__jira_get_transitions, find a transition whose name matches \"In Progress\" (case-insensitive), and call mcp__atlassian__jira_transition_issue.\n   f. STOP here. Do not continue to further steps.\n\n6. IF PLAN COMMENT EXISTS AND COMPLETED TASK HAS A PR URL (matches https://github.com/.*/pull/\\d+):\n   a. Call mcp__atlassian__jira_create_remote_issue_link with the PR URL and title from the task subject.\n   b. Post a comment: \"[jira-auto-pm] Progress Update\\n\\nLinked PR: <url>\\nCompleted task: <task_subject>\".\n   c. Validate card is In Progress. If not, output WARNING with current vs expected status.\n\n7. CHECK FOR CODE REVIEW TRANSITION: If all tasks whose subject contains \"PR\", \"pull request\", or \"merge\" (case-insensitive) are completed:\n   a. Validate card is currently In Progress. If not, output WARNING, do NOT transition.\n   b. Call mcp__atlassian__jira_get_transitions, find transition matching \"Code Review\" or \"In Review\" (case-insensitive).\n   c. If found, call mcp__atlassian__jira_transition_issue.\n\n8. CHECK FOR COMPLETION: Call TaskList again. If ALL tasks are completed:\n   a. Post comment: \"[jira-auto-pm] Implementation Complete\\n\\nAll tasks finished.\".\n   b. Validate card is in Code Review or In Review. If not, output WARNING, do NOT transition.\n   c. Call mcp__atlassian__jira_get_transitions, find transition matching \"Done\" or \"Closed\" (case-insensitive).\n   d. If found, call mcp__atlassian__jira_transition_issue.\n\nSTATE VALIDATION RULE: Before ANY transition, verify the current status matches the expected pre-condition. If misaligned, output \"WARNING: Status mismatch. Current: <status>, Expected: <expected>. Suggested remediation: <action>.\" and take NO action.\n\nAlways use mcp__atlassian__jira_get_transitions to discover valid transitions and match by name pattern. Never hardcode transition IDs.",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/check_jira_plugin.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/jira-auto-pm/scripts/check_jira_plugin.sh
+++ b/plugins/jira-auto-pm/scripts/check_jira_plugin.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Check if jira@ai-helpers plugin is installed
+# Outputs a warning if not found, or context injection if present
+
+if ! find "${HOME}/.claude/plugins" -path "*/jira/*" -name "plugin.json" 2>/dev/null | grep -q .; then
+  echo '{"additionalContext": "WARNING: jira-auto-pm plugin requires jira@ai-helpers to be installed. Some features may not work correctly. Install with: /plugin install jira@ai-helpers"}'
+else
+  echo '{"additionalContext": "The jira-auto-pm plugin is active. When planning work related to a JIRA card, invoke the jira-auto-pm skill to ensure the plan references the JIRA key for automatic lifecycle tracking."}'
+fi

--- a/plugins/jira-auto-pm/skills/jira-auto-pm/SKILL.md
+++ b/plugins/jira-auto-pm/skills/jira-auto-pm/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: JIRA Auto PM Plan Tracker
+description: Ensures implementation plans reference a JIRA issue key for automatic lifecycle tracking
+---
+
+# JIRA Auto PM Plan Tracker
+
+This skill ensures that implementation plans created during plan mode reference a JIRA issue key so that the PM agent hook can automatically track lifecycle events (status transitions, PR linking, verification) during implementation.
+
+## When to Use This Skill
+
+This skill is automatically invoked when:
+- The user enters plan mode to create an implementation plan
+- The user asks to implement work related to a JIRA issue
+- A JIRA key is detected in the conversation context, git branch name, or recent commit messages
+
+## JIRA Key Detection
+
+The skill uses deterministic detection methods in the following priority order. The first match wins.
+
+### 1. Conversation Context
+
+The user explicitly mentions a JIRA key in their message (e.g., "implement GCP-123", "work on OCPBUGS-456").
+
+Scan the user's message for patterns matching `[A-Z][A-Z0-9]+-\d+`.
+
+### 2. Git Branch Name
+
+Run `git branch --show-current` and extract a JIRA key using the regex `[A-Z]+-\d+`.
+
+Common branch naming conventions that contain JIRA keys:
+- `GCP-123-add-feature`
+- `feature/GCP-123-description`
+- `ocpbugs-456/fix-thing` (case-insensitive match, normalize to uppercase)
+
+### 3. Recent Commit Messages
+
+Scan recent commit messages (e.g., `git log --oneline -10`) for patterns matching `^[A-Z]+-\d+:` at the start of commit message subjects.
+
+### 4. No Key Found
+
+If no JIRA key is found from any of the above sources, ask the user:
+
+> No JIRA issue key detected in the conversation, branch name, or recent commits. Would you like to associate this work with a JIRA card? If so, provide the issue key (e.g., GCP-123).
+
+If the user declines, proceed without JIRA tracking. The PM agent hook will simply have no key to act on.
+
+## Plan Requirements
+
+Once a JIRA key is detected, the skill augments the implementation plan with the following elements.
+
+### 1. Fetch Card State
+
+Before finalizing the plan, fetch the current JIRA issue state using `mcp__atlassian__jira_get_issue` to retrieve:
+- Current status
+- Summary
+- Description and acceptance criteria
+
+Use this information to ensure the plan aligns with the card's requirements and definition of done.
+
+### 2. Reference the JIRA Key in the Plan
+
+The first task in the plan must clearly reference the JIRA key. For example:
+
+```
+1. Post implementation plan for GCP-123 to JIRA
+```
+
+This ensures the JIRA key is present in the plan file itself, which the PM agent hook uses to locate the associated card.
+
+### 3. Identify Expected PRs
+
+The plan must identify which tasks involve opening pull requests and what each PR covers. For example:
+
+```
+3. Implement the new controller logic
+   - Open PR: "GCP-123: Add firewall rule controller"
+5. Update documentation
+   - Open PR: "GCP-123: Add firewall controller docs"
+```
+
+The PM agent uses this information to know when to link PRs to the JIRA card and when to transition the card status.
+
+### 4. Include a Final Verification Task
+
+The plan must end with a verification task that confirms all work is complete. For example:
+
+```
+7. Verify all work for GCP-123 is complete
+   - All PRs merged
+   - Acceptance criteria met
+   - Definition of done satisfied
+```
+
+## What This Skill Does NOT Do
+
+- **Add per-task tags** -- the JIRA key referenced in the plan is sufficient for the PM agent to track progress. Individual tasks do not need JIRA key annotations.
+- **Add separate "JIRA update" tasks** -- the PM agent handles JIRA status transitions and comment updates transparently during implementation. The plan should not include explicit "update JIRA" steps beyond the initial plan posting and final verification.
+- **Execute JIRA calls during planning** -- all JIRA interaction (status transitions, PR linking, comment updates) happens during implementation, not during plan creation. The only JIRA call during planning is the initial `mcp__atlassian__jira_get_issue` to fetch card context.
+
+## Context Survival
+
+The skill ensures the JIRA key survives across plan mode exit and context boundaries:
+
+1. **Key in the plan file** -- the JIRA key is written directly into the plan file content (in the first task and verification task). When the user exits plan mode, the plan file is re-loaded with the JIRA key intact, even if conversation context is cleared.
+2. **SessionStart hook re-injection** -- the SessionStart hook re-injects awareness of the jira-auto-pm plugin when a new session begins. If a plan file exists with a JIRA key, the PM agent can pick it up without requiring the user to re-state the key.
+3. **No reliance on ephemeral state** -- the skill does not depend on conversation memory or session variables to preserve the JIRA key. The plan file is the single source of truth.


### PR DESCRIPTION
## Summary

New `jira-auto-pm` plugin that automatically keeps JIRA cards in sync with Claude Code task progress:

- Posts implementation plans to JIRA as comments on first task completion
- Links PRs to JIRA cards when tasks containing PR URLs complete
- Transitions cards through workflow states (In Progress → Code Review → Done)
- Validates card state before every transition — flags misalignment instead of forcing

## Components

- **Skill** (`skills/jira-auto-pm/SKILL.md`) — ensures implementation plans reference a JIRA key during planning
- **Agent** (`agents/project-manager.md`) — Haiku-based PM agent with 6-step decision logic
- **Hooks** (`hooks/hooks.json`) — `TaskCompleted` (agent) + `SessionStart` (command)
- **Script** (`scripts/check_jira_plugin.sh`) — dependency check for `jira@ai-helpers` plugin

## Prerequisites

- `jira@ai-helpers` plugin installed
- Atlassian MCP server configured

## Testing

- [x] `make lint` passes (after linter update for `TaskCompleted` event)
- [x] `make update` succeeds
- [ ] Manual: install plugin, verify SessionStart context injection
- [ ] Manual: plan with JIRA key, verify skill augments plan
- [ ] Manual: complete tasks, verify PM agent posts comments and transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced JIRA Auto PM plugin enabling automatic implementation plan posting to JIRA issues
  * Automatically links pull requests to JIRA and transitions issue statuses
  * Detects JIRA keys from conversation context, git branches, and recent commits
  * Validates state changes and supports session continuity for uninterrupted workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->