### PR TITLE
Add force_accept_recommended to payload analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.38"
+      "version": "0.0.39"
     },
     {
       "name": "teams",

--- a/docs/data.json
+++ b/docs/data.json
@@ -585,7 +585,7 @@
           "name": "Trigger Payload Job"
         }
       ],
-      "version": "0.0.38"
+      "version": "0.0.39"
     },
     {
       "commands": [

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "author": {
     "name": "openshift"
   }

--- a/plugins/ci/skills/analyze-payload/SKILL.md
+++ b/plugins/ci/skills/analyze-payload/SKILL.md
@@ -65,9 +65,9 @@ if [ -z "$FETCH_PAYLOADS" ] || [ ! -f "$FETCH_PAYLOADS" ]; then echo "ERROR: fet
 python3 "$FETCH_PAYLOADS" <architecture> <version> <stream> --limit <lookback * 2>
 ```
 
-Parse the output to extract payload tag names, phases, and job details.
+The output is a JSON object with `hours_since_last_accepted` and `last_accepted_tag` at the top level and `payloads` as an array. Extract the payloads array for analysis and retain `hours_since_last_accepted` and `last_accepted_tag` for Step 6.4.
 
-Find the **target payload** (the tag from Step 1) in the fetched list. Based on its phase:
+Find the **target payload** (the tag from Step 1) in the payloads array. Based on its phase:
 
 - **Rejected**: Extract all failed blocking job names, their Prow URLs, and any previous attempt URLs. Proceed with full analysis.
 - **Ready**: Extract blocking jobs that have already **failed** (with their Prow URLs and previous attempt URLs). These are jobs that will not pass — they indicate the payload is on track for rejection. Proceed with analysis of those failed jobs and note in the report that the payload is still in progress.
@@ -136,7 +136,7 @@ You MUST use the following prompt verbatim (substituting the placeholder values)
 
 ```
 ANALYSIS_RESULT:
-- failure_type: install|test
+- failure_type: install|test|upgrade|infra
 - root_cause_summary: <one-line summary>
 - affected_components: <comma-separated list of affected operators/components>
 - key_error_patterns: <comma-separated key error strings for matching>
@@ -256,7 +256,19 @@ If a revert PR is found:
 
 3. **If a revert PR is open but not merged**, still recommend the revert but note that a revert PR already exists and link to it, so the reader can help expedite the merge.
 
-#### 6.4: Write Payload Results YAML
+#### 6.4: Determine Force-Accept Recommendation
+
+Recommend force-accepting the payload when **all** of the following are true:
+
+1. **All failures are temporary infrastructure issues**: Every failed blocking job has `failure_type: "infra"` and the subagent analysis confirms the failures are transient infrastructure problems (cloud quota, API rate limits, CI platform issues, network timeouts) — not product regressions masquerading as infrastructure. If any job has a non-infra failure type, or if any infrastructure failure appears to be caused by a product change, do not recommend.
+
+2. **No more than 2 blocking jobs failed**: A small number of infrastructure failures (1-2) indicates enough signal that the payload is otherwise healthy. If 3 or more blocking jobs failed, do not recommend — too many simultaneous failures reduce confidence even if each appears infrastructure-related.
+
+3. **No payload has been accepted in this stream for more than 18 hours**: Use the `hours_since_last_accepted` field from the `fetch-payloads` output (Step 2). If the value is `null` (no accepted payload in the fetched history) or >= 18, this condition is met.
+
+Record the determination in the payload results YAML and autodl JSON (see their respective schemas for the field).
+
+#### 6.5: Write Payload Results YAML
 
 After scoring all (job, candidate PR) pairs and checking for existing reverts, use the `payload-results-yaml` skill to create the results file in the current working directory: `payload-results-{tag}.yaml` (sanitize the tag for filename safety).
 
@@ -419,7 +431,26 @@ If **no** revert candidates were identified, include a brief note instead:
 </div>
 ```
 
-#### 7.5: Styling
+#### 7.5: Force-Accept Recommendation
+
+If a force-accept was recommended (Step 6.4), include a prominent callout immediately after the revert/no-revert verdict:
+
+```html
+<div class="verdict verdict-infra">
+  <strong>Force-Accept Recommended</strong>
+  <p>All blocking job failures are temporary infrastructure issues and no payload has been accepted
+     in this stream for more than 18 hours. Consider force-accepting this payload to unblock
+     the release stream.</p>
+  <p class="last-accepted">Last accepted payload: <a href="{last_accepted_url}">{last_accepted_tag}</a>
+     ({hours_since} hours ago)</p>
+</div>
+```
+
+Use the `last_accepted_tag` from the `fetch-payloads` output (Step 2) and construct the release controller URL for the link. If `last_accepted_tag` is `null`, replace the last-accepted line with "No accepted payload found in recent history."
+
+If a force-accept was not recommended, omit this section entirely.
+
+#### 7.6: Styling
 
 The HTML must be fully self-contained with embedded CSS. Use a GitHub-inspired dark mode design. Wrap all content in a `<div class="container">`. Use CSS variables for the color palette and the following base styles as a guide:
 
@@ -491,7 +522,7 @@ See the `payload-autodl-json` skill for the complete schema, row cardinality rul
 1. Save all output files to the current working directory:
    - HTML report: `payload-analysis-<sanitized_tag>-summary.html`
    - JSON data file: `payload-analysis-<sanitized_tag>-autodl.json`
-   - Payload results YAML: `payload-results-<sanitized_tag>.yaml` (written in Step 6.4)
+   - Payload results YAML: `payload-results-<sanitized_tag>.yaml` (written in Step 6.5)
    - Sanitize the tag: replace any characters not safe for filenames
 
 2. Tell the user:

--- a/plugins/ci/skills/fetch-payloads/SKILL.md
+++ b/plugins/ci/skills/fetch-payloads/SKILL.md
@@ -55,12 +55,19 @@ The script outputs one block per payload to stdout with job details. Present to 
 
 ## Output Format
 
-For each payload, the script outputs:
+The script outputs a JSON object to stdout:
 
-- **Tag line**: `<tag>  (<phase>)  <timestamp>  <url>`
-- **Rejected payloads**: lists each failed blocking job with retry count, Prow link for the final attempt, and Prow links for all previous attempts
-- **Ready payloads**: summary of succeeded/pending/failed counts
-- **Accepted payloads**: confirmation that all blocking jobs succeeded
+```json
+{
+  "hours_since_last_accepted": 23.5,
+  "last_accepted_tag": "4.22.0-0.nightly-2026-02-24-030944",
+  "payloads": [ ... ]
+}
+```
+
+- **`hours_since_last_accepted`**: Hours since the most recent Accepted payload in the stream (from the full unfiltered history), or `null` if none found.
+- **`last_accepted_tag`**: Tag name of the most recent Accepted payload, or `null` if none found.
+- **`payloads`**: Array of payload objects, each containing tag, phase, release controller URL, and job results (blocking and async jobs with Prow URLs and retry details).
 
 ## Error Handling
 

--- a/plugins/ci/skills/fetch-payloads/fetch_payloads.py
+++ b/plugins/ci/skills/fetch-payloads/fetch_payloads.py
@@ -11,6 +11,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 
 # Architectures that have their own release controller domain.
 KNOWN_ARCHITECTURES = ["amd64", "arm64", "ppc64le", "s390x", "multi"]
@@ -136,8 +137,9 @@ def main():
 
     stream = args.stream
     stream_name = release_stream_name(version, stream, architecture)
-    tags = fetch_tags(architecture, version, stream)
+    all_tags = fetch_tags(architecture, version, stream)
 
+    tags = all_tags
     if args.phase:
         tags = [t for t in tags if t.get("phase") == args.phase]
     if args.limit > 0:
@@ -165,7 +167,26 @@ def main():
             "results": filtered_results,
         })
 
-    print(json.dumps(payloads, indent=2))
+    hours_since_last_accepted = None
+    last_accepted_tag = None
+    for tag in all_tags:
+        if tag.get("phase") == "Accepted":
+            last_accepted_tag = tag.get("name")
+            m = re.search(r"(\d{4}-\d{2}-\d{2}-\d{6})$", last_accepted_tag or "")
+            if m:
+                ts = datetime.strptime(m.group(1), "%Y-%m-%d-%H%M%S").replace(
+                    tzinfo=timezone.utc
+                )
+                delta = datetime.now(timezone.utc) - ts
+                hours_since_last_accepted = delta.total_seconds() / 3600
+                break
+
+    output = {
+        "hours_since_last_accepted": hours_since_last_accepted,
+        "last_accepted_tag": last_accepted_tag,
+        "payloads": payloads,
+    }
+    print(json.dumps(output, indent=2))
 
 
 if __name__ == "__main__":

--- a/plugins/ci/skills/payload-autodl-json/SKILL.md
+++ b/plugins/ci/skills/payload-autodl-json/SKILL.md
@@ -37,6 +37,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
         "rejection_streak": "int64",
         "total_blocking_jobs": "int64",
         "failed_blocking_jobs": "int64",
+        "force_accept_recommended": "int64",
         "job_name": "string",
         "prow_url": "string",
         "failure_type": "string",
@@ -65,6 +66,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
             "rejection_streak": "5",
             "total_blocking_jobs": "42",
             "failed_blocking_jobs": "4",
+            "force_accept_recommended": "0",
             "job_name": "periodic-ci-openshift-release-main-ci-4.22-e2e-aws-ovn",
             "prow_url": "https://prow.ci.openshift.org/view/gs/...",
             "failure_type": "test",
@@ -91,6 +93,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
             "rejection_streak": "5",
             "total_blocking_jobs": "42",
             "failed_blocking_jobs": "4",
+            "force_accept_recommended": "0",
             "job_name": "periodic-ci-openshift-release-main-ci-4.22-e2e-gcp-ovn",
             "prow_url": "https://prow.ci.openshift.org/view/gs/...",
             "failure_type": "install",
@@ -149,6 +152,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
 | `rejection_streak` | int64 | Number of consecutive rejected payloads leading up to the target |
 | `total_blocking_jobs` | int64 | Total number of blocking jobs in the payload |
 | `failed_blocking_jobs` | int64 | Number of failed blocking jobs |
+| `force_accept_recommended` | int64 | `1` if all failures are temporary infrastructure, no more than 2 blocking jobs failed, and no payload accepted in 18+ hours; `0` otherwise |
 
 ### Job-level fields
 
@@ -156,7 +160,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
 |-------|------|-------------|
 | `job_name` | string | Full periodic job name |
 | `prow_url` | string | Prow URL for the failing run |
-| `failure_type` | string | `"test"`, `"install"`, `"upgrade"`, or `"infrastructure"` |
+| `failure_type` | string | `"test"`, `"install"`, `"upgrade"`, or `"infra"` |
 | `root_cause_summary` | string | Brief description of the failure mode |
 | `streak_length` | int64 | Consecutive payloads this job has been failing |
 | `is_new_failure` | int64 | `1` if the job first started failing in the target payload, `0` otherwise |

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -35,6 +35,7 @@ metadata:
   architecture: "amd64"
   release_controller_url: "https://amd64.ocp.releases.ci.openshift.org/..."
   analyzed_at: "2026-02-26T10:30:00Z"
+  force_accept_recommended: false
 
 failing_jobs:
   - job_name: "periodic-ci-...-e2e-aws-ovn"
@@ -91,6 +92,7 @@ Written once by `analyze-payload`. Never modified by downstream skills.
 | `architecture` | string | `"amd64"`, `"arm64"`, `"multi"`, etc. |
 | `release_controller_url` | string | URL to the payload on the release controller |
 | `analyzed_at` | string | ISO 8601 timestamp of when the analysis was performed |
+| `force_accept_recommended` | bool | `true` when all failures are temporary infrastructure issues, no more than 2 blocking jobs failed, and no payload has been accepted in the stream for 18+ hours. Determined by `analyze-payload` Step 6.4. |
 
 ### `failing_jobs[]`
 


### PR DESCRIPTION
## Summary
- Adds `force_accept_recommended` boolean to the payload results YAML metadata and autodl JSON schema
- The analyze-payload agent sets it to `true` when all failures are temporary infrastructure and no payload has been accepted in the stream for 18+ hours
- Renders a "Force-Accept Recommended" callout in the HTML report when true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Force-Accept recommendation to payload analysis reports, with last-accepted tag and hours-since-last-accepted shown when applicable.

* **New Features / Tools**
  * Fetch tool now emits a single JSON object containing payloads plus hours-since-last-accepted and last-accepted-tag.

* **Documentation**
  * Added force_accept_recommended to autodl JSON and payload-results YAML docs/examples; clarified when it is set.
  * Renamed documented failure_type value from "infrastructure" to "infra".

* **Chores**
  * Plugin version bumped to 0.0.39.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->