### PR TITLE
Add openshift:api-review command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.6"
+      "version": "0.0.7"
     },
     {
       "name": "openshift-tls-profile",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "name": "openshift-tls-profile",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -291,7 +291,7 @@ OpenShift development utilities and helpers
 
 **Commands:**
 - **`/openshift:add-enhancement` `[area] <name> <description> <jira>`** - Create a new OpenShift Enhancement Proposal
-- **`/openshift:api-review` `[pr_url]`** - Run strict OpenShift API review workflow for PR changes or local changes
+- **`/openshift:api-review` `<pr_url> [--api-dir <path>]`** - Run strict OpenShift API review workflow for PR changes or local changes
 - **`/openshift:bootstrap-om`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
 - **`/openshift:bump-deps` `<dependency> [version] [--create-jira] [--create-pr]`** - Bump dependencies in OpenShift projects with automated analysis and PR creation
 - **`/openshift:cluster-health-check` `[--verbose] [--output-format]`** - Perform comprehensive health check on OpenShift cluster and report issues

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -291,6 +291,7 @@ OpenShift development utilities and helpers
 
 **Commands:**
 - **`/openshift:add-enhancement` `[area] <name> <description> <jira>`** - Create a new OpenShift Enhancement Proposal
+- **`/openshift:api-review` `[pr_url]`** - Run strict OpenShift API review workflow for PR changes or local changes
 - **`/openshift:bootstrap-om`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
 - **`/openshift:bump-deps` `<dependency> [version] [--create-jira] [--create-pr]`** - Bump dependencies in OpenShift projects with automated analysis and PR creation
 - **`/openshift:cluster-health-check` `[--verbose] [--output-format]`** - Perform comprehensive health check on OpenShift cluster and report issues

--- a/docs/data.json
+++ b/docs/data.json
@@ -1016,7 +1016,7 @@
           "argument_hint": "[pr_url]",
           "description": "Run strict OpenShift API review workflow for PR changes or local changes",
           "name": "api-review",
-          "synopsis": "/openshift:api-review [pr_url]"
+          "synopsis": "text"
         },
         {
           "argument_hint": "",

--- a/docs/data.json
+++ b/docs/data.json
@@ -1013,10 +1013,10 @@
           "synopsis": "/openshift:add-enhancement [area] <name> <description> <jira>"
         },
         {
-          "argument_hint": "[pr_url]",
+          "argument_hint": "<pr_url> [--api-dir <path>]",
           "description": "Run strict OpenShift API review workflow for PR changes or local changes",
           "name": "api-review",
-          "synopsis": "text"
+          "synopsis": "/openshift:api-review <pr_url> [--api-dir <path>]"
         },
         {
           "argument_hint": "",
@@ -1131,7 +1131,7 @@
           "name": "OpenShift Node Kernel Inspection"
         }
       ],
