### PR TITLE
jira: catch-me-up

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     {
       "name": "ci",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -207,6 +207,7 @@ A plugin to automate tasks with Jira
 
 **Commands:**
 - **`/jira:backlog` `[project-key] [--assignee username] [--days-inactive N]`** - Find suitable JIRA tickets from the backlog to work on based on priority and activity
+- **`/jira:catch-me-up` `[N | --days N] [--no-cache]`** - Triage recent Jira activity — surface what needs attention, filter out noise
 - **`/jira:categorize-activity-type` `<issue-key> [--auto-apply]`** - Categorize JIRA tickets into activity types using AI
 - **`/jira:clone-from-github` `<issue-number> [issue-number...] [--github-project <org/repo>] [--jira-project <key>] [--dryrun]`** - Clone GitHub issues to Jira with proper formatting and linking
 - **`/jira:create-release-note` `<issue-key>`** - Generate bug fix release notes from Jira tickets and linked GitHub PRs

--- a/docs/data.json
+++ b/docs/data.json
@@ -103,6 +103,12 @@
           "synopsis": "/jira:backlog [project-key] [--assignee username] [--days-inactive N]"
         },
         {
+          "argument_hint": "[N | --days N] [--no-cache]",
+          "description": "Triage recent Jira activity \u2014 surface what needs attention, filter out noise",
+          "name": "catch-me-up",
+          "synopsis": "/jira:catch-me-up [14] [--days 7] [--no-cache]"
+        },
+        {
           "argument_hint": "<issue-key> [--auto-apply]",
           "description": "Categorize JIRA tickets into activity types using AI",
           "name": "categorize-activity-type",
@@ -205,6 +211,11 @@
       "name": "jira",
       "skills": [
         {
+          "description": "Gather and classify recent Jira activity to surface what needs attention",
+          "id": "catch-me-up",
+          "name": "Catch Me Up"
+        },
+        {
           "description": "Detailed categorization logic for assigning JIRA tickets to activity type categories",
           "id": "categorize-activity-type",
           "name": "JIRA Activity Type Categorizer"
@@ -300,7 +311,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/catch-me-up.md
+++ b/plugins/jira/commands/catch-me-up.md
@@ -1,0 +1,171 @@
+---
+description: Triage recent Jira activity — surface what needs attention, filter out noise
+argument-hint: "[N | --days N] [--no-cache]"
+---
+
+## Name
+jira:catch-me-up
+
+## Synopsis
+```text
+/jira:catch-me-up [14] [--days 7] [--no-cache]
+```
+
+## Description
+
+Fetches recent activity on Jira issues where you are assignee or watcher, then classifies each event into three tiers: needs attention, unsure, or noise. Uses a map/reduce approach — fast model classifies batches in parallel, then a review pass catches cross-event patterns.
+
+## Prerequisites
+
+- `JIRA_API_TOKEN` and `JIRA_USERNAME` environment variables set
+- `uv` ([astral.sh/uv](https://astral.sh/uv)) — the gather script is run via `uv run --with aiohttp`
+- `JIRA_URL` defaults to `https://redhat.atlassian.net`
+
+## Implementation
+
+### Step 1: Parse arguments
+
+Default `--days` to 7 if not specified. The user may pass a number directly (e.g., `/jira:catch-me-up 14` means 14 days).
+
+### Step 2: Check subagent permissions
+
+Read `.claude/settings.local.json`. If the file exists, check whether `Read(.work/catch-me-up/**)` is in the `permissions.allow` array.
+
+If present, continue silently.
+
+If missing (or the file doesn't exist), append `Read(.work/catch-me-up/**)` to the `permissions.allow` array. Preserve all existing content — only add this one entry. Tell the user:
+
+> Added `Read(.work/catch-me-up/**)` to `.claude/settings.local.json` — subagents need this to read batch files.
+
+### Step 3: Gather data
+
+Run the data gathering script. Use `uv run` to handle the aiohttp dependency automatically.
+
+```bash
+uv run --with aiohttp plugins/jira/skills/catch-me-up/scripts/gather.py --days <N> -v --output-dir .work/catch-me-up/runs
+```
+
+If the user passed `--no-cache`, append `--no-cache` to the command above.
+
+Check the output stats. If there are 0 events, tell the user and stop. Read the output file path from stderr.
+
+### Step 4: Split into batches
+
+```bash
+python3 plugins/jira/skills/catch-me-up/scripts/split_batches.py .work/catch-me-up/runs/<date>-<days>d/events.json 5
+```
+
+This creates batch files and prints a JSON manifest with `batch_files` paths.
+
+### Step 5: Classify batches in parallel
+
+Spawn one Agent per batch file, **all in a single message** so they run in parallel. Use `model: "haiku"` for each agent.
+
+Each agent's prompt must be exactly:
+
+```text
+You are classifying Jira activity events for triage. The user is <JIRA_USERNAME> — they are the assignee or watcher on these issues. Any events authored by the user themselves should be tier 3 (noise) since they already know about their own actions.
+
+Read <batch_file_path>. The file contains a batch of events plus a `context` field showing author/field frequency counts and the user's Jira username (`jira_username`).
+
+Classify each event into one of three tiers:
+
+**Tier 1 — Needs attention:** Someone @mentions the user, asks them a question, assigns something to them, raises a blocker on their issue, or posts a substantive comment on their bug. Human priority/severity escalations.
+
+**Tier 2 — Unsure:** Ambiguous — could be signal or noise. Humans doing mechanical/formulaic work, field changes that might imply a decision, bot actions that might carry meaning.
+
+**Tier 3 — Noise:** Mechanical process work, formulaic status updates, link churn, release process bookkeeping, bot-like behavior regardless of actor.
+
+Output ONLY a JSON array. Each element must have exactly these fields:
+{
+  "tier": 1,
+  "date": "2026-04-17",
+  "issue_key": "OCPBUGS-12345",
+  "title": "the Jira issue title, copied verbatim from the event data",
+  "author": "Person Name",
+  "summary": "one-line description of what happened and why it's in this tier"
+}
+
+List every event. Do not skip, summarize, or group.
+```
+
+### Step 6: Collect and merge results
+
+Parse the JSON arrays returned by each agent. Merge into a single list. If any agent returned non-JSON output, try to extract the JSON portion.
+
+Group by tier:
+- Count of tier 1, tier 2, tier 3 events
+- Sort tier 1 and tier 2 by date descending
+- Condense tier 3 into one line per event: `ISSUE-KEY | author | summary` (no full JSON, just scannable text)
+
+### Step 7: Review pass
+
+Spawn a single review Agent with `model: "opus"` to synthesize per-event classifications into per-issue narratives.
+
+```text
+You are reviewing classified Jira events. The initial classification was done per-batch, per-event. Your job is to synthesize these into per-issue narratives grouped by tier.
+
+Tier 1 and tier 2 events (full detail):
+<paste merged tier 1 and tier 2 as JSON>
+
+Tier 3 events (condensed — scan for false negatives):
+<for each tier 3 event, one line: "ISSUE-KEY | author | summary">
+
+Your tasks:
+1. Group events by issue key. For each issue, write a summary of what happened and what (if anything) needs the user's action. Default to 1-2 sentences — only go longer when the situation is genuinely complex (e.g., multiple people disagreeing, a subtle root cause, a decision with non-obvious tradeoffs). Omit triage churn, field-change play-by-play, and intermediate states that were superseded. Name people only when the user needs to respond to them specifically.
+2. Assign each issue (not event) a tier. An issue is tier 1 if any of its events need the user's attention. An issue is tier 2 if the activity is ambiguous but worth knowing about.
+3. Demote to tier 3: authors doing purely mechanical work across many issues, duplicate events (e.g., status change that just echoes a comment), superseded actions (e.g., priority escalation reversed the next day).
+4. Promote from tier 3: scan the condensed tier 3 list for events that look like they were wrongly classified as noise — substantive comments, @mentions, or escalations that Haiku missed.
+
+Output JSON:
+{
+  "tier_1": [
+    {
+      "issue_key": "OCPBUGS-12345",
+      "title": "Jira issue title from the classified events",
+      "summary": "What happened and why it matters. 1-2 sentences unless complexity demands more.",
+      "action": "One concrete next step."
+    }
+  ],
+  "tier_2": [
+    {
+      "issue_key": "OCPBUGS-12345",
+      "title": "Jira issue title from the classified events",
+      "summary": "What happened. 1-2 sentences.",
+      "reason": "Why worth a glance"
+    }
+  ],
+  "demoted_to_tier_3": ["OCPBUGS-xxxxx: reason", ...]
+}
+```
+
+### Step 8: Present results
+
+Display to the user in this format:
+
+```markdown
+## Needs your attention (N issues)
+
+### ISSUE-KEY: issue summary
+narrative — what happened, who's involved, the arc
+→ **Action:** what you should do
+
+### ISSUE-KEY: issue summary
+...
+
+## Worth a glance (N issues)
+
+### ISSUE-KEY: issue summary
+narrative
+→ reason it's ambiguous
+
+## Filtered out (N events across M issues)
+  Summary by category, e.g.:
+  23 link changes (various contributors)
+  12 status transitions
+   8 field housekeeping
+```
+
+### Step 9: Save classified output
+
+Write the full classification (all three tiers with individual events) to `.work/catch-me-up/runs/<date>-<days>d/classified.json` for later inspection.

--- a/plugins/jira/skills/catch-me-up/SKILL.md
+++ b/plugins/jira/skills/catch-me-up/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: Catch Me Up
+description: Gather and classify recent Jira activity to surface what needs attention
+---
+
+# Catch Me Up
+
+Gathers recent Jira activity (changelogs and comments) for issues where the user is assignee or watcher, then classifies events into three tiers: needs attention, unsure, or noise.
+
+## Scripts
+
+- `scripts/gather.py` — Fetches events from Jira REST API. Requires `aiohttp`. Outputs JSON to `.work/catch-me-up/runs/{date}-{days}d/events.json`. Caches by date and lookback window.
+- `scripts/split_batches.py` — Splits gathered events into batch files for parallel classification.
+
+## Usage
+
+Invoked by the `/jira:catch-me-up` command. Not intended for standalone use.

--- a/plugins/jira/skills/catch-me-up/scripts/gather.py
+++ b/plugins/jira/skills/catch-me-up/scripts/gather.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Gather Jira activity for catch-me-up triage.
+
+Fetches recent activity (changelogs + comments) on issues where the user is
+assignee or watcher. Dumps raw events as JSON for inspection.
+
+Requires: pip install aiohttp
+
+Environment:
+    JIRA_URL          Jira instance URL (default: https://redhat.atlassian.net)
+    JIRA_API_TOKEN    Atlassian API token
+    JIRA_USERNAME     Atlassian account email
+"""
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# Stored lowercase — is_bot() lowercases before comparison.
+BOT_ACCOUNTS = {
+    "openshift jira links copy bot",     # 766 events
+    "pme-bot service account",           # 487
+    "osi db",                            # 204
+    "rh-internal-custom-fields",         # 101
+    "scriptrunner for jira",             # 75
+    "art bot",                           # 64
+    "openshift jira bot",                # 64
+    "automation for jira",               # 58
+    "openshift prow bot",                # 42
+    "scriptrunner service account",      # 28
+    "konflux release team",              # 27
+    "dptp bot",                          # 23
+    "openshift release-controller bot",  # 16
+    "jira-sd-elements-integration bot",  # 14
+    "cucushift bot",                     # 11
+    "openshift jira automation bot",     # 9
+}
+
+
+def is_bot(display_name: str) -> bool:
+    """Check display name against the known bot accounts list."""
+    return (display_name or "").lower().strip() in BOT_ACCOUNTS
+
+
+JIRA_REQUEST_DELAY = 0.05
+
+
+@dataclass
+class Config:
+    jira_url: str
+    jira_token: str
+    jira_username: str
+    days: int
+    output_dir: Path
+
+
+def parse_datetime(date_str: str | None) -> datetime | None:
+    """Parse an ISO datetime string, handling Jira's Z suffix."""
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def in_range(dt: datetime | None, start: date, end: date) -> bool:
+    """Return True if dt falls within [start, end] inclusive."""
+    if dt is None:
+        return False
+    d = dt.date() if isinstance(dt, datetime) else dt
+    return start <= d <= end
+
+
+def adf_to_text(node: Any) -> str:
+    """Convert Atlassian Document Format to plain text."""
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return str(node)
+
+    parts: list[str] = []
+    node_type = node.get("type")
+
+    if node_type == "text":
+        text = node.get("text", "")
+        for mark in node.get("marks", []):
+            if mark.get("type") == "link":
+                href = mark.get("attrs", {}).get("href", "")
+                if href and href != text:
+                    text = f"{text} ({href})"
+        parts.append(text)
+    elif node_type in ("inlineCard", "blockCard", "embedCard"):
+        url = node.get("attrs", {}).get("url", "")
+        if url:
+            parts.append(url)
+    elif node_type == "mention":
+        parts.append(f"@{node.get('attrs', {}).get('text', '')}")
+
+    for child in node.get("content", []):
+        parts.append(adf_to_text(child))
+
+    block_types = ("doc", "paragraph", "heading", "bulletList",
+                   "orderedList", "listItem", "blockquote")
+    sep = "\n" if node_type in block_types else ""
+    return sep.join(parts)
+
+
+class JiraClient:
+    ISSUE_FIELDS = "summary,status,assignee,comment,updated,created,issuetype,priority,labels"
+
+    def __init__(self, config: Config):
+        self.base_url = config.jira_url.rstrip("/")
+        parsed = urlparse(self.base_url)
+        if parsed.scheme != "https":
+            raise ValueError("JIRA_URL must be https")
+        credentials = base64.b64encode(
+            f"{config.jira_username}:{config.jira_token}".encode()
+        ).decode()
+        self.headers = {
+            "Authorization": f"Basic {credentials}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        self.request_count = 0
+
+    async def fetch_json(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        method: str = "GET",
+        json_body: dict | None = None,
+        retries: int = 3,
+    ) -> dict | list | None:
+        """Make a rate-limited, retrying HTTP request to Jira."""
+        await asyncio.sleep(JIRA_REQUEST_DELAY)
+        self.request_count += 1
+        logger.debug("Request #%d: %s %s", self.request_count, method, url[:100])
+
+        if method == "POST":
+            req = session.post(url, headers=self.headers, json=json_body)
+        else:
+            req = session.get(url, headers=self.headers)
+
+        async with req as resp:
+            if resp.status == 200:
+                return await resp.json()
+            if resp.status == 401:
+                raise ValueError("Jira auth failed (401). Check JIRA_API_TOKEN and JIRA_USERNAME.")
+            if resp.status == 429:
+                if retries <= 0:
+                    logger.error("Rate limited, no retries left: %s", url[:100])
+                    return None
+                logger.warning("Rate limited, waiting 30s (%d retries left)", retries)
+                await asyncio.sleep(30)
+                return await self.fetch_json(session, url, method, json_body, retries - 1)
+            text = await resp.text()
+            logger.warning("Jira %d: %s", resp.status, text[:200])
+            return None
+
+    async def search(
+        self,
+        session: aiohttp.ClientSession,
+        jql: str,
+        fields: str = ISSUE_FIELDS,
+        max_results: int = 500,
+    ) -> list[dict]:
+        """Run a paginated JQL search and return all matching issues."""
+        all_issues: list[dict] = []
+        next_page_token: str | None = None
+
+        while len(all_issues) < max_results:
+            body: dict[str, Any] = {
+                "jql": jql,
+                "maxResults": min(100, max_results - len(all_issues)),
+                "fields": [f.strip() for f in fields.split(",")],
+            }
+            if next_page_token:
+                body["nextPageToken"] = next_page_token
+
+            url = f"{self.base_url}/rest/api/3/search/jql"
+            result = await self.fetch_json(session, url, method="POST", json_body=body)
+            if not result or not isinstance(result, dict):
+                break
+
+            issues = result.get("issues", [])
+            if not issues:
+                break
+            all_issues.extend(issues)
+
+            next_page_token = result.get("nextPageToken")
+            if not next_page_token:
+                break
+
+        if len(all_issues) >= max_results:
+            logger.warning("Hit %d-issue search limit — results may be incomplete", max_results)
+        return all_issues
+
+    async def get_changelog(
+        self, session: aiohttp.ClientSession, issue_key: str
+    ) -> list[dict]:
+        """Fetch the full paginated changelog for an issue."""
+        all_values: list[dict] = []
+        start_at = 0
+        while True:
+            url = (f"{self.base_url}/rest/api/3/issue/{issue_key}/changelog"
+                   f"?maxResults=100&startAt={start_at}")
+            result = await self.fetch_json(session, url)
+            if not isinstance(result, dict):
+                break
+            values = result.get("values", [])
+            if not values:
+                break
+            all_values.extend(values)
+            if start_at + len(values) >= result.get("total", 0):
+                break
+            start_at += len(values)
+        return all_values
+
+
+
+async def gather(config: Config) -> dict:
+    """Fetch changelogs and comments for all watched/assigned issues, emit events JSON."""
+    start_time = datetime.now()
+    start_date = date.today() - timedelta(days=config.days)
+    end_date = date.today()
+
+    client = JiraClient(config)
+
+    timeout = aiohttp.ClientTimeout(total=120)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        jql = (
+            f'(assignee = "{config.jira_username}" OR watcher = "{config.jira_username}") '
+            f"AND updated >= -{config.days}d "
+            f"ORDER BY updated DESC"
+        )
+        logger.info("JQL: %s", jql)
+        issues = await client.search(session, jql)
+        logger.info("Found %d issues", len(issues))
+
+        issues_by_key: dict[str, dict] = {}
+        for issue in issues:
+            issues_by_key[issue["key"]] = issue
+
+        total = len(issues_by_key)
+        completed = 0
+
+        print(f"Fetching changelogs for {total} issues...", file=sys.stderr)
+        changelogs: dict[str, list[dict]] = {}
+        for i, key in enumerate(issues_by_key, 1):
+            changelogs[key] = await client.get_changelog(session, key)
+            if i % 20 == 0 or i == total:
+                print(f"  Changelogs: {i}/{total}", file=sys.stderr)
+
+    all_events: list[dict] = []
+
+    for key, issue in issues_by_key.items():
+        fields = issue.get("fields", {})
+        assignee = fields.get("assignee") or {}
+        issue_meta = {
+            "key": key,
+            "summary": fields.get("summary", ""),
+            "status": (fields.get("status") or {}).get("name", "Unknown"),
+            "assignee": assignee.get("displayName"),
+        }
+
+        for entry in changelogs.get(key, []):
+            created = parse_datetime(entry.get("created"))
+            if not in_range(created, start_date, end_date):
+                continue
+
+            author = entry.get("author", {})
+            author_name = author.get("displayName", "Unknown")
+            if (author.get("emailAddress") or "").lower() == config.jira_username.lower():
+                continue
+            if is_bot(author_name):
+                continue
+            for item in entry.get("items", []):
+                all_events.append({
+                    "type": "field_change",
+                    "issue": issue_meta,
+                    "date": entry.get("created"),
+                    "author": author.get("displayName", "Unknown"),
+                    "field": item.get("field", ""),
+                    "from": item.get("fromString"),
+                    "to": item.get("toString"),
+                })
+
+        comments = fields.get("comment", {}).get("comments", [])
+        for comment in comments:
+            created = parse_datetime(comment.get("created"))
+            if not in_range(created, start_date, end_date):
+                continue
+
+            author = comment.get("author", {})
+            author_name = author.get("displayName", "Unknown")
+            if (author.get("emailAddress") or "").lower() == config.jira_username.lower():
+                continue
+            if is_bot(author_name):
+                continue
+            body = adf_to_text(comment.get("body", ""))
+
+            all_events.append({
+                "type": "comment",
+                "issue": issue_meta,
+                "date": comment.get("created"),
+                "author": author.get("displayName", "Unknown"),
+                "body": body,
+            })
+
+    all_events.sort(key=lambda e: e.get("date", ""), reverse=True)
+
+    duration = (datetime.now() - start_time).total_seconds()
+
+    output = {
+        "generated_at": datetime.now().isoformat(),
+        "config": {
+            "jira_username": config.jira_username,
+            "days": config.days,
+            "date_range": {
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+        },
+        "stats": {
+            "total_issues": len(issues_by_key),
+            "total_events": len(all_events),
+            "jira_requests": client.request_count,
+            "duration_seconds": round(duration, 2),
+        },
+        "events": all_events,
+    }
+
+    output_dir = config.output_dir / f"{end_date.isoformat()}-{config.days}d"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_file = output_dir / "events.json"
+    with open(output_file, "w") as f:
+        json.dump(output, f, indent=2)
+
+    return output
+
+
+def main():
+    """CLI entry point: parse args, configure, and run the gather loop."""
+    import os
+
+    parser = argparse.ArgumentParser(description="Gather Jira activity for catch-me-up triage")
+    parser.add_argument("--days", type=int, default=7, help="Days to look back (default: 7)")
+    parser.add_argument("--output-dir", default=".work/catch-me-up/runs", help="Output directory")
+    parser.add_argument("--no-cache", action="store_true", help="Ignore cached results and re-fetch")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.debug else logging.INFO if args.verbose else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    jira_url = os.environ.get("JIRA_URL", "https://redhat.atlassian.net")
+    jira_token = os.environ.get("JIRA_API_TOKEN")
+    jira_username = os.environ.get("JIRA_USERNAME")
+
+    if not jira_token:
+        print("Error: JIRA_API_TOKEN not set", file=sys.stderr)
+        sys.exit(1)
+    if not jira_username:
+        print("Error: JIRA_USERNAME not set", file=sys.stderr)
+        sys.exit(1)
+
+    config = Config(
+        jira_url=jira_url,
+        jira_token=jira_token,
+        jira_username=jira_username,
+        days=args.days,
+        output_dir=Path(args.output_dir),
+    )
+
+    # Check cache — keyed by date AND days parameter
+    cache_file = config.output_dir / f"{date.today().isoformat()}-{config.days}d" / "events.json"
+    if cache_file.exists() and not args.no_cache:
+        print(f"Using cached results from {cache_file}", file=sys.stderr)
+        with open(cache_file) as f:
+            result = json.load(f)
+        print(f"Events: {result['stats']['total_events']}", file=sys.stderr)
+        return
+
+    print(f"Gathering Jira activity for {jira_username}", file=sys.stderr)
+    print(f"Looking back {config.days} days", file=sys.stderr)
+
+    result = asyncio.run(gather(config))
+
+    print(f"\nDone in {result['stats']['duration_seconds']}s", file=sys.stderr)
+    print(f"Issues: {result['stats']['total_issues']}", file=sys.stderr)
+    print(f"Events: {result['stats']['total_events']}", file=sys.stderr)
+    print(f"Jira requests: {result['stats']['jira_requests']}", file=sys.stderr)
+    print(f"Output: {config.output_dir / f'{date.today().isoformat()}-{config.days}d' / 'events.json'}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/jira/skills/catch-me-up/scripts/split_batches.py
+++ b/plugins/jira/skills/catch-me-up/scripts/split_batches.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Split gathered events into batch files for parallel classification.
+
+Groups events by issue key so all events for an issue stay in the same batch.
+Oversized issues (>3x target) are split chronologically.
+"""
+
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+def main():
+    """Split events into batches grouped by issue key for parallel classification."""
+    if len(sys.argv) < 2:
+        print("Usage: split_batches.py <events.json> [batch_size]", file=sys.stderr)
+        sys.exit(1)
+
+    events_file = Path(sys.argv[1])
+    batch_size = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+
+    with open(events_file) as f:
+        data = json.load(f)
+
+    events = data["events"]
+
+    authors = Counter(e["author"] for e in events)
+    fields = Counter(e["field"] for e in events if e["type"] == "field_change")
+
+    context = {
+        "total_events": len(events),
+        "jira_username": data.get("config", {}).get("jira_username"),
+        "top_authors": dict(authors.most_common(20)),
+        "top_fields": dict(fields.most_common(15)),
+    }
+
+    groups = defaultdict(list)
+    for event in events:
+        groups[event["issue"]["key"]].append(event)
+
+    max_batch_size = batch_size * 3
+
+    batches: list[list[dict]] = []
+    current_batch: list[dict] = []
+
+    for issue_key, issue_events in groups.items():
+        if len(issue_events) > max_batch_size:
+            if current_batch:
+                batches.append(current_batch)
+                current_batch = []
+            for i in range(0, len(issue_events), max_batch_size):
+                batches.append(issue_events[i : i + max_batch_size])
+            continue
+
+        if current_batch and len(current_batch) + len(issue_events) > batch_size:
+            batches.append(current_batch)
+            current_batch = []
+        current_batch.extend(issue_events)
+
+    if current_batch:
+        batches.append(current_batch)
+
+    batch_dir = events_file.parent / "batches"
+    if batch_dir.exists():
+        for old_file in batch_dir.glob("batch_*.json"):
+            old_file.unlink()
+    batch_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_files = []
+    for i, batch in enumerate(batches):
+        batch_num = i + 1
+        batch_data = {
+            "batch_number": batch_num,
+            "total_batches": len(batches),
+            "context": context,
+            "events": batch,
+        }
+        batch_file = batch_dir / f"batch_{batch_num}.json"
+        with open(batch_file, "w") as f:
+            json.dump(batch_data, f, indent=2)
+        batch_files.append(str(batch_file.resolve()))
+
+    output = {
+        "batch_files": batch_files,
+        "batch_count": len(batch_files),
+        "total_events": len(events),
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Our jira is a noisy firehose, lots of bots, lots of label changes, field updates etc. This isn't always filterable with simple rules (e.g if bot: ignore). 

This is a rough attempt at parsing events to try to distil the story of a ticket, and determine if it needs acting upon. It splits events into small batches (aiming to batch by ticket), and uses haiku to summarise them - with opus then synthesising the results later.

More generally, the pattern of using small cheaper models to clean up input for more expensive models, to not exhaust context on easy work I think may be useful in different areas / as parts of different harnesses. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /jira:catch-me-up command to gather and triage recent Jira activity
  * Supports [N | --days N] (default 7) to adjust lookback and --no-cache to bypass cached results
  * Outputs results in three tiers: "Needs your attention", "Worth a glance", "Filtered out"

* **Chores**
  * Jira plugin bumped to version 0.4.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->