### PR TITLE
Add openshift: Operator dashboad generator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -71,6 +71,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "operator-dashboard",
+      "source": "./plugins/ai-operator-dashboard-generator",
+      "description": "Generate OpenShift Console operator dashboard: CRD discovery, list/detail components from templates",
+      "version": "0.0.1"
+    },
+    {
       "name": "agendas",
       "source": "./plugins/agendas",
       "description": "A plugin to create various meeting agendas",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -3,6 +3,7 @@
 This document lists all available Claude Code plugins and their commands in the ai-helpers repository.
 
 - [Agendas](#agendas-plugin)
+- [Operator Dashboard](#operator-dashboard-plugin)
 - [Bigquery](#bigquery-plugin)
 - [Ci](#ci-plugin)
 - [Code Review](#code-review-plugin)
@@ -42,6 +43,13 @@ A plugin to create various meeting agendas
 - **`/agendas:outcome-refinement`** - Analyze the list of JIRA outcome issues to prepare an outcome refinement meeting agenda.
 
 See [plugins/agendas/README.md](plugins/agendas/README.md) for detailed documentation.
+
+### Operator Dashboard Plugin
+
+Generate OpenShift Console operator dashboard: CRD discovery, list/detail components from templates
+
+**Commands:**
+- **`/operator-dashboard:generate-dashboard` `<operator-name> [--namespace <ns>] [--output-dir <dir>]`** - Generate OpenShift Console operator dashboard from operator name and CRD discovery
 
 ### Bigquery Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -930,6 +930,28 @@
     {
       "commands": [
         {
+          "argument_hint": "<operator-name> [--namespace <ns>] [--output-dir <dir>]",
+          "description": "Generate OpenShift Console operator dashboard from operator name and CRD discovery",
+          "name": "generate-dashboard",
+          "synopsis": "/operator-dashboard:generate-dashboard <operator-name> [--namespace <ns>] [--output-dir <dir>]"
+        }
+      ],
+      "description": "Generate OpenShift Console operator dashboard: CRD discovery, list/detail components from templates",
+      "has_readme": true,
+      "hooks": [],
+      "name": "operator-dashboard",
+      "skills": [
+        {
+          "description": "Reference components for generating Kubernetes operator CRD dashboards",
+          "id": "dashboard-templates",
+          "name": "Dashboard Template Components"
+        }
+      ],
+      "version": "0.0.1"
+    },
+    {
+      "commands": [
+        {
           "argument_hint": "",
           "description": "Analyze the list of JIRA outcome issues to prepare an outcome refinement meeting agenda.",
           "name": "outcome-refinement",

--- a/docs/data.json
+++ b/docs/data.json
@@ -947,7 +947,7 @@
           "name": "Dashboard Template Components"
         }
       ],
-      "version": "0.0.1"
+      "version": "1.0.0"
     },
     {
       "commands": [

--- a/plugins/ai-operator-dashboard-generator/.claude-plugin/plugin.json
+++ b/plugins/ai-operator-dashboard-generator/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "operator-dashboard",
   "description": "Generate OpenShift Console operator dashboard: CRD discovery, list/detail components from templates",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ai-operator-dashboard-generator/.claude-plugin/plugin.json
+++ b/plugins/ai-operator-dashboard-generator/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "operator-dashboard",
+  "description": "Generate OpenShift Console operator dashboard: CRD discovery, list/detail components from templates",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/ai-operator-dashboard-generator/README.md
+++ b/plugins/ai-operator-dashboard-generator/README.md
@@ -1,0 +1,29 @@
+# operator-dashboard
+
+Generate OpenShift Console operator dashboards from an operator name and cluster CRD discovery. The plugin uses template components (CRD models and list/detail UI) in `skills/dashboard-templates/` as the basis for generated files, adapting API group, version, kind, and column definitions to the target operator.
+
+## Commands
+
+### `/operator-dashboard:generate-dashboard`
+
+Adds a new operator to an OpenShift Console dynamic plugin: discovers CRDs via the cluster, then generates the dashboard page, table components per resource kind, CSS, and extends ResourceInspect for the detail view.
+
+**Usage:**
+```
+/operator-dashboard:generate-dashboard <operator-name> [--namespace <ns>] [--output-dir <dir>]
+```
+
+**Example:**
+```
+/operator-dashboard:generate-dashboard cert-manager
+```
+
+## Installation
+
+```bash
+/plugin install operator-dashboard@ai-helpers
+```
+
+## How It Works
+
+Discovers the operator's CRDs via `kubectl` (e.g. `oc api-resources | grep -i <keyword>`), then uses the template components in `skills/dashboard-templates/` as the basis for generated files — the `.ts` files model each CRD kind (K8sGroupVersionKind and optional interfaces) and the `.tsx` files provide the list (ResourceTable) and detail (ResourceInspect) UI components — adapting field names and structure to match the target operator.

--- a/plugins/ai-operator-dashboard-generator/README.md
+++ b/plugins/ai-operator-dashboard-generator/README.md
@@ -27,3 +27,18 @@ Adds a new operator to an OpenShift Console dynamic plugin: discovers CRDs via t
 ## How It Works
 
 Discovers the operator's CRDs via `kubectl` (e.g. `oc api-resources | grep -i <keyword>`), then uses the template components in `skills/dashboard-templates/` as the basis for generated files — the `.ts` files model each CRD kind (K8sGroupVersionKind and optional interfaces) and the `.tsx` files provide the list (ResourceTable) and detail (ResourceInspect) UI components — adapting field names and structure to match the target operator.
+
+## Version 1.0.0 Updates
+
+**Major improvements to match PatternFly 6 best practices:**
+
+- ✅ **Delete Button**: ResourceTableRowActions now includes both Inspect AND Delete buttons
+- ✅ **PatternFly 6 Tokens**: Updated CSS to use `--pf-t--global--*` semantic token variables
+- ✅ **Modern EmptyState API**: Uses props-based API (`titleText`, `icon`, `headingLevel`)
+- ✅ **Proper Button Components**: Uses `<Button variant="primary|danger">` instead of plain `<button>` tags
+- ✅ **Better Page Titles**: Uses `size="xl"` for main page titles
+- ✅ **Plugin-Prefixed Classes**: Uses `console-plugin-template__*` instead of console classes
+- ✅ **Correct Timestamp API**: Uses `timestamp` prop instead of `date`
+- ✅ **Shared ResourceTableRowActions**: Exported from ResourceTable.tsx for reusability
+
+These updates ensure generated dashboards have professional appearance, proper delete functionality, and follow current OpenShift Console plugin standards.

--- a/plugins/ai-operator-dashboard-generator/commands/generate-dashboard.md
+++ b/plugins/ai-operator-dashboard-generator/commands/generate-dashboard.md
@@ -22,6 +22,41 @@ This command adds a new operator to an OpenShift Console dynamic plugin. It disc
 > explains when to use each one, and describes the patterns to follow when
 > adapting them to a new operator's CRDs.
 
+### CRITICAL: What NOT to Do
+
+Before implementing, review these common mistakes that break dashboard quality:
+
+**Button & Actions:**
+- ❌ **DO NOT** create inline `ResourceTableRowActions` components in table files
+- ❌ **DO NOT** use plain `<button>` tags — use PatternFly `<Button>` component
+- ❌ **DO NOT** put `className` on `<Link>` wrapper — put it on `<Button>`
+- ❌ **DO NOT** add custom background-color/border-color CSS for buttons
+- ❌ **DO NOT** call `useDeleteModal` inside `.map()` loops
+- ❌ **DO NOT** forget the Delete button — users need to delete resources!
+- ✅ **DO** use `<Button variant="primary">` for Inspect (blue)
+- ✅ **DO** use `<Button variant="danger">` for Delete (red)
+- ✅ **DO** import and use shared `ResourceTableRowActions` from `./ResourceTable`
+
+**PatternFly 6 APIs:**
+- ❌ **DO NOT** use old CSS variable format `--pf-v6-global--*`
+- ❌ **DO NOT** use old EmptyState API with child `<Title>` component
+- ❌ **DO NOT** use `date={new Date(...)}` with Timestamp
+- ❌ **DO NOT** use `variant` prop for Label status colors
+- ✅ **DO** use token variables `--pf-t--global--*` (PatternFly 6 semantic tokens)
+- ✅ **DO** use EmptyState props: `titleText`, `icon={SearchIcon}`, `headingLevel`
+- ✅ **DO** use `timestamp={resource.metadata?.creationTimestamp}` with Timestamp
+- ✅ **DO** use Label `status` prop: `status="success|danger|warning"`
+
+**Page Layout:**
+- ❌ **DO NOT** use `size="lg"` for main page titles
+- ❌ **DO NOT** use OpenShift console classes (`co-m-*`, `table-hover`)
+- ❌ **DO NOT** use hex colors in CSS
+- ✅ **DO** use `size="xl"` for page titles (`<Title headingLevel="h1" size="xl">`)
+- ✅ **DO** use plugin-prefixed classes (`console-plugin-template__*`)
+- ✅ **DO** use PatternFly token variables only
+
+---
+
 1. **Step 0 — Verify API groups on the cluster (REQUIRED before any coding)**
    - Run on the cluster and record the output:
      ```bash
@@ -51,20 +86,71 @@ This command adds a new operator to an OpenShift Console dynamic plugin. It disc
 
 6. **Step 5 — `src/components/OperatorNotInstalled.tsx`**
    - Create only if missing.
-   - Generic empty state with `EmptyState` (titleText, icon={SearchIcon}, headingLevel), `EmptyStateBody`, and operator display name message.
+   - Use PatternFly 6 EmptyState props API: `<EmptyState titleText={...} icon={SearchIcon} headingLevel="h4"><EmptyStateBody>...</EmptyStateBody></EmptyState>`.
+   - **DO NOT** use old API with separate `<Title>` component child.
+
+6a. **Step 5b — `src/components/ResourceTable.tsx` (shared component)**
+   - Create or verify this file exists with **ResourceTable** component AND **ResourceTableRowActions** export.
+   - **ResourceTable** component:
+     - Props: `columns`, `rows`, `loading`, `error`, `emptyStateTitle`, `emptyStateBody`, `selectedProject`, `data-test`.
+     - Renders three-dot loader (`.console-plugin-template__loader` with three `.console-plugin-template__loader-dot`), error Alert, EmptyState with **props API** (`titleText`, `icon={SearchIcon}`, `headingLevel="h4"`), or table with plugin-prefixed classes.
+     - Uses `console-plugin-template__table`, `__table-th`, `__table-td`, `__table-tr` classes (NO `co-m-*` or `table-hover`).
+   - **ResourceTableRowActions** component (CRITICAL - exports both Inspect AND Delete):
+     ```tsx
+     import { Link } from 'react-router-dom';
+     import { Button } from '@patternfly/react-core';
+     import { useDeleteModal } from '@openshift-console/dynamic-plugin-sdk';
+     
+     interface ResourceTableRowActionsProps {
+       resource: any;
+       inspectHref: string;
+     }
+     
+     export const ResourceTableRowActions: React.FC<ResourceTableRowActionsProps> = ({
+       resource,
+       inspectHref,
+     }) => {
+       const { t } = useTranslation('plugin__console-plugin-template');
+       const launchDeleteModal = useDeleteModal(resource);
+     
+       return (
+         <div className="console-plugin-template__action-buttons">
+           <Link to={inspectHref}>
+             <Button className="console-plugin-template__action-inspect" variant="primary" size="sm">
+               {t('Inspect')}
+             </Button>
+           </Link>
+           <Button
+             className="console-plugin-template__action-delete"
+             variant="danger"
+             size="sm"
+             onClick={launchDeleteModal}
+           >
+             {t('Delete')}
+           </Button>
+         </div>
+       );
+     };
+     ```
+   - **CRITICAL PATTERNS:**
+     - Use PatternFly `<Button>` component (NOT plain `<button>` tag)
+     - `className` goes on `<Button>` (NOT on wrapping `<Link>`)
+     - Colors from `variant` prop: `variant="primary"` (blue Inspect), `variant="danger"` (red Delete)
+     - Never add custom background-color/border-color CSS for buttons
+     - `useDeleteModal` called once per row (in this component), NOT in table's `.map()` loop
 
 7. **Step 6 — Table components (`src/components/<KindPlural>Table.tsx`)**
-   - Use **ResourceTable** only. One file per resource kind.
-   - Import: `import { Link } from 'react-router-dom';`
+   - Use **ResourceTable** with **ResourceTableRowActions** (both imported from `./ResourceTable`). One file per resource kind.
+   - Imports: `import { Link } from 'react-router-dom';`, `import { Label } from '@patternfly/react-core';`, `import { useK8sWatchResource, Timestamp } from '@openshift-console/dynamic-plugin-sdk';`, `import { ResourceTable, ResourceTableRowActions } from './ResourceTable';`
    - Build **columns**: array of `{ title, width? }` — Name, Namespace (if namespaced), then columns from algorithm (additionalPrinterColumns priority 0; priority 1 if total ≤ 8; fallback: Status from `status.conditions[type=Ready]`, Age from `metadata.creationTimestamp`), then Actions.
    - Build **rows** from `useK8sWatchResource` list; each row **cells**:
      - Name: `<Link key="name" to={inspectHref}>{name}</Link>` (no `<a href>`).
-     - Namespace (if namespaced), Status (Label with **status** prop), Created (Timestamp).
-     - Actions: `<ResourceTableRowActions resource={obj} inspectHref={inspectHref} />` (do not call `useDeleteModal` inside `.map()`).
+     - Namespace (if namespaced), Status (`<Label key="status" status={statusColor}>{t(statusText)}</Label>` with **status** prop: `"success"` for ready, `"danger"` for not ready, `"warning"` for unknown), Age (`<Timestamp key="age" timestamp={resource.metadata?.creationTimestamp} />`).
+     - Actions: `<ResourceTableRowActions key="actions" resource={obj} inspectHref={inspectHref} />` (ResourceTableRowActions internally calls `useDeleteModal`, do NOT call it in `.map()`).
    - Pass **loading** (`!loaded && !loadError`), **error** (`loadError?.message`), **emptyStateTitle**, **emptyStateBody**, **selectedProject** (namespaced only), **data-test**.
    - Namespaced: `selectedProject`, inspect href `/<page>/inspect/<plural>/${namespace}/${name}`.
    - Cluster-scoped: no `selectedProject`, inspect href `/<page>/inspect/<plural>/${name}`.
-   - Do not use VirtualizedTable, `<a href>`, or custom button logic; use ResourceTableRowActions for Actions cell.
+   - **CRITICAL:** Use `ResourceTableRowActions` from `./ResourceTable` (includes both Inspect AND Delete buttons). Do NOT create inline action components. Do NOT use VirtualizedTable, `<a href>`, or custom button logic.
 
 8. **Step 6b — Expandable Row Components (if relationships defined)**
    - When one-to-many relationships are specified (e.g. parent → child with matchField/matchType):
@@ -73,24 +159,175 @@ This command adds a new operator to an OpenShift Console dynamic plugin. It disc
      - Parent table uses ExpandableResourceTable; state `expandedRows: Set<string>`; each row's expandedContent is the child table component with parentName/parentNamespace.
 
 9. **Step 7 — CSS (`src/components/<operator-short-name>.css`)**
-   - Add only missing classes. Use **PatternFly variables only** (no hex). Required classes:
-   - **Page Layout:** `.console-plugin-template__inspect-page` (padding), `.console-plugin-template__dashboard-cards` (display flex, flex-direction column, gap), `.console-plugin-template__resource-card` (margin-bottom 0).
-   - **Table Structure:** `.console-plugin-template__resource-table`, `.console-plugin-template__table-responsive`, `.console-plugin-template__table` (border-collapse, width 100%, background-color var), `.console-plugin-template__table-th` (padding, text-align, vertical-align, background-color, border-bottom, font-weight), `.console-plugin-template__table-tr` (border-bottom), `.console-plugin-template__table-tr:hover` (background-color hover), `.console-plugin-template__table-td` (padding, text-align, vertical-align, word-wrap, overflow), `.console-plugin-template__table-message` (padding).
-   - **Loading:** `.console-plugin-template__loader` (flex, gap, align-items, justify-content, padding), `.console-plugin-template__loader-dot` (width 10px, height 10px, border-radius 50%, background-color var, animation), nth-child(1)(2)(3) animation-delay 0s, 0.2s, 0.4s; keyframes `console-plugin-template-loader-bounce`: 0%/80%/100% scale(0.6) opacity 0.5, 40% scale(1) opacity 1.
-   - **Action Buttons:** `.console-plugin-template__action-buttons` (display flex, gap, flex-wrap nowrap), `.console-plugin-template__action-inspect`, `.console-plugin-template__action-delete` (flex-shrink 0). Do NOT add background-color/border-color for buttons; colors from variant prop.
-   - **Expandable Rows (if relationships):** `.console-plugin-template__expand-toggle`, `.console-plugin-template__expanded-row`, `.console-plugin-template__expanded-content`, `.console-plugin-template__child-table`, `.console-plugin-template__no-children`.
-   - Never use `co-m-*`, `table-hover`, or inline `style`; keyframes names must be **kebab-case**.
+   - Add only missing classes. Use **PatternFly 6 token variables only** (format: `var(--pf-t--global--*)`). **NEVER use hex colors or old `--pf-v6-global--*` format.**
+   - **Page Layout:**
+     ```css
+     .console-plugin-template__inspect-page {
+       padding: var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--xl);
+     }
+     .console-plugin-template__dashboard-cards {
+       display: flex;
+       flex-direction: column;
+       gap: var(--pf-t--global--spacer--xl);
+     }
+     .console-plugin-template__resource-card {
+       margin-bottom: 0;
+     }
+     ```
+   - **Table Structure:**
+     ```css
+     .console-plugin-template__resource-table {
+       overflow: hidden;
+     }
+     .console-plugin-template__table-responsive {
+       overflow-x: auto;
+     }
+     .console-plugin-template__table {
+       border-collapse: collapse;
+       width: 100%;
+       background-color: var(--pf-t--global--background--color--primary--default);
+     }
+     .console-plugin-template__table-th {
+       padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+       text-align: left;
+       vertical-align: middle;
+       background-color: var(--pf-t--global--background--color--secondary--default);
+       border-bottom: 1px solid var(--pf-t--global--border--color--default);
+       font-weight: var(--pf-t--global--font--weight--body--bold);
+     }
+     .console-plugin-template__table-tr {
+       border-bottom: 1px solid var(--pf-t--global--border--color--default);
+     }
+     .console-plugin-template__table-tr:hover {
+       background-color: var(--pf-t--global--background--color--secondary--hover);
+     }
+     .console-plugin-template__table-td {
+       padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+       text-align: left;
+       vertical-align: middle;
+       word-wrap: break-word;
+       overflow: hidden;
+     }
+     .console-plugin-template__table-message {
+       padding: var(--pf-t--global--spacer--lg);
+     }
+     ```
+   - **Loading (three-dot animated loader):**
+     ```css
+     .console-plugin-template__loader {
+       display: flex;
+       gap: var(--pf-t--global--spacer--sm);
+       align-items: center;
+       justify-content: center;
+       padding: var(--pf-t--global--spacer--lg);
+     }
+     .console-plugin-template__loader-dot {
+       width: 10px;
+       height: 10px;
+       border-radius: 50%;
+       background-color: var(--pf-t--global--color--brand--default);
+       animation: console-plugin-template-loader-bounce 1.2s infinite ease-in-out;
+     }
+     .console-plugin-template__loader-dot:nth-child(1) {
+       animation-delay: 0s;
+     }
+     .console-plugin-template__loader-dot:nth-child(2) {
+       animation-delay: 0.2s;
+     }
+     .console-plugin-template__loader-dot:nth-child(3) {
+       animation-delay: 0.4s;
+     }
+     @keyframes console-plugin-template-loader-bounce {
+       0%, 80%, 100% {
+         transform: scale(0.6);
+         opacity: 0.5;
+       }
+       40% {
+         transform: scale(1);
+         opacity: 1;
+       }
+     }
+     ```
+   - **Action Buttons:**
+     ```css
+     .console-plugin-template__action-buttons {
+       display: flex;
+       gap: var(--pf-t--global--spacer--xs);
+       flex-wrap: nowrap;
+     }
+     .console-plugin-template__action-inspect {
+       flex-shrink: 0;
+     }
+     .console-plugin-template__action-delete {
+       flex-shrink: 0;
+     }
+     ```
+     **CRITICAL:** Do NOT add background-color/border-color CSS for buttons. Button colors come from PatternFly's `variant` prop (`variant="primary"` for blue Inspect, `variant="danger"` for red Delete).
+   - **Expandable Rows (if relationships):** `.console-plugin-template__expand-toggle`, `.console-plugin-template__expanded-row`, `.console-plugin-template__expanded-content`, `.console-plugin-template__child-table`, `.console-plugin-template__no-children` (use token variables for colors/spacing).
+   - **Never use:** `co-m-*`, `table-hover`, inline `style` attributes, hex colors, or old `--pf-v6-global--*` variable format. Keyframes names must be **kebab-case**.
 
 10. **Step 7b — Optional: Overview dashboard**
     - Optional: summary count cards above tables (useK8sWatchResource per kind, Grid + Card, plugin-prefixed classes). Not required.
 
 11. **Step 8 — Operator page (`src/<OperatorShortName>Page.tsx`)**
-    - Imports: Title, Card, CardTitle, CardBody, Spinner from `@patternfly/react-core`; Helmet; useTranslation, useActiveNamespace, useOperatorDetection.
-    - `selectedProject = activeNamespace === '#ALL_NS#' ? '#ALL_NS#' : activeNamespace` (do not use `'all'`).
-    - If `operatorStatus === 'loading'`: wrap in `console-plugin-template__inspect-page`, render `<Spinner size="lg">`.
-    - If `operatorStatus === 'not-installed'`: same wrapper, Title, OperatorNotInstalled with operator display name.
-    - Else: Helmet, wrapper, Title with marginBottom, optional fixed-namespace Alert, `console-plugin-template__dashboard-cards` containing one Card per resource kind with CardTitle and CardBody wrapping the corresponding Table. Pass selectedProject only to namespaced tables; for fixed-namespace operator pass the fixed namespace value.
-    - Export both named (`export const`) and default (`export default`).
+    - **Imports:** `import { Title, Card, CardTitle, CardBody, Spinner } from '@patternfly/react-core';`, `import Helmet from 'react-helmet';`, `import { useTranslation } from 'react-i18next';`, `import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';`, `import { useOperatorDetection, <OPERATOR>_OPERATOR_INFO } from './hooks/useOperatorDetection';`, `import { OperatorNotInstalled } from './components/OperatorNotInstalled';`, table imports, CSS import.
+    - **Structure:**
+      ```tsx
+      const selectedProject = activeNamespace === '#ALL_NS#' ? '#ALL_NS#' : activeNamespace;
+      const pageTitle = t('<operator-display-name>');
+      
+      if (operatorStatus === 'loading') {
+        return (
+          <>
+            <Helmet><title>{pageTitle}</title></Helmet>
+            <div className="console-plugin-template__inspect-page">
+              <Spinner size="lg" aria-label={t('Loading...')} />
+            </div>
+          </>
+        );
+      }
+      
+      if (operatorStatus === 'not-installed') {
+        return (
+          <>
+            <Helmet><title>{pageTitle}</title></Helmet>
+            <div className="console-plugin-template__inspect-page">
+              <Title headingLevel="h1" size="xl">
+                {pageTitle}
+              </Title>
+              <OperatorNotInstalled operatorDisplayName={<OPERATOR>_OPERATOR_INFO.displayName} />
+            </div>
+          </>
+        );
+      }
+      
+      return (
+        <>
+          <Helmet><title>{pageTitle}</title></Helmet>
+          <div className="console-plugin-template__inspect-page">
+            <Title
+              headingLevel="h1"
+              size="xl"
+              style={{ marginBottom: 'var(--pf-t--global--spacer--lg)' }}
+            >
+              {pageTitle}
+            </Title>
+            
+            <div className="console-plugin-template__dashboard-cards">
+              <Card className="console-plugin-template__resource-card">
+                <CardTitle>{t('<ResourceKind Plural>')}</CardTitle>
+                <CardBody>
+                  <<KindPlural>Table selectedProject={selectedProject} />
+                </CardBody>
+              </Card>
+              {/* Repeat Card for each resource kind */}
+            </div>
+          </div>
+        </>
+      );
+      ```
+    - **CRITICAL:** Use `size="xl"` for page title (NOT `size="lg"`). Pass `selectedProject` only to namespaced tables. For cluster-scoped tables, do not pass `selectedProject`. For fixed-namespace operators, pass the fixed namespace string instead of `selectedProject`.
+    - Export both named (`export const <OperatorShortName>Page`) and default (`export default <OperatorShortName>Page`).
 
 12. **Step 9 — `src/ResourceInspect.tsx` (extend only)**
     - Do not rewrite. Add: DISPLAY_NAMES entries (plural → display name), getResourceModel(resourceType) cases returning the new kind's K8sModel, getPagePath(resourceType) returning the operator page path (e.g. `'/cert-manager'`). Cluster-scoped: component already handles 2-segment path (plural/name). Keep URL parsing and Card + Grid layout as-is.
@@ -104,7 +341,7 @@ This command adds a new operator to an OpenShift Console dynamic plugin. It disc
     - Add to `consolePlugin.exposedModules`: `"<OperatorShortName>Page": "./<OperatorShortName>Page"`. Add `"ResourceInspect": "./ResourceInspect"` only if not already present.
 
 15. **Step 12 — Locales**
-    - Add all new strings to `locales/en/plugin__console-plugin-template.json` (page title, resource display names, empty states, Inspect, Delete, error messages, "Plugins" if section added). Do not remove existing keys.
+    - Add all new strings to `locales/en/plugin__console-plugin-template.json`. **CRITICAL:** Include `"Inspect": "Inspect"` and `"Delete": "Delete"` for action buttons. Also add page title, resource display names, empty states, error messages, "Plugins" if section added, "Loading..." for spinner aria-label. Do not remove existing keys.
 
 16. **Step 13 — RBAC**
     - In `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`, add or append ClusterRoles and bindings: Reader (get, list, watch) and Admin (get, list, watch, delete) for the new API groups/resources. Template names: `{{ template "openshift-console-plugin.name" . }}-<operator-short-name>-reader` and `-admin`.
@@ -117,7 +354,21 @@ This command adds a new operator to an OpenShift Console dynamic plugin. It disc
 
 ## Return Value
 
-- **Generated/updated files**: `src/hooks/useOperatorDetection.ts`, `src/components/crds/index.ts`, `src/components/crds/Events.ts`, `src/components/OperatorNotInstalled.tsx` (if created), `src/components/<KindPlural>Table.tsx` per kind, `src/components/ExpandableResourceTable.tsx` (if relationships), `src/components/<operator-short-name>.css`, `src/<OperatorShortName>Page.tsx`, `src/ResourceInspect.tsx` (extended), `console-extensions.json`, `package.json`, `locales/en/plugin__console-plugin-template.json`, `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`.
+- **Generated/updated files**: 
+  - `src/hooks/useOperatorDetection.ts`
+  - `src/components/ResourceTable.tsx` (CRITICAL: must export ResourceTableRowActions with Delete button)
+  - `src/components/crds/index.ts`
+  - `src/components/crds/Events.ts`
+  - `src/components/OperatorNotInstalled.tsx` (if created)
+  - `src/components/<KindPlural>Table.tsx` per kind (imports ResourceTableRowActions)
+  - `src/components/ExpandableResourceTable.tsx` (if relationships)
+  - `src/components/<operator-short-name>.css` (PatternFly 6 token variables)
+  - `src/<OperatorShortName>Page.tsx`
+  - `src/ResourceInspect.tsx` (extended)
+  - `console-extensions.json`
+  - `package.json`
+  - `locales/en/plugin__console-plugin-template.json` (includes "Inspect" and "Delete")
+  - `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`
 
 ## Examples
 

--- a/plugins/ai-operator-dashboard-generator/commands/generate-dashboard.md
+++ b/plugins/ai-operator-dashboard-generator/commands/generate-dashboard.md
@@ -1,0 +1,143 @@
+---
+description: Generate OpenShift Console operator dashboard from operator name and CRD discovery
+argument-hint: "<operator-name> [--namespace <ns>] [--output-dir <dir>]"
+---
+
+## Name
+operator-dashboard:generate-dashboard
+
+## Synopsis
+```
+/operator-dashboard:generate-dashboard <operator-name> [--namespace <ns>] [--output-dir <dir>]
+```
+
+## Description
+
+This command adds a new operator to an OpenShift Console dynamic plugin. It discovers the operator's CRDs via cluster API (e.g. `oc api-resources`), then generates the dashboard page, one table component per resource kind using the shared ResourceTable pattern, operator CSS, and extends ResourceInspect for the detail view. Optional parameters allow scoping to a namespace and writing output to a custom directory. The template components in `skills/dashboard-templates/` define the CRD models (`.ts`) and list/detail UI components (ResourceTable, ResourceInspect) that are adapted to the target operator's API group, version, kind, and printer columns.
+
+## Implementation
+
+> Before starting, read the skill at
+> `skills/dashboard-templates/SKILL.md`. It documents every template component,
+> explains when to use each one, and describes the patterns to follow when
+> adapting them to a new operator's CRDs.
+
+1. **Step 0 — Verify API groups on the cluster (REQUIRED before any coding)**
+   - Run on the cluster and record the output:
+     ```bash
+     oc api-resources | grep -i <operator-keyword>
+     ```
+   - From the output use:
+     - **APIVERSION column** → correct `group` and `version` for every K8s model and GVK. Format `<group>/<version>` (e.g. `nfd.openshift.io/v1` → group `nfd.openshift.io`, version `v1`). Entry with no slash (e.g. `v1`) means core group (`""`).
+     - **NAMESPACED column** → `true` means resource needs `selectedProject` and Namespace column; `false` means cluster-scoped (no namespace in inspect URL, no `selectedProject`).
+     - **KIND column** → exact kind name to use.
+   - Do not proceed until verified API group/version/scope for every resource kind to expose.
+
+2. **Step 1 — Directories**
+   - Create: `mkdir -p src/hooks src/components/crds`
+
+3. **Step 2 — `src/hooks/useOperatorDetection.ts`**
+   - Use `useK8sModel` with `{ group, version, kind }` for the primary resource.
+   - Export `OperatorStatus`, `OperatorInfo`, `<OPERATOR>_OPERATOR_INFO`, and `useOperatorDetection()`.
+   - If the file exists, add the new operator's info and extend the hook.
+   - **Critical:** `useK8sModel` returns `[model, inFlight]` where `inFlight` is `true` **while loading**. Check `if (inFlight) return 'loading'` — NOT `if (!inFlight)`.
+
+4. **Step 3 — `src/components/crds/index.ts`**
+   - For each resource kind, export a **K8sModel** (K8sGroupVersionKind) and a TypeScript interface extending `K8sResourceCommon` with optional `spec`/`status`.
+   - Append if the file exists.
+
+5. **Step 4 — `src/components/crds/Events.ts`**
+   - Add `plural: 'Kind'` to **RESOURCE_TYPE_TO_KIND** for each new resource (so events can resolve involvedObject kind from resource type).
+
+6. **Step 5 — `src/components/OperatorNotInstalled.tsx`**
+   - Create only if missing.
+   - Generic empty state with `EmptyState` (titleText, icon={SearchIcon}, headingLevel), `EmptyStateBody`, and operator display name message.
+
+7. **Step 6 — Table components (`src/components/<KindPlural>Table.tsx`)**
+   - Use **ResourceTable** only. One file per resource kind.
+   - Import: `import { Link } from 'react-router-dom';`
+   - Build **columns**: array of `{ title, width? }` — Name, Namespace (if namespaced), then columns from algorithm (additionalPrinterColumns priority 0; priority 1 if total ≤ 8; fallback: Status from `status.conditions[type=Ready]`, Age from `metadata.creationTimestamp`), then Actions.
+   - Build **rows** from `useK8sWatchResource` list; each row **cells**:
+     - Name: `<Link key="name" to={inspectHref}>{name}</Link>` (no `<a href>`).
+     - Namespace (if namespaced), Status (Label with **status** prop), Created (Timestamp).
+     - Actions: `<ResourceTableRowActions resource={obj} inspectHref={inspectHref} />` (do not call `useDeleteModal` inside `.map()`).
+   - Pass **loading** (`!loaded && !loadError`), **error** (`loadError?.message`), **emptyStateTitle**, **emptyStateBody**, **selectedProject** (namespaced only), **data-test**.
+   - Namespaced: `selectedProject`, inspect href `/<page>/inspect/<plural>/${namespace}/${name}`.
+   - Cluster-scoped: no `selectedProject`, inspect href `/<page>/inspect/<plural>/${name}`.
+   - Do not use VirtualizedTable, `<a href>`, or custom button logic; use ResourceTableRowActions for Actions cell.
+
+8. **Step 6b — Expandable Row Components (if relationships defined)**
+   - When one-to-many relationships are specified (e.g. parent → child with matchField/matchType):
+     - Create or extend `src/components/ExpandableResourceTable.tsx` with props: columns, rows (each row: key, cells, isExpanded, onToggle, expandedContent), loading, error, emptyStateTitle, emptyStateBody, selectedProject, data-test. First column is expand toggle (AngleRightIcon/AngleDownIcon); expanded row `<tr><td colSpan={columns.length + 1}>...</td></tr>`.
+     - For each relationship, create a child table component that fetches children with `useK8sWatchResource`, filters by matchField/matchType (field | ownerRef | label), and renders ResourceTable or "No related <ChildKind>s" when empty. Children must be fetched **lazily** only when the parent row is expanded.
+     - Parent table uses ExpandableResourceTable; state `expandedRows: Set<string>`; each row's expandedContent is the child table component with parentName/parentNamespace.
+
+9. **Step 7 — CSS (`src/components/<operator-short-name>.css`)**
+   - Add only missing classes. Use **PatternFly variables only** (no hex). Required classes:
+   - **Page Layout:** `.console-plugin-template__inspect-page` (padding), `.console-plugin-template__dashboard-cards` (display flex, flex-direction column, gap), `.console-plugin-template__resource-card` (margin-bottom 0).
+   - **Table Structure:** `.console-plugin-template__resource-table`, `.console-plugin-template__table-responsive`, `.console-plugin-template__table` (border-collapse, width 100%, background-color var), `.console-plugin-template__table-th` (padding, text-align, vertical-align, background-color, border-bottom, font-weight), `.console-plugin-template__table-tr` (border-bottom), `.console-plugin-template__table-tr:hover` (background-color hover), `.console-plugin-template__table-td` (padding, text-align, vertical-align, word-wrap, overflow), `.console-plugin-template__table-message` (padding).
+   - **Loading:** `.console-plugin-template__loader` (flex, gap, align-items, justify-content, padding), `.console-plugin-template__loader-dot` (width 10px, height 10px, border-radius 50%, background-color var, animation), nth-child(1)(2)(3) animation-delay 0s, 0.2s, 0.4s; keyframes `console-plugin-template-loader-bounce`: 0%/80%/100% scale(0.6) opacity 0.5, 40% scale(1) opacity 1.
+   - **Action Buttons:** `.console-plugin-template__action-buttons` (display flex, gap, flex-wrap nowrap), `.console-plugin-template__action-inspect`, `.console-plugin-template__action-delete` (flex-shrink 0). Do NOT add background-color/border-color for buttons; colors from variant prop.
+   - **Expandable Rows (if relationships):** `.console-plugin-template__expand-toggle`, `.console-plugin-template__expanded-row`, `.console-plugin-template__expanded-content`, `.console-plugin-template__child-table`, `.console-plugin-template__no-children`.
+   - Never use `co-m-*`, `table-hover`, or inline `style`; keyframes names must be **kebab-case**.
+
+10. **Step 7b — Optional: Overview dashboard**
+    - Optional: summary count cards above tables (useK8sWatchResource per kind, Grid + Card, plugin-prefixed classes). Not required.
+
+11. **Step 8 — Operator page (`src/<OperatorShortName>Page.tsx`)**
+    - Imports: Title, Card, CardTitle, CardBody, Spinner from `@patternfly/react-core`; Helmet; useTranslation, useActiveNamespace, useOperatorDetection.
+    - `selectedProject = activeNamespace === '#ALL_NS#' ? '#ALL_NS#' : activeNamespace` (do not use `'all'`).
+    - If `operatorStatus === 'loading'`: wrap in `console-plugin-template__inspect-page`, render `<Spinner size="lg">`.
+    - If `operatorStatus === 'not-installed'`: same wrapper, Title, OperatorNotInstalled with operator display name.
+    - Else: Helmet, wrapper, Title with marginBottom, optional fixed-namespace Alert, `console-plugin-template__dashboard-cards` containing one Card per resource kind with CardTitle and CardBody wrapping the corresponding Table. Pass selectedProject only to namespaced tables; for fixed-namespace operator pass the fixed namespace value.
+    - Export both named (`export const`) and default (`export default`).
+
+12. **Step 9 — `src/ResourceInspect.tsx` (extend only)**
+    - Do not rewrite. Add: DISPLAY_NAMES entries (plural → display name), getResourceModel(resourceType) cases returning the new kind's K8sModel, getPagePath(resourceType) returning the operator page path (e.g. `'/cert-manager'`). Cluster-scoped: component already handles 2-segment path (plural/name). Keep URL parsing and Card + Grid layout as-is.
+
+13. **Step 10 — `console-extensions.json`**
+    - Append page route: exact true, path `/<operator-short-name>`, component `$codeRef`: `"<OperatorShortName>Page.<OperatorShortName>Page"` (e.g. `CertManagerPage.CertManagerPage`).
+    - Append inspect route: exact false, path `["/<operator-short-name>/inspect"]`, component `$codeRef`: `"ResourceInspect.ResourceInspect"`.
+    - If missing, add `console.navigation/section` with id `"plugins"`, insertAfter `"observe"`. Add `console.navigation/href` with id `<operator-short-name>`, href `/<operator-short-name>`, **section: "plugins"** (do not use section "home").
+
+14. **Step 11 — `package.json`**
+    - Add to `consolePlugin.exposedModules`: `"<OperatorShortName>Page": "./<OperatorShortName>Page"`. Add `"ResourceInspect": "./ResourceInspect"` only if not already present.
+
+15. **Step 12 — Locales**
+    - Add all new strings to `locales/en/plugin__console-plugin-template.json` (page title, resource display names, empty states, Inspect, Delete, error messages, "Plugins" if section added). Do not remove existing keys.
+
+16. **Step 13 — RBAC**
+    - In `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`, add or append ClusterRoles and bindings: Reader (get, list, watch) and Admin (get, list, watch, delete) for the new API groups/resources. Template names: `{{ template "openshift-console-plugin.name" . }}-<operator-short-name>-reader` and `-admin`.
+
+17. **Validation**
+    - Confirm `oc api-resources` output was used for all API groups/versions/scope.
+    - Run `yarn build-dev`; it must succeed. If "Invalid module export 'default' in extension [N] property 'component'" appears, fix `console-extensions.json` to use `moduleName.exportName` for every route component.
+    - Run `yarn lint`; fix any issues in src/ or CSS.
+    - Runtime: navigate to `/<operator-short-name>`; if "Operator not installed" when operator is installed, re-run `oc api-resources` and correct CRD models and useOperatorDetection.
+
+## Return Value
+
+- **Generated/updated files**: `src/hooks/useOperatorDetection.ts`, `src/components/crds/index.ts`, `src/components/crds/Events.ts`, `src/components/OperatorNotInstalled.tsx` (if created), `src/components/<KindPlural>Table.tsx` per kind, `src/components/ExpandableResourceTable.tsx` (if relationships), `src/components/<operator-short-name>.css`, `src/<OperatorShortName>Page.tsx`, `src/ResourceInspect.tsx` (extended), `console-extensions.json`, `package.json`, `locales/en/plugin__console-plugin-template.json`, `charts/openshift-console-plugin/templates/rbac-clusterroles.yaml`.
+
+## Examples
+
+1. **Basic usage**:
+   ```
+   /operator-dashboard:generate-dashboard cert-manager
+   ```
+
+2. **Scoped to a namespace**:
+   ```
+   /operator-dashboard:generate-dashboard external-secrets --namespace external-secrets
+   ```
+
+3. **Custom output directory**:
+   ```
+   /operator-dashboard:generate-dashboard my-operator --output-dir ./src/dashboard
+   ```
+
+## Arguments
+
+- `$1`: The operator name used to discover its CRDs (and for naming the dashboard route and page).
+- `--namespace`: Kubernetes namespace to scope CR listing. Default: all namespaces.
+- `--output-dir`: Directory to write generated files into. Default: project root (e.g. `./` or `./src` as appropriate).

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Certificate.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Certificate.ts
@@ -1,0 +1,7 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const CertificateModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Certificate',
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Events.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Events.ts
@@ -1,0 +1,47 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const EventModel: K8sGroupVersionKind = {
+  group: '',
+  version: 'v1',
+  kind: 'Event',
+};
+
+export interface K8sEvent {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  type?: string;
+  reason?: string;
+  message?: string;
+  count?: number;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  involvedObject?: {
+    kind?: string;
+    name?: string;
+    namespace?: string;
+    [key: string]: unknown;
+  };
+}
+
+const RESOURCE_TYPE_TO_KIND: Record<string, string> = {
+  certificates: 'Certificate',
+  issuers: 'Issuer',
+  clusterissuers: 'ClusterIssuer',
+  externalsecrets: 'ExternalSecret',
+  clusterexternalsecrets: 'ClusterExternalSecret',
+  secretstores: 'SecretStore',
+  clustersecretstores: 'ClusterSecretStore',
+  pushsecrets: 'PushSecret',
+  clusterpushsecrets: 'ClusterPushSecret',
+  secretproviderclasses: 'SecretProviderClass',
+};
+
+export function getInvolvedObjectKind(resourceType: string): string {
+  return RESOURCE_TYPE_TO_KIND[resourceType] ?? resourceType;
+}

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ExternalSecret.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ExternalSecret.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const ExternalSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ExternalSecret',
+};
+
+export const ClusterExternalSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterExternalSecret',
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Issuer.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/Issuer.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const IssuerModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Issuer',
+};
+
+export const ClusterIssuerModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'ClusterIssuer',
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/PushSecret.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/PushSecret.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const PushSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'PushSecret',
+};
+
+export const ClusterPushSecretModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterPushSecret',
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceInspect.tsx
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceInspect.tsx
@@ -1,0 +1,856 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import Helmet from 'react-helmet';
+import {
+  Title,
+  Card,
+  CardTitle,
+  CardBody,
+  Grid,
+  GridItem,
+  Button,
+  Label,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  Alert,
+  AlertVariant,
+  Switch,
+} from '@patternfly/react-core';
+import { ArrowLeftIcon, KeyIcon, CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { CertificateModel } from './components/crds/Certificate';
+import { IssuerModel, ClusterIssuerModel } from './components/crds/Issuer';
+import { ExternalSecretModel, ClusterExternalSecretModel } from './components/crds/ExternalSecret';
+import { SecretStoreModel, ClusterSecretStoreModel } from './components/crds/SecretStore';
+import { PushSecretModel, ClusterPushSecretModel } from './components/crds/PushSecret';
+import {
+  SecretProviderClassModel,
+  SecretProviderClassPodStatusModel,
+  SecretProviderClassPodStatus,
+} from './components/crds/SecretProviderClass';
+import { EventModel, getInvolvedObjectKind, K8sEvent } from './components/crds/Events';
+import { dump as yamlDump } from 'js-yaml';
+
+// YAML syntax colors (on black background): blue (keys), mustard yellow (values)
+const YAML_KEY_COLOR = '#60a5fa';
+const YAML_VALUE_COLOR = '#eab308';
+const HIDDEN_VALUE_PLACEHOLDER = '********';
+
+function colorizeYaml(yamlString: string): React.ReactNode {
+  const lines = yamlString.split('\n');
+  return (
+    <>
+      {lines.map((line, i) => {
+        // Key: value
+        const keyValueMatch = line.match(/^(\s*)(.+?)(\s*:\s*)(.*)$/);
+        if (keyValueMatch) {
+          const [, indent, key, sep, value] = keyValueMatch;
+          return (
+            <span key={i}>
+              {indent}
+              <span style={{ color: YAML_KEY_COLOR }}>{key}</span>
+              {sep}
+              <span style={{ color: YAML_VALUE_COLOR }}>{value}</span>
+              {'\n'}
+            </span>
+          );
+        }
+        // List item: - value
+        const listMatch = line.match(/^(\s*)(-\s+)(.*)$/);
+        if (listMatch) {
+          const [, indent, dash, rest] = listMatch;
+          return (
+            <span key={i}>
+              {indent}
+              <span style={{ color: YAML_KEY_COLOR }}>{dash.trim() || '-'}</span>
+              <span style={{ color: YAML_VALUE_COLOR }}>{rest}</span>
+              {'\n'}
+            </span>
+          );
+        }
+        // Comment or continuation line: use value color for non-empty, keep structure
+        if (line.trim().startsWith('#')) {
+          return (
+            <span key={i} style={{ color: '#6b7280' }}>
+              {line}
+              {'\n'}
+            </span>
+          );
+        }
+        return (
+          <span key={i}>
+            {line ? <span style={{ color: YAML_VALUE_COLOR }}>{line}</span> : null}
+            {'\n'}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+export const ResourceInspect: React.FC = () => {
+  const { t } = useTranslation('plugin__ocp-secrets-management');
+
+  // State for revealing sensitive data (separate for spec and status)
+  const [showSpecSensitiveData, setShowSpecSensitiveData] = React.useState(false);
+  const [showStatusSensitiveData, setShowStatusSensitiveData] = React.useState(false);
+
+  // Parse URL manually since useParams() isn't working in plugin environment
+  const pathname = window.location.pathname;
+  const pathParts = pathname.split('/');
+
+  // Expected format: /secrets-management/inspect/{resourceType}/{namespace}/{name}
+  // or: /secrets-management/inspect/{resourceType}/{name} (for cluster-scoped)
+  const baseIndex = pathParts.findIndex((part) => part === 'inspect');
+  const resourceType =
+    baseIndex >= 0 && pathParts.length > baseIndex + 1 ? pathParts[baseIndex + 1] : '';
+
+  let namespace: string | undefined;
+  let name: string;
+
+  if (pathParts.length > baseIndex + 3) {
+    // Format: /secrets-management/inspect/{resourceType}/{namespace}/{name}
+    namespace = pathParts[baseIndex + 2];
+    name = pathParts[baseIndex + 3];
+  } else {
+    // Format: /secrets-management/inspect/{resourceType}/{name} (cluster-scoped)
+    name = pathParts[baseIndex + 2] || '';
+  }
+
+  const handleBackClick = () => {
+    window.history.back();
+  };
+
+  // Determine the correct model based on resource type
+  const getResourceModel = () => {
+    switch (resourceType) {
+      case 'certificates':
+        return CertificateModel;
+      case 'issuers':
+        return IssuerModel;
+      case 'clusterissuers':
+        return ClusterIssuerModel;
+      case 'externalsecrets':
+        return ExternalSecretModel;
+      case 'clusterexternalsecrets':
+        return ClusterExternalSecretModel;
+      case 'secretstores':
+        return SecretStoreModel;
+      case 'clustersecretstores':
+        return ClusterSecretStoreModel;
+      case 'pushsecrets':
+        return PushSecretModel;
+      case 'clusterpushsecrets':
+        return ClusterPushSecretModel;
+      case 'secretproviderclasses':
+        return SecretProviderClassModel;
+      default:
+        return null;
+    }
+  };
+
+  const model = getResourceModel();
+  const isClusterScoped =
+    resourceType === 'clusterissuers' ||
+    resourceType === 'clustersecretstores' ||
+    resourceType === 'clusterexternalsecrets' ||
+    resourceType === 'clusterpushsecrets';
+
+  const [resource, loaded, loadError] = useK8sWatchResource<any>({
+    groupVersionKind: model,
+    name: name,
+    namespace: isClusterScoped ? undefined : namespace || 'demo',
+    isList: false,
+  });
+
+  // Watch SecretProviderClassPodStatus resources when inspecting a SecretProviderClass
+  const [podStatuses, podStatusesLoaded, podStatusesError] = useK8sWatchResource<
+    SecretProviderClassPodStatus[]
+  >({
+    groupVersionKind: SecretProviderClassPodStatusModel,
+    namespace: resourceType === 'secretproviderclasses' ? namespace || 'demo' : undefined,
+    isList: true,
+  });
+
+  // Watch Events for this resource (involvedObject name/kind/namespace)
+  const eventsNamespace = isClusterScoped ? 'default' : namespace || 'default';
+  const involvedKind = getInvolvedObjectKind(resourceType);
+  const eventsFieldSelector = [
+    `involvedObject.name=${name}`,
+    `involvedObject.kind=${involvedKind}`,
+    ...(!isClusterScoped && namespace ? [`involvedObject.namespace=${namespace}`] : []),
+  ].join(',');
+  const [events, eventsLoaded, eventsError] = useK8sWatchResource<K8sEvent[]>({
+    groupVersionKind: EventModel,
+    namespace: eventsNamespace,
+    isList: true,
+    fieldSelector: eventsFieldSelector,
+  });
+
+  const formatTimestamp = (timestamp: string) => {
+    if (!timestamp) return '-';
+    try {
+      return new Date(timestamp).toLocaleString();
+    } catch {
+      return timestamp;
+    }
+  };
+
+  const renderMetadata = () => {
+    if (!resource?.metadata) return null;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Metadata')}</CardTitle>
+        <CardBody>
+          <DescriptionList
+            isHorizontal
+            style={{
+              rowGap: '0.25rem',
+              background: '#1e1e1e',
+              paddingTop: '16px',
+              paddingLeft: '16px',
+              paddingBottom: '16px',
+            }}
+          >
+            <DescriptionListGroup
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'baseline',
+                marginBottom: 0,
+              }}
+            >
+              <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                {t('Name:')}
+              </DescriptionListTerm>
+              <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                {resource.metadata.name || '-'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {resource.kind && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Kind:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.kind}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.metadata.namespace && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Namespace:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.namespace}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.apiVersion && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('API version:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.apiVersion}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            <DescriptionListGroup
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'baseline',
+                marginBottom: 0,
+              }}
+            >
+              <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                {t('Creation timestamp:')}
+              </DescriptionListTerm>
+              <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                {formatTimestamp(resource.metadata.creationTimestamp)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            {resource.metadata.uid && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('UID:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.uid}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+            {resource.metadata.resourceVersion && (
+              <DescriptionListGroup
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {t('Resource version:')}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {resource.metadata.resourceVersion}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            )}
+          </DescriptionList>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderLabels = () => {
+    const labels = resource?.metadata?.labels;
+    if (!labels || Object.keys(labels).length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Labels')}</CardTitle>
+          <CardBody>
+            <em>{t('No labels')}</em>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    const cardStyle = {
+      background: '#1e1e1e',
+      borderRadius: '4px',
+      border: '1px solid #374151',
+    };
+    return (
+      <Card style={cardStyle}>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Labels')}</CardTitle>
+        <CardBody>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {Object.entries(labels).map(([key, value]) => (
+              <Label key={key} color="blue">
+                {key}: {value}
+              </Label>
+            ))}
+          </div>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderAnnotations = () => {
+    const annotations = resource?.metadata?.annotations;
+    if (!annotations || Object.keys(annotations).length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+            {t('Annotations')}
+          </CardTitle>
+          <CardBody>
+            <em>{t('No annotations')}</em>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    const cardStyle = {
+      background: '#1e1e1e',
+      borderRadius: '4px',
+      border: '1px solid #374151',
+    };
+    return (
+      <Card style={cardStyle}>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>{t('Annotations')}</CardTitle>
+        <CardBody>
+          <DescriptionList isHorizontal style={{ rowGap: '0.25rem', background: '#1e1e1e' }}>
+            {Object.entries(annotations).map(([key, value]) => (
+              <DescriptionListGroup
+                key={key}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  marginBottom: 0,
+                }}
+              >
+                <DescriptionListTerm style={{ minWidth: '16rem', flexShrink: 0 }}>
+                  {key}
+                </DescriptionListTerm>
+                <DescriptionListDescription style={{ wordBreak: 'break-all', flex: 1 }}>
+                  {value}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            ))}
+          </DescriptionList>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  // Function to check if object contains sensitive data
+  const containsSensitiveData = (obj: any): boolean => {
+    const sensitiveKeys = [
+      'password',
+      'secret',
+      'token',
+      'key',
+      'privateKey',
+      'secretKey',
+      'accessKey',
+      'secretAccessKey',
+      'clientSecret',
+      'apiKey',
+      'auth',
+      'authentication',
+      'credential',
+      'cert',
+      'certificate',
+      'tls',
+      // SecretProviderClass specific sensitive patterns
+      'tenantId',
+      'clientId',
+      'subscriptionId',
+      'resourceGroup',
+      'vaultName',
+      'keyVaultName',
+      'servicePrincipal',
+      'roleArn',
+      'region',
+      'vaultUrl',
+      'vaultAddress',
+      'vaultNamespace',
+      'vaultRole',
+      'vaultPath',
+      'parameters',
+    ];
+
+    const checkObject = (data: any): boolean => {
+      if (Array.isArray(data)) {
+        return data.some(checkObject);
+      }
+
+      if (data && typeof data === 'object') {
+        for (const [key, value] of Object.entries(data)) {
+          const lowerKey = key.toLowerCase();
+          const isSensitive = sensitiveKeys.some((sensitiveKey) =>
+            lowerKey.includes(sensitiveKey.toLowerCase()),
+          );
+
+          if (isSensitive || checkObject(value)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    };
+
+    return checkObject(obj);
+  };
+
+  const renderSpecification = () => {
+    if (!resource?.spec) return null;
+
+    const hasSensitiveData = containsSensitiveData(resource.spec);
+    const shouldHideContent = hasSensitiveData && !showSpecSensitiveData;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            {t('Specification')}
+            {hasSensitiveData && (
+              <Switch
+                id="spec-sensitive-toggle"
+                label={showSpecSensitiveData ? t('Hide sensitive data') : t('Show sensitive data')}
+                isChecked={showSpecSensitiveData}
+                onChange={(event, checked) => setShowSpecSensitiveData(checked)}
+                ouiaId="SpecificationSensitiveToggle"
+              />
+            )}
+          </div>
+        </CardTitle>
+        <CardBody>
+          <pre
+            style={{
+              padding: '16px',
+              borderRadius: '4px',
+              overflow: 'auto',
+              fontSize: '13px',
+              maxHeight: '400px',
+              background: '#1e1e1e',
+              border: '1px solid #374151',
+            }}
+          >
+            {shouldHideContent ? (
+              <span style={{ color: YAML_VALUE_COLOR }}>{HIDDEN_VALUE_PLACEHOLDER}</span>
+            ) : (
+              colorizeYaml(yamlDump(resource.spec, { lineWidth: -1 }))
+            )}
+          </pre>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderStatus = () => {
+    if (!resource?.status) return null;
+
+    // For Certificates, always show the toggle when status exists (status may reference secrets/certs);
+    // for other resources, only show when status contains sensitive-looking keys.
+    const hasSensitiveData =
+      resourceType === 'certificates' || containsSensitiveData(resource.status);
+    const shouldHideContent = hasSensitiveData && !showStatusSensitiveData;
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            {t('Status')}
+            {hasSensitiveData && (
+              <Switch
+                id="status-sensitive-toggle"
+                label={
+                  showStatusSensitiveData ? t('Hide sensitive data') : t('Show sensitive data')
+                }
+                isChecked={showStatusSensitiveData}
+                onChange={(event, checked) => setShowStatusSensitiveData(checked)}
+                ouiaId="StatusSensitiveToggle"
+              />
+            )}
+          </div>
+        </CardTitle>
+        <CardBody>
+          <pre
+            style={{
+              padding: '16px',
+              borderRadius: '4px',
+              overflow: 'auto',
+              fontSize: '13px',
+              maxHeight: '400px',
+              background: '#1e1e1e',
+              border: '1px solid #374151',
+            }}
+          >
+            {shouldHideContent ? (
+              <span style={{ color: YAML_VALUE_COLOR }}>{HIDDEN_VALUE_PLACEHOLDER}</span>
+            ) : (
+              colorizeYaml(yamlDump(resource.status, { lineWidth: -1 }))
+            )}
+          </pre>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderSecretProviderClassPodStatuses = () => {
+    if (resourceType !== 'secretproviderclasses' || !resource) return null;
+
+    // Filter pod statuses that reference this SecretProviderClass
+    const relevantPodStatuses = (podStatuses || []).filter(
+      (podStatus) => podStatus.status.secretProviderClassName === resource.metadata.name,
+    );
+
+    if (relevantPodStatuses.length === 0) {
+      return (
+        <Card>
+          <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+            {t('Pod Statuses')}
+          </CardTitle>
+          <CardBody>
+            <p>{t('No pods are currently using this SecretProviderClass.')}</p>
+          </CardBody>
+        </Card>
+      );
+    }
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          {t('Pod Statuses')} ({relevantPodStatuses.length})
+        </CardTitle>
+        <CardBody>
+          <div style={{ overflowX: 'auto' }}>
+            <table className="pf-c-table pf-m-compact pf-m-grid-md" style={{ width: '100%' }}>
+              <thead>
+                <tr>
+                  <th>{t('Pod Name')}</th>
+                  <th>{t('Mounted')}</th>
+                  <th>{t('Created')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {relevantPodStatuses.map((podStatus) => (
+                  <tr key={podStatus.metadata.name}>
+                    <td>{podStatus.status.podName || podStatus.metadata.name}</td>
+                    <td>
+                      <Label
+                        color={podStatus.status.mounted ? 'green' : 'red'}
+                        icon={podStatus.status.mounted ? <CheckCircleIcon /> : <TimesCircleIcon />}
+                      >
+                        {podStatus.status.mounted ? t('Yes') : t('No')}
+                      </Label>
+                    </td>
+                    <td>{formatTimestamp(podStatus.metadata.creationTimestamp)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const renderEvents = () => {
+    if (!resource) return null;
+    const list = events ?? [];
+    const sorted = [...list].sort((a, b) => {
+      const tA = a.lastTimestamp || a.firstTimestamp || a.metadata?.creationTimestamp || '';
+      const tB = b.lastTimestamp || b.firstTimestamp || b.metadata?.creationTimestamp || '';
+      return tB.localeCompare(tA);
+    });
+
+    return (
+      <Card>
+        <CardTitle style={{ color: 'var(--pf-t--color--blue--30)' }}>
+          {t('Events')} {eventsLoaded && `(${sorted.length})`}
+        </CardTitle>
+        <CardBody>
+          {!eventsLoaded && <em>{t('Loading events...')}</em>}
+          {eventsLoaded && eventsError && (
+            <Alert variant={AlertVariant.warning} isInline title={t('Could not load events')}>
+              {eventsError?.message || String(eventsError)}
+            </Alert>
+          )}
+          {eventsLoaded && !eventsError && sorted.length === 0 && <em>{t('No events')}</em>}
+          {eventsLoaded && !eventsError && sorted.length > 0 && (
+            <div
+              style={{
+                overflowX: 'auto',
+                background: '#1e1e1e',
+                borderRadius: '4px',
+                border: '1px solid #374151',
+                paddingLeft: '16px',
+                paddingTop: '16px',
+              }}
+            >
+              <table className="pf-c-table pf-m-grid-md" style={{ width: '100%' }}>
+                <thead>
+                  <tr>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Type')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Reason')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Message')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Count')}
+                    </th>
+                    <th style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                      {t('Last seen')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sorted.map((evt) => (
+                    <tr key={evt.metadata?.name ?? evt.reason ?? ''}>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        <Label color={evt.type === 'Warning' ? 'orange' : 'blue'}>
+                          {evt.type || 'Normal'}
+                        </Label>
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {evt.reason ?? '-'}
+                      </td>
+                      <td
+                        style={{
+                          maxWidth: '20rem',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          paddingTop: '0.75rem',
+                          paddingBottom: '0.75rem',
+                        }}
+                        title={evt.message}
+                      >
+                        {evt.message ?? '-'}
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {evt.count ?? 1}
+                      </td>
+                      <td style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}>
+                        {formatTimestamp(
+                          evt.lastTimestamp ||
+                            evt.firstTimestamp ||
+                            evt.metadata?.creationTimestamp,
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardBody>
+      </Card>
+    );
+  };
+
+  const getResourceTypeDisplayName = () => {
+    switch (resourceType) {
+      case 'certificates':
+        return t('Certificate');
+      case 'issuers':
+        return t('Issuer');
+      case 'clusterissuers':
+        return t('ClusterIssuer');
+      case 'externalsecrets':
+        return t('ExternalSecret');
+      case 'clusterexternalsecrets':
+        return t('ClusterExternalSecret');
+      case 'secretstores':
+        return t('SecretStore');
+      case 'clustersecretstores':
+        return t('ClusterSecretStore');
+      case 'pushsecrets':
+        return t('PushSecret');
+      case 'clusterpushsecrets':
+        return t('ClusterPushSecret');
+      case 'secretproviderclasses':
+        return t('SecretProviderClass');
+      default:
+        return t('Resource');
+    }
+  };
+
+  if (!model) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.danger} title={t('Invalid resource type')} isInline>
+          {t('The resource type "{resourceType}" is not supported.', { resourceType })}
+        </Alert>
+      </div>
+    );
+  }
+
+  // For SecretProviderClass, also wait for pod statuses to load
+  const allLoaded = resourceType === 'secretproviderclasses' ? loaded && podStatusesLoaded : loaded;
+
+  if (!allLoaded) {
+    return (
+      <div className="co-m-loader co-an-fade-in-out">
+        <div className="co-m-loader-dot__one"></div>
+        <div className="co-m-loader-dot__two"></div>
+        <div className="co-m-loader-dot__three"></div>
+      </div>
+    );
+  }
+
+  // Handle errors from both resource and pod status loading
+  const anyError =
+    loadError || (resourceType === 'secretproviderclasses' ? podStatusesError : null);
+
+  if (anyError) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.danger} title={t('Error loading resource')} isInline>
+          {anyError.message}
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!resource) {
+    return (
+      <div className="co-m-pane__body">
+        <Alert variant={AlertVariant.warning} title={t('Resource not found')} isInline>
+          {t('The {resourceType} "{name}" was not found.', {
+            resourceType: getResourceTypeDisplayName(),
+            name,
+          })}
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>{t('{resourceType} details', { resourceType: getResourceTypeDisplayName() })}</title>
+      </Helmet>
+
+      <div className="co-m-pane__body">
+        <div className="co-m-pane__heading">
+          <div className="co-m-pane__name co-resource-item">
+            <Button variant="plain" onClick={handleBackClick} style={{ marginRight: '16px' }}>
+              <ArrowLeftIcon />
+            </Button>
+            <KeyIcon className="co-m-resource-icon" style={{ marginRight: '8px' }} />
+            <Title headingLevel="h1" size="lg">
+              {getResourceTypeDisplayName()}: {name}
+            </Title>
+          </div>
+        </div>
+
+        <Grid hasGutter>
+          <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+            {renderMetadata()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingLeft: '2rem' }}>
+            {renderLabels()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingRight: '2rem' }}>
+            {renderAnnotations()}
+          </GridItem>
+          <GridItem span={6} style={{ paddingLeft: '2rem' }}>
+            {renderSpecification()}
+          </GridItem>
+          <GridItem span={6}>{renderStatus()}</GridItem>
+          <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+            {renderEvents()}
+          </GridItem>
+          {resourceType === 'secretproviderclasses' && (
+            <GridItem span={12} style={{ padding: '0rem 2rem' }}>
+              {renderSecretProviderClassPodStatuses()}
+            </GridItem>
+          )}
+        </Grid>
+      </div>
+    </>
+  );
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceTable.tsx
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceTable.tsx
@@ -1,13 +1,9 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  EmptyState,
-  EmptyStateBody,
-  Title,
-  Alert,
-  AlertVariant,
-} from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { EmptyState, EmptyStateBody, Alert, AlertVariant, Button } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import { useDeleteModal } from '@openshift-console/dynamic-plugin-sdk';
 
 interface Column {
   title: string;
@@ -25,7 +21,6 @@ interface ResourceTableProps {
   error?: string;
   emptyStateTitle?: string;
   emptyStateBody?: string;
-  /** When set, fallback empty state body is project-aware (e.g. "in project X" vs "in the demo project"). */
   selectedProject?: string;
   'data-test'?: string;
 }
@@ -40,31 +35,29 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
   selectedProject,
   'data-test': dataTest,
 }) => {
-  const { t } = useTranslation('plugin__ocp-secrets-management');
+  const { t } = useTranslation('plugin__console-plugin-template');
 
   const defaultEmptyStateBody =
-    selectedProject && selectedProject !== 'all'
-      ? t('No resources of this type are currently available in project {{project}}.', { project: selectedProject })
-      : t('No resources of this type are currently available in the demo project.');
+    selectedProject && selectedProject !== '#ALL_NS#'
+      ? t('No resources of this type are currently available in project {{project}}.', {
+          project: selectedProject,
+        })
+      : t('No resources of this type are currently available.');
 
   if (loading) {
     return (
-      <div className="co-m-loader co-an-fade-in-out" data-test={`${dataTest}-loading`}>
-        <div className="co-m-loader-dot__one"></div>
-        <div className="co-m-loader-dot__two"></div>
-        <div className="co-m-loader-dot__three"></div>
+      <div className="console-plugin-template__loader" data-test={`${dataTest}-loading`}>
+        <div className="console-plugin-template__loader-dot"></div>
+        <div className="console-plugin-template__loader-dot"></div>
+        <div className="console-plugin-template__loader-dot"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="co-m-pane__body" data-test={`${dataTest}-error`}>
-        <Alert
-          variant={AlertVariant.danger}
-          title={t('Error loading resources')}
-          isInline
-        >
+      <div className="console-plugin-template__table-message" data-test={`${dataTest}-error`}>
+        <Alert variant={AlertVariant.danger} title={t('Error loading resources')} isInline>
           {error}
         </Alert>
       </div>
@@ -73,69 +66,41 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
 
   if (rows.length === 0) {
     return (
-      <div className="co-m-pane__body" data-test={`${dataTest}-empty`}>
-        <EmptyState>
-          <SearchIcon className="co-m-empty-state__icon" />
-          <Title size="lg" headingLevel="h4">
-            {emptyStateTitle || t('No resources found')}
-          </Title>
-          <EmptyStateBody>
-            {emptyStateBody ?? defaultEmptyStateBody}
-          </EmptyStateBody>
+      <div className="console-plugin-template__table-message" data-test={`${dataTest}-empty`}>
+        <EmptyState
+          titleText={emptyStateTitle || t('No resources found')}
+          icon={SearchIcon}
+          headingLevel="h4"
+        >
+          <EmptyStateBody>{emptyStateBody ?? defaultEmptyStateBody}</EmptyStateBody>
         </EmptyState>
       </div>
     );
   }
 
-  // Calculate column widths - distribute evenly if no widths specified
-  const totalSpecifiedWidth = columns.reduce((sum, col) => sum + (col.width || 0), 0);
-  const hasSpecifiedWidths = totalSpecifiedWidth > 0;
-  const defaultWidth = hasSpecifiedWidths ? undefined : 100 / columns.length;
-
   return (
-    <div className="co-m-table-grid co-m-table-grid--bordered" data-test={dataTest}>
-      <div className="table-responsive">
-        <table className="table table-hover" style={{ tableLayout: 'fixed', width: '100%' }}>
+    <div className="console-plugin-template__resource-table" data-test={dataTest}>
+      <div className="console-plugin-template__table-responsive">
+        <table className="console-plugin-template__table">
           <thead>
             <tr>
-              {columns.map((column, index) => {
-                const width = hasSpecifiedWidths 
-                  ? `${(column.width || 0)}%`
-                  : `${defaultWidth}%`;
-                
-                return (
-                  <th 
-                    key={index} 
-                    role="columnheader"
-                    style={{ 
-                      width,
-                      paddingLeft: '1rem',
-                      paddingRight: '1rem',
-                      textAlign: 'left',
-                      verticalAlign: 'middle'
-                    }}
-                  >
-                    {column.title}
-                  </th>
-                );
-              })}
+              {columns.map((column, index) => (
+                <th
+                  key={index}
+                  className="console-plugin-template__table-th"
+                  role="columnheader"
+                  style={column.width ? { width: `${column.width}%` } : undefined}
+                >
+                  {column.title}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
             {rows.map((row, rowIndex) => (
-              <tr key={rowIndex}>
+              <tr key={rowIndex} className="console-plugin-template__table-tr">
                 {row.cells.map((cell, cellIndex) => (
-                  <td 
-                    key={cellIndex}
-                    style={{
-                      paddingLeft: '1rem',
-                      paddingRight: '1rem',
-                      textAlign: 'left',
-                      verticalAlign: 'middle',
-                      wordWrap: 'break-word',
-                      overflow: 'hidden'
-                    }}
-                  >
+                  <td key={cellIndex} className="console-plugin-template__table-td">
                     {cell}
                   </td>
                 ))}
@@ -144,6 +109,37 @@ export const ResourceTable: React.FC<ResourceTableProps> = ({
           </tbody>
         </table>
       </div>
+    </div>
+  );
+};
+
+interface ResourceTableRowActionsProps {
+  resource: any;
+  inspectHref: string;
+}
+
+export const ResourceTableRowActions: React.FC<ResourceTableRowActionsProps> = ({
+  resource,
+  inspectHref,
+}) => {
+  const { t } = useTranslation('plugin__console-plugin-template');
+  const launchDeleteModal = useDeleteModal(resource);
+
+  return (
+    <div className="console-plugin-template__action-buttons">
+      <Link to={inspectHref}>
+        <Button className="console-plugin-template__action-inspect" variant="primary" size="sm">
+          {t('Inspect')}
+        </Button>
+      </Link>
+      <Button
+        className="console-plugin-template__action-delete"
+        variant="danger"
+        size="sm"
+        onClick={launchDeleteModal}
+      >
+        {t('Delete')}
+      </Button>
     </div>
   );
 };

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceTable.tsx
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/ResourceTable.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  EmptyState,
+  EmptyStateBody,
+  Title,
+  Alert,
+  AlertVariant,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+interface Column {
+  title: string;
+  width?: number;
+}
+
+interface Row {
+  cells: React.ReactNode[];
+}
+
+interface ResourceTableProps {
+  columns: Column[];
+  rows: Row[];
+  loading?: boolean;
+  error?: string;
+  emptyStateTitle?: string;
+  emptyStateBody?: string;
+  /** When set, fallback empty state body is project-aware (e.g. "in project X" vs "in the demo project"). */
+  selectedProject?: string;
+  'data-test'?: string;
+}
+
+export const ResourceTable: React.FC<ResourceTableProps> = ({
+  columns,
+  rows,
+  loading = false,
+  error,
+  emptyStateTitle,
+  emptyStateBody,
+  selectedProject,
+  'data-test': dataTest,
+}) => {
+  const { t } = useTranslation('plugin__ocp-secrets-management');
+
+  const defaultEmptyStateBody =
+    selectedProject && selectedProject !== 'all'
+      ? t('No resources of this type are currently available in project {{project}}.', { project: selectedProject })
+      : t('No resources of this type are currently available in the demo project.');
+
+  if (loading) {
+    return (
+      <div className="co-m-loader co-an-fade-in-out" data-test={`${dataTest}-loading`}>
+        <div className="co-m-loader-dot__one"></div>
+        <div className="co-m-loader-dot__two"></div>
+        <div className="co-m-loader-dot__three"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="co-m-pane__body" data-test={`${dataTest}-error`}>
+        <Alert
+          variant={AlertVariant.danger}
+          title={t('Error loading resources')}
+          isInline
+        >
+          {error}
+        </Alert>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="co-m-pane__body" data-test={`${dataTest}-empty`}>
+        <EmptyState>
+          <SearchIcon className="co-m-empty-state__icon" />
+          <Title size="lg" headingLevel="h4">
+            {emptyStateTitle || t('No resources found')}
+          </Title>
+          <EmptyStateBody>
+            {emptyStateBody ?? defaultEmptyStateBody}
+          </EmptyStateBody>
+        </EmptyState>
+      </div>
+    );
+  }
+
+  // Calculate column widths - distribute evenly if no widths specified
+  const totalSpecifiedWidth = columns.reduce((sum, col) => sum + (col.width || 0), 0);
+  const hasSpecifiedWidths = totalSpecifiedWidth > 0;
+  const defaultWidth = hasSpecifiedWidths ? undefined : 100 / columns.length;
+
+  return (
+    <div className="co-m-table-grid co-m-table-grid--bordered" data-test={dataTest}>
+      <div className="table-responsive">
+        <table className="table table-hover" style={{ tableLayout: 'fixed', width: '100%' }}>
+          <thead>
+            <tr>
+              {columns.map((column, index) => {
+                const width = hasSpecifiedWidths 
+                  ? `${(column.width || 0)}%`
+                  : `${defaultWidth}%`;
+                
+                return (
+                  <th 
+                    key={index} 
+                    role="columnheader"
+                    style={{ 
+                      width,
+                      paddingLeft: '1rem',
+                      paddingRight: '1rem',
+                      textAlign: 'left',
+                      verticalAlign: 'middle'
+                    }}
+                  >
+                    {column.title}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.cells.map((cell, cellIndex) => (
+                  <td 
+                    key={cellIndex}
+                    style={{
+                      paddingLeft: '1rem',
+                      paddingRight: '1rem',
+                      textAlign: 'left',
+                      verticalAlign: 'middle',
+                      wordWrap: 'break-word',
+                      overflow: 'hidden'
+                    }}
+                  >
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SKILL.md
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: Dashboard Template Components
+description: Reference components for generating Kubernetes operator CRD dashboards
+---
+
+# Dashboard Template Components
+
+Read this before generating any dashboard component. It explains which template file to use for each component type and how to adapt it to a new operator's CRDs.
+
+## When to Use This Skill
+
+Use this skill when:
+- Generating a list view for a CRD kind (use ResourceTable.tsx)
+- Generating a detail/inspect view for a single CR (use ResourceInspect.tsx)
+- Defining the TypeScript model for a specific CRD kind (use the matching .ts file)
+- Adapting any reference component to a new operator's CRD schema
+
+## CRD Model Files (`.ts` files)
+
+These files define the TypeScript types and K8sGroupVersionKind models for each CRD kind. Use them as the starting point when modelling a new CRD's API group, version, kind, and optional spec/status interfaces.
+
+### `Certificate.ts`
+
+**Purpose**: Exports the K8sGroupVersionKind model for cert-manager's Certificate CRD. Used for operator detection and for useK8sWatchResource / useK8sModel.
+
+**Key interfaces**: None (model only).
+
+**Model**:
+```ts
+export const CertificateModel: K8sGroupVersionKind = {
+  group: 'cert-manager.io',
+  version: 'v1',
+  kind: 'Certificate',
+};
+```
+
+**Fields to adapt**: Replace `group`, `version`, and `kind` with the target operator's values from `oc api-resources` (APIVERSION and KIND columns).
+
+### `Events.ts`
+
+**Purpose**: Core v1 Event model and a map from resource type (plural) to Kind for event involvedObject lookups; provides `getInvolvedObjectKind(resourceType)` for filtering events by resource.
+
+**Key interfaces**:
+```ts
+export interface K8sEvent {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  type?: string;
+  reason?: string;
+  message?: string;
+  count?: number;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  involvedObject?: {
+    kind?: string;
+    name?: string;
+    namespace?: string;
+    [key: string]: unknown;
+  };
+}
+```
+
+**Fields to adapt**: Extend `RESOURCE_TYPE_TO_KIND` with `plural: 'Kind'` for each new resource type so events display correctly on the inspect page.
+
+### `ExternalSecret.ts`
+
+**Purpose**: K8sGroupVersionKind models for ExternalSecret and ClusterExternalSecret (external-secrets operator).
+
+**Key interfaces**: None (models only).
+
+**Models**: ExternalSecretModel, ClusterExternalSecretModel — group `external-secrets.io`, version `v1beta1`.
+
+**Fields to adapt**: Replace group/version/kind with target operator's CRD. Use two models when the operator has both namespaced and cluster-scoped variants of the same kind.
+
+### `Issuer.ts`
+
+**Purpose**: K8sGroupVersionKind models for Issuer and ClusterIssuer (cert-manager).
+
+**Key interfaces**: None (models only).
+
+**Models**: IssuerModel, ClusterIssuerModel — group `cert-manager.io`, version `v1`.
+
+**Fields to adapt**: Same as Certificate.ts; use for any operator that exposes namespaced and cluster-scoped kinds.
+
+### `PushSecret.ts`
+
+**Purpose**: K8sGroupVersionKind models for PushSecret and ClusterPushSecret (external-secrets operator).
+
+**Key interfaces**: None (models only).
+
+**Fields to adapt**: Replace group/version/kind with the target operator's API from cluster verification.
+
+### `SecretProviderClass.ts`
+
+**Purpose**: Models for SecretProviderClass and SecretProviderClassPodStatus (CSI secrets store); includes an interface for the pod status subresource used on the inspect page.
+
+**Key interfaces**:
+```ts
+export interface SecretProviderClassPodStatus {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  status?: {
+    secretProviderClassName?: string;
+    podName?: string;
+    mounted?: boolean;
+    [key: string]: unknown;
+  };
+}
+```
+
+**Fields to adapt**: Group/version/kind for both models. If the target operator has a similar “status” or pod-binding resource, add a parallel interface and model.
+
+### `SecretStore.ts`
+
+**Purpose**: K8sGroupVersionKind models for SecretStore and ClusterSecretStore (external-secrets operator).
+
+**Key interfaces**: None (models only).
+
+**Fields to adapt**: Replace group/version/kind with values from `oc api-resources`.
+
+## UI Component Files (`.tsx` files)
+
+### `ResourceTable.tsx`
+
+**Purpose**: Shared table for listing CRs of a given kind. Renders loading (three-dot loader), error Alert, empty EmptyState, or a plain table with thead/tbody. Accepts columns and rows (cells as React nodes).
+
+**Use when**: Displaying a list of CRs of a given kind in a table on the operator dashboard.
+
+**Key patterns**:
+- Columns: array of `{ title, width? }`; last column is typically Actions.
+- Rows: array of `{ cells: React.ReactNode[] }`; build from `useK8sWatchResource` list; Name cell uses `<Link to={inspectHref}>`, Actions cell uses ResourceTableRowActions (so useDeleteModal is per row).
+- Loading: show three-dot loader when `loading` is true; error: show Alert; empty: show EmptyState with titleText and EmptyStateBody; selectedProject used for project-aware empty message.
+
+**Props interface**:
+```ts
+interface Column {
+  title: string;
+  width?: number;
+}
+interface Row {
+  cells: React.ReactNode[];
+}
+interface ResourceTableProps {
+  columns: Column[];
+  rows: Row[];
+  loading?: boolean;
+  error?: string;
+  emptyStateTitle?: string;
+  emptyStateBody?: string;
+  selectedProject?: string;
+  'data-test'?: string;
+}
+```
+
+**How to adapt**:
+1. Replace CRD kind and API group/version in the table’s useK8sWatchResource (use the corresponding .ts model).
+2. Build columns from the target CRD: Name, Namespace (if namespaced), then additionalPrinterColumns or fallback (Status, Age), then Actions.
+3. Build rows from the list: name link (Link to inspect href), namespace, status Label, timestamp, ResourceTableRowActions. Use plugin-prefixed CSS classes (e.g. `console-plugin-template__table`) and PatternFly variables; do not use co-m-* or inline styles in the consuming plugin.
+
+### `ResourceInspect.tsx`
+
+**Purpose**: Shared resource detail (inspect) page: Card + Grid layout with back button, Metadata, Labels, Annotations, Specification, Status, Events (and optional Pod Statuses for SecretProviderClass). Parses URL for resourceType, namespace, name; uses getResourceModel(resourceType) and getPagePath(resourceType); supports optional “Show/Hide sensitive data” for spec/status.
+
+**Use when**: Displaying the full detail view for a single CR instance at `/<operator-short-name>/inspect/<plural>/[namespace/]<name>`.
+
+**Key patterns**:
+- Parse path: find segment after `inspect` for resourceType; then either `namespace` + `name` (namespaced) or `name` only (cluster-scoped).
+- getResourceModel(resourceType): switch returning the K8sGroupVersionKind for the resource (from crds/*.ts).
+- useK8sWatchResource for the single resource; for Events, use EventModel and fieldSelector by involvedObject name/kind/namespace; getInvolvedObjectKind(resourceType) from Events.ts.
+- Render: Metadata (DescriptionList), Labels/Annotations (Cards), Spec/Status (YAML dump with optional sensitive-data toggle), Events table, and optional kind-specific block (e.g. SecretProviderClassPodStatus).
+
+**Props interface**: None (component uses URL and hooks only).
+
+**How to adapt**:
+1. Add DISPLAY_NAMES entries for each new plural (plural → display name).
+2. Add cases in getResourceModel(resourceType) returning the new kind’s K8sModel.
+3. Add case in getPagePath(resourceType) returning the operator page path (e.g. `'/cert-manager'`).
+4. Add plural → Kind in Events.ts RESOURCE_TYPE_TO_KIND so events load correctly.
+5. Do not change the overall Card + Grid layout or back button; extend only the maps and model lookups.
+
+## Shared Patterns
+
+### Data fetching
+
+- **List view**: `useK8sWatchResource({ groupVersionKind, namespace?, isList: true })`; use `loaded` and `loadError` for loading/error; build rows from the list.
+- **Detail view**: `useK8sWatchResource({ groupVersionKind, name, namespace?, isList: false })`; same loading/error handling.
+- **Operator detection**: `useK8sModel({ group, version, kind })`; returns `[model, inFlight]`; check `if (inFlight) return 'loading'`.
+
+### Status display
+
+- Use PatternFly `<Label>` with **status** prop for status/conditions: `status="success"` (green), `status="danger"` (red), `status="warning"` (orange). Do not use `variant` for status colors.
+- Status value often comes from `status.conditions` (e.g. type=Ready); map to success/danger/warning as appropriate.
+
+### TypeScript model → UI column mapping
+
+- Each CRD kind has a .ts file exporting a K8sGroupVersionKind (and optionally an interface). Table components import that model and pass it to useK8sWatchResource. Columns are derived from CRD additionalPrinterColumns (jsonPath, type) or fallback (Name, Namespace, Status, Age, Actions). Map jsonPath to row cells (e.g. Timestamp for dates, Label for status).
+
+## Which File to Use
+
+| What you need | Use this file |
+|---------------|---------------|
+| Type model for a known CRD kind | The matching `.ts` file (e.g. `Certificate.ts`) |
+| Type model for a new/unknown CRD kind | Use the most structurally similar `.ts` file as a base (same group/version pattern or namespaced+cluster pair) |
+| List view of CRs | `ResourceTable.tsx` |
+| Detail view of a single CR | `ResourceInspect.tsx` |

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SecretProviderClass.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SecretProviderClass.ts
@@ -1,0 +1,30 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const SecretProviderClassModel: K8sGroupVersionKind = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClass',
+};
+
+export const SecretProviderClassPodStatusModel: K8sGroupVersionKind = {
+  group: 'secrets-store.csi.x-k8s.io',
+  version: 'v1',
+  kind: 'SecretProviderClassPodStatus',
+};
+
+export interface SecretProviderClassPodStatus {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    creationTimestamp?: string;
+    [key: string]: unknown;
+  };
+  status?: {
+    secretProviderClassName?: string;
+    podName?: string;
+    mounted?: boolean;
+    [key: string]: unknown;
+  };
+}

--- a/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SecretStore.ts
+++ b/plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SecretStore.ts
@@ -1,0 +1,13 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+
+export const SecretStoreModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'SecretStore',
+};
+
+export const ClusterSecretStoreModel: K8sGroupVersionKind = {
+  group: 'external-secrets.io',
+  version: 'v1beta1',
+  kind: 'ClusterSecretStore',
+};


### PR DESCRIPTION


<!--
** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:
This command genenrate the Operator dashboard for the given operator name.
- New plugin: operator-dashboard for OpenShift Console operator dashboard generation
- CRD discovery, list/detail components from templates
- Register in marketplace and update PLUGINS.md/docs

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-dashboard plugin to generate OpenShift Console operator dashboards from CRDs, including templated list/detail UI and an operator dashboard generation command.

* **Documentation**
  * Added comprehensive docs and command reference for the operator-dashboard plugin, usage examples, scaffolding details, and template/skill guidance for adapting generated dashboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->