### PR TITLE
Make ci:analyze-payload aware of informing tests and JIRA incidents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.34"
+      "version": "0.0.35"
     },
     {
       "name": "teams",

--- a/docs/data.json
+++ b/docs/data.json
@@ -574,7 +574,7 @@
           "name": "Trigger Payload Job"
         }
       ],
-      "version": "0.0.34"
+      "version": "0.0.35"
     },
     {
       "commands": [

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "author": {
     "name": "openshift"
   }

--- a/plugins/ci/skills/analyze-payload/SKILL.md
+++ b/plugins/ci/skills/analyze-payload/SKILL.md
@@ -258,6 +258,31 @@ If a revert PR is found:
 
 3. **If a revert PR is open but not merged**, still recommend the revert but note that a revert PR already exists and link to it, so the reader can help expedite the merge.
 
+#### 6.3b: Search for Existing TRT Incident Cards
+
+Search JIRA for existing incident cards that may already track the failures found in this payload. Incident cards are JIRA issues in the **TRT** or **OCPBUGS** project labeled with `trt-incident`. They may have been created by the `ci:stage-payload-reverts` skill or filed manually by humans.
+
+**Prerequisites**: Requires `JIRA_API_TOKEN` and `JIRA_USERNAME` environment variables (same credentials used by the `fetch-jira-issue` skill). If either is not set, skip this step silently — incident card lookup is informational and must not block the analysis.
+
+**Search**: Fetch all open `trt-incident` cards — there are typically very few at any given time:
+
+```jql
+project in (TRT, OCPBUGS) AND labels = "trt-incident" AND statusCategory != Done ORDER BY created DESC
+```
+
+Query the JIRA REST API search endpoint (`POST https://redhat.atlassian.net/rest/api/3/search/jql`) with Basic authentication (`JIRA_USERNAME:JIRA_API_TOKEN`, base64-encoded). Request fields: `summary`, `status`, `description`, `labels`, `components`. Limit to 50 results. Avoid exposing credentials in process arguments — use Python `urllib` (as in `fetch_jira_issue.py`) rather than passing the auth header as a CLI argument.
+
+**Match**: For each returned issue, read its summary and description and check whether it relates to any of the failing jobs or candidate PRs found in this analysis. Prefer exact matches first (PR URL, PR number, full job name) before falling back to fuzzy matches (component name, error description keywords). Record each match:
+- `jira_key`: Issue key (e.g., `TRT-1234` or `OCPBUGS-54321`)
+- `jira_url`: `https://redhat.atlassian.net/browse/{jira_key}`
+- `summary`: Issue summary text
+- `status`: Issue status (e.g., `New`, `In Progress`)
+- `matched_jobs`: List of failing job names this card relates to
+
+Include each incident card in the detail section of every job listed in its `matched_jobs`.
+
+If the API call fails, log a warning and continue without incident card data.
+
 #### 6.4: Write Payload Results YAML
 
 After scoring all (job, candidate PR) pairs and checking for existing reverts, use the `payload-results-yaml` skill to create the results file in the current working directory: `payload-results-{tag}.yaml` (sanitize the tag for filename safety).
@@ -292,6 +317,8 @@ The report must include the following sections:
   <p>{total_blocking} blocking jobs: {succeeded} passed, {failed} failed</p>
   <p>{new_failures} new failure(s), {persistent_failures} persistent failure(s)</p>
   <p>Rejected payload streak: {streak} consecutive rejected payloads</p>
+  <!-- Omit this line entirely if no incident cards were found in Step 6.3b -->
+  <p>{N} existing TRT incident card(s) linked to failures in this payload</p>
 </div>
 ```
 
@@ -329,6 +356,13 @@ For each failed job, a collapsible section containing:
     <h4>First Failed In</h4>
     <p><a href="{originating_payload_url}">{originating_payload_tag}</a></p>
 
+    <!-- Only include if incident cards matched this job in Step 6.3b -->
+    <h4>TRT Incident Cards</h4>
+    <ul>
+      <li><a href="{jira_url}">{jira_key}</a>: {summary} <span class="badge badge-infra">{status}</span></li>
+      <!-- One item per matched incident card -->
+    </ul>
+
     <h4>Candidate PRs (introduced in {originating_payload_tag})</h4>
     <table>
       <tr><th>Component</th><th>PR</th><th>Description</th><th>Bug</th></tr>
@@ -358,6 +392,7 @@ If any revert candidates were identified in Step 6.2, show copy-paste revert ins
       <th>Description</th>
       <th>Caused Failure In</th>
       <th>Failing Since</th>
+      <th>Incident</th>
       <th>Rationale</th>
     </tr>
     <tr>
@@ -366,6 +401,7 @@ If any revert candidates were identified in Step 6.2, show copy-paste revert ins
       <td>{pr_description}</td>
       <td>{job_name(s) this PR is blamed for}</td>
       <td>{originating_payload_tag} ({streak_length} payloads ago)</td>
+      <td><!-- Link to all incident cards whose matched_jobs overlap with this PR's blamed jobs, or "—" if none --><a href="{jira_url}">{jira_key}</a></td>
       <td>{confidence_rationale}</td>
     </tr>
   </table>

--- a/plugins/ci/skills/analyze-payload/SKILL.md
+++ b/plugins/ci/skills/analyze-payload/SKILL.md
@@ -126,6 +126,8 @@ You MUST use the following prompt verbatim (substituting the placeholder values)
 > - **Install failure**: Use the `ci:prow-job-analyze-install-failure` skill. For metal/bare-metal jobs (job name contains "metal"), perform additional analysis using the `ci:prow-job-analyze-metal-install-failure` skill as needed for dev-scripts, Metal3/Ironic, and BareMetalHost-specific diagnostics.
 > - **Test failure**: Use the `ci:prow-job-analyze-test-failure` skill. Do NOT use `--fast` — always perform the full analysis including must-gather extraction and analysis.
 >
+> **Informing (non-blocking) tests**: JUnit `<testcase>` elements may have a `lifecycle` attribute. Tests with `lifecycle="informing"` are non-blocking — their failures do not cause the job to fail. Tests with `lifecycle="blocking"` or no `lifecycle` attribute are blocking. Focus your analysis on **blocking** test failures only. Informing test failures may appear in JUnit results but should not be treated as the cause of the job failure. You may reference them as supporting evidence when they help explain why a blocking test failed.
+>
 > **IMPORTANT** — Trace every failure to its specific root cause by examining actual logs. Never stop at high-level symptoms like "0 nodes ready", "operator degraded", or "containers are crash-looping". Download and read the actual log bundles, pod logs, and container previous logs. Cite specific error messages. The root cause must be actionable, not a restatement of the symptom.
 >
 > Return a concise summary including: failure type (install vs test), root cause, key error messages, and any relevant log excerpts. Do not ask user questions. Keep the output concise for inclusion in a summary report.

--- a/plugins/ci/skills/prow-job-analyze-test-failure/SKILL.md
+++ b/plugins/ci/skills/prow-job-analyze-test-failure/SKILL.md
@@ -180,10 +180,16 @@ where failures occur in CI steps rather than named unit tests.
    - A `<failure>` or `<error>` child element is present, OR
    - The `<testcase>` has attribute `status="failed"`
 
+   **Blocking vs informing tests**: Each `<testcase>` element may have a `lifecycle` attribute (e.g., `<testcase lifecycle="informing">` or `<testcase lifecycle="blocking">`). A test with `lifecycle="informing"` is **non-blocking** — its failure does not cause the overall job to fail. A test with `lifecycle="blocking"` or **no** `lifecycle` attribute is blocking. When collecting failed testcases:
+   - Record the `lifecycle` value for each failed test (default to `"blocking"` if absent)
+   - Treat only **blocking** test failures as primary failures for root cause analysis
+   - **Do not focus on informing test failures.** They should be noted separately but not treated as the reason the job failed. They may provide useful supporting evidence — for example, an informing test failure in a related component may help corroborate why a blocking test also failed
+
    For each failed testcase record:
    - `step_name`: value of `classname` or `name` attribute (whichever identifies the CI step)
    - `failure_message`: text content of the `<failure>` or `<error>` element
    - `junit_file`: path of the XML file it came from
+   - `lifecycle`: value of the `lifecycle` attribute (`"blocking"` or `"informing"`; default `"blocking"` if absent)
 
 2. **Classify each failed step by phase**
 


### PR DESCRIPTION
- **Informing/blocking test awareness**: CI analyzers (`analyze-payload`, `prow-job-analyze-test-failure`) now recognize the `lifecycle` attribute on JUnit `<testcase>` elements, distinguishing blocking tests from informing (non-blocking) ones. Only blocking test failures are treated as primary failure causes.
- **JIRA incident card lookup**: `ci:analyze-payload` now searches for existing TRT incident cards (`trt-incident` label) in JIRA and links them to matching failing jobs in the report, including a new "Incident" column in the revert candidates table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test-failure analysis now distinguishes blocking vs. non-blocking (informing) failures for more accurate root-cause insights.
  * Automatic lookup of related JIRA incident cards; incident counts and matched cards are shown in reports.
  * Reports now include incident lists per failed job and incident links in recommended revert tables.

* **Chores**
  * CI plugin upgraded to version 0.0.35.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->