### PR TITLE
Modify Podman command for JIRA setup

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -27,7 +27,7 @@ Comprehensive Jira integration for Claude Code, providing AI-powered tools to an
 
 ```bash
 # Start the atlassian mcp server using podman
-podman run -i --rm -p 8080:8080 -e "JIRA_URL=https://redhat.atlassian.net" -e "JIRA_USERNAME" -e "JIRA_API_TOKEN" ghcr.io/sooperset/mcp-atlassian:latest --transport sse --port 8080 -vv
+podman run -i --rm -p 8080:8080 -e JIRA_URL="https://redhat.atlassian.net" -e JIRA_USERNAME="user@redhat.com" -e JIRA_API_TOKEN="token" ghcr.io/sooperset/mcp-atlassian:latest --transport sse --port 8080 -vv
 ```
 
 Then add it to Claude as an SSE server:


### PR DESCRIPTION
Updated example command with specific JIRA username and API token.

<!--

** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:
The command wasn't working for me. I found out the structure wasn't quite right. Providing the email address for the username works. I tried just pasting my username (without the @redhat.com), but ran into some permission issues.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
N/A

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Jira plugin setup documentation with clearer examples of environment variable configuration, including explicit values for `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN` in the Podman container startup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->