-      "version": "0.0.6"
+      "version": "0.0.7"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -1013,6 +1013,12 @@
           "synopsis": "/openshift:add-enhancement [area] <name> <description> <jira>"
         },
         {
+          "argument_hint": "[pr_url]",
+          "description": "Run strict OpenShift API review workflow for PR changes or local changes",
+          "name": "api-review",
+          "synopsis": "/openshift:api-review [pr_url]"
+        },
+        {
           "argument_hint": "",
           "description": "Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery",
           "name": "bootstrap-om",
@@ -1125,7 +1131,7 @@
           "name": "OpenShift Node Kernel Inspection"
         }
       ],
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "commands": [

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/commands/api-review.md
+++ b/plugins/openshift/commands/api-review.md
@@ -1,0 +1,232 @@
+---
+description: Run strict OpenShift API review workflow for PR changes or local changes
+argument-hint: "[pr_url]"
+---
+
+## Name
+openshift:api-review
+
+## Synopsis
+```
+/openshift:api-review [pr_url]
+```
+
+## Description
+
+Run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
+
+## Implementation
+
+# Output Format Requirements
+You MUST use this EXACT format for ALL review feedback:
+
+
++LineNumber: Brief description
+**Current (problematic) code:**
+```go
+[exact code from the PR diff]
+```
+
+**Suggested change:**
+```diff
+- [old code line]
++ [new code line]
+```
+
+**Explanation:** [Why this change is needed]
+
+
+I'll run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
+
+## Step 1: Pre-flight checks and determine review mode
+
+First, I'll check the arguments and determine whether to review a PR or local changes:
+
+```bash
+# Save current branch
+CURRENT_BRANCH=$(git branch --show-current)
+echo "📍 Current branch: $CURRENT_BRANCH"
+
+# Check if a PR URL was provided
+if [ -n "$ARGUMENTS" ] && [[ "$ARGUMENTS" =~ github\.com.*pull ]]; then
+    REVIEW_MODE="pr"
+    PR_NUMBER=$(echo "$ARGUMENTS" | grep -oE '[0-9]+$')
+    echo "🔍 PR review mode: Reviewing PR #$PR_NUMBER"
+
+    # For PR review, check for uncommitted changes
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "❌ ERROR: Uncommitted changes detected. Cannot proceed with PR review."
+        echo "Please commit or stash your changes before running the API review."
+        git status --porcelain
+        exit 1
+    fi
+    echo "✅ No uncommitted changes detected. Safe to proceed with PR review."
+else
+    REVIEW_MODE="local"
+    echo "🔍 Local review mode: Reviewing local changes against upstream master"
+
+    # Find a remote pointing to openshift/api repository
+    OPENSHIFT_REMOTE=""
+    for remote in $(git remote); do
+        remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "")
+        if [[ "$remote_url" =~ github\.com[/:]openshift/api(\.git)?$ ]]; then
+            OPENSHIFT_REMOTE="$remote"
+            echo "✅ Found OpenShift API remote: '$remote' -> $remote_url"
+            break
+        fi
+    done
+
+    # If no existing remote found, add upstream
+    if [ -z "$OPENSHIFT_REMOTE" ]; then
+        echo "⚠️  No remote pointing to openshift/api found. Adding upstream remote..."
+        git remote add upstream https://github.com/openshift/api.git
+        OPENSHIFT_REMOTE="upstream"
+    fi
+
+    # Fetch latest changes from the OpenShift API remote
+    echo "🔄 Fetching latest changes from $OPENSHIFT_REMOTE..."
+    git fetch "$OPENSHIFT_REMOTE" master
+fi
+```
+
+## Step 2: Get changed files based on review mode
+
+```bash
+if [ "$REVIEW_MODE" = "pr" ]; then
+    # PR Review: Checkout the PR and get changed files
+    echo "🔄 Checking out PR #$PR_NUMBER..."
+    gh pr checkout "$PR_NUMBER"
+
+    echo "📁 Analyzing changed files in PR..."
+    CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
+else
+    # Local Review: Get changed files compared to openshift remote master
+    echo "📁 Analyzing locally changed files compared to $OPENSHIFT_REMOTE/master..."
+    CHANGED_FILES=$(git diff --name-only "$OPENSHIFT_REMOTE/master...HEAD" | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
+
+    # Also include staged changes
+    STAGED_FILES=$(git diff --cached --name-only | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/' || true)
+    if [ -n "$STAGED_FILES" ]; then
+        CHANGED_FILES=$(echo -e "$CHANGED_FILES\n$STAGED_FILES" | sort -u)
+    fi
+fi
+
+echo "Changed API files:"
+echo "$CHANGED_FILES"
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo "ℹ️  No API files changed. Nothing to review."
+    if [ "$REVIEW_MODE" = "pr" ]; then
+        git checkout "$CURRENT_BRANCH"
+    fi
+    exit 0
+fi
+```
+
+## Step 3: Run linting checks on changes
+
+```bash
+echo "⏳ Running linting checks on changes..."
+make lint
+
+if [ $? -ne 0 ]; then
+    echo "❌ Linting checks failed. Please fix the issues before proceeding."
+    if [ "$REVIEW_MODE" = "pr" ]; then
+        echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
+        git checkout "$CURRENT_BRANCH"
+    fi
+    exit 1
+fi
+
+echo "✅ Linting checks passed."
+```
+
+## Step 4: Documentation validation
+
+For each changed API file, I'll validate:
+
+1. **Field Documentation**: All struct fields must have documentation comments
+2. **Optional Field Behavior**: Optional fields must explain what happens when they are omitted
+3. **Validation Documentation**: Validation rules must be documented and match markers
+
+Let me check each changed file for these requirements:
+
+```thinking
+I need to analyze the changed files to:
+1. Find struct fields without documentation
+2. Find optional fields without behavior documentation
+3. Find validation annotations without corresponding documentation
+
+For each Go file, I'll:
+- Look for struct field definitions
+- Check if they have preceding comment documentation
+- For optional fields (those with `+kubebuilder:validation:Optional` or `+optional`), verify behavior is explained
+- For fields with validation annotations, ensure the validation is documented
+```
+
+## Step 5: Generate comprehensive review report
+
+I'll provide a comprehensive report showing:
+- ✅ Files that pass all checks
+- ❌ Files with documentation issues
+- 📋 Specific lines that need attention
+- 📚 Guidance on fixing any issues
+
+The review will fail if any documentation requirements are not met for the changed files.
+
+## Step 6: Switch back to original branch (PR mode only)
+
+After completing the review, if we were reviewing a PR, I'll switch back to the original branch:
+
+```bash
+if [ "$REVIEW_MODE" = "pr" ]; then
+    echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
+    git checkout "$CURRENT_BRANCH"
+    echo "✅ API review complete. Back on branch: $(git branch --show-current)"
+else
+    echo "✅ Local API review complete."
+fi
+```
+
+**CRITICAL WORKFLOW REQUIREMENTS:**
+
+**For PR Review Mode:**
+1. MUST check for uncommitted changes before starting
+2. MUST abort if uncommitted changes are detected
+3. MUST save current branch name before switching
+4. MUST checkout the PR before running `make lint`
+5. MUST switch back to original branch when complete
+6. If any step fails, MUST attempt to switch back to original branch before exiting
+
+**For Local Review Mode:**
+1. MUST detect existing remotes pointing to openshift/api repository (supports any remote name)
+2. MUST add upstream remote only if no existing openshift/api remote is found
+3. MUST fetch latest changes from the detected openshift/api remote
+4. MUST compare against the detected remote's master branch
+5. MUST include both committed and staged changes in analysis
+6. No branch switching required since we're reviewing local changes
+
+## Examples
+
+1. **Review a PR**:
+   ```
+   /openshift:api-review https://github.com/openshift/api/pull/2145
+   ```
+   Checks out the PR, runs lint and convention checks, then switches back to your branch.
+
+2. **Review local changes**:
+   ```
+   /openshift:api-review
+   ```
+   Reviews local changes against upstream master in the current openshift/api clone.
+
+## Arguments
+
+- **pr_url** (optional): GitHub PR URL to review (e.g., `https://github.com/openshift/api/pull/2145`). If not provided, reviews local changes against upstream master.
+
+## See Also
+
+- `/openshift:crd-review` - Review CRD types in any repository against conventions
+- [OpenShift API Conventions](https://github.com/openshift/enhancements/blob/master/dev-guide/api-conventions.md)
+- [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
+- [Source command](https://github.com/openshift/api/blob/master/.claude/commands/api-review.md) in the openshift/api repository

--- a/plugins/openshift/commands/api-review.md
+++ b/plugins/openshift/commands/api-review.md
@@ -1,6 +1,6 @@
 ---
 description: Run strict OpenShift API review workflow for PR changes or local changes
-argument-hint: "[pr_url]"
+argument-hint: "<pr_url> [--api-dir <path>]"
 ---
 
 ## Name
@@ -8,12 +8,12 @@ openshift:api-review
 
 ## Synopsis
 ```text
-/openshift:api-review [pr_url]
+/openshift:api-review <pr_url> [--api-dir <path>]
 ```
 
 ## Description
 
-Run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
+Run a comprehensive API review for OpenShift API changes. Works with any GitHub repository — provide a full PR URL and the command extracts the owner/repo automatically. Optionally specify `--api-dir` to scope the review to a specific directory (e.g., `api/` for HyperShift). If omitted, the command auto-detects API directories.
 
 ## Implementation
 
@@ -36,82 +36,137 @@ You MUST use this EXACT format for ALL review feedback:
 **Explanation:** [Why this change is needed]
 
 
-I'll run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
-
-## Step 1: Pre-flight checks and determine review mode
-
-First, I'll check the arguments and determine whether to review a PR or local changes:
+## Step 1: Pre-flight checks and parse arguments
 
 ```bash
+set -euo pipefail
+
 # Save current branch
 CURRENT_BRANCH=$(git branch --show-current)
 echo "📍 Current branch: $CURRENT_BRANCH"
 
-# Check if a PR URL was provided
-if [ -n "$ARGUMENTS" ] && [[ "$ARGUMENTS" =~ github\.com.*pull ]]; then
-    REVIEW_MODE="pr"
-    PR_NUMBER=$(echo "$ARGUMENTS" | sed -nE 's#^.*/pull/([0-9]+)([/?].*)?$#\1#p')
-    if [ -z "$PR_NUMBER" ]; then
-        echo "❌ ERROR: Could not parse PR number from: $ARGUMENTS"
-        exit 1
-    fi
-    echo "🔍 PR review mode: Reviewing PR #$PR_NUMBER"
+# Ensure we always return to the original branch on exit
+cleanup() {
+    git checkout "$CURRENT_BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
-    # For PR review, check for uncommitted changes
-    if ! git diff --quiet || ! git diff --cached --quiet; then
-        echo "❌ ERROR: Uncommitted changes detected. Cannot proceed with PR review."
-        echo "Please commit or stash your changes before running the API review."
-        git status --porcelain
-        exit 1
+# Parse arguments: extract PR URL and optional --api-dir
+API_DIR=""
+PR_URL=""
+prev_arg=""
+for arg in $ARGUMENTS; do
+    if [ "$prev_arg" = "--api-dir" ]; then
+        API_DIR="$arg"
+        prev_arg=""
+        continue
     fi
-    echo "✅ No uncommitted changes detected. Safe to proceed with PR review."
+    if [ "$arg" = "--api-dir" ]; then
+        prev_arg="$arg"
+        continue
+    fi
+    if [[ "$arg" =~ github\.com.*pull ]]; then
+        PR_URL="$arg"
+    fi
+done
+
+# A PR URL is required
+if [ -z "$PR_URL" ]; then
+    echo "❌ ERROR: A GitHub PR URL is required."
+    echo "Usage: /openshift:api-review <pr_url> [--api-dir <path>]"
+    echo "Example: /openshift:api-review https://github.com/openshift/api/pull/2145"
+    exit 1
+fi
+
+# Extract owner, repo, and PR number from the URL
+OWNER=$(echo "$PR_URL" | sed -nE 's#^.*github\.com/([^/]+)/([^/]+)/pull/([0-9]+).*$#\1#p')
+REPO=$(echo "$PR_URL" | sed -nE 's#^.*github\.com/([^/]+)/([^/]+)/pull/([0-9]+).*$#\2#p')
+PR_NUMBER=$(echo "$PR_URL" | sed -nE 's#^.*github\.com/([^/]+)/([^/]+)/pull/([0-9]+).*$#\3#p')
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ -z "$PR_NUMBER" ]; then
+    echo "❌ ERROR: Could not parse owner/repo/PR number from: $PR_URL"
+    exit 1
+fi
+
+echo "🔍 Reviewing PR #$PR_NUMBER in $OWNER/$REPO"
+if [ -n "$API_DIR" ]; then
+    echo "📂 API directory: $API_DIR"
+fi
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "❌ ERROR: Uncommitted changes detected. Cannot proceed with PR review."
+    echo "Please commit or stash your changes before running the API review."
+    git status --porcelain
+    exit 1
+fi
+echo "✅ No uncommitted changes detected. Safe to proceed."
+
+# Find or add an upstream remote for the target repository
+UPSTREAM_REMOTE=""
+for remote in $(git remote); do
+    remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "")
+    if [[ "$remote_url" =~ github\.com[/:]${OWNER}/${REPO}(\.git)?$ ]]; then
+        UPSTREAM_REMOTE="$remote"
+        echo "✅ Found remote: '$remote' -> $remote_url"
+        break
+    fi
+done
+
+if [ -z "$UPSTREAM_REMOTE" ]; then
+    echo "⚠️  No remote pointing to $OWNER/$REPO found. Adding upstream-review remote..."
+    git remote add upstream-review "https://github.com/${OWNER}/${REPO}.git"
+    UPSTREAM_REMOTE="upstream-review"
+fi
+
+echo "🔄 Fetching latest changes from $UPSTREAM_REMOTE..."
+git fetch "$UPSTREAM_REMOTE" master || git fetch "$UPSTREAM_REMOTE" main
+```
+
+## Step 2: Checkout the PR and identify API files
+
+```bash
+echo "🔄 Checking out PR #$PR_NUMBER..."
+gh pr checkout "$PR_NUMBER" --repo "$OWNER/$REPO"
+
+echo "📁 Analyzing changed files in PR..."
+ALL_CHANGED_GO=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json files --jq '.files[].path' | grep '\.go$' || true)
+
+# Filter to API files using --api-dir if provided, otherwise auto-detect
+if [ -n "$API_DIR" ]; then
+    # User specified the API directory — scope to that
+    CHANGED_FILES=$(echo "$ALL_CHANGED_GO" | grep "^${API_DIR}" || true)
+    echo "📂 Scoped to --api-dir=$API_DIR"
 else
-    REVIEW_MODE="local"
-    echo "🔍 Local review mode: Reviewing local changes against upstream master"
-
-    # Find a remote pointing to openshift/api repository
-    OPENSHIFT_REMOTE=""
-    for remote in $(git remote); do
-        remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "")
-        if [[ "$remote_url" =~ github\.com[/:]openshift/api(\.git)?$ ]]; then
-            OPENSHIFT_REMOTE="$remote"
-            echo "✅ Found OpenShift API remote: '$remote' -> $remote_url"
-            break
+    # Auto-detect: check for common API directory patterns in the changed files
+    # Priority: api/, apis/, pkg/api/, pkg/apis/, or files matching API version patterns
+    API_DIRS=""
+    for pattern in "^api/" "^apis/" "^pkg/api/" "^pkg/apis/"; do
+        if echo "$ALL_CHANGED_GO" | grep -q "$pattern"; then
+            API_DIRS="$API_DIRS $pattern"
         fi
     done
 
-    # If no existing remote found, add one with a unique name
-    if [ -z "$OPENSHIFT_REMOTE" ]; then
-        echo "⚠️  No remote pointing to openshift/api found. Adding upstream-openshift-api remote..."
-        git remote add upstream-openshift-api https://github.com/openshift/api.git
-        OPENSHIFT_REMOTE="upstream-openshift-api"
-    fi
-
-    # Fetch latest changes from the OpenShift API remote
-    echo "🔄 Fetching latest changes from $OPENSHIFT_REMOTE..."
-    git fetch "$OPENSHIFT_REMOTE" master
-fi
-```
-
-## Step 2: Get changed files based on review mode
-
-```bash
-if [ "$REVIEW_MODE" = "pr" ]; then
-    # PR Review: Checkout the PR and get changed files
-    echo "🔄 Checking out PR #$PR_NUMBER..."
-    gh pr checkout "$PR_NUMBER"
-
-    echo "📁 Analyzing changed files in PR..."
-    CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
-else
-    # Local Review: Get changed files compared to openshift remote master
-    echo "📁 Analyzing locally changed files compared to $OPENSHIFT_REMOTE/master..."
-    CHANGED_FILES=$(git diff --name-only "$OPENSHIFT_REMOTE/master...HEAD" | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
-
-    # Also include staged changes
-    STAGED_FILES=$(git diff --cached --name-only | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/' || true)
-    if [ -n "$STAGED_FILES" ]; then
-        CHANGED_FILES=$(echo -e "$CHANGED_FILES\n$STAGED_FILES" | sort -u)
+    if [ -n "$API_DIRS" ]; then
+        # Filter to files in detected API directories
+        CHANGED_FILES=""
+        for pattern in $API_DIRS; do
+            matches=$(echo "$ALL_CHANGED_GO" | grep "$pattern" || true)
+            CHANGED_FILES=$(echo -e "$CHANGED_FILES\n$matches" | sed '/^$/d' | sort -u)
+        done
+        echo "📂 Auto-detected API directories: $API_DIRS"
+    else
+        # Fallback: look for files with API version directory patterns or types.go
+        CHANGED_FILES=$(echo "$ALL_CHANGED_GO" | grep -E '/(v1|v1alpha[0-9]*|v1beta[0-9]*|v2|v2alpha[0-9]*|v2beta[0-9]*)/' || true)
+        if [ -z "$CHANGED_FILES" ]; then
+            CHANGED_FILES=$(echo "$ALL_CHANGED_GO" | grep -E 'types\.go$' || true)
+        fi
+        if [ -z "$CHANGED_FILES" ]; then
+            # No API files detected — review all changed Go files
+            CHANGED_FILES="$ALL_CHANGED_GO"
+            echo "⚠️  Could not auto-detect API directory. Reviewing all changed Go files."
+            echo "    Tip: Use --api-dir <path> to scope the review (e.g., --api-dir api/)"
+        fi
     fi
 fi
 
@@ -120,29 +175,29 @@ echo "$CHANGED_FILES"
 
 if [ -z "$CHANGED_FILES" ]; then
     echo "ℹ️  No API files changed. Nothing to review."
-    if [ "$REVIEW_MODE" = "pr" ]; then
-        git checkout "$CURRENT_BRANCH"
-    fi
+    git checkout "$CURRENT_BRANCH"
     exit 0
 fi
 ```
 
-## Step 3: Run linting checks on changes
+## Step 3: Run linting checks on changes (if available)
 
 ```bash
-echo "⏳ Running linting checks on changes..."
-make lint
+# Check if a lint target exists in the Makefile before running
+if [ -f Makefile ] && grep -qE '^lint[[:space:]]*:' Makefile; then
+    echo "⏳ Running linting checks on changes..."
+    make lint
 
-if [ $? -ne 0 ]; then
-    echo "❌ Linting checks failed. Please fix the issues before proceeding."
-    if [ "$REVIEW_MODE" = "pr" ]; then
+    if [ $? -ne 0 ]; then
+        echo "❌ Linting checks failed. Please fix the issues before proceeding."
         echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
         git checkout "$CURRENT_BRANCH"
+        exit 1
     fi
-    exit 1
+    echo "✅ Linting checks passed."
+else
+    echo "⚠️  No 'lint' Makefile target found — skipping lint step."
 fi
-
-echo "✅ Linting checks passed."
 ```
 
 ## Step 4: Documentation validation
@@ -178,55 +233,49 @@ I'll provide a comprehensive report showing:
 
 The review will fail if any documentation requirements are not met for the changed files.
 
-## Step 6: Switch back to original branch (PR mode only)
+## Step 6: Switch back to original branch
 
-After completing the review, if we were reviewing a PR, I'll switch back to the original branch:
+After completing the review, switch back to the original branch:
 
 ```bash
-if [ "$REVIEW_MODE" = "pr" ]; then
-    echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
-    git checkout "$CURRENT_BRANCH"
-    echo "✅ API review complete. Back on branch: $(git branch --show-current)"
-else
-    echo "✅ Local API review complete."
-fi
+echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
+git checkout "$CURRENT_BRANCH"
+echo "✅ API review complete. Back on branch: $(git branch --show-current)"
 ```
 
 **CRITICAL WORKFLOW REQUIREMENTS:**
 
-**For PR Review Mode:**
 1. MUST check for uncommitted changes before starting
 2. MUST abort if uncommitted changes are detected
 3. MUST save current branch name before switching
-4. MUST checkout the PR before running `make lint`
+4. MUST checkout the PR before running lint or review steps
 5. MUST switch back to original branch when complete
 6. If any step fails, MUST attempt to switch back to original branch before exiting
 
-**For Local Review Mode:**
-1. MUST detect existing remotes pointing to openshift/api repository (supports any remote name)
-2. MUST add upstream remote only if no existing openshift/api remote is found
-3. MUST fetch latest changes from the detected openshift/api remote
-4. MUST compare against the detected remote's master branch
-5. MUST include both committed and staged changes in analysis
-6. No branch switching required since we're reviewing local changes
-
 ## Examples
 
-1. **Review a PR**:
+1. **Review an openshift/api PR**:
    ```text
    /openshift:api-review https://github.com/openshift/api/pull/2145
    ```
    Checks out the PR, runs lint and convention checks, then switches back to your branch.
 
-2. **Review local changes**:
+2. **Review a HyperShift PR with explicit API directory**:
    ```text
-   /openshift:api-review
+   /openshift:api-review https://github.com/openshift/hypershift/pull/1234 --api-dir api/
    ```
-   Reviews local changes against upstream master in the current openshift/api clone.
+   Scopes the review to files under `api/` in the HyperShift repo.
+
+3. **Review a PR in any repository**:
+   ```text
+   /openshift:api-review https://github.com/openshift/cluster-version-operator/pull/567
+   ```
+   Auto-detects API directories or falls back to reviewing all changed Go files.
 
 ## Arguments
 
-- **pr_url** (optional): GitHub PR URL to review (e.g., `https://github.com/openshift/api/pull/2145`). If not provided, reviews local changes against upstream master.
+- **pr_url** (required): Full GitHub PR URL (e.g., `https://github.com/openshift/api/pull/2145`). Owner and repo are extracted from the URL.
+- **--api-dir** (optional): Path to the API directory within the repository (e.g., `api/`, `pkg/api/`). If omitted, the command auto-detects API directories from common patterns.
 
 ## See Also
 

--- a/plugins/openshift/commands/api-review.md
+++ b/plugins/openshift/commands/api-review.md
@@ -7,7 +7,7 @@ argument-hint: "[pr_url]"
 openshift:api-review
 
 ## Synopsis
-```
+```text
 /openshift:api-review [pr_url]
 ```
 
@@ -50,7 +50,11 @@ echo "📍 Current branch: $CURRENT_BRANCH"
 # Check if a PR URL was provided
 if [ -n "$ARGUMENTS" ] && [[ "$ARGUMENTS" =~ github\.com.*pull ]]; then
     REVIEW_MODE="pr"
-    PR_NUMBER=$(echo "$ARGUMENTS" | grep -oE '[0-9]+$')
+    PR_NUMBER=$(echo "$ARGUMENTS" | sed -nE 's#^.*/pull/([0-9]+)([/?].*)?$#\1#p')
+    if [ -z "$PR_NUMBER" ]; then
+        echo "❌ ERROR: Could not parse PR number from: $ARGUMENTS"
+        exit 1
+    fi
     echo "🔍 PR review mode: Reviewing PR #$PR_NUMBER"
 
     # For PR review, check for uncommitted changes
@@ -76,11 +80,11 @@ else
         fi
     done
 
-    # If no existing remote found, add upstream
+    # If no existing remote found, add one with a unique name
     if [ -z "$OPENSHIFT_REMOTE" ]; then
-        echo "⚠️  No remote pointing to openshift/api found. Adding upstream remote..."
-        git remote add upstream https://github.com/openshift/api.git
-        OPENSHIFT_REMOTE="upstream"
+        echo "⚠️  No remote pointing to openshift/api found. Adding upstream-openshift-api remote..."
+        git remote add upstream-openshift-api https://github.com/openshift/api.git
+        OPENSHIFT_REMOTE="upstream-openshift-api"
     fi
 
     # Fetch latest changes from the OpenShift API remote
@@ -209,13 +213,13 @@ fi
 ## Examples
 
 1. **Review a PR**:
-   ```
+   ```text
    /openshift:api-review https://github.com/openshift/api/pull/2145
    ```
    Checks out the PR, runs lint and convention checks, then switches back to your branch.
 
 2. **Review local changes**:
-   ```
+   ```text
    /openshift:api-review
    ```
    Reviews local changes against upstream master in the current openshift/api clone.


### PR DESCRIPTION
## Summary

- Adds the `openshift:api-review` command to the existing `openshift` plugin
- Ported from the [openshift/api repo's custom command](https://github.com/openshift/api/blob/master/.claude/commands/api-review.md) so it can be used as an ai-helpers plugin
- Supports PR review mode (pass a GitHub PR URL) and local review mode (reviews changes against upstream master)
- Bumps openshift plugin version from 0.0.5 to 0.0.6

## Test plan

- [ ] Run `/openshift:api-review` from within an openshift/api clone with local changes
- [ ] Run `/openshift:api-review https://github.com/openshift/api/pull/<number>` to review a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift API review command (`/openshift:api-review`) to validate API changes in pull requests with comprehensive feedback on documentation, optional field handling, and validation consistency.

* **Chores**
  * Updated OpenShift plugin version to 0.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->