### PR TITLE
jira: add ready-to-solve command for validating issue readiness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "name": "ci",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.3.9"
+      "version": "0.4.0"
     },
     {
       "name": "ci",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -216,6 +216,7 @@ A plugin to automate tasks with Jira
 - **`/jira:generate-test-plan` `[JIRA issue key] [GitHub PR URLs]`** - Generate test steps for a JIRA issue
 - **`/jira:grooming` `[project-filter] [time-period] [--component component-name] [--label label-name] [--type issue-type] [--status status] [--story-points]`** - Analyze new bugs and cards added over a time period and generate grooming meeting agenda
 - **`/jira:issues-by-component` `<project-key> [time-period] [--component name] [--assignee username] [--reporter username] [--status status] [--search term] [--search-description]`** - List and analyze JIRA issues organized by component with flexible filtering
+- **`/jira:ready-to-solve` `<jira-issue-key> [--dry-run] [--verbose] [--fix]`** - Check whether a Jira issue is well-groomed and ready for /jira:solve
 - **`/jira:reconcile-github` `[--github-project <org/repo>] [--jira-project <key>] [--profile <name>] [--porcelain] [--output json|yaml]`** - Reconcile state mismatches between GitHub and Jira issues
 - **`/jira:setup-gh2jira`** - Install and configure the gh2jira utility with all required tools and credentials
 - **`/jira:solve`** - Analyze a JIRA issue and create a pull request to solve it.

--- a/docs/data.json
+++ b/docs/data.json
@@ -157,6 +157,12 @@
           "synopsis": "/jira:issues-by-component <project-key> [time-period] [--component component-name] [--assignee username] [--reporter username] [--status status] [--search search-term] [--search-description]"
         },
         {
+          "argument_hint": "<jira-issue-key> [--dry-run] [--verbose] [--fix]",
+          "description": "Check whether a Jira issue is well-groomed and ready for /jira:solve",
+          "name": "ready-to-solve",
+          "synopsis": "/jira:ready-to-solve <jira-issue-key> [--dry-run] [--verbose] [--fix]"
+        },
+        {
           "argument_hint": "[--github-project <org/repo>] [--jira-project <key>] [--profile <name>] [--porcelain] [--output json|yaml]",
           "description": "Reconcile state mismatches between GitHub and Jira issues",
           "name": "reconcile-github",
@@ -284,12 +290,17 @@
           "name": "OCPBUGS Jira Conventions"
         },
         {
+          "description": "Detailed implementation guide for checking Jira issue readiness for /jira:solve",
+          "id": "ready-to-solve",
+          "name": "Jira Issue Readiness Validator"
+        },
+        {
           "description": "Shared engine for analyzing Jira issue activity and generating status summaries",
           "id": "status-analysis",
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.3.9"
+      "version": "0.4.0"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -300,7 +300,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/ready-to-solve.md
+++ b/plugins/jira/commands/ready-to-solve.md
@@ -7,7 +7,7 @@ argument-hint: <jira-issue-key> [--dry-run] [--verbose] [--fix]
 jira:ready-to-solve
 
 ## Synopsis
-```
+```bash
 /jira:ready-to-solve <jira-issue-key> [--dry-run] [--verbose] [--fix]
 ```
 
@@ -28,7 +28,7 @@ With `--fix`, when validation fails the command generates a revised description 
 
 Load the skill file for detailed implementation guidance:
 
-```
+```text
 plugins/jira/skills/ready-to-solve/SKILL.md
 ```
 
@@ -88,22 +88,22 @@ plugins/jira/skills/ready-to-solve/SKILL.md
 ## Examples
 
 1. **Check readiness of an issue**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345
    ```
 
 2. **Preview without applying labels**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --dry-run
    ```
 
 3. **Get detailed output with section content**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --verbose
    ```
 
 4. **Validate and fix failing checks**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --fix
    ```
 

--- a/plugins/jira/commands/ready-to-solve.md
+++ b/plugins/jira/commands/ready-to-solve.md
@@ -1,0 +1,114 @@
+---
+description: Check whether a Jira issue is well-groomed and ready for /jira:solve
+argument-hint: <jira-issue-key> [--dry-run] [--verbose] [--fix]
+---
+
+## Name
+jira:ready-to-solve
+
+## Synopsis
+```
+/jira:ready-to-solve <jira-issue-key> [--dry-run] [--verbose] [--fix]
+```
+
+## Description
+
+The `jira:ready-to-solve` command checks whether a Jira issue has sufficient grooming for `/jira:solve` to produce a quality solution.
+
+It runs a two-phase validation:
+
+1. **Deterministic checks** via a Python script that verifies structural requirements: required sections exist, are non-empty, have adequate content, and contain no placeholder text.
+2. **AI qualitative assessment** that evaluates whether the acceptance criteria are specific and testable, whether there is enough implementation context, and whether clear success/failure conditions exist.
+
+On pass, the label `ready-to-solve` is added to the issue. On fail, `not-ready-to-solve` is added. The stale opposite label is removed if present.
+
+With `--fix`, when validation fails the command generates a revised description that adds or improves the failing sections, shows the proposed changes to the user for approval, and updates the Jira issue description upon confirmation. After fixing, validation is re-run to confirm the issue now passes.
+
+## Implementation
+
+Load the skill file for detailed implementation guidance:
+
+```
+plugins/jira/skills/ready-to-solve/SKILL.md
+```
+
+### Process Flow
+
+1. **Fetch Issue**: Use `mcp__atlassian__jira_get_issue` to retrieve the issue. Extract `description`, `summary`, `labels`, `status`, and `issuetype`. If MCP is unavailable, fall back to curl with `JIRA_PERSONAL_TOKEN`.
+
+2. **Deterministic Checks**: Pipe the description as JSON to the section checker script:
+   ```bash
+   echo "$DESCRIPTION" | jq -Rs '{"description": .}' | python3 plugins/jira/skills/ready-to-solve/check_sections.py
+   ```
+   The script validates:
+   - Context/Description section exists and has >= 50 characters
+   - Acceptance Criteria section exists and has >= 30 characters
+   - Technical Details section exists and has >= 30 characters
+   - AC has multiple list items (warning)
+   - Overall description length >= 200 characters (warning)
+
+3. **AI Qualitative Assessment**: Evaluate three dimensions using the full description content:
+   - **AC Specificity**: Are criteria concrete and testable, not vague?
+   - **Implementation Context**: Is there enough detail to identify relevant code?
+   - **Success/Failure Conditions**: Can a reviewer tell if the solution is correct?
+
+   Each dimension gets PASS, FAIL, or WARNING with a 1-2 sentence justification.
+
+4. **Aggregate Verdict**: The issue passes only if all REQUIRED deterministic checks pass AND no AI check returns FAIL. Warnings are reported but do not block.
+
+5. **Fix (if `--fix` and validation failed)**: If the `--fix` flag is set and the issue failed validation:
+   - Analyze which checks failed (deterministic and AI qualitative)
+   - Generate a revised description that preserves all existing content and adds or improves the failing sections:
+     - Missing Context/Why section: generate from the issue summary, existing description text, and issue metadata
+     - Missing Acceptance Criteria: generate concrete, testable criteria from the description context
+     - Missing Technical Details: generate from any code references, file paths, or component mentions in the description
+     - Sections too short: expand with additional relevant detail
+     - AC lacks list items: restructure into proper bullet points
+     - AI qualitative failures: improve vague AC to be specific and testable, add implementation pointers, clarify success/failure conditions
+   - Present the proposed new description to the user, clearly showing what was added or changed
+   - Ask the user for confirmation before applying
+   - If confirmed, update the issue description via `mcp__atlassian__jira_update_issue` or curl fallback
+   - Re-run validation (steps 2-4) on the updated description to confirm the issue now passes
+   - If the user declines, skip the update and report the original validation result
+
+6. **Apply Label**: Unless `--dry-run`, update the issue labels via `mcp__atlassian__jira_update_issue`. Fetch current labels first, remove the stale opposite label, add the new label, and PUT the full array in a single call.
+
+7. **Report**: Display a structured markdown report with per-check results, AI assessments, overall verdict, and label applied.
+
+## Return Value
+
+- **Format**: Structured markdown report with:
+  - Deterministic check results table (per-check pass/fail with details)
+  - AI qualitative assessment (3 dimensions with verdicts and reasoning)
+  - Overall PASS/FAIL verdict
+  - Label applied (or dry-run indication)
+- **PASS**: All required checks pass, no AI FAIL verdicts
+- **FAIL**: At least one required check failed or AI flagged a critical issue
+
+## Examples
+
+1. **Check readiness of an issue**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345
+   ```
+
+2. **Preview without applying labels**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --dry-run
+   ```
+
+3. **Get detailed output with section content**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --verbose
+   ```
+
+4. **Validate and fix failing checks**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --fix
+   ```
+
+## Arguments:
+- $1: Jira issue key (required). Examples: `OCPBUGS-12345`, `HOSTEDCP-999`, `GCP-456`.
+- `--dry-run`: Optional. Skip label application, only report results.
+- `--verbose`: Optional. Show full per-check details including matched section content.
+- `--fix`: Optional. When validation fails, generate a revised description fixing the failing checks, show the proposed changes, and update the issue upon user confirmation.

--- a/plugins/jira/commands/ready-to-solve.md
+++ b/plugins/jira/commands/ready-to-solve.md
@@ -44,7 +44,7 @@ plugins/jira/skills/ready-to-solve/SKILL.md
    - Context/Description section exists and has >= 50 characters
    - Acceptance Criteria section exists and has >= 30 characters
    - Technical Details section exists and has >= 30 characters
-   - AC has multiple list items (warning)
+   - AC has fewer than 2 list items (warning)
    - Overall description length >= 200 characters (warning)
 
 3. **AI Qualitative Assessment**: Evaluate three dimensions using the full description content:

--- a/plugins/jira/skills/ready-to-solve/SKILL.md
+++ b/plugins/jira/skills/ready-to-solve/SKILL.md
@@ -100,7 +100,7 @@ Read the full description and evaluate three dimensions. For each, produce a ver
 
 ### Phase 4: Aggregate Verdict
 
-```
+```text
 overall_pass = (all REQUIRED deterministic checks pass) AND (no AI check has verdict FAIL)
 ```
 
@@ -121,9 +121,9 @@ When validation fails and `--fix` is set, generate a revised description that fi
    - **Missing Technical Details**: Generate an `h2. Technical Details` section from any code references, file paths, component mentions, or technical context in the description.
    - **Section too short**: Expand the existing section with additional relevant detail while preserving the original content.
    - **AC lacks list items**: Restructure the existing AC text into proper bullet points and add additional criteria if needed.
-   - **AI qualitative failures (vague AC)**: Rewrite vague criteria to be specific and testable (e.g., "works properly" becomes "returns 200 on valid input").
-   - **AI qualitative failures (insufficient context)**: Add implementation pointers -- component names, likely file paths, related features.
-   - **AI qualitative failures (unclear success conditions)**: Add explicit done criteria and edge cases.
+   - **Vague acceptance criteria**: Rewrite vague criteria to be specific and testable (e.g., "works properly" becomes "returns 200 on valid input").
+   - **Insufficient implementation context**: Add implementation pointers -- component names, likely file paths, related features.
+   - **Unclear success conditions**: Add explicit done criteria and edge cases.
 
 3. **Present proposed changes to the user**: Show the full proposed description, clearly indicating what was added or changed (e.g., mark new sections with a note). Ask the user: "Here is the proposed updated description. Apply this to the Jira issue? (yes/no)"
 
@@ -227,22 +227,22 @@ Output format:
 ## Examples
 
 1. **Basic usage**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345
    ```
 
 2. **Dry run (no label changes)**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --dry-run
    ```
 
 3. **Verbose output**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --verbose
    ```
 
 4. **Validate and fix failing checks**:
-   ```
+   ```bash
    /jira:ready-to-solve OCPBUGS-12345 --fix
    ```
 

--- a/plugins/jira/skills/ready-to-solve/SKILL.md
+++ b/plugins/jira/skills/ready-to-solve/SKILL.md
@@ -79,8 +79,10 @@ The script outputs JSON with per-check results. Parse the output to get:
 | `ac_not_empty` | AC has content | At least 30 characters below the heading | REQUIRED |
 | `has_tech` | Technical Details present | Heading matching: Technical Details, Technical Context, Implementation Details, Implementation Notes, or Technical Notes | REQUIRED |
 | `tech_not_empty` | Technical Details has content | At least 30 characters below the heading | REQUIRED |
-| `ac_has_items` | AC has multiple items | At least 2 bullet points or numbered items | WARNING |
+| `ac_has_items` | AC has multiple items | Warns if fewer than 2 bullet points or numbered items | WARNING |
 | `min_description_length` | Adequate overall length | Total description at least 200 characters | WARNING |
+
+**Note:** WARNING checks are reported but do not block the overall verdict. Only REQUIRED checks must pass for the issue to be considered ready.
 
 ### Phase 3: AI Qualitative Assessment
 

--- a/plugins/jira/skills/ready-to-solve/SKILL.md
+++ b/plugins/jira/skills/ready-to-solve/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: Jira Issue Readiness Validator
+description: Detailed implementation guide for checking Jira issue readiness for /jira:solve
+command: /jira:ready-to-solve
+---
+
+# Jira Issue Readiness Validator
+
+## When to Use This Skill
+
+Invoked by `/jira:ready-to-solve`. Validates whether a Jira issue is well-groomed enough for `/jira:solve` to produce a quality solution.
+
+## Prerequisites
+
+- Jira MCP server configured, or `JIRA_PERSONAL_TOKEN` env var for CLI fallback
+- Python 3.8+ (`which python3`)
+
+**Reference Documentation:**
+- [MCP Tools](../../reference/mcp-tools.md)
+- [CLI Fallback](../../reference/cli-fallback.md)
+
+## Implementation Steps
+
+### Phase 1: Fetch Issue Data
+
+Use MCP as primary method:
+
+```python
+issue = mcp__atlassian__jira_get_issue(issue_key="PROJ-123")
+```
+
+Extract from the response:
+- `fields.description` -- full description text
+- `fields.summary` -- issue title
+- `fields.labels` -- current labels array (needed for label updates)
+- `fields.status.name` -- current status
+- `fields.issuetype.name` -- issue type
+
+**CLI fallback** if MCP is unavailable:
+
+```bash
+curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+  "https://redhat.atlassian.net/rest/api/2/issue/{issue_key}?fields=description,summary,labels,status,issuetype"
+```
+
+If `description` is null or empty, skip to Phase 4 with an automatic FAIL verdict.
+
+### Phase 2: Run Deterministic Checks
+
+Pipe the description to the Python script:
+
+```bash
+echo '{"description": "<description_content>"}' | python3 plugins/jira/skills/ready-to-solve/check_sections.py
+```
+
+For verbose output (includes matched content):
+```bash
+echo '{"description": "<description_content>"}' | python3 plugins/jira/skills/ready-to-solve/check_sections.py --verbose
+```
+
+**Important**: Construct the JSON input carefully. The description may contain quotes, newlines, and special characters. Use Python or `jq` to safely serialize:
+
+```bash
+echo "$DESCRIPTION" | jq -Rs '{"description": .}' | python3 plugins/jira/skills/ready-to-solve/check_sections.py
+```
+
+The script outputs JSON with per-check results. Parse the output to get:
+- `overall_pass`: boolean -- whether all REQUIRED checks passed
+- `checks`: array of individual check results
+- `stats`: summary counts
+
+**Deterministic checks performed by the script:**
+
+| Check ID | Name | Pass Condition | Severity |
+|----------|------|----------------|----------|
+| `has_context` | Context section present | Heading matching: Context, Description, Background, Overview, or Why | REQUIRED |
+| `has_ac` | Acceptance Criteria present | Heading matching: Acceptance Criteria, AC, or Definition of Done | REQUIRED |
+| `context_not_empty` | Context has content | At least 50 characters below the heading | REQUIRED |
+| `ac_not_empty` | AC has content | At least 30 characters below the heading | REQUIRED |
+| `has_tech` | Technical Details present | Heading matching: Technical Details, Technical Context, Implementation Details, Implementation Notes, or Technical Notes | REQUIRED |
+| `tech_not_empty` | Technical Details has content | At least 30 characters below the heading | REQUIRED |
+| `ac_has_items` | AC has multiple items | At least 2 bullet points or numbered items | WARNING |
+| `min_description_length` | Adequate overall length | Total description at least 200 characters | WARNING |
+
+### Phase 3: AI Qualitative Assessment
+
+Read the full description and evaluate three dimensions. For each, produce a verdict (PASS, FAIL, WARNING) and a 1-2 sentence justification.
+
+1. **AC Specificity and Testability**: Are acceptance criteria specific enough to write tests against? Do they describe observable behavior rather than vague goals?
+   - FAIL examples: "it should work properly", "system performs well", "user can do things"
+   - PASS examples: "when X happens, Y returns Z", "API returns 404 for missing resources", "latency stays under 200ms"
+
+2. **Implementation Context Sufficiency**: Is there enough description of the problem, affected code area, or desired behavior that `/jira:solve` could identify relevant files and implement a solution?
+   - FAIL if a codebase search would be ambiguous (no component, file, or feature area mentioned)
+   - PASS if the description points to a specific area of the codebase or behavior
+
+3. **Clear Success/Failure Conditions**: Can a reviewer determine whether a proposed solution addresses the issue?
+   - WARNING if AC exists but lacks edge cases
+   - PASS if conditions are explicit and unambiguous
+
+### Phase 4: Aggregate Verdict
+
+```
+overall_pass = (all REQUIRED deterministic checks pass) AND (no AI check has verdict FAIL)
+```
+
+Collect all failures and warnings into a list for the report.
+
+### Phase 5: Fix Failing Checks (if `--fix`)
+
+Skip if `--fix` is not set or if validation already passed.
+
+When validation fails and `--fix` is set, generate a revised description that fixes the failing checks:
+
+1. **Identify failures**: Collect all failed deterministic checks and AI qualitative FAILs from phases 2-4.
+
+2. **Generate revised description**: Preserve ALL existing content from the original description. Only add or expand sections -- never remove or rewrite content the user wrote. For each failure:
+
+   - **Missing Context/Why section**: Generate an `h2. Why` section from the issue summary and any context in the existing description text.
+   - **Missing Acceptance Criteria**: Generate an `h2. Acceptance Criteria` section with concrete, testable bullet points derived from the description context.
+   - **Missing Technical Details**: Generate an `h2. Technical Details` section from any code references, file paths, component mentions, or technical context in the description.
+   - **Section too short**: Expand the existing section with additional relevant detail while preserving the original content.
+   - **AC lacks list items**: Restructure the existing AC text into proper bullet points and add additional criteria if needed.
+   - **AI qualitative failures (vague AC)**: Rewrite vague criteria to be specific and testable (e.g., "works properly" becomes "returns 200 on valid input").
+   - **AI qualitative failures (insufficient context)**: Add implementation pointers -- component names, likely file paths, related features.
+   - **AI qualitative failures (unclear success conditions)**: Add explicit done criteria and edge cases.
+
+3. **Present proposed changes to the user**: Show the full proposed description, clearly indicating what was added or changed (e.g., mark new sections with a note). Ask the user: "Here is the proposed updated description. Apply this to the Jira issue? (yes/no)"
+
+4. **If confirmed**: Update the issue description via MCP:
+
+```python
+mcp__atlassian__jira_update_issue(
+    issue_key="PROJ-123",
+    fields={"description": revised_description},
+    additional_fields={}
+)
+```
+
+**CLI fallback:**
+```bash
+curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" -H "Content-Type: application/json" \
+  -X PUT "https://redhat.atlassian.net/rest/api/2/issue/PROJ-123" \
+  -d '{"fields":{"description":"...revised description..."}}'
+```
+
+5. **Re-run validation**: After updating, re-run phases 2-4 on the new description to confirm the issue now passes. Report the re-validation results.
+
+6. **If declined**: Skip the update and proceed to label application and reporting with the original validation result.
+
+### Phase 6: Apply Jira Label
+
+Skip if `--dry-run` is set.
+
+1. Get current labels from the fetched issue data
+2. Build the updated label list:
+   - If PASS: remove `not-ready-to-solve` (if present), add `ready-to-solve`
+   - If FAIL: remove `ready-to-solve` (if present), add `not-ready-to-solve`
+3. Skip update if labels haven't changed
+4. Apply via MCP (single API call to avoid partial updates):
+
+```python
+mcp__atlassian__jira_update_issue(
+    issue_key="PROJ-123",
+    fields={},
+    additional_fields={
+        "labels": updated_labels_list
+    }
+)
+```
+
+**CLI fallback:**
+```bash
+jira issue edit PROJ-123 -l "ready-to-solve"
+```
+
+Note: The `labels` field in Jira REST API replaces the entire array, so always include all existing labels plus the new one.
+
+### Phase 7: Generate Report
+
+Output format:
+
+```markdown
+## Readiness Validation: {issue-key}
+**Summary**: {summary} | **Verdict**: PASS/FAIL
+
+### Deterministic Checks
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Context section present | PASS/FAIL | {details} |
+| Acceptance Criteria present | PASS/FAIL | {details} |
+| ... | ... | ... |
+
+### AI Qualitative Assessment
+
+**AC Specificity and Testability**: PASS/FAIL/WARNING
+{reasoning}
+
+**Implementation Context Sufficiency**: PASS/FAIL/WARNING
+{reasoning}
+
+**Clear Success/Failure Conditions**: PASS/FAIL/WARNING
+{reasoning}
+
+### Overall Verdict: PASS/FAIL
+
+{Summary of failures or confirmation that issue is ready}
+
+**Label Applied**: `ready-to-solve` / `not-ready-to-solve` / _(dry run -- no label applied)_
+```
+
+## Error Handling
+
+| Error | Handling |
+|-------|----------|
+| Issue not found | "Could not find issue {key}. Verify the issue key is correct." |
+| MCP unavailable | Fall back to curl for fetching, jira CLI for label update |
+| Python not available | "Python 3 is required. Check: `which python3`" |
+| `check_sections.py` fails | Display script error, proceed with AI-only assessment, note in report |
+| Description is null/empty | Automatic FAIL: "Issue has no description. Add Context and Acceptance Criteria sections." |
+| Label update fails | Display warning but still show report. Non-fatal. |
+| Description update fails (`--fix`) | Display error, report original validation result. Non-fatal. |
+| User declines fix (`--fix`) | Skip update, proceed with original validation result. |
+| Re-validation fails after fix | Report the new failures. The fix improved but did not fully resolve all issues. |
+
+## Examples
+
+1. **Basic usage**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345
+   ```
+
+2. **Dry run (no label changes)**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --dry-run
+   ```
+
+3. **Verbose output**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --verbose
+   ```
+
+4. **Validate and fix failing checks**:
+   ```
+   /jira:ready-to-solve OCPBUGS-12345 --fix
+   ```
+
+## See Also
+
+- [/jira:solve](../../commands/solve.md) -- the command this validates readiness for

--- a/plugins/jira/skills/ready-to-solve/check_sections.py
+++ b/plugins/jira/skills/ready-to-solve/check_sections.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Deterministic section checker for Jira issue readiness validation.
+
+Reads a JSON object with a 'description' field from stdin and validates
+that the issue description contains required sections with adequate content.
+
+Usage:
+    echo '{"description": "..."}' | python3 check_sections.py
+    echo '{"description": "..."}' | python3 check_sections.py --verbose
+
+Exit codes:
+    0 - Checks completed (see JSON output for results)
+    1 - Script error (bad input)
+    2 - No description provided
+"""
+
+import argparse
+import json
+import re
+import sys
+from typing import List, Pattern, Tuple
+
+
+CONTEXT_HEADINGS = ["Context", "Description", "Background", "Overview", "Why"]
+AC_HEADINGS = ["Acceptance Criteria", "AC", "Definition of Done"]
+TECH_HEADINGS = ["Technical Details", "Technical Context", "Implementation Details",
+                 "Implementation Notes", "Technical Notes"]
+
+HEADING_PATTERNS = [
+    r"^h[1-6]\.\s+{heading}\s*$",          # Jira wiki: h2. Context
+    r"^#{{1,6}}\s+{heading}\s*$",          # Markdown: ## Context
+    r"^\*\*{heading}\*\*\s*$",              # Bold: **Context**
+    r"^{heading}\s*:\s*$",                  # Colon: Context:
+    r"^{heading}\s*$",                      # Plain heading on its own line
+]
+
+ANY_HEADING_RE = re.compile(
+    r"^(?:h[1-6]\.\s+.+|#{1,6}\s+.+|\*\*.+\*\*)\s*$",
+    re.MULTILINE,
+)
+
+
+def build_heading_regex(headings: List[str]) -> Pattern:
+    parts = []
+    for heading in headings:
+        escaped = re.escape(heading)
+        for pattern in HEADING_PATTERNS:
+            parts.append(pattern.format(heading=escaped))
+    return re.compile("|".join(parts), re.MULTILINE | re.IGNORECASE)
+
+
+def find_section(text: str, headings: List[str]) -> Tuple[bool, str]:
+    regex = build_heading_regex(headings)
+    match = regex.search(text)
+    if not match:
+        return False, ""
+
+    start = match.end()
+    next_heading = ANY_HEADING_RE.search(text, start)
+    end = next_heading.start() if next_heading else len(text)
+    content = text[start:end].strip()
+    return True, content
+
+
+def count_list_items(text: str) -> int:
+    patterns = [
+        r"^\s*[\*\-]\s+",        # * item or - item
+        r"^\s*#\s+",             # Jira wiki ordered: # item
+        r"^\s*\d+[\.\)]\s+",    # 1. item or 1) item
+    ]
+    count = 0
+    for line in text.splitlines():
+        for pattern in patterns:
+            if re.match(pattern, line):
+                count += 1
+                break
+    return count
+
+
+def make_check(check_id: str, name: str, severity: str, passed: bool,
+               details: str, content: str = "") -> dict:
+    result = {
+        "id": check_id,
+        "name": name,
+        "severity": severity,
+        "passed": passed,
+        "details": details,
+    }
+    if content:
+        result["content"] = content
+    return result
+
+
+def run_checks(description: str, verbose: bool = False) -> dict:
+    checks = []
+
+    ctx_found, ctx_content = find_section(description, CONTEXT_HEADINGS)
+    ac_found, ac_content = find_section(description, AC_HEADINGS)
+    tech_found, tech_content = find_section(description, TECH_HEADINGS)
+
+    checks.append(make_check(
+        "has_context", "Context section present", "REQUIRED",
+        ctx_found,
+        "Found context/description section" if ctx_found
+        else "Missing section. Expected one of: " + ", ".join(CONTEXT_HEADINGS),
+        ctx_content if verbose else "",
+    ))
+
+    checks.append(make_check(
+        "has_ac", "Acceptance Criteria present", "REQUIRED",
+        ac_found,
+        "Found acceptance criteria section" if ac_found
+        else "Missing section. Expected one of: " + ", ".join(AC_HEADINGS),
+        ac_content if verbose else "",
+    ))
+
+    if ctx_found:
+        ctx_len = len(ctx_content)
+        checks.append(make_check(
+            "context_not_empty", "Context has content", "REQUIRED",
+            ctx_len >= 50,
+            f"Context has {ctx_len} characters (minimum 50)"
+            if ctx_len >= 50
+            else f"Context too short: {ctx_len} characters (minimum 50)",
+        ))
+    else:
+        checks.append(make_check(
+            "context_not_empty", "Context has content", "REQUIRED",
+            False, "Skipped: no context section found",
+        ))
+
+    if ac_found:
+        ac_len = len(ac_content)
+        checks.append(make_check(
+            "ac_not_empty", "Acceptance Criteria has content", "REQUIRED",
+            ac_len >= 30,
+            f"AC has {ac_len} characters (minimum 30)"
+            if ac_len >= 30
+            else f"AC too short: {ac_len} characters (minimum 30)",
+        ))
+    else:
+        checks.append(make_check(
+            "ac_not_empty", "Acceptance Criteria has content", "REQUIRED",
+            False, "Skipped: no AC section found",
+        ))
+
+    checks.append(make_check(
+        "has_tech", "Technical Details present", "REQUIRED",
+        tech_found,
+        "Found technical details section" if tech_found
+        else "Missing section. Expected one of: " + ", ".join(TECH_HEADINGS),
+        tech_content if verbose else "",
+    ))
+
+    if tech_found:
+        tech_len = len(tech_content)
+        checks.append(make_check(
+            "tech_not_empty", "Technical Details has content", "REQUIRED",
+            tech_len >= 30,
+            f"Technical Details has {tech_len} characters (minimum 30)"
+            if tech_len >= 30
+            else f"Technical Details too short: {tech_len} characters (minimum 30)",
+        ))
+    else:
+        checks.append(make_check(
+            "tech_not_empty", "Technical Details has content", "REQUIRED",
+            False, "Skipped: no technical details section found",
+        ))
+
+    if ac_found:
+        item_count = count_list_items(ac_content)
+        checks.append(make_check(
+            "ac_has_items", "AC has multiple items", "WARNING",
+            item_count >= 2,
+            f"AC has {item_count} list items (recommended minimum 2)"
+            if item_count >= 2
+            else f"AC has only {item_count} list item(s) (recommended minimum 2)",
+        ))
+    else:
+        checks.append(make_check(
+            "ac_has_items", "AC has multiple items", "WARNING",
+            False, "Skipped: no AC section found",
+        ))
+
+    desc_len = len(description.strip())
+    checks.append(make_check(
+        "min_description_length", "Adequate overall length", "WARNING",
+        desc_len >= 200,
+        f"Description has {desc_len} characters (recommended minimum 200)"
+        if desc_len >= 200
+        else f"Description has only {desc_len} characters (recommended minimum 200)",
+    ))
+
+    required_checks = [c for c in checks if c["severity"] == "REQUIRED"]
+    overall_pass = all(c["passed"] for c in required_checks)
+
+    stats = {
+        "total": len(checks),
+        "passed": sum(1 for c in checks if c["passed"]),
+        "failed": sum(1 for c in checks if not c["passed"] and c["severity"] == "REQUIRED"),
+        "warnings": sum(1 for c in checks if not c["passed"] and c["severity"] == "WARNING"),
+    }
+
+    return {
+        "overall_pass": overall_pass,
+        "checks": checks,
+        "stats": stats,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", action="store_true",
+                        help="Include matched section content in output")
+    args = parser.parse_args()
+
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            print(json.dumps({
+                "overall_pass": False,
+                "checks": [],
+                "stats": {"total": 0, "passed": 0, "failed": 0, "warnings": 0},
+                "error": "No input provided on stdin",
+            }))
+            sys.exit(2)
+
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"error": f"Invalid JSON input: {e}"}), file=sys.stdout)
+        sys.exit(1)
+
+    description = data.get("description")
+    if not description or not description.strip():
+        print(json.dumps({
+            "overall_pass": False,
+            "checks": [
+                make_check("has_description", "Issue has a description",
+                           "REQUIRED", False,
+                           "Issue description is empty or null"),
+            ],
+            "stats": {"total": 1, "passed": 0, "failed": 1, "warnings": 0},
+        }))
+        sys.exit(2)
+
+    result = run_checks(description, verbose=args.verbose)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `/jira:ready-to-solve` command that validates whether a Jira issue is well-groomed enough for `/jira:solve` to produce a quality solution
- Runs two-phase validation: deterministic checks via Python script (required sections, content length, structure) + AI qualitative assessment (AC specificity, implementation context, success/failure conditions)
- Supports `--dry-run`, `--verbose`, and `--fix` flags — `--fix` generates a revised description for failing sections and asks for user confirmation before updating
- On pass, adds the Jira label `ready-to-solve`. On fail, adds `not-ready-to-solve`. Removes the stale opposite label if present.

## Test plan

- [x] Tested deterministic script against [CNTRLPLANE-2789](https://redhat.atlassian.net/browse/CNTRLPLANE-2789) (passes all 8 checks)
- [x] Tested against issues with missing sections (correctly reports failures)
- [x] Tested null/empty description handling
- [x] Tested both Jira wiki markup (`h2.`) and Markdown (`##`) heading formats
- [x] `make lint` passes
- [ ] End-to-end test with `--fix` flag on a failing issue

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:ready-to-solve`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /jira:ready-to-solve — validates Jira issue readiness with deterministic structure checks plus AI assessments and returns a structured PASS/FAIL readiness report.
* **Options**
  * Supports --fix (propose and apply confirmed description fixes), --dry-run (no label/issue changes), and --verbose (include detailed validation output).
* **Documentation**
  * Added usage guide, examples, error handling, and implementation notes for the new command.
* **Chore**
  * Jira plugin version bumped to 0.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->