### PR TITLE
fix(utils): batch push and add preview mode to address-reviews

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "name": "openshift-tls-profile",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,7 +62,7 @@
       "name": "utils",
       "source": "./plugins/utils",
       "description": "A generic utilities plugin serving as a catch-all for various helper commands",
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "name": "olm",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -291,6 +291,7 @@ OpenShift development utilities and helpers
 
 **Commands:**
 - **`/openshift:add-enhancement` `[area] <name> <description> <jira>`** - Create a new OpenShift Enhancement Proposal
+- **`/openshift:api-review` `[pr_url]`** - Run strict OpenShift API review workflow for PR changes or local changes
 - **`/openshift:bootstrap-om`** - Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery
 - **`/openshift:bump-deps` `<dependency> [version] [--create-jira] [--create-pr]`** - Bump dependencies in OpenShift projects with automated analysis and PR creation
 - **`/openshift:cluster-health-check` `[--verbose] [--output-format]`** - Perform comprehensive health check on OpenShift cluster and report issues

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -408,7 +408,7 @@ See [plugins/testing/README.md](plugins/testing/README.md) for detailed document
 A generic utilities plugin serving as a catch-all for various helper commands and agents
 
 **Commands:**
-- **`/utils:address-reviews` `[PR number] [--preview]`** - Fetch and address all PR review comments
+- **`/utils:address-reviews` `[PR number (optional - uses current branch if omitted)] [--preview]`** - Fetch and address all PR review comments
 - **`/utils:auto-approve-konflux-prs` `<target-repository>`** - Automate approving Konflux bot PRs for the given repository by adding /lgtm and /approve
 - **`/utils:find-konflux-images` `<PR-URL>`** - Find and verify Konflux-built container images from a GitHub PR
 - **`/utils:generate-test-plan` `[GitHub PR URLs]`** - Generate test steps for one or more related PRs

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -408,7 +408,7 @@ See [plugins/testing/README.md](plugins/testing/README.md) for detailed document
 A generic utilities plugin serving as a catch-all for various helper commands and agents
 
 **Commands:**
-- **`/utils:address-reviews` `[PR number (optional - uses current branch if omitted)]`** - Fetch and address all PR review comments
+- **`/utils:address-reviews` `[PR number] [--preview]`** - Fetch and address all PR review comments
 - **`/utils:auto-approve-konflux-prs` `<target-repository>`** - Automate approving Konflux bot PRs for the given repository by adding /lgtm and /approve
 - **`/utils:find-konflux-images` `<PR-URL>`** - Find and verify Konflux-built container images from a GitHub PR
 - **`/utils:generate-test-plan` `[GitHub PR URLs]`** - Generate test steps for one or more related PRs

