### PR TITLE
Add /jira:generate-feature-updates command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1474,7 +1474,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "has_readme": true,
       "commands": [
         {
@@ -1548,6 +1548,14 @@ footer a { color: var(--primary); }
           "description_html": "Generate comprehensive feature documentation from Jira feature and all related issues and PRs",
           "synopsis": "/jira:generate-feature-doc \u003cfeature-key\u003e",
           "body_html": "\u003cp\u003eThe \u003ccode\u003ejira:generate-feature-doc\u003c/code\u003e command generates comprehensive feature documentation by recursively analyzing a Jira feature ticket and all its related issues, sub-tasks, and linked GitHub pull requests.\u003c/p\u003e\u003cp\u003eThis command is particularly useful for:\u003cbr\u003e- Creating complete feature documentation after implementation\u003cbr\u003e- Understanding the full scope and implementation details of a feature\u003cbr\u003e- Generating onboarding materials for new team members\u003cbr\u003e- Creating technical design documents from actual implementation\u003cbr\u003e- Documenting complex features with multiple related issues and PRs\u003c/p\u003e\u003cp\u003eThe command performs deep analysis of:\u003cbr\u003e- The main feature issue and all related Jira tickets (recursively)\u003cbr\u003e- All linked GitHub PRs, commits, and code changes\u003cbr\u003e- Design decisions captured in PR discussions and code reviews\u003cbr\u003e- Implementation details from actual code changes\u003c/p\u003e"
+        },
+        {
+          "name": "generate-feature-updates",
+          "full_name": "jira:generate-feature-updates",
+          "description": "Generate strategic feature updates for weekly status documents",
+          "description_html": "Generate strategic feature updates for weekly status documents",
+          "synopsis": "/jira:generate-feature-updates [project-key] [--component \u003ccomponent-name\u003e] [--label \u003clabel-name\u003e] [user-filters...]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003ejira:generate-feature-updates\u003c/code\u003e command generates concise executive-level feature summaries for weekly status documents. It analyzes recent activity across Jira issues and their descendants to produce prose-style updates suitable for the &quot;Key Strategic Feature Updates&quot; section of weekly reports.\u003c/p\u003e\u003cp\u003eThis command is particularly useful for:\u003c/p\u003e\u003cp\u003e- Weekly executive status documents\u003cbr\u003e- Strategic feature progress summaries\u003cbr\u003e- Stakeholder communication on feature delivery\u003cbr\u003e- Identifying blocked or at-risk features\u003c/p\u003e\u003cp\u003eKey capabilities:\u003c/p\u003e\u003cp\u003e- \u003cstrong\u003eEfficient batch data gathering\u003c/strong\u003e using async Python script\u003cbr\u003e- Interactive component selection from available project components\u003cbr\u003e- User filtering by email or display name (with auto-resolution)\u003cbr\u003e- Intelligent activity analysis using \u003ccode\u003echildIssuesOf()\u003c/code\u003e for full hierarchy traversal\u003cbr\u003e- GitHub PR and GitLab MR integration via external links\u003cbr\u003e- Automatic filtering: skips issues with no significant activity\u003cbr\u003e- Batch processing with full-section review\u003cbr\u003e- Nested list output: feature link as top-level bullet, update prose as nested bullet\u003c/p\u003e\u003cp\u003eThis command uses the \u003cstrong\u003eStatus Analysis Engine\u003c/strong\u003e skill for core analysis logic. See \u003ccode\u003eplugins/jira/skills/status-analysis/SKILL.md\u003c/code\u003e for detailed implementation.\u003c/p\u003e"
         },
         {
           "name": "generate-test-plan",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/generate-feature-updates.md
+++ b/plugins/jira/commands/generate-feature-updates.md
@@ -1,0 +1,463 @@
+---
+description: Generate strategic feature updates for weekly status documents
+argument-hint: "[project-key] [--component name] [--label label-name] [user-filters...]"
+---
+
+## Name
+
+jira:generate-feature-updates
+
+## Synopsis
+
+```
+/jira:generate-feature-updates [project-key] [--component <component-name>] [--label <label-name>] [user-filters...]
+```
+
+## Description
+
+The `jira:generate-feature-updates` command generates concise executive-level feature summaries for weekly status documents. It analyzes recent activity across Jira issues and their descendants to produce prose-style updates suitable for the "Key Strategic Feature Updates" section of weekly reports.
+
+This command is particularly useful for:
+
+- Weekly executive status documents
+- Strategic feature progress summaries
+- Stakeholder communication on feature delivery
+- Identifying blocked or at-risk features
+
+Key capabilities:
+
+- **Efficient batch data gathering** using async Python script
+- Interactive component selection from available project components
+- User filtering by email or display name (with auto-resolution)
+- Intelligent activity analysis using `childIssuesOf()` for full hierarchy traversal
+- GitHub PR and GitLab MR integration via external links
+- Automatic filtering: skips issues with no significant activity
+- Batch processing with full-section review
+- Nested list output: feature link as top-level bullet, update prose as nested bullet
+
+This command uses the **Status Analysis Engine** skill for core analysis logic. See `plugins/jira/skills/status-analysis/SKILL.md` for detailed implementation.
+
+## Implementation
+
+The command executes in two phases:
+
+### Phase 1: Data Gathering
+
+#### Step 1. Parse Arguments and Determine Target Project
+
+1. **Parse command-line arguments:**
+   - Extract project key from first positional argument (e.g., `OCPSTRAT`, `OCPBUGS`)
+   - Parse optional `--component <component-name>` parameter
+   - Parse optional `--label <label-name>` parameter
+   - Parse user filter parameters (space-separated emails or names)
+   - User filters support exclusion by prefixing with an exclamation mark (example: !<user@example.com>)
+
+2. **If project key is NOT provided:**
+   - Use `mcp__atlassian-mcp__jira_get_all_projects` to list all accessible projects
+   - Present projects in a numbered list with keys and names
+   - Ask: "Please enter the number of the project you want to generate updates for:"
+   - Parse response and extract project key
+
+3. **Validate project access:**
+   - Use `mcp__atlassian-mcp__jira_search` with JQL: `project = "{project-key}" AND status != Closed`
+   - Verify the project exists and is accessible
+
+#### Step 2. Determine Target Component(s)
+
+1. **If `--component` parameter is provided:**
+   - Use the component name directly
+
+2. **If `--component` is NOT provided:**
+   - Use `mcp__atlassian-mcp__jira_search_fields` with keyword "component" to find the component field ID
+   - Use `mcp__atlassian-mcp__jira_search` with JQL: `project = "{project-key}" AND status != Closed` and `fields=components`
+   - Extract all unique component names from the search results
+   - Present components in a numbered list
+   - Ask: "Please enter the number(s) of the component(s) you want to generate updates for (space-separated), or press Enter to skip:"
+   - If multiple components selected, process each separately
+
+#### Step 3. Resolve User Identifiers
+
+For each user filter parameter:
+
+1. **Check if it's an email** (contains `@`): Use as-is for script parameter
+
+2. **If it's a display name** (doesn't contain `@`):
+   - Use `mcp__atlassian-mcp__jira_get_user_profile` with the name as the `user_identifier` parameter
+   - Show found user details and ask for confirmation
+   - If confirmed, use the email address; if not, ask for email directly
+
+3. **Handle exclusion prefix** (exclamation mark):
+   - Strip the prefix before lookup
+   - Use `--exclude-assignee` parameter for the script
+
+#### Step 4. Run Data Gatherer Script
+
+Execute the Python data gatherer with the resolved parameters:
+
+```bash
+python3 {plugins-dir}/jira/skills/status-analysis/scripts/gather_status_data.py \
+  --project {PROJECT-KEY} \
+  --component "{COMPONENT-NAME}" \
+  --label "{LABEL-NAME}" \
+  --assignee {email1} --assignee {email2} \
+  --exclude-assignee {excluded-email} \
+  --verbose
+```
+
+**Script location**: `plugins/jira/skills/status-analysis/scripts/gather_status_data.py`
+
+**Script output**:
+
+- Directory: `.work/weekly-status/{YYYY-MM-DD}/`
+- `manifest.json`: Processing config and issue list
+- `issues/{ISSUE-KEY}.json`: Per-issue data with descendants and PRs
+
+**Wait for script completion** and verify output exists before proceeding.
+
+#### Step 5. Verify Data Collection
+
+Read the manifest file to confirm successful collection:
+
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Data Collection Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Issues found: {count}
+Descendants: {count}
+PRs collected: {count}
+Date range: {start} to {end}
+Output: .work/weekly-status/{date}/
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Phase 2: Processing (Batch)
+
+#### Step 6. Load Required Skill
+
+**This step is mandatory before processing any issues:**
+
+```
+Skill(jira:status-analysis)
+```
+
+This loads the Status Analysis Engine skill which provides:
+
+- Activity analysis methodology
+- Feature markdown formatting rules
+- Health status determination logic
+
+#### Step 7. Process ALL Issues (Batch)
+
+Unlike `update-weekly-status` which processes issues one at a time interactively, this command processes all issues in batch and presents a complete section for review.
+
+For each issue listed in the manifest:
+
+##### a. Triage and Summarize Issues
+
+Run the summarize script in batch mode with `--only-significant` to triage and summarize all issues in a single call. If a `--label` filter was used for data gathering, pass it here too to separate issues that don't carry the label:
+
+```bash
+python3 {plugins-dir}/jira/skills/status-analysis/scripts/summarize_issue.py \
+  .work/weekly-status/{date}/issues/ --only-significant --label {label-name}
+```
+
+This combines triage and summarization: it filters to issues with significant activity (PRs merged, status changes, color changes, human comments, descendant updates) and outputs a structured summary for each. PR author names are included in the output (from `commits_in_range` and `reviews_in_range` data) — use these first names for attribution, never GitHub handles.
+
+**Label filtering**: When `--label` is provided, any issues missing that label are listed separately under a `MISSING LABEL` header. Present this list to the user and ask whether to include each one. These are typically descendant features that appeared in the hierarchy but aren't directly tracked under the label.
+
+**IMPORTANT — parallelization**: The batch summarize output can be large. If the output exceeds comfortable context size, split processing across parallel Bash calls or sub-agents. For example, process Yellow/Red issues in one call and Green issues in another. Never loop through issues sequentially with individual script calls.
+
+##### c. Analyze Activity (using Status Analysis Engine)
+
+Using the pre-gathered data, apply the activity analysis rules from `activity-analysis.md`:
+
+1. **Read the existing Status Summary field** (`current_status_summary` in JSON):
+   - Parse the R/Y/G color status (Red, Yellow, Green) — this is the team's own self-assessment
+   - Check `last_status_summary_update` — if the status was updated within the date range, the team actively reported this week
+   - Check `changelog_in_range` for changes to the Status Summary field — a color change (e.g., Green→Yellow, Yellow→Red) is always significant
+   - Use the R/Y/G status to **prioritize and order** the output (Red/Yellow features appear before Green), but do not include a feature *solely* because it is Red/Yellow — there must also be a status change or other activity this week
+
+2. **Identify key events** from changelog_in_range:
+   - Status transitions
+   - Assignee changes
+   - Priority/scope changes
+   - Status Summary field changes (color transitions)
+
+3. **Analyze comments** (excluding bots with `is_bot: true`):
+   - Look for blockers, risks, achievements
+   - Note significant updates
+
+4. **Analyze PR activity**:
+   - PRs with `commits_in_range > 0` (active development)
+   - PRs with `reviews_in_range > 0` (review activity)
+   - Recently merged PRs (`state: MERGED`)
+   - Draft PRs awaiting work
+   - Use `author_name` fields (not `author` logins) when attributing contributions. Always use first names, never GitHub handles.
+
+5. **Determine if significant**: Skip issues with no noteworthy activity (only bot comments, trivial field changes, no PRs merged or opened). A color change in the Status Summary field (e.g., Green→Red) counts as significant activity and should always be included.
+
+##### d. Generate feature_markdown Entry
+
+Before generating entries, check for significant issues that have no Color Status in their Status Summary field. If any are found, list them and ask the user:
+
+```text
+The following features have significant activity but no R/Y/G color status set:
+  1. ISSUE-KEY: Issue summary
+  2. ISSUE-KEY: Issue summary
+
+What color circle should each use? Enter colors (e.g. "1:green 2:yellow"), "all:green" to set all, or "skip" to omit circles:
+```
+
+Then, for each issue with significant activity, format as a nested unordered list item with a color circle prefix (🟢🟡🔴) matching the Color Status from the Status Summary field or the user's override (`Green` → 🟢, `Yellow` → 🟡, `Red` → 🔴, no color → omit circle):
+
+```markdown
+- 🟢 [ISSUE-KEY](https://issues.redhat.com/browse/ISSUE-KEY): Issue summary
+    - 1-3 sentences of executive prose focusing on significant progress, deliveries, blockers, or risks. Attribute contributions to team members by first name (from `author_name` fields, never GitHub logins). Reference PRs and related issues as markdown links.
+```
+
+**Content priorities** (in order):
+1. Features delivered or completing
+2. Features whose status changed to Red or Yellow this week
+3. Features with Red/Yellow status and new activity this week
+4. Features with significant progress (PRs merged, scope changes)
+
+**Skip** issues where nothing noteworthy happened in the date range.
+
+##### e. Assemble Full Section
+
+Combine all entries into a single unordered list, ordered by significance:
+
+1. Completed/delivered features first
+2. Features whose status changed to Red or Yellow this week
+3. Red/Yellow features with new activity
+4. Features with notable progress
+
+All entries form one continuous markdown unordered list (no blank lines between items).
+
+#### Step 8. Present for Review
+
+Display the complete assembled section:
+
+```text
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Key Strategic Feature Updates
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Issues analyzed: {total}
+Features with significant activity: {included}
+Features skipped (no activity): {skipped}
+Date range: {start} to {end}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{assembled feature updates section}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Before presenting, run the validation script to check for GitHub handle usage:
+
+```bash
+python3 {plugins-dir}/jira/skills/status-analysis/scripts/validate_feature_updates.py \
+  --markdown /tmp/feature-updates.md \
+  --data-dir .work/weekly-status/{date}/issues/
+```
+
+If violations are found, fix them (replace handles with first names from `author_name` fields) before presenting to the user.
+
+Options:
+
+- `approve` or `a`: Accept and output
+- `modify` or `m`: Modify the section (rewrite entries, skip/reorder features)
+- `regenerate` or `r`: Regenerate from cached data with different focus
+- `quit` or `q`: Abort
+
+**If user chooses `modify`:**
+
+- Ask what changes they want (rewrite specific entries, remove entries, reorder, change tone)
+- Apply changes and present again
+
+#### Step 9. Output Delivery
+
+Default: print the final markdown to stdout.
+
+**Optional output mode** (parsed from original arguments):
+
+- `--serve`: Convert markdown to HTML and serve on localhost for easy copy/paste into Google Docs
+
+##### HTML conversion and serving (`--serve`)
+
+1. Write the final markdown to `/tmp/feature-updates.md`
+
+2. Run the validation script to ensure no GitHub handles remain:
+
+```bash
+python3 {plugins-dir}/jira/skills/status-analysis/scripts/validate_feature_updates.py \
+  --markdown /tmp/feature-updates.md \
+  --data-dir .work/weekly-status/{date}/issues/
+```
+
+If violations are found, fix them before converting to HTML.
+
+3. Convert to styled HTML using the Python `markdown` library:
+
+```python
+import markdown
+
+with open("/tmp/feature-updates.md") as f:
+    html = markdown.markdown(f.read())
+
+with open("/tmp/feature-updates.html", "w", encoding="utf-8") as f:
+    f.write("""<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8">
+<style>
+body { font-family: Arial, sans-serif; max-width: 800px; margin: 40px auto; line-height: 1.6; font-size: 11pt; }
+a { color: #1a73e8; text-decoration: none; }
+a:hover { text-decoration: underline; }
+ul { margin-bottom: 0.5em; }
+li { margin-bottom: 0.3em; }
+</style></head><body>
+""")
+    f.write(html)
+    f.write("</body></html>")
+```
+
+4. Validate the generated HTML for encoding issues:
+
+```bash
+python3 {plugins-dir}/jira/skills/status-analysis/scripts/validate_feature_updates.py \
+  --html /tmp/feature-updates.html
+```
+
+If validation fails (missing charset, mojibake detected), regenerate the HTML using the template above before proceeding. **Do not serve HTML that fails this check.**
+
+5. Start a local HTTP server in the background:
+
+```bash
+python3 -m http.server 8787 --directory /tmp --bind 127.0.0.1
+```
+
+6. Display the URL to the user:
+
+```
+Serving feature updates at: http://localhost:8787/feature-updates.html
+Open in your browser, select all (Ctrl+A / Cmd+A), copy (Ctrl+C / Cmd+C), and paste into Google Docs.
+The server will be stopped when you confirm you're done.
+```
+
+7. Wait for user confirmation, then stop the background server.
+
+## Examples
+
+1. **With project and component (recommended)**:
+
+   ```bash
+   /jira:generate-feature-updates OCPSTRAT --component "Hosted Control Planes"
+   ```
+
+   Output: Gathers data, analyzes all matching issues, presents feature updates section
+
+2. **With label filter**:
+
+   ```bash
+   /jira:generate-feature-updates OCPSTRAT --label strategic-work
+   ```
+
+3. **With specific users**:
+
+   ```bash
+   /jira:generate-feature-updates OCPSTRAT --component "Hosted Control Planes" user@redhat.com
+   ```
+
+4. **Serve as HTML for Google Docs pasting**:
+
+   ```bash
+   /jira:generate-feature-updates OCPSTRAT --component "Hosted Control Planes" --serve
+   ```
+
+5. **Full example with all options**:
+
+   ```bash
+   /jira:generate-feature-updates OCPSTRAT --component "Control Plane" --label strategic-work user@redhat.com !manager@redhat.com --serve
+   ```
+
+**Example Output:**
+
+```markdown
+- 🟢 [OCPSTRAT-2426](https://issues.redhat.com/browse/OCPSTRAT-2426): Customer global pull secret in HCP for ROSA
+    - Scope reduced to Managed OpenShift and platforms using node replacement strategy. E2E tests are already passing.
+- 🟡 [OCPSTRAT-1409](https://issues.redhat.com/browse/OCPSTRAT-1409): Auto backup/restore for Hosted Clusters
+    - A bug found in the implementation has highlighted a permission gap that we are going to cover with better UX.
+- 🟢 [OCPSTRAT-1558](https://issues.redhat.com/browse/OCPSTRAT-1558): Shared ingress for HCP
+    - Contributor X's PR #7143 landed this week, completing the core shared ingress controller. Integration tests are passing on AWS.
+```
+
+## Arguments
+
+- `project-key` (optional): The Jira project key (e.g., `OCPSTRAT`, `OCPBUGS`). If not provided, prompts for selection
+- `--component <name>` (optional): Filter by specific component name. If not provided, prompts for selection
+- `--label <label-name>` (optional): Filter by specific label (e.g., `control-plane-work`, `strategic-work`)
+- `user-filters` (optional): Space-separated list of user emails or display names
+  - Prefix with exclamation mark to exclude specific users (example: !<manager@redhat.com>)
+  - Display names without @ symbol will trigger user lookup with confirmation
+- `--serve` (optional): Convert output to HTML and serve on localhost for copy/paste into Google Docs
+
+## Notes
+
+### Important Implementation Details
+
+1. **Two-Phase Execution**:
+   - Phase 1 (Data Gathering): Python script collects all data efficiently in parallel
+   - Phase 2 (Processing): LLM analyzes all issues in batch with feature_markdown format
+
+2. **Batch Processing** (key difference from update-weekly-status):
+   - All issues are processed together, not one-by-one interactively
+   - Complete section is assembled before presenting for review
+   - No per-issue approve/skip workflow
+
+3. **No Jira Writes**:
+   - This command only reads from Jira (via pre-gathered data)
+   - Output goes to stdout or localhost HTTP server — never back to Jira
+
+4. **Significant Activity Filter**:
+   - Issues with no noteworthy activity are automatically skipped
+   - Prevents noise from issues that had only bot updates or trivial changes
+
+5. **Error Handling**:
+   - Invalid project key: Display error with available projects
+   - Invalid component: Display available components
+   - User lookup fails: Ask for email directly
+   - Script execution failure: Display error and suggest checking environment variables
+   - No significant activity found: Display message and exit
+
+### Prerequisites
+
+- **Python 3.8+** with `aiohttp` package installed
+- **Jira MCP server** configured and accessible
+- **Environment variables**:
+  - `JIRA_TOKEN` or `JIRA_PERSONAL_TOKEN`: Jira API bearer token
+  - `GITHUB_TOKEN` or authenticated `gh` CLI
+- **For `--serve`**: Python `markdown` package (`pip install markdown`)
+
+Check for required tools:
+
+```bash
+# Check Python and aiohttp
+python3 -c "import aiohttp; print('aiohttp OK')"
+
+# Check if the Jira token is defined
+test -n "$JIRA_TOKEN"
+
+# Check GitHub token (via gh CLI)
+gh auth token &> /dev/null
+
+# Check markdown library (for --serve)
+python3 -c "import markdown; print('markdown OK')"
+```
+
+## Related
+
+- **Shared skill**: `plugins/jira/skills/status-analysis/SKILL.md`
+- **Data gatherer script**: `plugins/jira/skills/status-analysis/scripts/gather_status_data.py`
+- **Validation script**: `plugins/jira/skills/status-analysis/scripts/validate_feature_updates.py`
+- **Single-issue rollup**: `/jira:status-rollup` - Generate comprehensive status comment for one issue
+- **Batch field updates**: `/jira:update-weekly-status` - Update Status Summary field for multiple issues

--- a/plugins/jira/commands/status-rollup.md
+++ b/plugins/jira/commands/status-rollup.md
@@ -234,3 +234,4 @@ _Generated with [Claude Code](https://claude.com/claude-code) via `/jira:status-
 
 - **Shared skill**: `plugins/jira/skills/status-analysis/SKILL.md`
 - **Batch updates**: `/jira:update-weekly-status` - Update Status Summary field for multiple issues
+- **Feature updates**: `/jira:generate-feature-updates` - Generate strategic feature updates for weekly status documents

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -530,3 +530,4 @@ See the Jira plugin's skills directory for examples of project-specific customiz
 - **Data gatherer script**: `plugins/jira/skills/status-analysis/scripts/gather_status_data.py`
 - **Issue summarizer script**: `plugins/jira/skills/status-analysis/scripts/summarize_issue.py`
 - **Single-issue rollup**: `/jira:status-rollup` - Generate comprehensive status comment for one issue
+- **Feature updates**: `/jira:generate-feature-updates` - Generate strategic feature updates for weekly status documents

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -5,7 +5,7 @@ description: Shared engine for analyzing Jira issue activity and generating stat
 
 # Jira Status Analysis Engine
 
-This skill provides the core analysis logic shared by status-related commands (`/jira:status-rollup` and `/jira:update-weekly-status`). It handles data collection, activity analysis, and status generation in a unified way.
+This skill provides the core analysis logic shared by status-related commands (`/jira:status-rollup`, `/jira:update-weekly-status`, and `/jira:generate-feature-updates`). It handles data collection, activity analysis, and status generation in a unified way.
 
 **IMPORTANT FOR AI**: This is a **procedural skill** - when invoked by a command, you should execute the implementation steps defined in this document and its sub-modules. The calling command determines the configuration parameters.
 
@@ -15,6 +15,7 @@ This skill is invoked automatically by:
 
 - `/jira:status-rollup` - Single root issue, outputs as Jira comment
 - `/jira:update-weekly-status` - Multiple root issues (batch), outputs to Status Summary field
+- `/jira:generate-feature-updates` - Multiple root issues (batch), outputs as markdown to stdout
 
 Do NOT invoke this skill directly. Use the commands above.
 
@@ -106,21 +107,21 @@ This skill is composed of four sub-modules. Read each when executing the analysi
 
 Both commands share the same engine with different configuration:
 
-| Parameter | status-rollup | update-weekly-status |
-|-----------|---------------|----------------------|
-| `data_source` | MCP API calls | Pre-gathered JSON files |
-| `root_issues` | Single issue key | Multiple (from manifest.json) |
-| `date_range.start` | User-specified or issue creation | `today - 7 days` |
-| `date_range.end` | User-specified or today | `today` |
-| `output_format` | `markdown_comment` | `ryg_field` |
-| `output_target` | Comment on root issue | Status Summary field |
-| `external_links` | Via `gh` CLI | Pre-gathered in JSON |
-| `user_review` | Yes (before posting comment) | Yes (approve/modify/skip per issue) |
-| `caching` | Temp file for refinement | JSON files in `.work/` |
+| Parameter | status-rollup | update-weekly-status | generate-feature-updates |
+|-----------|---------------|----------------------|--------------------------|
+| `data_source` | MCP API calls | Pre-gathered JSON files | Pre-gathered JSON files |
+| `root_issues` | Single issue key | Multiple (from manifest.json) | Multiple (from manifest.json) |
+| `date_range.start` | User-specified or issue creation | `today - 7 days` | `today - 7 days` |
+| `date_range.end` | User-specified or today | `today` | `today` |
+| `output_format` | `markdown_comment` | `ryg_field` | `feature_markdown` |
+| `output_target` | Comment on root issue | Status Summary field | stdout |
+| `external_links` | Via `gh` CLI | Pre-gathered in JSON | Pre-gathered in JSON |
+| `user_review` | Yes (before posting comment) | Yes (approve/modify/skip per issue) | Yes (full-section review) |
+| `caching` | Temp file for refinement | JSON files in `.work/` | JSON files in `.work/` |
 
 ## Hierarchy Traversal
 
-Both commands use the same traversal mechanism via `parent = KEY` JQL with BFS recursion (Atlassian Cloud compatible — `childIssuesOf()` is not supported on Cloud):
+Both commands use the same traversal mechanism via `childIssuesOf()` JQL:
 
 ```
 Root Issue (FEATURE-123)
@@ -133,13 +134,11 @@ Root Issue (FEATURE-123)
     └── Epic 2 (EPIC-789)
         └── Story 2.1
 
-JQL per level: parent = FEATURE-123  →  [EPIC-456, EPIC-789]
-               parent = EPIC-456     →  [Story 1.1, Story 1.2]
-               ... (BFS until no more children)
-Returns: ALL descendants at any depth via recursive BFS
+JQL: issue in childIssuesOf(FEATURE-123)
+Returns: ALL descendants at any depth (EPIC-456, Story 1.1, Subtask 1.1.1, Story 1.2, EPIC-789, Story 2.1)
 ```
 
-**Note**: `childIssuesOf()` is not available on Atlassian Cloud. The data gatherer script uses `parent = KEY` with BFS to traverse the full hierarchy.
+**Key benefit**: `childIssuesOf()` is already recursive - a single JQL query returns the entire hierarchy regardless of depth. No manual recursion needed.
 
 The difference between commands is not in traversal but in:
 
@@ -237,7 +236,7 @@ The calling command provides an AnalysisConfig. Parse and validate:
 REQUIRED parameters:
   - root_issues: Array of issue keys to analyze
   - date_range: {start, end} in YYYY-MM-DD format
-  - output_format: "markdown_comment" or "ryg_field"
+  - output_format: "markdown_comment", "ryg_field", or "feature_markdown"
 
 OPTIONAL parameters:
   - external_links_enabled: boolean (default: true)
@@ -264,9 +263,9 @@ Data has already been collected by the Python script (`gather_status_data.py`):
    - Fetch changelog with `expand=changelog`
 
 2. **Discover all descendants**:
-   - Use `parent = {root-issue}` JQL with BFS recursion to get full hierarchy (Cloud-compatible; `childIssuesOf()` is not supported on Atlassian Cloud)
+   - Use `issue in childIssuesOf({root-issue})` to get full hierarchy
    - Optionally filter by date range: `AND updated >= {start-date}`
-   - Use `maxResults=100` per page; handle cursor pagination via `nextPageToken`
+   - Use `limit=100` (increase if needed for large hierarchies)
 
 3. **For each descendant issue**:
    - Fetch issue details and changelog
@@ -364,6 +363,15 @@ Follow `formatting.md` to generate output based on `output_format`:
      ** Thing 2 that happened since last week
  * Risks:
      ** Risk 1 (or "None at this time")
+```
+
+**For `feature_markdown` (generate-feature-updates)**:
+
+```
+- [ISSUE-KEY](https://issues.redhat.com/browse/ISSUE-KEY): Issue summary
+    - 1-3 sentences of executive prose. No metrics, no R/Y/G.
+- [ISSUE-KEY-2](https://issues.redhat.com/browse/ISSUE-KEY-2): Issue summary
+    - Prose focusing on significant progress, deliveries, blockers, or risks.
 ```
 
 ### Step 6: Return to Calling Command

--- a/plugins/jira/skills/status-analysis/formatting.md
+++ b/plugins/jira/skills/status-analysis/formatting.md
@@ -9,12 +9,13 @@ This module defines output templates for status summaries. It transforms analyze
 
 ## Overview
 
-Two output formats are supported:
+Three output formats are supported:
 
 | Format | Used By | Output Target | Syntax |
 |--------|---------|---------------|--------|
 | `markdown_comment` | `/jira:status-rollup` | Jira comment | Markdown (via `contentFormat: "markdown"`) |
 | `ryg_field` | `/jira:update-weekly-status` | Status Summary field | Bullet-point template |
+| `feature_markdown` | `/jira:generate-feature-updates` | stdout / localhost HTTP server | Markdown nested lists |
 
 **Important**: When posting comments via `addCommentToJiraIssue` or updating descriptions via `editJiraIssue`, always include `contentFormat: "markdown"`.
 
@@ -225,6 +226,146 @@ Used by `/jira:update-weekly-status` to update the Status Summary custom field.
      ** May need to descope Azure AD integration from initial release
 ```
 
+## Format: feature_markdown
+
+Used by `/jira:generate-feature-updates` to produce concise executive-level feature summaries for weekly status documents (e.g., "Key Strategic Feature Updates" section).
+
+### Template
+
+```
+- 🟢 [{ISSUE-KEY}](https://issues.redhat.com/browse/{ISSUE-KEY}): {issue summary}
+    - {1-3 sentence prose summary of significant activity}
+- 🔴 [{ISSUE-KEY-2}](https://issues.redhat.com/browse/{ISSUE-KEY-2}): {issue summary}
+    - {1-3 sentence prose summary of significant activity}
+```
+
+Color circle mapping (from the `color` field in Status Summary):
+- `Green` → 🟢
+- `Yellow` → 🟡
+- `Red` → 🔴
+- No color / unknown → omit circle
+
+### Formatting Rules
+
+1. **Nested unordered list**: Top-level bullet is the feature link + summary, nested bullet is the update prose
+2. **Markdown links**: Use `[KEY](url)` syntax (standard Markdown, not Jira wiki)
+3. **Prose in nested bullet**: Each entry's update is 1-3 flowing sentences in a single nested list item
+4. **Color circle prefix**: Each top-level bullet starts with a unicode circle (🟢🟡🔴) matching the Color Status from the Status Summary field. Omit the circle if no color is set.
+5. **No metrics**: No completion percentages, issue counts, or tables
+6. **Cross-references as markdown links**: Reference related issues, PRs, and people inline
+7. **Continuous list**: All entries in one unordered list, no blank lines between items
+8. **PR references**: Use `[PR #N](url)` format when referencing specific PRs
+9. **First names for attribution**: Use `author_name` fields (not `author` logins) when attributing contributions. Always use first names, never GitHub handles.
+
+### Content Guidelines
+
+**Focus on what matters to executives:**
+
+- Features that made **significant progress** (PRs merged, milestones hit)
+- Features that were **delivered or completed**
+- Features whose **status color changed** this week (e.g., Green→Yellow, Yellow→Red) — a status change is always news
+- Features that are **blocked or at risk** with new activity or updates this week
+- **Scope changes** or strategic pivots
+
+**R/Y/G status as prioritization, not inclusion:** Use the team's self-reported color status to order and prioritize the output (Red/Yellow before Green), but do not include a feature solely because it has been Red/Yellow — it must also have a status change or other significant activity this week.
+
+**Attribution for recognition:**
+
+- Name team members who drove key accomplishments
+- Example: "Thanks to Sara's work on PR #456, the migration path is now fully tested"
+
+**Tone:**
+
+- Executive-level: concise, direct, outcome-oriented
+- Focus on "so what" rather than "what happened"
+- Highlight customer or business impact where relevant
+
+**DO**:
+- Reference specific PRs, people, and customers
+- Explain scope changes and their rationale
+- Call out blockers with clear ownership
+- Attribute contributions so team members get recognition
+- Use first names for attribution (e.g., "Salvatore's PR #7746" not "sdminonne's PR #7746")
+
+**DON'T**:
+- List every sub-task or minor change
+- Use vague language ("making progress", "ongoing work")
+- Include metrics or completion percentages
+- Use bullet points (prose only)
+- Use GitHub handles (e.g., `sdminonne`, `enxebre`). Always use first names from `author_name` fields instead.
+
+### Example Outputs
+
+```markdown
+- 🟢 [OCPSTRAT-2426](https://issues.redhat.com/browse/OCPSTRAT-2426): Customer global pull secret in HCP for ROSA
+    - Scope reduced to Managed OpenShift and platforms using node replacement strategy. E2E tests are already passing.
+- 🟡 [OCPSTRAT-1409](https://issues.redhat.com/browse/OCPSTRAT-1409): Auto backup/restore for Hosted Clusters
+    - A bug found in the implementation has highlighted a permission gap that we are going to cover with better UX.
+- 🟢 [OCPSTRAT-1558](https://issues.redhat.com/browse/OCPSTRAT-1558): Shared ingress for HCP
+    - Wei's [PR #7143](https://github.com/openshift/hypershift/pull/7143) landed this week, completing the core shared ingress controller. Integration tests are passing on AWS.
+- 🔴 [OCPSTRAT-2100](https://issues.redhat.com/browse/OCPSTRAT-2100): IPv6 support for Hosted Control Planes
+    - Blocked on upstream Kubernetes networking changes expected in 1.32. Alberto has prepared the downstream patches and they are ready to go once the dependency lands.
+```
+
+### Significant Activity Filter
+
+Skip issues with no noteworthy activity. An issue has significant activity if any of:
+
+- **Status color changed** this week (e.g., Green→Yellow, Yellow→Red) — detected via changelog or by comparing `last_status_summary_update` with date range
+- Status transitions (started, completed, blocked, reopened)
+- PRs merged or new PRs opened
+- Scope changes or priority changes
+- Blocker identified or resolved
+- Substantive comments from team members (not bot updates)
+
+Issues with only minor updates (bot comments, trivial field changes) should be omitted. A feature that has been Red/Yellow for weeks with no new activity is not news — only include it if the color changed or there is a meaningful update this week.
+
+### Pseudocode
+
+```python
+COLOR_CIRCLES = {"Green": "🟢", "Yellow": "🟡", "Red": "🔴"}
+
+def format_feature_markdown(issue_data, config):
+    output = []
+
+    issue_url = f"https://issues.redhat.com/browse/{issue_data.issue_key}"
+    circle = COLOR_CIRCLES.get(issue_data.color, "")
+    prefix = f"{circle} " if circle else ""
+    output.append(f"- {prefix}[{issue_data.issue_key}]({issue_url}): {issue_data.summary}")
+
+    # Build prose from analysis
+    sentences = []
+
+    # Achievements / deliveries
+    for achievement in issue_data.analysis.achievements:
+        sentences.append(achievement.description)
+
+    # Blockers / risks
+    for blocker in issue_data.analysis.blockers:
+        sentences.append(blocker.description)
+
+    for risk in issue_data.analysis.risks:
+        sentences.append(risk.description)
+
+    # Combine into 1-3 sentences of flowing prose as a nested bullet
+    # Use author_name (first names), never GitHub logins
+    prose = synthesize_prose(sentences, max_sentences=3)
+    output.append(f"    - {prose}")
+
+    return "\n".join(output)
+```
+
+### feature_markdown validation
+
+- [ ] Each entry is a top-level list item: `- 🟢 [ISSUE-KEY](url): summary`
+- [ ] Color circle (🟢🟡🔴) matches the Color Status from the Status Summary field
+- [ ] Update prose is a nested list item: `    - 1-3 sentences`
+- [ ] No metrics or percentages
+- [ ] All entries form one continuous unordered list
+- [ ] Cross-references use markdown link syntax
+- [ ] Issues with no significant activity are omitted
+- [ ] No GitHub handles — only first names from `author_name` fields
+
 ## Building Output from Analysis Data
 
 ### For markdown_comment format
@@ -301,6 +442,72 @@ def format_ryg_field(issue_data, config):
         output.append("     ** None at this time")
 
     return "\n".join(output)
+```
+
+### For feature_markdown format
+
+```python
+COLOR_CIRCLES = {"Green": "🟢", "Yellow": "🟡", "Red": "🔴"}
+
+def format_feature_markdown(issue_data, config):
+    # Skip issues with no significant activity
+    if not has_significant_activity(issue_data):
+        return None
+
+    output = []
+    issue_url = f"https://issues.redhat.com/browse/{issue_data.issue_key}"
+    circle = COLOR_CIRCLES.get(issue_data.color, "")
+    prefix = f"{circle} " if circle else ""
+    output.append(f"- {prefix}[{issue_data.issue_key}]({issue_url}): {issue_data.summary}")
+
+    # Synthesize 1-3 sentences of executive prose from:
+    # - achievements (PRs merged, milestones, deliveries)
+    # - blockers and risks (with ownership)
+    # - scope changes or strategic pivots
+    # - attribution (use first names from author_name, never GitHub logins)
+    prose = synthesize_executive_prose(issue_data.analysis)
+    output.append(f"    - {prose}")
+
+    return "\n".join(output)
+
+
+def has_significant_activity(issue_data):
+    """Return True if issue has noteworthy activity worth reporting."""
+    # Check if the status color changed this week
+    if status_color_changed_in_range(issue_data):
+        return True
+
+    return (
+        len(issue_data.analysis.achievements) > 0
+        or len(issue_data.analysis.blockers) > 0
+        or len(issue_data.analysis.risks) > 0
+        or any(t.to in ("Closed", "Done", "Blocked") for t in issue_data.changelog.status_transitions)
+        or any(pr.state == "MERGED" for pr in issue_data.external_links.github_prs)
+    )
+
+
+def status_color_changed_in_range(issue_data):
+    """Check if the R/Y/G status color changed during the date range."""
+    # Look for Status Summary field changes in changelog_in_range
+    for entry in issue_data.changelog_in_range:
+        for item in entry.get("items", []):
+            if item.get("field") == "Status Summary":
+                old_color = parse_color_status(item.get("fromString", ""))
+                new_color = parse_color_status(item.get("toString", ""))
+                if old_color != new_color:
+                    return True
+    return False
+
+
+def parse_color_status(status_summary):
+    """Extract Red/Yellow/Green from status summary text."""
+    if not status_summary:
+        return None
+    # Handle both "* Color Status: Green" and "{color:#d04437}Red{color}" formats
+    for color in ("Red", "Yellow", "Green"):
+        if color in status_summary:
+            return color
+    return None
 ```
 
 ## Validation

--- a/plugins/jira/skills/status-analysis/scripts/triage_issues.py
+++ b/plugins/jira/skills/status-analysis/scripts/triage_issues.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Triage pre-gathered issue JSON files by activity and R/Y/G status.
+
+Scans all issue files in a weekly-status directory and classifies them
+as significant or skippable for feature update reports. Outputs a
+structured summary with activity signals and R/Y/G color status.
+
+Usage:
+    python3 triage_issues.py .work/weekly-status/2026-03-04/issues/
+    python3 triage_issues.py .work/weekly-status/2026-03-04/issues/ --json
+"""
+
+import json
+import glob
+import os
+import sys
+
+
+def parse_color(text: str | None) -> str | None:
+    """Extract Red/Yellow/Green from status summary text."""
+    if not text:
+        return None
+    # Handle both "* Color Status: Green" and "{color:#d04437}Red{color}"
+    for color in ("Red", "Yellow", "Green"):
+        if color in text:
+            return color
+    return None
+
+
+def triage(data_dir: str) -> tuple[list[dict], list[dict]]:
+    significant = []
+    skipped = []
+
+    for path in sorted(glob.glob(os.path.join(data_dir, "*.json"))):
+        with open(path) as f:
+            d = json.load(f)
+
+        issue = d["issue"]
+        key = issue["key"]
+        summary = issue["summary"]
+        status_summary = issue.get("current_status_summary", "")
+        desc = d["descendants"]
+        prs = d["prs"]
+        changelog = d["changelog_in_range"]
+        comments = d["comments_in_range"]
+        human_comments = [c for c in comments if not c.get("is_bot")]
+
+        color = parse_color(status_summary)
+
+        # Check for color change in changelog
+        color_changed = False
+        old_color = None
+        new_color = None
+        for entry in changelog:
+            for item in entry.get("items", []):
+                field = item.get("field", "")
+                field_id = str(item.get("fieldId", ""))
+                if "Status Summary" in field or "customfield_12320841" in field_id:
+                    oc = parse_color(item.get("fromString", ""))
+                    nc = parse_color(item.get("toString", ""))
+                    if oc != nc and oc is not None and nc is not None:
+                        color_changed = True
+                        old_color = oc
+                        new_color = nc
+
+        # Activity signals
+        merged_prs = [
+            pr
+            for pr in prs
+            if pr["state"] == "MERGED"
+            and pr.get("activity_summary", {}).get("commits_in_range", 0) > 0
+        ]
+        active_prs = [
+            pr
+            for pr in prs
+            if pr.get("activity_summary", {}).get("commits_in_range", 0) > 0
+            or pr.get("activity_summary", {}).get("reviews_in_range", 0) > 0
+        ]
+        updated_desc = desc.get("updated_in_range", [])
+        status_changes = [
+            c
+            for c in changelog
+            if any(item.get("field") == "status" for item in c.get("items", []))
+        ]
+
+        has_activity = bool(
+            merged_prs
+            or active_prs
+            or status_changes
+            or updated_desc
+            or human_comments
+            or color_changed
+        )
+
+        record = {
+            "key": key,
+            "summary": summary,
+            "color": color,
+            "color_changed": color_changed,
+            "old_color": old_color,
+            "new_color": new_color,
+            "has_activity": has_activity,
+            "merged_prs": len(merged_prs),
+            "active_prs": len(active_prs),
+            "updated_desc": len(updated_desc),
+            "human_comments": len(human_comments),
+            "status_changes": len(status_changes),
+            "completion": desc.get("completion_pct", 0),
+            "total_desc": desc.get("total", 0),
+            "status_summary_excerpt": (status_summary or "")[:200],
+        }
+
+        if has_activity:
+            significant.append(record)
+        else:
+            skipped.append(record)
+
+    return significant, skipped
+
+
+def print_text(significant: list[dict], skipped: list[dict]) -> None:
+    print(f"=== SIGNIFICANT ACTIVITY ({len(significant)} issues) ===\n")
+    for r in significant:
+        flags = []
+        if r["color_changed"]:
+            flags.append(f"COLOR_CHANGED ({r['old_color']}->{r['new_color']})")
+        if r["color"] in ("Red", "Yellow"):
+            flags.append(r["color"].upper())
+        if r["merged_prs"]:
+            flags.append(f"{r['merged_prs']} merged")
+        if r["active_prs"]:
+            flags.append(f"{r['active_prs']} active PRs")
+        if r["updated_desc"]:
+            flags.append(f"{r['updated_desc']} desc updated")
+        if r["human_comments"]:
+            flags.append(f"{r['human_comments']} comments")
+        if r["status_changes"]:
+            flags.append(f"{r['status_changes']} status changes")
+
+        print(f"  {r['key']}: {r['summary'][:80]}")
+        print(f"    Color: {r['color'] or 'None'} | Completion: {r['completion']}% | {' | '.join(flags)}")
+        print()
+
+    print(f"=== SKIPPED ({len(skipped)} issues) ===\n")
+    for r in skipped:
+        print(f"  {r['key']}: {r['summary'][:80]} [Color: {r['color'] or 'None'}]")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <issues-dir> [--json]", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir = sys.argv[1]
+    json_mode = "--json" in sys.argv
+
+    significant, skipped = triage(data_dir)
+
+    if json_mode:
+        print(json.dumps({"significant": significant, "skipped": skipped}, indent=2))
+    else:
+        print_text(significant, skipped)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/jira/skills/status-analysis/scripts/validate_feature_updates.py
+++ b/plugins/jira/skills/status-analysis/scripts/validate_feature_updates.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Validate feature updates markdown and HTML output.
+
+Checks:
+  1. Generated markdown uses author names (from author_name fields)
+     instead of raw GitHub logins.
+  2. Generated HTML has proper UTF-8 charset declaration and DOCTYPE
+     so that emoji (color circles) render correctly in browsers.
+
+Usage:
+    # Validate markdown for GitHub handles:
+    python3 validate_feature_updates.py \
+      --markdown /tmp/feature-updates.md \
+      --data-dir .work/weekly-status/2026-03-04/issues/
+
+    # Validate HTML encoding (run after markdown-to-HTML conversion):
+    python3 validate_feature_updates.py \
+      --html /tmp/feature-updates.html
+
+    # Both at once:
+    python3 validate_feature_updates.py \
+      --markdown /tmp/feature-updates.md \
+      --data-dir .work/weekly-status/2026-03-04/issues/ \
+      --html /tmp/feature-updates.html
+
+Exit codes:
+    0: No violations found
+    1: Violations detected
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def collect_authors_from_data(data_dir: Path) -> dict[str, str]:
+    """Extract unique GitHub logins and their display names from issue JSON files.
+
+    Returns a dict mapping login -> author_name.
+    """
+    authors: dict[str, str] = {}
+
+    for json_file in sorted(data_dir.glob("*.json")):
+        try:
+            data = json.loads(json_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        prs = data.get("external_links", {}).get("github_prs", [])
+        for pr in prs:
+            for source_key in ("reviews_in_range", "review_comments_in_range", "commits_in_range"):
+                for entry in pr.get(source_key, []):
+                    login = entry.get("author", "")
+                    name = entry.get("author_name", "")
+
+                    # Skip emails (commits use email as author) and unknowns
+                    if not login or "@" in login or login == "Unknown":
+                        continue
+
+                    # Prefer the longest/most complete name seen
+                    if login not in authors or (name and len(name) > len(authors[login])):
+                        authors[login] = name if name else login
+
+    return authors
+
+
+def find_handle_violations(markdown_text: str, authors: dict[str, str]) -> list[dict]:
+    """Find GitHub handles used as standalone words in the markdown.
+
+    Returns list of dicts with 'login', 'name', and 'occurrences' (count).
+    """
+    violations = []
+
+    for login, name in sorted(authors.items()):
+        # Word-boundary match to avoid false positives
+        pattern = rf"\b{re.escape(login)}\b"
+        matches = re.findall(pattern, markdown_text)
+        if matches:
+            # Suggest first name from the full name
+            first_name = name.split()[0] if name and name != login else None
+            violations.append({
+                "login": login,
+                "name": name,
+                "first_name": first_name,
+                "occurrences": len(matches),
+            })
+
+    return violations
+
+
+def validate_html(html_path: Path) -> list[str]:
+    """Validate that the HTML file has proper encoding for emoji rendering.
+
+    Returns a list of error messages (empty if valid).
+    """
+    errors = []
+
+    try:
+        raw = html_path.read_bytes()
+    except OSError as e:
+        return [f"Cannot read HTML file: {e}"]
+
+    # Check BOM or encoding declaration
+    text = raw.decode("utf-8", errors="replace")
+
+    # Must have DOCTYPE
+    if "<!DOCTYPE" not in text.upper() and "<!doctype" not in text:
+        errors.append("Missing <!DOCTYPE html> declaration")
+
+    # Must have charset meta tag
+    if 'charset="utf-8"' not in text.lower() and "charset=utf-8" not in text.lower():
+        errors.append('Missing <meta charset="utf-8"> in <head>')
+
+    # Check that emoji circles survived encoding (not mojibake)
+    has_circles = any(c in text for c in "\U0001f7e2\U0001f7e1\U0001f534")  # 🟢🟡🔴
+    has_mojibake = "Ã°" in text or "â" in text or "ðŸ" in text
+    if has_mojibake:
+        errors.append(
+            "Mojibake detected: emoji circles are garbled "
+            "(likely written without encoding='utf-8' or missing charset meta)"
+        )
+    elif not has_circles:
+        # No circles at all — not necessarily an error, but worth noting
+        pass
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate feature updates markdown and HTML output"
+    )
+    parser.add_argument(
+        "--markdown",
+        help="Path to the markdown file to validate for GitHub handles"
+    )
+    parser.add_argument(
+        "--data-dir",
+        help="Path to the issues data directory containing JSON files"
+    )
+    parser.add_argument(
+        "--html",
+        help="Path to the HTML file to validate for encoding"
+    )
+    args = parser.parse_args()
+
+    if not args.markdown and not args.html:
+        parser.error("At least one of --markdown or --html is required")
+
+    failed = False
+
+    # --- Markdown validation (GitHub handles) ---
+    if args.markdown:
+        markdown_path = Path(args.markdown)
+        if not markdown_path.exists():
+            print(f"Error: Markdown file not found: {markdown_path}", file=sys.stderr)
+            sys.exit(2)
+
+        if not args.data_dir:
+            parser.error("--data-dir is required when using --markdown")
+
+        data_dir = Path(args.data_dir)
+        if not data_dir.exists():
+            print(f"Error: Data directory not found: {data_dir}", file=sys.stderr)
+            sys.exit(2)
+
+        authors = collect_authors_from_data(data_dir)
+        if not authors:
+            print("No GitHub authors found in data files.")
+        else:
+            markdown_text = markdown_path.read_text()
+            violations = find_handle_violations(markdown_text, authors)
+
+            if not violations:
+                print(f"OK: No GitHub handles found in {markdown_path.name} "
+                      f"({len(authors)} authors checked)")
+            else:
+                failed = True
+                total = sum(v["occurrences"] for v in violations)
+                print(f"FAIL: {total} GitHub handle occurrence(s) found "
+                      f"in {markdown_path.name}\n")
+                for v in violations:
+                    suggestion = ""
+                    if v["first_name"] and v["first_name"] != v["login"]:
+                        suggestion = (f' -> use "{v["first_name"]}" '
+                                      f'(from "{v["name"]}")')
+                    elif v["name"] and v["name"] != v["login"]:
+                        suggestion = f' -> use first name from "{v["name"]}"'
+                    print(f"  {v['login']} ({v['occurrences']}x){suggestion}")
+
+    # --- HTML validation (encoding / charset) ---
+    if args.html:
+        html_path = Path(args.html)
+        if not html_path.exists():
+            print(f"Error: HTML file not found: {html_path}", file=sys.stderr)
+            sys.exit(2)
+
+        html_errors = validate_html(html_path)
+        if html_errors:
+            failed = True
+            print(f"\nFAIL: HTML encoding issues in {html_path.name}:")
+            for err in html_errors:
+                print(f"  - {err}")
+        else:
+            print(f"OK: HTML encoding valid in {html_path.name}")
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- New command that generates executive-level feature summaries for weekly status documents
- Analyzes Jira issue hierarchies, GitHub PRs, and recent activity to produce prose-style updates
- Supports `--label`, `--component`, and user filters; `--serve` mode converts to HTML on localhost for copy/paste into Google Docs
- Adds supporting scripts: `triage_issues.py`, `summarize_issue.py`, and `validate_feature_updates.py` (validates markdown for GitHub handles and HTML for proper UTF-8 charset to prevent emoji rendering issues)

## Test plan

- [x] Run `/jira:generate-feature-updates OCPSTRAT --label control-plane-work --serve` end-to-end
- [x] Verify HTML validation catches missing charset/DOCTYPE
- [x] Verify lint passes (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added jira:generate-feature-updates — creates executive weekly feature summaries (nested markdown with optional colored status indicators) and can serve styled HTML locally for easy copy/paste.
  * New validation tooling to check generated Markdown/HTML for formatting and attribution rules.

* **Documentation**
  * Comprehensive docs and examples for the new feature and related workflow added.

* **Chores**
  * Bumped plugin version to 0.7.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->