### PR TITLE
feat(bug-triage): Add bug-triage plugin for AI-powered bug scrub preparation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -191,6 +191,12 @@
       "version": "0.0.2"
     },
     {
+      "name": "bug-triage",
+      "source": "./plugins/bug-triage",
+      "description": "AI-powered bug triage for OpenShift teams — analyzes untriaged OCPBUGS issues and posts structured triage comments",
+      "version": "0.1.0"
+    },
+    {
       "name": "workspaces",
       "source": "./plugins/workspaces",
       "description": "Manage isolated git worktree workspaces for multi-repo development",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,6 +5,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Agendas](#agendas-plugin)
 - [Operator Dashboard](#operator-dashboard-plugin)
 - [Bigquery](#bigquery-plugin)
+- [Bug Triage](#bug-triage-plugin)
 - [Ci](#ci-plugin)
 - [Code Review](#code-review-plugin)
 - [Compliance](#compliance-plugin)
@@ -61,6 +62,15 @@ BigQuery cost analysis and optimization utilities
 - **`/bigquery:analyze-usage` `<project-id> <timeframe>`** - Analyze BigQuery usage and costs for a project
 
 See [plugins/bigquery/README.md](plugins/bigquery/README.md) for detailed documentation.
+
+### Bug Triage Plugin
+
+AI-powered bug triage for OpenShift teams — analyzes untriaged OCPBUGS issues and posts structured triage comments before bug scrub meetings
+
+**Commands:**
+- **`/bug-triage:scrub` `--team <team-name> [--team-docs <path>] [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]`** - Analyze untriaged OCPBUGS bugs for a team and post AI triage comments directly on each issue before bug scrub meetings
+
+See [plugins/bug-triage/README.md](plugins/bug-triage/README.md) for detailed documentation.
 
 ### Ci Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1584,6 +1584,28 @@
     {
       "commands": [
         {
+          "argument_hint": "--team <team-name> [--team-docs <path>] [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]",
+          "description": "Analyze untriaged OCPBUGS bugs for a team and post AI triage comments directly on each issue before bug scrub meetings",
+          "name": "scrub",
+          "synopsis": "/bug-triage:scrub --team <team-name> [--team-docs <path>] [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]"
+        }
+      ],
+      "description": "AI-powered bug triage for OpenShift teams \u2014 analyzes untriaged OCPBUGS issues and posts structured triage comments",
+      "has_readme": true,
+      "hooks": [],
+      "name": "bug-triage",
+      "skills": [
+        {
+          "description": "General-purpose analysis logic and comment template for posting AI triage comments on OCPBUGS issues before bug scrub meetings",
+          "id": "triage-comment",
+          "name": "Bug Triage Comment"
+        }
+      ],
+      "version": "0.1.0"
+    },
+    {
+      "commands": [
+        {
           "argument_hint": "<short-description> <repo1|url> [repo2...]",
           "description": "Create a workspace with git worktrees for multi-repository development",
           "name": "create",

--- a/plugins/bug-triage/.claude-plugin/plugin.json
+++ b/plugins/bug-triage/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bug-triage",
+  "description": "AI-powered bug triage for OpenShift teams — analyzes untriaged OCPBUGS issues and posts structured triage comments before bug scrub meetings",
+  "version": "0.1.0",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/bug-triage/README.md
+++ b/plugins/bug-triage/README.md
@@ -1,0 +1,48 @@
+# bug-triage
+
+AI-powered bug triage for OpenShift teams. Analyzes untriaged OCPBUGS issues and posts structured triage comments directly on each Jira issue before bug scrub meetings.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/bug-triage:scrub` | Analyze untriaged bugs for a team and post AI triage comments |
+
+## How It Works
+
+1. Looks up the team's components and repos from `team_component_map.json` (via the `teams` plugin)
+2. Queries OCPBUGS for untriaged bugs under those components
+3. Groups CVE trackers and ART Bot issues into clusters
+4. Analyzes each bug: sub-area, routing, importance, bug vs RFE, duplicates, related context
+5. Posts a structured triage comment on each issue with a confidence score
+6. Adds an idempotency label to prevent double-commenting
+
+## Quick Start
+
+```bash
+# Basic triage (any team)
+/bug-triage:scrub --team "Network Ingress and DNS" --since last-week
+
+# With team-specific docs for richer analysis
+/bug-triage:scrub --team "Network Ingress and DNS" --team-docs ~/network-edge-tools/plugins/nid/team-docs
+
+# Single issue (demo/testing)
+/bug-triage:scrub --team "Core Networking" --issue OCPBUGS-83283 --dry-run
+```
+
+## Team Documentation
+
+Teams can provide optional documentation files for richer triage analysis. See `reference/team-docs-spec.md` for the full specification.
+
+```text
+team-docs/
+├── sub-areas.md        # Sub-area taxonomy (enables detailed classification)
+├── routing-guide.md    # Misrouting detection keywords
+└── context/            # FAQs, AGENTS.md copies, dev guides
+```
+
+## Prerequisites
+
+- `jira` CLI ([ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli)) installed and authenticated
+- `gh` CLI for GitHub PR discovery (optional but recommended)
+- OCPBUGS project access (view, comment, edit labels)

--- a/plugins/bug-triage/commands/scrub.md
+++ b/plugins/bug-triage/commands/scrub.md
@@ -1,0 +1,197 @@
+---
+description: Analyze untriaged OCPBUGS bugs for a team and post AI triage comments directly on each issue before bug scrub meetings
+argument-hint: "--team <team-name> [--team-docs <path>] [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]"
+---
+
+## Name
+bug-triage:scrub
+
+## Synopsis
+```text
+/bug-triage:scrub --team <team-name> [--team-docs <path>] [--since last-week] [--issue OCPBUGS-XXXXX] [--dry-run]
+```
+
+## Description
+The `bug-triage:scrub` command prepares OpenShift teams for bug scrub meetings by analyzing untriaged bugs and posting structured triage comments **directly on each Jira issue**. When someone opens a bug during the meeting, the AI triage comment is already there with routing checks, importance signals, duplicate candidates, and a recommended action.
+
+This command is designed to:
+- Reduce pre-meeting prep time from manual scanning to zero
+- Catch misrouted bugs before the meeting
+- Surface customer-impacting bugs with importance signals
+- Flag possible duplicates and RFEs disguised as bugs
+- Collapse CVE tracker clusters and ART Bot PRs into grouped summaries
+- Never double-comment -- uses a team-specific label as an idempotency gate
+
+The command integrates with the `teams` plugin's `team_component_map.json` for team identity (components, repos) and optionally reads team-specific documentation for richer analysis (sub-area taxonomy, routing rules, FAQs).
+
+## Implementation
+
+The command follows the detailed implementation in `plugins/bug-triage/skills/triage-comment/SKILL.md`. The high-level flow is:
+
+### Phase 0: Load Team Context
+
+1. **Look up team** in `plugins/teams/team_component_map.json` using the `--team` argument. Extract: components, repos, description, team size.
+
+2. **Load team docs** (if `--team-docs` provided): Read `sub-areas.md`, `routing-guide.md`, and any files in `context/` from the specified directory. These provide team-specific knowledge for richer triage.
+
+3. **Derive idempotency label**: If `sub-areas.md` contains a `Label:` line (e.g., `Label: nid-ai-triaged`), use that. Otherwise, derive from the team name: lowercase, drop filler words (`and`, `the`, `of`, `for`), join remaining words with hyphens, append `-ai-triaged` (e.g., "Network Ingress and DNS" becomes `network-ingress-dns-ai-triaged`). See `plugins/bug-triage/skills/triage-comment/SKILL.md` Idempotency section for the full specification.
+
+### Phase 1: Query Untriaged Bugs
+
+4. **Determine scope** based on arguments:
+   - If `--issue OCPBUGS-XXXXX` is provided: operate on that single issue only (skip the JQL query). Useful for demos and testing.
+   - Otherwise: query OCPBUGS for untriaged bugs owned by the team.
+
+5. **Build and execute JQL query** (when not in single-issue mode):
+   ```jql
+   project = OCPBUGS
+   AND component in ({team-components})
+   AND status = New
+   AND labels not in ({team-label})
+   AND created >= {since-clause}
+   ```
+   Build `{team-components}` from the team's components array (e.g., `"Networking / router", "Networking / DNS"`).
+   Build `{team-label}` from the idempotency label derived in Phase 0, step 3 (e.g., `nid-ai-triaged`).
+   Build `{since-clause}` from the `--since` argument: relative values get a `-` prefix (e.g., `last-week` becomes `-1w`, `last-2-weeks` becomes `-2w`); absolute dates (YYYY-MM-DD) are passed as-is with no prefix (e.g., `"2026-04-01"`).
+
+   Use `jira issue list --jql "<query>" --plain` to fetch matching issues.
+
+   **Note on JQL syntax**: Do not quote `New` in the `status =` clause. Do not append `ORDER BY` -- the `jira` CLI handles sorting internally.
+
+6. **Parse results** into a list of issue keys.
+   - If no issues found, report "No untriaged bugs found for the given period" and exit.
+
+### Phase 2: Classify and Group
+
+Before analyzing individual bugs, scan all results and group special categories:
+
+7. **Identify CVE/Security tracker clusters**:
+   - Issues with labels matching `SecurityTracking`, `CVE-*`, or `Security`.
+   - Group by CVE ID (extract from summary or labels).
+   - These will get a single collapsed triage comment on the newest tracker in each group.
+
+8. **Identify ART Bot reconciliation bugs**:
+   - Issues where reporter is `ART Bot` or labels contain `art:reconciliation` or `art:package:*`.
+   - Group all ART bugs together.
+   - These will get a single summary comment on the newest ART issue.
+
+9. **Remaining bugs** are processed individually (the main path).
+
+### Phase 3: Analyze Each Bug
+
+For each individual (non-CVE, non-ART) bug, perform the full triage analysis. Follow the detailed steps in `plugins/bug-triage/skills/triage-comment/SKILL.md`:
+
+10. **Fetch full issue details** (Step 1 of SKILL.md)
+11. **Sub-area classification** (Step 2) -- uses `sub-areas.md` if available
+12. **Routing check** (Step 3) -- uses `routing-guide.md` if available
+13. **Importance assessment** (Step 4) -- universal tiers
+14. **Bug vs RFE classification** (Step 5) -- universal
+15. **Age, completeness, versions, PR discovery** (Steps 5a-d)
+16. **Duplicate detection** (Step 6) -- uses team components for JQL
+17. **Related context** (Step 7)
+18. **Confidence assessment** (Step 8) -- quality gate
+
+### Phase 4: Post Triage Comments
+
+19. **Format the triage comment** for each bug. Follow the comment template in `plugins/bug-triage/skills/triage-comment/SKILL.md`.
+
+20. **Post the comment** (unless `--dry-run` is set). Use a template file to preserve URL formatting:
+    ```bash
+    # Write comment to temp file
+    cat > /tmp/bug-triage-{ISSUE-KEY}.txt << 'EOF'
+    {formatted-comment}
+    EOF
+
+    # Post using --template flag
+    jira issue comment add {ISSUE-KEY} --template /tmp/bug-triage-{ISSUE-KEY}.txt --no-input
+
+    # Clean up
+    rm /tmp/bug-triage-{ISSUE-KEY}.txt
+    ```
+    **Important**: Do NOT pass the comment as an inline argument or `$'...'` string -- shell escaping breaks URLs at period characters.
+
+21. **Add the idempotency label** to prevent double-commenting on subsequent runs:
+    ```bash
+    jira issue edit {ISSUE-KEY} -l "{team-label}" --no-input
+    ```
+
+22. **For CVE tracker clusters**, post a single collapsed comment on the newest tracker. Add the label to ALL trackers in the group.
+
+23. **For ART Bot bugs**, post a single grouped comment on the newest ART issue. Add the label to ALL ART issues in the group.
+
+### Phase 5: Terminal Summary
+
+24. **Print a summary** to the terminal regardless of dry-run mode:
+    ```text
+    {team-name} Bug Scrub Complete
+    ----------------------
+    Period: {since}
+    Total bugs analyzed: {N}
+    - By sub-area: {sub-area counts}
+    - Likely misrouted: {count}
+    - Customer-impacting: {count}
+    - Possible duplicates: {count}
+    - Possible RFEs: {count}
+    - CVE clusters: {count} ({total trackers} trackers)
+    - ART reconciliation: {count}
+
+    Comments posted: {N} (or "DRY RUN -- no comments posted")
+    ```
+
+## Return Value
+- **Per-issue**: A structured triage comment posted directly on each Jira issue
+- **Terminal**: Summary of all bugs analyzed with counts by category
+- **Labels**: Team-specific idempotency label added to each processed issue
+
+## Examples
+
+1. **Triage all untriaged bugs for a team (last week)**:
+   ```bash
+   /bug-triage:scrub --team "Network Ingress and DNS" --team-docs ~/network-edge-tools/plugins/nid/team-docs
+   ```
+
+2. **Triage a single issue (demo/testing)**:
+   ```bash
+   /bug-triage:scrub --team "Core Networking" --issue OCPBUGS-83283 --dry-run
+   ```
+
+3. **Without team docs (basic triage only)**:
+   ```bash
+   /bug-triage:scrub --team "API Server" --since last-2-weeks
+   ```
+
+4. **Dry run to preview comments**:
+   ```bash
+   /bug-triage:scrub --team "Network Ingress and DNS" --team-docs ~/network-edge-tools/plugins/nid/team-docs --since last-week --dry-run
+   ```
+
+## Arguments
+
+- **--team** *(required)*
+  Team name as it appears in `plugins/teams/team_component_map.json`. Case-sensitive.
+  Run `/teams:list-teams` to see available team names.
+  Example: `--team "Network Ingress and DNS"`
+
+- **--team-docs** *(optional)*
+  Path to a directory containing team-specific documentation files (`sub-areas.md`, `routing-guide.md`, `context/`). See `plugins/bug-triage/reference/team-docs-spec.md` for the expected format.
+  If omitted, the command performs basic triage without sub-area classification or routing checks.
+  Example: `--team-docs ~/network-edge-tools/plugins/nid/team-docs`
+
+- **--issue** *(optional)*
+  A specific OCPBUGS issue key to triage. When provided, skips the JQL query and operates on this single issue only. Useful for demos and testing.
+  Example: `--issue OCPBUGS-83283`
+
+- **--since** *(optional)*
+  Time window for querying untriaged bugs.
+  Options: `last-week` (default) | `last-2-weeks` | `last-month` | `YYYY-MM-DD`
+  Example: `--since last-2-weeks`
+
+- **--dry-run** *(optional)*
+  Preview triage comments in the terminal without posting them to Jira or adding labels. Use this to review output before enabling live posting.
+
+## See Also
+- `plugins/bug-triage/skills/triage-comment/SKILL.md` -- Detailed analysis logic and comment template
+- `plugins/bug-triage/reference/team-docs-spec.md` -- Team documentation format specification
+- `/teams:list-teams` -- List available team names
+- `/teams:list-components` -- List components for a team
+- `/jira:grooming` -- Generic Jira grooming agenda generator

--- a/plugins/bug-triage/reference/team-docs-spec.md
+++ b/plugins/bug-triage/reference/team-docs-spec.md
@@ -1,0 +1,85 @@
+# Team Documentation Specification
+
+This document describes the format and contents of the team-specific documentation files that enrich the `/bug-triage:scrub` command. These files live in the team's own repository and are passed via the `--team-docs` argument.
+
+## Directory Structure
+
+```text
+team-docs/
+├── sub-areas.md           # Recommended: enables sub-area classification
+├── routing-guide.md       # Recommended: enables misrouting detection
+└── context/               # Optional: additional context docs
+    ├── faqs.md            # Common issues and known patterns
+    ├── triage-policies.md # Team-specific triage conventions
+    └── *.md               # AGENTS.md copies, dev guides, etc.
+```
+
+## File Formats
+
+### sub-areas.md (recommended)
+
+Defines the team's sub-area taxonomy. Each sub-area is a markdown heading (`##`) followed by a prose description. The AI uses these descriptions to semantically classify bugs — write descriptions that explain what each area covers, not just keyword lists.
+
+```markdown
+# Sub-Area Taxonomy
+
+## Router / HAProxy
+The HAProxy-based router handles all ingress traffic in OpenShift. Issues in
+this area involve haproxy configuration, reload behavior, route annotations,
+route certificates, backend health checks, connection handling (408s, 503s),
+sticky sessions, and TLS termination modes (reencrypt, edge, passthrough).
+
+## Cluster Ingress Operator (CIO)
+The operator that manages IngressController custom resources. Issues here
+involve the ingresscontroller CR lifecycle, canary checks, default
+certificates, wildcard policies, route admission, publish strategies, and
+endpoint publishing.
+
+## Non-functional Categories
+If the issue is not about a functional problem in any sub-area above:
+- Documentation — AGENTS.md, README, docs, enhancement proposals
+- CI / Infrastructure — test infra, prow jobs, CI config, Dockerfiles
+- Tooling — developer tooling, scripts, automation
+- Dependency Management — go.mod bumps, image updates, ART reconciliation
+```
+
+### routing-guide.md (recommended)
+
+Defines keyword groups for bugs that don't belong to this team, with suggested reroute targets. Each group is a markdown heading followed by keywords and a suggested component.
+
+```markdown
+# Bugs That Don't Belong to This Team
+
+## OVN / SDN
+Keywords: ovn, ovs, sdn, networkpolicy, egressip, egressfirewall, multus,
+whereabouts, macvlan, ipvlan, ovn-kubernetes, ovnkube
+Suggested component: Networking / ovn-kubernetes
+
+## Load Balancer / Cloud
+Keywords: metallb, load balancer type, cloud-provider, CCM, cloud controller,
+keepalived, IPVS, speaker, frr, bgp peer
+Suggested component: Networking / metal
+
+## Service Mesh
+Keywords: istio sidecar, service mesh, envoy proxy, ossm, maistra, kiali
+Suggested component: Networking / service-mesh
+```
+
+### context/*.md (optional)
+
+Any additional markdown files that provide useful context for triage. These are read by the AI and used to inform its analysis — common issues, known quirks, team conventions, component architecture docs, etc.
+
+Examples:
+- `faqs.md` — "HAProxy reload failures are commonly caused by X, Y, Z"
+- `triage-policies.md` — "Bugs affecting the canary route should always be prioritized"
+- Copies of `AGENTS.md` from component repos — gives the AI architectural context
+
+## Graceful Degradation
+
+All team docs are optional. If `--team-docs` is not provided, or if specific files are missing:
+
+| Missing File | Impact |
+|---|---|
+| `sub-areas.md` | Sub-area reported as Jira component name (e.g., "Networking / router") |
+| `routing-guide.md` | Routing check skipped; assumes correctly assigned |
+| `context/*.md` | No extra context; core analysis proceeds normally |

--- a/plugins/bug-triage/skills/triage-comment/SKILL.md
+++ b/plugins/bug-triage/skills/triage-comment/SKILL.md
@@ -1,0 +1,658 @@
+---
+name: Bug Triage Comment
+description: General-purpose analysis logic and comment template for posting AI triage comments on OCPBUGS issues before bug scrub meetings
+---
+
+# Bug Triage Comment
+
+This skill defines the complete analysis logic, decision trees, and comment templates used to generate AI triage comments on OCPBUGS issues for any OpenShift team. Each comment is posted directly on the Jira issue so the team can review it during bug scrub meetings.
+
+The skill is designed to be team-agnostic. Team-specific knowledge (sub-area taxonomy, routing rules, FAQs) is loaded at runtime from documentation files provided via the `--team-docs` argument.
+
+## When to Use This Skill
+
+- **Referenced by**: The `/bug-triage:scrub` command at `plugins/bug-triage/commands/scrub.md`. That command handles the query, grouping, and posting lifecycle; this skill defines what goes *inside* the comment.
+- **Trigger**: When analyzing an individual OCPBUGS issue owned by the team specified via `--team`.
+- **Not used for**: CVE cluster summaries or ART reconciliation summaries, which have their own lightweight templates at the end of this document.
+
+## Prerequisites
+
+- **jira CLI** (`jira`) must be installed and authenticated. The CLI is the `jira-cli` tool available via `brew install jira-cli` or from [github.com/ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli).
+- **OCPBUGS project access**: The authenticated user must have permission to view, comment on, and edit labels for issues in the `OCPBUGS` Jira project.
+- **Network access**: The machine must be able to reach the Red Hat Jira instance.
+- **Team component map**: The `plugins/teams/team_component_map.json` file must be available in the ai-helpers repo for team lookup.
+
+## Analysis Steps
+
+Each step below is performed sequentially for a single issue. The outputs feed into the final comment template.
+
+---
+
+### Step 0: Load Team Context
+
+Before analyzing any issue, load the team's identity and domain knowledge from two sources:
+
+#### A. Team Component Map (required)
+
+Read the team entry from `plugins/teams/team_component_map.json` using the `--team` argument as the key. Extract:
+
+| Field | Source | Used In |
+|---|---|---|
+| Team name | Map key (e.g., "Network Ingress and DNS") | Comment header, display |
+| Components | `components` array (e.g., ["Networking / DNS", "Networking / router"]) | JQL queries (Steps 1, 6), routing check (Step 3) |
+| Repos | `repos` array (each has `repo_name` URL and optional `description`) | PR discovery (Steps 1, 5d) |
+| Description | `description` field | Context for sub-area classification |
+| Slack channels | `slack_channels` array | Informational only |
+| Team size | `team_size` integer | Context |
+
+If the team name is not found in the map, report an error and exit: "Team '{name}' not found in team_component_map.json. Run /teams:list-teams to see available teams."
+
+#### B. Team Documentation (optional, from `--team-docs`)
+
+If `--team-docs` is provided, read all markdown files from that directory:
+
+| File | Purpose | If Missing |
+|---|---|---|
+| `sub-areas.md` | Sub-area taxonomy with descriptions and keywords | Report sub-area as the Jira component name (e.g., "Networking / router") |
+| `routing-guide.md` | Non-team keyword groups for misrouting detection | Skip routing check; assume correctly assigned |
+| `context/*.md` | Additional docs (FAQs, AGENTS.md, dev guides) | No extra context; proceed with core analysis |
+
+Read each file using the Read tool. Store the contents for use in subsequent steps. If `--team-docs` is not provided, all team-doc-dependent steps degrade gracefully (see each step for fallback behavior).
+
+---
+
+### Step 1: Fetch Issue Details
+
+Retrieve the full issue context using both the plain and raw (JSON) outputs:
+
+```bash
+jira issue view {KEY} --plain --comments 10
+jira issue view {KEY} --raw 2>/dev/null
+```
+
+The `--plain` output is for human-readable analysis. The `--raw` JSON output provides structured access to fields not visible in plain text.
+
+Extract and store the following fields for use in subsequent steps:
+
+| Field | Source | Notes |
+|---|---|---|
+| Summary | Issue title | |
+| Description | Full description body | |
+| Component(s) | Jira component field | |
+| Priority | Current priority value | |
+| Reporter | Reporter display name and username | |
+| Labels | All labels on the issue | |
+| Linked Issues | All issue links (type and target key) | |
+| Assignee | Current assignee (may be empty) | |
+| Created Date | Issue creation timestamp | Used for bug age calculation |
+| Status | Current workflow status | |
+| Comments | Last 10 comments | Increased from 5 for better SFDC/PR detection |
+| Affected Versions | `versions` field from raw JSON | Used for regression detection |
+| Fix Versions | `fixVersions` field from raw JSON | Shows if fix is targeted |
+| Sprint | `customfield_10020` from raw JSON | Active sprint detection |
+| Votes | `votes.votes` from raw JSON | Community impact signal |
+| Watchers | `watches.watchCount` from raw JSON | Team interest signal |
+| Attachments | `attachment` array from raw JSON | Log/stack trace availability |
+
+#### Enrichment: Extract GitHub PRs from Comments
+
+Scan all fetched comments for GitHub PR URLs matching the team's repos (from Step 0).
+
+Build a regex pattern from the team's repo list. For example, if the team owns `openshift/router` and `openshift/cluster-ingress-operator`, match:
+```text
+Pattern: https://github.com/openshift/(router|cluster-ingress-operator)/pull/(\d+)
+```
+
+For each extracted PR URL, fetch metadata:
+```bash
+gh pr view {url} --json number,title,state,isDraft,url,mergedAt 2>/dev/null
+```
+
+Store extracted PRs for use in the comment template.
+
+#### Enrichment: Extract SFDC Cases from Comments
+
+Scan all fetched comments for SFDC Integration bot patterns:
+```text
+Pattern: created new external case link for case: (\d+)
+```
+
+If SFDC case IDs are found, store them. This is a strong signal for Customer-Impacting importance tier (Step 4).
+
+#### Enrichment: Detect Workarounds in Comments
+
+Scan all fetched comments for workaround language:
+```text
+Keywords: workaround, work around, work-around, alternative, bypass, temporary fix, mitigation, you can use, as a workaround
+```
+
+If found, store the commenter name and a brief excerpt. This context helps the team decide urgency during scrub.
+
+If the jira CLI returns an error (e.g., issue not found, auth failure), log the error and skip this issue entirely. Do not attempt to construct a partial comment. If the `--raw` command fails, continue with `--plain` output only -- the enrichment fields will be empty but core analysis can proceed.
+
+---
+
+### Step 2: Sub-area Classification
+
+Map the bug to one of the team's sub-areas based on **what the issue is about** (the problem being described), not merely which repo or component name appears in the text.
+
+**Important**: Repo names and component names appearing in the summary or description are context clues, not deterministic classifiers. Read the description to understand what functional area the bug/story affects. If the issue is about infrastructure, CI, documentation, or tooling that happens to touch a team repo, classify it as the relevant non-functional category rather than forcing it into a component sub-area.
+
+#### Loading sub-areas
+
+If `--team-docs` was provided and `sub-areas.md` exists, read the sub-area taxonomy from that file. The file contains sections with sub-area names as headings and prose descriptions with keywords. Use the descriptions to semantically classify the issue -- the LLM should understand what each sub-area covers and match based on meaning, not just keyword hits.
+
+If `sub-areas.md` is not available, skip detailed sub-area classification and report the sub-area as the Jira component name (e.g., "Networking / router").
+
+#### Non-functional Categories
+
+These categories are universal across all teams. If the issue is not about a functional problem in any team-specific sub-area, classify into one of:
+
+- **Documentation** -- AGENTS.md, README, docs, enhancement proposals, conventions
+- **CI / Infrastructure** -- test infrastructure, prow jobs, CI config, Dockerfiles, build scripts
+- **Tooling** -- developer tooling, scripts, automation, MCP server, plugins
+- **Dependency Management** -- go.mod bumps, image updates, ART reconciliation
+
+#### Decision
+
+- If the issue describes a functional bug or feature in a specific sub-area, assign that sub-area.
+- If one sub-area has clear keyword/semantic matches, assign it.
+- If multiple sub-areas match with similar strength, assign the one with the most hits and note the secondary match.
+- If the issue is about non-functional work (docs, CI, tooling, deps), use the non-functional category instead.
+- If no keywords match any sub-area or non-functional category, classify as **"Uncategorized -- needs manual review"**.
+
+---
+
+### Step 3: Routing Check (Is This the Right Team's Bug?)
+
+Scan the summary and description for keywords that indicate the bug may have been misrouted to this team when it actually belongs to a different team.
+
+#### Loading routing rules
+
+If `--team-docs` was provided and `routing-guide.md` exists, read the non-team keyword groups from that file. Each group should have: a name, keywords, and a suggested reroute target.
+
+If `routing-guide.md` is not available, skip the routing check and assume the bug is correctly assigned. Report: "(/) Assumed correctly assigned (no routing guide provided)".
+
+#### Team keywords (for comparison)
+
+Use the combined keyword set from Step 2 (all sub-area keywords from `sub-areas.md`) as the team keyword set. If no sub-areas are loaded, use the team's component names as a minimal keyword set.
+
+#### Decision Logic
+
+1. Count non-team keyword hits in the summary + description (from routing guide).
+2. Count team keyword hits in the summary + description (from sub-areas).
+3. Apply the following rules:
+
+| Non-Team Hits | Team Hits | Verdict |
+|---|---|---|
+| >= 1 | 0 | **Likely misrouted** |
+| >= 1 | >= 1 | **Needs review -- may span multiple areas** |
+| 0 | >= 1 | **Correctly assigned** |
+| 0 | 0 | **Correctly assigned** (generic description, keep with filed component) |
+
+When flagging as "Likely misrouted", suggest the correct component based on the routing guide's suggested targets.
+
+---
+
+### Step 4: Importance Assessment
+
+Check multiple signals and assign exactly one importance tier. Evaluate tiers in the order listed below; the first match wins.
+
+#### Reporter Analysis
+
+To distinguish internal bugs from externally reported ones, check whether the reporter is a member of the team. You can infer this from:
+- The team size from `team_component_map.json`
+- If `--team-docs` provides a team roster or member list
+- The reporter's association with the team's Jira components
+
+If the reporter cannot be identified as a team member, treat them as external for importance assessment purposes.
+
+#### Tier: Customer-Impacting
+
+Matches when ANY of the following are true:
+- **SFDC case detected** (from Step 1 enrichment): If an SFDC case ID was extracted from comments, this is definitively customer-impacting. Include the case ID in the importance explanation.
+- The reporter appears to be external to the team AND at least one of:
+  - Reporter appears to be CEE/support (display name or username contains "CEE", or user is in a known support org)
+  - Description contains any of: `customer`, `case`, `production`, `outage`, `escalation`, `P1`, `sev1`, `sev2`, `incident`, `critical environment`, `revenue impact`
+  - Labels include `needs_manual_sfdc`, `ocp-sustaining`, or `ServiceDeliveryBlocker`
+  - Linked to a Salesforce case (link type or label referencing SFDC)
+- **High community signal**: `votes` count >= 5 (many users affected)
+
+#### Tier: Regression
+
+Matches when any of the following are true:
+- Labels include `component-regression` or `backport-requested`
+- Description or summary contains any of: `regression`, `used to work`, `broke after upgrade`, `worked in 4.`, `no longer works after`, `bisected to`, `started failing in`
+
+#### Tier: Security/CVE
+
+Matches when any of the following are true:
+- Labels include `SecurityTracking`, `Security`, or any label matching pattern `CVE-*`
+- Summary contains `CVE-` followed by a year and sequence number
+
+#### Tier: CI/Test
+
+Matches when any of the following are true:
+- Labels include `ci`, `e2e`, `ci-fix`, `test`, `CI`, `ci-fail`, `ci-only`, `test-flake`
+- Summary or description primarily discusses test failures, CI flakes, or test infrastructure
+- Summary contains: `e2e`, `CI failure`, `flake`, `test failure`, `periodic`, `periodic-ci-`, `rehearsal`, `prow job`
+- Comments contain: "Won't affect the product", "only affects CI", "CI-only", "test infrastructure"
+
+When classified as CI/Test, note whether this is a **product-affecting test failure** vs. **CI infrastructure noise**:
+- If description mentions a real product symptom that surfaces in a test, classify as the functional sub-area with a CI/Test note
+- If purely CI infrastructure (prow config, test image, rehearsal failure), keep as CI/Test
+
+#### Tier: Internal
+
+Default tier when:
+- Reporter is a known team member
+- No customer, regression, security, or CI signals are present
+
+#### Priority Suggestion
+
+If the current priority is `Undefined` or blank, suggest a priority based on the importance tier:
+
+| Importance Tier | Suggested Priority |
+|---|---|
+| Customer-Impacting | `Major` or `Critical` (use `Critical` if description mentions outage, P1, or sev1) |
+| Regression | `Major` |
+| Security/CVE | Per CVE severity: Critical/High -> `Critical`, Medium -> `Major`, Low -> `Minor` |
+| CI/Test | `Minor` |
+| Internal | `Normal` |
+
+If the priority is already set, do not suggest a change -- simply report the current value.
+
+---
+
+### Step 5: Bug vs RFE Classification
+
+Analyze the description and summary language to determine whether this issue is a genuine bug report or a feature request (RFE).
+
+#### Bug Indicators
+Keywords and phrases that signal a bug: `fails`, `broken`, `error`, `crash`, `regression`, `used to work`, `no longer works`, `unexpected behavior`, `panic`, `nil pointer`, `segfault`, `data loss`, `does not work`, `should not`, `wrong`, `incorrect`, `missing`, `timeout unexpectedly`, `connection reset`, `SIGSEGV`, `stack trace`, `degraded`, `CrashLoopBackOff`
+
+#### RFE Indicators
+Keywords and phrases that signal a feature request: `would be nice`, `feature request`, `please add`, `support for`, `enhance`, `new capability`, `proposal`, `wish`, `ability to`, `it would be great`, `consider adding`, `we need`, `use case`, `can we`, `could you add`, `improvement`, `nice to have`, `should support`
+
+#### Decision Logic
+
+1. Count bug indicator hits in the summary + description.
+2. Count RFE indicator hits in the summary + description.
+3. Apply:
+
+| Bug Hits | RFE Hits | Verdict |
+|---|---|---|
+| >= 1 | 0 | **Bug** |
+| 0 | >= 1 | **Possible RFE -- consider converting** |
+| >= 1 | >= 1 | **Unclear -- needs discussion** (include both signal counts in the comment) |
+| 0 | 0 | **Bug** (default -- absence of RFE language implies a bug report) |
+
+When flagging as "Possible RFE", add a note: "This issue reads more like a feature request than a bug report. Consider converting to an RFE."
+
+---
+
+### Step 5a: Bug Age Classification
+
+Calculate the age of the bug from its Created Date to today and assign an age category:
+
+| Age | Category | Display |
+|---|---|---|
+| < 7 days | Very Fresh | `(/) Very Fresh ({N}d)` |
+| 7-30 days | Fresh | `(/) Fresh ({N}d)` |
+| 30-60 days | Getting Stale | `(i) Getting Stale ({N}d)` |
+| 60-90 days | Stale | `(!) Stale ({N}d)` |
+| > 90 days | Old | `(!) Old ({N}d) -- has been sitting untriaged` |
+
+Bugs older than 60 days that are still in `New` status should be flagged for attention -- they may need to be closed, reassigned, or escalated.
+
+---
+
+### Step 5b: Description Completeness Check
+
+Check whether the bug has sufficient information for the team to triage effectively. Look for:
+
+| Section | How to detect | Status if missing |
+|---|---|---|
+| Steps to Reproduce | Text block under "Steps to Reproduce" or "How reproducible" or numbered steps (1. 2. 3.) | `(!) Missing reproduction steps` |
+| Expected Results | Text under "Expected results" or "Expected behavior" | `(i) Missing expected results` |
+| Actual Results | Text under "Actual results" or "Actual behavior" | `(i) Missing actual results` |
+| Version Info | Text under "Version" or presence of OCP version like "4.XX" | `(i) No version specified` |
+| Description present | Any description at all | `(x) No description provided` |
+
+#### Output
+
+- If all key fields are present: `*Completeness:* (/) Complete`
+- If some are missing: `*Completeness:* (i) Partial -- missing: {list}`
+- If description is empty: `*Completeness:* (x) Empty -- no description provided. Needs more info from reporter.`
+
+This directly informs the Suggested Action -- bugs with empty descriptions should get "Needs more info from reporter".
+
+---
+
+### Step 5c: Version & Regression Analysis
+
+Use the `versions` (Affected Versions) and `fixVersions` (Fix Versions) fields from the raw JSON output to detect regressions and version scope:
+
+1. **Multi-version detection**: If `versions` contains 3+ versions, this is likely a regression affecting multiple releases. Auto-upgrade importance to `Regression` tier if not already Customer-Impacting.
+
+2. **Fix already targeted**: If `fixVersions` is populated, note which versions have the fix targeted. This is useful context: "Fix targeted for 4.22" tells the team the bug is being tracked.
+
+3. **Backport signals**: If `versions` includes older releases (e.g., 4.14, 4.15) alongside current ones, flag as needing backport attention.
+
+#### Output
+
+Include version context in the comment when relevant:
+- `*Versions:* Affects 4.18, 4.19, 4.20. Fix targeted for 4.21.`
+- Or omit if no version data is available.
+
+---
+
+### Step 5d: GitHub PR Discovery
+
+If GitHub PRs were extracted from comments in Step 1 (Enrichment), store their metadata for use in the Related Context section (Step 7).
+
+Additionally, if no PRs were found in comments, perform a fallback search across the team's repos (from Step 0):
+```bash
+gh pr list --repo {repo-url} --search "{ISSUE-KEY} in:title,body" --state all --limit 5 --json number,title,state,url 2>/dev/null
+```
+
+Search across all repos listed in the team's `repos` array from `team_component_map.json`. Extract the repo org/name from the `repo_name` URL field.
+
+For each discovered PR, note: repo, PR number, title, state (MERGED/OPEN/DRAFT/CLOSED), and URL.
+
+**Output**: Do NOT create a standalone "Fix status" section. Instead, include relevant PRs inline in the *Related context* section (Step 7) where they add useful context.
+
+---
+
+### Step 6: Duplicate Detection
+
+Attempt to find existing open issues that may be duplicates of the current bug.
+
+#### Procedure
+
+1. **Check existing links**: Look at the issue's linked issues for `DUPLICATES` or `IS DUPLICATED BY` relationships. If such links already exist, report them and skip the search.
+
+2. **Extract search terms**: Take 2-3 key terms from the summary after removing noise words (articles, prepositions, "OpenShift", "OCP", version numbers). Focus on the technical noun phrases.
+
+3. **Search for candidates**: Run a JQL query against open OCPBUGS with the team's components (from Step 0):
+
+   ```bash
+   jira issue list --jql "project = OCPBUGS AND component in ({quoted-components}) AND status not in (Closed) AND key != {KEY} AND summary ~ \"{terms}\"" --plain --no-truncate
+   ```
+
+   Build the `{quoted-components}` from the team's components array, e.g., `"Networking / router", "Networking / DNS"`.
+
+4. **Evaluate candidates**:
+   - If the search returns results, compare the top 3 candidates against the current issue.
+   - For each candidate, note: issue key, summary, and a brief reason why it might be a duplicate.
+   - Only include candidates that have genuine similarity, not just shared generic terms.
+
+5. **Report findings**:
+   - If candidates found: list the top 3 with key, summary, and similarity reason.
+   - If no candidates found: state "No obvious duplicates found".
+   - If the duplicate search query times out or fails: state "Duplicate check skipped (search timed out)".
+
+---
+
+### Step 7: Related Context
+
+Identify issues that are **related but not duplicates** -- sibling tasks, parallel efforts, or useful background context that would help the team during scrub.
+
+#### What to look for
+
+1. **Clone relationships**: If the issue has a `CLONES` or `IS CLONED BY` link, the linked issue is the same task applied to a different scope. Note the relationship explicitly.
+
+2. **Blocks / Blocked-by**: If the issue blocks or is blocked by other issues, note them with context on why the dependency exists.
+
+3. **Related issues in the same epic**: If the issue has a parent epic, briefly note sibling stories that provide context.
+
+4. **GitHub PRs** (from Step 5d): Include discovered PRs inline with the related issue they belong to. For example, if the clone source has an open PR, mention it alongside the clone link.
+
+5. **Sprint context**: If the issue is in an active sprint (from Step 1 enrichment), note the sprint name and goal as a separate bullet.
+
+6. **Prior art**: If the duplicate search (Step 6) turned up issues that aren't duplicates but are thematically related, note them here instead of in the duplicate section.
+
+#### Output format
+
+- If related context is found, list each item with its key (hyperlinked), a one-line description, and the nature of the relationship.
+- Include PR links inline with the related issue they belong to, not as a separate section.
+- If no related context is found, omit this section from the comment entirely (do not print "No related context").
+
+---
+
+### Step 8: Confidence Assessment
+
+Before posting the comment, evaluate the overall confidence of the triage analysis. This serves as a quality gate to prevent incorrect or misleading triage comments.
+
+#### Per-field confidence scoring
+
+Assign a confidence level to each analysis field:
+
+| Field | High Confidence | Medium Confidence | Low Confidence |
+|---|---|---|---|
+| Sub-area | Clear keyword matches in description; obvious functional area | Repo name matches but description is vague | No keyword matches; ambiguous description |
+| Routing | Strong team or non-team keyword signals | Mixed signals from both team and non-team keywords | No keywords found; generic description |
+| Importance | Clear reporter + label + description signals align | Some signals present but not definitive | Reporter unknown, no labels, generic description |
+| Classification | Clear bug or RFE language in description | Mixed language or short description | No description provided |
+| Duplicate check | Exact or near-exact match found | Partial keyword match with plausible similarity | Search returned no results or timed out |
+
+#### Overall confidence
+
+- **High**: All fields are High or Medium confidence. Proceed with posting.
+- **Medium**: At least one field is Low confidence, but the others are High/Medium. Post the comment but include a confidence note in the comment footer.
+- **Low**: Multiple fields are Low confidence, or the description is missing/empty. Handle per mode:
+  - In `--dry-run` mode: display the analysis with low-confidence fields highlighted and ask for confirmation before proceeding.
+  - In live mode: post the comment but prepend a warning: `(?) *Confidence: Low* -- some fields could not be reliably assessed. Please verify during bug scrub.`
+
+#### How confidence appears in the comment
+
+Add a confidence line to the comment, after the suggested action:
+
+- High: `*Confidence:* (/) High`
+- Medium: `*Confidence:* (i) Medium -- {list fields with low confidence}`
+- Low: `*Confidence:* (?) Low -- {list fields with low confidence}. Manual verification recommended.`
+
+---
+
+## Comment Template
+
+The triage comment uses mixed Jira wiki markup (for headings and horizontal rules) and CommonMark markdown (for links). The `jira-cli` processes the content through `ToJiraMD()` which converts CommonMark to Jira wiki markup before posting via REST API v2.
+
+The `{team-name}` and `{command-name}` placeholders below should be replaced with the actual team name and the invoking command (e.g., `/nid:bug-scrub` for a team wrapper, or `/bug-triage:scrub` for direct usage).
+
+```text
+h2. {team-name} Bug Scrub -- AI Pre-Triage
+
+*Sub-area:* {sub-area classification}
+*Routing:* {routing check result with (/) or (!)}
+*Classification:* {Bug | Possible RFE | Unclear}
+*Importance:* {importance tier with emoji -- one-line explanation}
+*Priority suggestion:* {suggested priority} (currently: {current priority})
+*Age:* {age category with emoji and day count}
+*Completeness:* {completeness check result}
+
+*Duplicate check:*
+{duplicate findings with hyperlinked issue keys, or "No obvious duplicates found"}
+
+*Workaround:* {excerpt from comments if workaround detected, or omit section if none}
+
+*Versions:* {affected versions and fix versions, or omit if no version data}
+
+*Related context:*
+{related issues with hyperlinked keys, PR links, and relationship description, or omit if none}
+
+*Summary:* {2-3 sentence AI summary of the bug: what is broken, what component is affected, what is the user impact}
+
+*Suggested action:* {one-line recommendation}
+*Confidence:* {confidence level with explanation}
+
+----
+_Generated by_ {{{command-name}}} _via_ [ai-helpers bug-triage](https://github.com/openshift-eng/ai-helpers)
+```
+
+**Linking format**: `jira-cli` processes template content through `ToJiraMD()`, which converts CommonMark markdown to Jira wiki markup before posting via the REST API v2. This means:
+
+- **Use CommonMark markdown links** for ALL clickable references: `[OCPBUGS-12345](https://redhat.atlassian.net/browse/OCPBUGS-12345)`. jira-cli converts this to proper Jira wiki `[OCPBUGS-12345|url]` internally, which renders as a clickable link.
+- **Jira issue keys**: Always use `[KEY](https://redhat.atlassian.net/browse/KEY)` format. The Jira base URL is `https://redhat.atlassian.net/browse/`. Bare issue keys (e.g., `OCPBUGS-12345`) do NOT auto-link when posted via API -- they render as plain text with escaped dashes.
+- **GitHub URLs**: Use `[PR #1341](https://github.com/openshift/repo/pull/1341)` for a clean display, or write the full URL as plain text (Jira auto-links raw URLs).
+- **Do NOT use** `[text|url]` Jira wiki markup directly in the template -- `ToJiraMD()` escapes the brackets, breaking the link.
+- **Do NOT rely on bare issue keys auto-linking** -- this only works in the Jira web editor, not via API.
+
+**Conditional sections**: The following sections should be OMITTED entirely (not printed as empty) if they have no data:
+- Workaround (no workaround language detected)
+- Versions (no version data in Jira)
+- Related context (no related issues found)
+
+**Note on GitHub PRs**: Do NOT include a standalone "Fix status" section. Instead, include relevant PR links inline within the *Related context* section where they provide useful context.
+
+**Comment posting method**: ALWAYS use a template file to post comments to avoid shell escaping issues that break URLs:
+```bash
+# Write comment to temp file
+cat > /tmp/bug-triage-{KEY}.txt << 'EOF'
+{comment content}
+EOF
+
+# Post using --template flag
+jira issue comment add {KEY} --template /tmp/bug-triage-{KEY}.txt --no-input
+
+# Clean up
+rm /tmp/bug-triage-{KEY}.txt
+```
+
+Do NOT use inline `$'...'` strings or heredocs passed directly to the comment body argument -- they break URLs at period characters.
+
+### Template Field Reference
+
+| Field | Example Value |
+|---|---|
+| Sub-area | Router / HAProxy |
+| Sub-area (non-functional) | Documentation (cluster-dns-operator) |
+| Sub-area (no team docs) | Networking / router |
+| Routing | (/) Correctly assigned |
+| Routing (misrouted) | (!) Likely misrouted -- consider Networking / ovn-kubernetes |
+| Routing (no guide) | (/) Assumed correctly assigned (no routing guide provided) |
+| Classification | Bug |
+| Importance | Customer-Impacting (!) -- SFDC case 04395474, reporter is CEE |
+| Priority suggestion | Major (currently: Undefined) |
+| Age | (!) Stale (74d) |
+| Completeness | (i) Partial -- missing: Steps to Reproduce, Expected Results |
+| Duplicate check | Possible duplicate of [OCPBUGS-12345](https://redhat.atlassian.net/browse/OCPBUGS-12345) (same symptom: route not admitted after upgrade) |
+| Workaround | Jane D. (Apr 13): "As a workaround, manually set the trustBundleName field..." |
+| Versions | Affects 4.20, 4.21. Fix targeted for 4.22. |
+| Related context | [OCPBUGS-11111](https://redhat.atlassian.net/browse/OCPBUGS-11111) -- same issue in 4.15 (clone source, Fixed). [PR #1341](https://github.com/openshift/cluster-ingress-operator/pull/1341) merged. |
+| Summary | HAProxy router pods enter CrashLoopBackOff after cluster upgrade to 4.16. The router template fails to render when custom annotations exceed the buffer size. |
+| Suggested action | Assign to engineer -- likely router template bug |
+| Confidence | (/) High |
+| Confidence (low) | (?) Low -- sub-area and classification could not be reliably assessed. Manual verification recommended. |
+
+### Suggested Action Options
+
+Use one of these standardized action phrases:
+
+- `Assign to engineer` -- standard bug that needs investigation
+- `Assign to engineer -- {sub-area context}` -- standard bug with sub-area hint
+- `Reroute to {component}` -- misrouted bug, specify target component
+- `Close as duplicate of {ISSUE-KEY}` -- clear duplicate found
+- `Convert to RFE` -- issue is a feature request, not a bug
+- `Needs more info from reporter` -- insufficient detail to triage
+- `Discuss in bug scrub` -- ambiguous situation requiring team discussion
+- `Verify fix is backported` -- for regression/backport scenarios
+- `Workaround exists -- prioritize accordingly` -- workaround detected in comments
+- `Fix in review -- monitor {PR link}` -- PR is open, awaiting merge
+
+### Jira Wiki Markup Emoji Reference
+
+Use these Jira wiki markup notations for visual signals:
+
+- `(/)` -- green checkmark (correct routing, resolved items)
+- `(!)` -- warning/attention (misrouted, customer-impacting, regression)
+- `(x)` -- red X (blocked, critical)
+- `(i)` -- info (neutral observation)
+- `(?)` -- question mark (unclear, needs discussion)
+
+---
+
+## Special Templates
+
+### CVE Cluster Template
+
+Used when CVE/Security tracker issues are grouped together (see Phase 2 of the scrub command). Post this comment on the newest tracker in each CVE group.
+
+```text
+h2. {team-name} Bug Scrub -- AI Pre-Triage (CVE Cluster)
+
+*CVE:* {CVE-ID} -- {brief description extracted from summary}
+*Component:* {affected image/component}
+*Tracker count:* {N} version-specific trackers
+*Versions:* {comma-separated version list}
+*Unresolved:* {count} trackers still open ({version list of open trackers})
+*Suggested action:* Verify fix is backported to remaining versions.
+
+----
+_Generated by_ {{{command-name}}} _via_ [ai-helpers bug-triage](https://github.com/openshift-eng/ai-helpers)
+```
+
+### ART Reconciliation Template
+
+Used when ART Bot reconciliation issues are grouped together (see Phase 2 of the scrub command). Post this comment on the newest ART issue in the group.
+
+```text
+h2. {team-name} Bug Scrub -- AI Pre-Triage (ART Reconciliation)
+
+*Count:* {N} image update requests this period
+*Packages:* {package name (count), e.g., haproxy (3), golang (2), coredns (1)}
+*Issues:* {OCPBUGS-XXXXX, OCPBUGS-YYYYY, OCPBUGS-ZZZZZ}
+*Suggested action:* Standard ART reconciliation flow -- review and approve.
+
+----
+_Generated by_ {{{command-name}}} _via_ [ai-helpers bug-triage](https://github.com/openshift-eng/ai-helpers)
+```
+
+---
+
+## Idempotency
+
+This skill MUST be idempotent. Running the triage analysis on the same issue multiple times must not produce duplicate comments.
+
+### Gate: Team-specific Label
+
+Use a label formatted as `{team-short-name}-ai-triaged` (e.g., `nid-ai-triaged`, `apiserver-ai-triaged`).
+
+**Label derivation priority:**
+1. **Explicit**: If `sub-areas.md` contains a `Label:` line (e.g., `Label: nid-ai-triaged`), use that value exactly.
+2. **Derived**: Otherwise, derive from the team name: lowercase, drop filler words (`and`, `the`, `of`, `for`), join remaining words with hyphens, append `-ai-triaged`. For example, "Network Ingress and DNS" becomes `network-ingress-dns-ai-triaged`; "API Server" becomes `api-server-ai-triaged`.
+
+Teams are strongly encouraged to specify an explicit `Label:` line in `sub-areas.md` to avoid collisions between teams whose names share a first word. The same derivation logic is used by the `scrub.md` command (Phase 0, step 3).
+
+1. **Before commenting**: ALWAYS check if the label already exists on the issue. If it does, skip the issue entirely.
+
+2. **After posting the comment**: Immediately add the label to the issue:
+
+   ```bash
+   jira issue edit {KEY} -l "{label}" --no-input
+   ```
+
+3. **For CVE/ART groups**: Add the label to ALL issues in the group, not just the one that received the comment.
+
+4. **On failure**: If the comment posting fails, do NOT add the label. This ensures the issue will be retried on the next run.
+
+### Re-triage
+
+If re-triage is needed (e.g., the issue description changed significantly), the user must manually remove the label from the issue before running the scrub command again.
+
+---
+
+## Error Handling
+
+| Failure Mode | Behavior |
+|---|---|
+| Team not found in component map | Report error with team name and exit. Suggest running `/teams:list-teams`. |
+| `--team-docs` path doesn't exist | Report warning. Proceed without team docs (graceful degradation). |
+| `jira issue view` fails (auth, network, 404) | Log error message with issue key. Skip the issue. Continue to next issue. |
+| Comment posting fails | Log error message with issue key. Do NOT add the triaged label. Continue to next issue. |
+| Label editing fails | Log warning. The comment is already posted, so the issue may be double-commented on next run. Log the key for manual label addition. |
+| Duplicate search query times out | Skip the duplicate section in the comment. Include "Duplicate check skipped (search timed out)" in the comment body. |
+| Issue has no description | Proceed with analysis using only the summary. Note in the comment: "No description provided -- analysis based on summary only." |
+| JQL query returns no results (Phase 1) | Report "No untriaged bugs found for the given period" and exit cleanly. |
+
+All errors should be logged to stderr so they appear in terminal output but do not interfere with the structured comment output.


### PR DESCRIPTION
## Summary

- Adds a new `bug-triage` plugin that any OpenShift team can use to analyze untriaged OCPBUGS issues and post structured AI triage comments directly on each Jira issue before bug scrub meetings
- Integrates with the existing `teams` plugin's `team_component_map.json` for team identity (components, repos, team size) — no duplicate team configuration needed
- Supports optional team-specific documentation (`sub-areas.md`, `routing-guide.md`, `context/`) for richer analysis; degrades gracefully without them

### How it works

1. `/bug-triage:scrub --team "Network Ingress and DNS"` looks up the team in `team_component_map.json`
2. Queries OCPBUGS for untriaged bugs under those components
3. Groups CVE trackers and ART Bot issues into clusters
4. Analyzes each bug: sub-area classification, routing check, importance assessment, bug vs RFE, duplicate detection, related context, confidence scoring
5. Posts a structured triage comment on each issue via `jira-cli`
6. Adds a team-specific idempotency label to prevent double-commenting

### Team docs (optional enrichment)

Teams can provide documentation in their own repo for richer triage:
```
team-docs/
├── sub-areas.md        # Sub-area taxonomy (enables semantic classification)
├── routing-guide.md    # Misrouting detection keywords
└── context/            # FAQs, AGENTS.md copies, dev guides
```

Pass via `--team-docs <path>`. Without it, the plugin still works using components from the team map.

### Files added
- `plugins/bug-triage/.claude-plugin/plugin.json` — plugin metadata (v0.1.0)
- `plugins/bug-triage/commands/scrub.md` — `/bug-triage:scrub` command definition
- `plugins/bug-triage/skills/triage-comment/SKILL.md` — generalized triage analysis logic (8 steps)
- `plugins/bug-triage/reference/team-docs-spec.md` — team docs format specification
- `plugins/bug-triage/README.md` — plugin documentation
- `.claude-plugin/marketplace.json` — registration (modified)
- `PLUGINS.md`, `docs/data.json` — auto-generated via `make update`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.

Assisted with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bug-triage plugin (v0.1.0) to analyze untriaged OCPBUGS issues.
  * Introduced /bug-triage:scrub command with options: --team <name>, optional --team-docs <path>, --since, --issue, and --dry-run.
  * Plugin posts structured triage comments and applies idempotency labels to prevent duplicate triage.

* **Documentation**
  * Added comprehensive docs: README, command reference, team-docs spec, and detailed triage-comment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->