--- a/docs/data.json
+++ b/docs/data.json
@@ -817,7 +817,7 @@
     {
       "commands": [
         {
-          "argument_hint": "[PR number] [--preview]",
+          "argument_hint": "[PR number (optional - uses current branch if omitted)] [--preview]",
           "description": "Fetch and address all PR review comments",
           "name": "address-reviews",
           "synopsis": ""

--- a/docs/data.json
+++ b/docs/data.json
@@ -876,7 +876,7 @@
       "hooks": [],
       "name": "utils",
       "skills": [],
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -1013,6 +1013,12 @@
           "synopsis": "/openshift:add-enhancement [area] <name> <description> <jira>"
         },
         {
+          "argument_hint": "[pr_url]",
+          "description": "Run strict OpenShift API review workflow for PR changes or local changes",
+          "name": "api-review",
+          "synopsis": "/openshift:api-review [pr_url]"
+        },
+        {
           "argument_hint": "",
           "description": "Bootstrap OpenShift Manager (OM) integration for OpenShift operators with automated resource discovery",
           "name": "bootstrap-om",
@@ -1125,7 +1131,7 @@
           "name": "OpenShift Node Kernel Inspection"
         }
       ],
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -817,7 +817,7 @@
     {
       "commands": [
         {
-          "argument_hint": "[PR number (optional - uses current branch if omitted)]",
+          "argument_hint": "[PR number] [--preview]",
           "description": "Fetch and address all PR review comments",
           "name": "address-reviews",
           "synopsis": ""

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/commands/api-review.md
+++ b/plugins/openshift/commands/api-review.md
@@ -1,0 +1,232 @@
+---
+description: Run strict OpenShift API review workflow for PR changes or local changes
+argument-hint: "[pr_url]"
+---
+
+## Name
+openshift:api-review
+
+## Synopsis
+```
+/openshift:api-review [pr_url]
+```
+
+## Description
+
+Run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
+
+## Implementation
+
+# Output Format Requirements
+You MUST use this EXACT format for ALL review feedback:
+
+
++LineNumber: Brief description
+**Current (problematic) code:**
+```go
+[exact code from the PR diff]
+```
+
+**Suggested change:**
+```diff
+- [old code line]
++ [new code line]
+```
+
+**Explanation:** [Why this change is needed]
+
+
+I'll run a comprehensive API review for OpenShift API changes. This can review either a specific GitHub PR or local changes against upstream master.
+
+## Step 1: Pre-flight checks and determine review mode
+
+First, I'll check the arguments and determine whether to review a PR or local changes:
+
+```bash
+# Save current branch
+CURRENT_BRANCH=$(git branch --show-current)
+echo "📍 Current branch: $CURRENT_BRANCH"
+
+# Check if a PR URL was provided
+if [ -n "$ARGUMENTS" ] && [[ "$ARGUMENTS" =~ github\.com.*pull ]]; then
+    REVIEW_MODE="pr"
+    PR_NUMBER=$(echo "$ARGUMENTS" | grep -oE '[0-9]+$')
+    echo "🔍 PR review mode: Reviewing PR #$PR_NUMBER"
+
+    # For PR review, check for uncommitted changes
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "❌ ERROR: Uncommitted changes detected. Cannot proceed with PR review."
+        echo "Please commit or stash your changes before running the API review."
+        git status --porcelain
+        exit 1
+    fi
+    echo "✅ No uncommitted changes detected. Safe to proceed with PR review."
+else
+    REVIEW_MODE="local"
+    echo "🔍 Local review mode: Reviewing local changes against upstream master"
+
+    # Find a remote pointing to openshift/api repository
+    OPENSHIFT_REMOTE=""
+    for remote in $(git remote); do
+        remote_url=$(git remote get-url "$remote" 2>/dev/null || echo "")
+        if [[ "$remote_url" =~ github\.com[/:]openshift/api(\.git)?$ ]]; then
+            OPENSHIFT_REMOTE="$remote"
+            echo "✅ Found OpenShift API remote: '$remote' -> $remote_url"
+            break
+        fi
+    done
+
+    # If no existing remote found, add upstream
+    if [ -z "$OPENSHIFT_REMOTE" ]; then
+        echo "⚠️  No remote pointing to openshift/api found. Adding upstream remote..."
+        git remote add upstream https://github.com/openshift/api.git
+        OPENSHIFT_REMOTE="upstream"
+    fi
+
+    # Fetch latest changes from the OpenShift API remote
+    echo "🔄 Fetching latest changes from $OPENSHIFT_REMOTE..."
+    git fetch "$OPENSHIFT_REMOTE" master
+fi
+```
+
+## Step 2: Get changed files based on review mode
+
+```bash
+if [ "$REVIEW_MODE" = "pr" ]; then
+    # PR Review: Checkout the PR and get changed files
+    echo "🔄 Checking out PR #$PR_NUMBER..."
+    gh pr checkout "$PR_NUMBER"
+
+    echo "📁 Analyzing changed files in PR..."
+    CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
+else
+    # Local Review: Get changed files compared to openshift remote master
+    echo "📁 Analyzing locally changed files compared to $OPENSHIFT_REMOTE/master..."
+    CHANGED_FILES=$(git diff --name-only "$OPENSHIFT_REMOTE/master...HEAD" | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/')
+
+    # Also include staged changes
+    STAGED_FILES=$(git diff --cached --name-only | grep '\.go$' | grep -E '/(v1|v1alpha1|v1beta1)/' || true)
+    if [ -n "$STAGED_FILES" ]; then
+        CHANGED_FILES=$(echo -e "$CHANGED_FILES\n$STAGED_FILES" | sort -u)
+    fi
+fi
+
+echo "Changed API files:"
+echo "$CHANGED_FILES"
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo "ℹ️  No API files changed. Nothing to review."
+    if [ "$REVIEW_MODE" = "pr" ]; then
+        git checkout "$CURRENT_BRANCH"
+    fi
+    exit 0
+fi
+```
+
+## Step 3: Run linting checks on changes
+
+```bash
+echo "⏳ Running linting checks on changes..."
+make lint
+
+if [ $? -ne 0 ]; then
+    echo "❌ Linting checks failed. Please fix the issues before proceeding."
+    if [ "$REVIEW_MODE" = "pr" ]; then
+        echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
+        git checkout "$CURRENT_BRANCH"
+    fi
+    exit 1
+fi
+
+echo "✅ Linting checks passed."
+```
+
+## Step 4: Documentation validation
+
+For each changed API file, I'll validate:
+
+1. **Field Documentation**: All struct fields must have documentation comments
+2. **Optional Field Behavior**: Optional fields must explain what happens when they are omitted
+3. **Validation Documentation**: Validation rules must be documented and match markers
+
+Let me check each changed file for these requirements:
+
+```thinking
+I need to analyze the changed files to:
+1. Find struct fields without documentation
+2. Find optional fields without behavior documentation
+3. Find validation annotations without corresponding documentation
+
+For each Go file, I'll:
+- Look for struct field definitions
+- Check if they have preceding comment documentation
+- For optional fields (those with `+kubebuilder:validation:Optional` or `+optional`), verify behavior is explained
+- For fields with validation annotations, ensure the validation is documented
+```
+
+## Step 5: Generate comprehensive review report
+
+I'll provide a comprehensive report showing:
+- ✅ Files that pass all checks
+- ❌ Files with documentation issues
+- 📋 Specific lines that need attention
+- 📚 Guidance on fixing any issues
+
+The review will fail if any documentation requirements are not met for the changed files.
+
+## Step 6: Switch back to original branch (PR mode only)
+
+After completing the review, if we were reviewing a PR, I'll switch back to the original branch:
+
+```bash
+if [ "$REVIEW_MODE" = "pr" ]; then
+    echo "🔄 Switching back to original branch: $CURRENT_BRANCH"
+    git checkout "$CURRENT_BRANCH"
+    echo "✅ API review complete. Back on branch: $(git branch --show-current)"
+else
+    echo "✅ Local API review complete."
+fi
+```
+
+**CRITICAL WORKFLOW REQUIREMENTS:**
+
+**For PR Review Mode:**
+1. MUST check for uncommitted changes before starting
+2. MUST abort if uncommitted changes are detected
+3. MUST save current branch name before switching
+4. MUST checkout the PR before running `make lint`
+5. MUST switch back to original branch when complete
+6. If any step fails, MUST attempt to switch back to original branch before exiting
+
+**For Local Review Mode:**
+1. MUST detect existing remotes pointing to openshift/api repository (supports any remote name)
+2. MUST add upstream remote only if no existing openshift/api remote is found
+3. MUST fetch latest changes from the detected openshift/api remote
+4. MUST compare against the detected remote's master branch
+5. MUST include both committed and staged changes in analysis
+6. No branch switching required since we're reviewing local changes
+
+## Examples
+
+1. **Review a PR**:
+   ```
+   /openshift:api-review https://github.com/openshift/api/pull/2145
+   ```
+   Checks out the PR, runs lint and convention checks, then switches back to your branch.
+
+2. **Review local changes**:
+   ```
+   /openshift:api-review
+   ```
+   Reviews local changes against upstream master in the current openshift/api clone.
+
+## Arguments
+
+- **pr_url** (optional): GitHub PR URL to review (e.g., `https://github.com/openshift/api/pull/2145`). If not provided, reviews local changes against upstream master.
+
+## See Also
+
+- `/openshift:crd-review` - Review CRD types in any repository against conventions
+- [OpenShift API Conventions](https://github.com/openshift/enhancements/blob/master/dev-guide/api-conventions.md)
+- [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
+- [Source command](https://github.com/openshift/api/blob/master/.claude/commands/api-review.md) in the openshift/api repository

--- a/plugins/utils/.claude-plugin/plugin.json
+++ b/plugins/utils/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "utils",
   "description": "A generic utilities plugin serving as a catch-all for various helper commands and agents",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/utils/commands/address-reviews.md
+++ b/plugins/utils/commands/address-reviews.md
@@ -1,6 +1,6 @@
 ---
 description: Fetch and address all PR review comments
-argument-hint: "[PR number] [--preview]"
+argument-hint: "[PR number (optional - uses current branch if omitted)] [--preview]"
 ---
 
 ## Name

--- a/plugins/utils/commands/address-reviews.md
+++ b/plugins/utils/commands/address-reviews.md
@@ -113,7 +113,7 @@ This command automates the process of addressing PR review comments by fetching 
 
 When multiple comments relate to the same concern/fix:
 - Make the code change once
-- Reply to EACH comment individually (don't copy-paste, tailor each reply)
+- Track replies for EACH comment individually (posted in Step 4 — don't copy-paste, tailor each reply)
 - Optional reference: `Done. (Also addresses feedback from @user)`
 
 #### Code Change Requests
@@ -122,7 +122,7 @@ When multiple comments relate to the same concern/fix:
 
 **b. If requested change is valid**:
 - Plan and implement changes
-- Commit and Push **(ALL sub-steps are MANDATORY — do not skip any)**
+- Commit locally **(do NOT push yet — all pushes are batched in Step 4)**
    1. **Review changes**: `git diff`
 
    2. **Sync with remote first**: `git pull --rebase origin <branch>` to ensure local branch is up to date. If the branch is behind or diverged, you MUST rebase before committing.
@@ -139,18 +139,36 @@ When multiple comments relate to the same concern/fix:
       - **When unsure**: Amend (keep git history clean)
       - **Multiple commits**: Use `git rebase -i origin/main` to amend the specific relevant commit
 
-   5. **Create commit AND push (both required)**:
+   5. **Create commit locally**:
       - Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
       - Always include body explaining "why"
-      - **Amend**: `git commit --amend --no-edit && git push --force-with-lease` (or update message if scope changed)
-      - **New commit**: Standard commit with message, then `git push`
-      - **⚠️ A commit without a push is incomplete. You MUST push.**
+      - **Amend**: `git commit --amend --no-edit` (or update message if scope changed)
+      - **New commit**: Standard commit with message
 
-   6. **Verify push succeeded (MANDATORY before replying)**:
-      - Run `git log -1 --format='%H'` locally and `git ls-remote origin <branch>` to confirm the remote has your commit
-      - **If they differ**: The push failed or was never executed. Do NOT post a "Done" reply. Diagnose and retry, or report the failure to the user.
-      - **If uncommitted changes remain** (`git status`): The commit failed. Fix it first.
-      - **⚠️ NEVER post a "Done" or "Fixed" reply unless the push is verified on the remote.** Posting false claims of completion erodes reviewer trust and wastes human reviewers' time.
+- Track what was done for each comment (change description, comment ID, author) so replies can be posted in Step 4
+
+**c. If declining change**:
+- Track the technical explanation for reply in Step 4
+
+**d. If unsure**: Ask user for clarification
+
+#### Clarification Requests
+
+- Prepare clear, detailed answer (2-4 sentences)
+- Include file:line references when applicable
+- Track for reply in Step 4
+
+#### Informational Comments
+
+- No action unless response is courteous
+
+### Step 4: Post Replies and Push
+
+After ALL comments from Step 3 are processed, post replies and push in this order:
+
+#### 4a. Post all replies
+
+For each comment addressed in Step 3, post the reply:
 
 - **Concise Reply template**: `Done. [1-line what changed]. [Optional 1-line why]`
   - Max 2 sentences + attribution footer
@@ -160,27 +178,22 @@ When multiple comments relate to the same concern/fix:
   ```
   If fails: `gh pr comment <PR_NUMBER> --body="@<author> <reply>"`
 
-**c. If declining change**:
-- **Reply with technical explanation** (3-5 sentences):
-  - Why current implementation is correct
-  - Specific reasoning with file:line references
-- Use same posting method as (b)
-
-**d. If unsure**: Ask user for clarification
-
-#### Clarification Requests
-
-- Provide clear, detailed answer (2-4 sentences)
-- Include file:line references when applicable
-- Post using same method as code changes
-
-#### Informational Comments
-
-- No action unless response is courteous
-
 **All replies must include**: `---\n*AI-assisted response via Claude Code*`
 
-### Step 4: Summary
+#### 4b. Push once
+
+After all replies are posted, push all committed changes in a single push:
+
+```bash
+git push --force-with-lease
+```
+
+#### 4c. Verify push
+
+- Run `git log -1 --format='%H'` locally and `git ls-remote origin <branch>` to confirm the remote has your commit
+- **If they differ**: Diagnose and retry the push
+
+### Step 5: Summary
 
 Show user:
 - Total comments found (raw count from API)

--- a/plugins/utils/commands/address-reviews.md
+++ b/plugins/utils/commands/address-reviews.md
@@ -1,13 +1,13 @@
 ---
 description: Fetch and address all PR review comments
-argument-hint: "[PR number (optional - uses current branch if omitted)]"
+argument-hint: "[PR number] [--preview]"
 ---
 
 ## Name
 utils:address-reviews
 
 ## Synopsis
-/utils:address-reviews [PR number (optional - uses current branch if omitted)]
+/utils:address-reviews [PR number] [--preview]
 
 ## Description
 This command automates the process of addressing PR review comments by fetching all comments from a pull request, categorizing them by priority (blocking, change requests, questions, suggestions), and systematically addressing each one. It intelligently filters out outdated comments, bot-generated content, and oversized responses to optimize context usage. The command handles code changes, posts replies to reviewers, and maintains a clean git history by amending relevant commits rather than creating unnecessary new ones.
@@ -108,6 +108,20 @@ This command automates the process of addressing PR review comments by fetching 
 5. **Present summary**: Show counts by category and file groupings, ask user to confirm
 
 ### Step 3: Address Comments
+
+#### Interactive Preview (`--preview`)
+
+When `--preview` is passed, preview each comment before acting:
+
+1. Show the reviewer's comment
+2. Show your proposed action: code change diff, explanation, or decline reasoning
+3. Show the draft reply you plan to post
+4. **Wait for user approval** before proceeding — the user can:
+   - **Approve** as-is
+   - **Edit** the proposed reply or approach
+   - **Skip** the comment entirely
+
+This applies to all comment types below. Without `--preview`, act autonomously.
 
 #### Grouped Comments
 
@@ -242,4 +256,5 @@ Where `<type>` is one of: `issue_comment`, `review_thread`, or `review_comment`
 
 
 ## Arguments:
-- $1: [PR number to address reviews (optional - uses current branch if omitted)]
+- $1: [PR number (optional - uses current branch if omitted)]
+- --preview: Preview each comment's proposed action and reply before proceeding


### PR DESCRIPTION
## Summary
- **Batch push to end of workflow**: Instead of pushing after each comment change, the skill now commits locally during Step 3 and pushes once at the end in Step 4 (after all replies are posted). This eliminates the prompt conflict with CI jobs that need to control push timing and prevents mid-execution self-abort in Prow presubmit jobs.
- **Add `--preview` flag**: Opt-in interactive preview mode that shows each comment's proposed action and draft reply before proceeding. Users can approve, edit, or skip each comment.

## Motivation

The `address-review-comments` presubmit job in openshift/release pushes commits back to the PR branch, which can cause Prow to abort the running job. Previously, the skill instructed Claude to push after every change ("A commit without a push is incomplete. You MUST push."), which conflicted with the CI script's "Do NOT push" override. Now both the skill and CI agree: commit locally during processing, post all replies, then push once at the very end.

## Test plan
- [ ] Run `/utils:address-reviews <PR> --preview` locally and verify each comment shows a preview before acting
- [ ] Run `/utils:address-reviews <PR>` locally and verify autonomous mode (no previews)
- [ ] Verify CI job still works via `/test address-review-comments` on a hypershift PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift API review command (`/openshift:api-review`) for strict automated API validation on pull requests and local changes.
  * Added preview mode (`--preview` flag) to address-reviews command to review proposed changes and replies before proceeding.

* **Chores**
  * Updated plugin versions: Utils (0.0.8) and OpenShift (0.0.6).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->