### PR TITLE
code-review:pre-commit-review: add --resolve parameter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -200,7 +200,7 @@
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "name": "golang",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -92,7 +92,7 @@ Automated code quality review with language-aware analysis for pre-commit verifi
 
 **Commands:**
 - **`/code-review:pr` `<pr-url-or-number> [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]`** - Automated PR code quality review with language-aware analysis and project-specific profiles
-- **`/code-review:pre-commit-review` `[--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]`** - Automated pre-commit code quality review with language-aware analysis and project-specific profiles
+- **`/code-review:pre-commit-review` `[--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]`** - Automated pre-commit code quality review with language-aware analysis and project-specific profiles
 
 See [plugins/code-review/README.md](plugins/code-review/README.md) for detailed documentation.
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1607,10 +1607,10 @@
           "synopsis": "/code-review:pr <pr-url-or-number> [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]"
         },
         {
-          "argument_hint": "[--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]",
+          "argument_hint": "[--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]",
           "description": "Automated pre-commit code quality review with language-aware analysis and project-specific profiles",
           "name": "pre-commit-review",
-          "synopsis": "/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]"
+          "synopsis": "/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]"
         }
       ],
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
@@ -1634,7 +1634,7 @@
           "name": "HyperShift Project Profile"
         }
       ],
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "commands": [

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/code-review/README.md
+++ b/plugins/code-review/README.md
@@ -10,12 +10,13 @@ Performs a comprehensive code quality review of staged and unstaged changes befo
 
 **Usage:**
 ```bash
-/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]
+/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]
 ```
 
 **Arguments:**
 - `--language <lang>`: Language skill to load. Currently shipped: `go`. Planned: `python`, `rust`, `typescript`, `java`. Auto-detected if omitted.
 - `--profile <name>`: Project profile to load for project-specific conventions.
+- `--resolve`: Enable the iterative review and resolve cycle to automatically fix identified issues.
 - `--skip-build`: Skip build verification.
 - `--skip-tests`: Skip unit test coverage review.
 
@@ -87,6 +88,7 @@ The command runs in a defined sequence of steps:
 7. **Build verification** using profile, language, or auto-detected build commands.
 8. **Project-specific checks** from the profile (if loaded).
 9. **Generate report** with verdict and actionable findings.
+10. **Resolve** identified issues (if enabled) by iterating up to 3 times to fix them.
 
 ## Examples
 
@@ -102,4 +104,7 @@ The command runs in a defined sequence of steps:
 
 # Python review without test checks
 /code-review:pre-commit-review --language python --skip-tests
+
+# Review and automatically fix identified issues
+/code-review:pre-commit-review --resolve
 ```

--- a/plugins/code-review/commands/pre-commit-review.md
+++ b/plugins/code-review/commands/pre-commit-review.md
@@ -1,6 +1,6 @@
 ---
 description: "Automated pre-commit code quality review with language-aware analysis and project-specific profiles"
-argument-hint: "[--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]"
+argument-hint: "[--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]"
 ---
 
 ## Name
@@ -8,7 +8,7 @@ code-review:pre-commit-review
 
 ## Synopsis
 ```
-/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]
+/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--resolve] [--skip-build] [--skip-tests]
 ```
 
 ## Description
@@ -29,6 +29,7 @@ The two layers compose: `--language go --profile hypershift` applies both Go idi
 - Parse `$ARGUMENTS` for the following flags:
   - `--language <lang>`: Language skill to load (e.g., `go`, `python`, `rust`, `typescript`, `java`)
   - `--profile <name>`: Project profile skill to load (e.g., `hypershift`)
+  - `--resolve`: Enable the iterative review and resolve cycle to automatically fix identified issues
   - `--skip-build`: Skip build verification step
   - `--skip-tests`: Skip unit test coverage review step
 - If `--language` is not specified, auto-detect the primary language from the file extensions of changed files:
@@ -139,6 +140,15 @@ After all sub-agents and build verification complete, aggregate findings into a 
 9. **Required Actions**: Issues that must be fixed before committing (blocking).
 10. **Recommended Improvements**: Suggestions that are not blocking but would improve code quality.
 
+### Step 5 — Resolve (if enabled)
+
+If the `--resolve` flag was provided and the Overall Verdict is FAIL or PASS WITH RECOMMENDATIONS:
+1. Present the current report to the user and announce the beginning of the resolve cycle.
+2. Attempt to automatically fix the identified Required Actions and Recommended Improvements in the codebase using appropriate file editing tools.
+3. After making changes, loop back to Step 1 to re-run the review on the newly modified code.
+4. Continue this cycle until the Overall Verdict is PASS, or a maximum of 3 iterations is reached.
+5. If the maximum iterations are reached and issues remain, report the final state to the user and stop.
+
 ### Critical Rules
 
 - **Never approve without build verification** unless `--skip-build` is explicitly specified.
@@ -187,8 +197,15 @@ After all sub-agents and build verification complete, aggregate findings into a 
    ```
    Applies Rust idiomatic checks with no project-specific profile.
 
+6. **Review and resolve issues**:
+   ```
+   /code-review:pre-commit-review --resolve
+   ```
+   Runs the review and automatically loops to fix identified issues until passing.
+
 ## Arguments:
 - `--language <lang>`: Language skill to load. Currently shipped: `go`. Planned: `python`, `rust`, `typescript`, `java`. If omitted, auto-detected from changed file extensions.
 - `--profile <name>`: Project profile skill to load. Loads `skills/profile-<name>/SKILL.md` for project-specific conventions. If omitted, no profile-specific checks are applied.
+- `--resolve`: Enable the iterative review and resolve cycle (Step 5) to automatically fix identified issues.
 - `--skip-build`: Skip the build verification step (Step 3). Useful for documentation-only changes or when build infrastructure is not available locally.
 - `--skip-tests`: Skip the unit test coverage review step (Unit Test Coverage sub-agent). Useful when changes do not affect testable code.


### PR DESCRIPTION
## What this PR does / why we need it:

Add a --resolve parameter to the code-review:pre-commit-review command. When invoked, it will cause the command to attempt to resolve all identified issues, looping up to three times until no further issues are identified.

When combined with /jira:resolve, this enables significantly improved code to be generated due to the multi-pass attempt at identifying and resolving issues.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--resolve` flag to `/code-review:pre-commit-review`. When enabled, the command will attempt automatic fixes for Required Actions and Recommended Improvements, iterating up to 3 times or until the verdict is PASS.

* **Documentation**
  * Updated command docs and examples to show `--resolve` usage and behavior.

* **Chores**
  * Bumped code-review plugin version to 0.0.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->