### PR TITLE
Add telcoeng-blueprint-workflow plugin for blueprint lifecycle automation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,9 @@
   "owner": {
     "name": "openshift-eng"
   },
-  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
+  "allowCrossMarketplaceDependenciesOn": [
+    "claude-plugins-official"
+  ],
   "plugins": [
     {
       "name": "git",
@@ -238,6 +240,12 @@
       "source": "./plugins/marketplace-ops",
       "description": "Maintenance commands for Claude Code plugin marketplaces",
       "version": "0.1.2"
+    },
+    {
+      "name": "telcoeng-blueprint-workflow",
+      "source": "./plugins/telcoeng-blueprint-workflow",
+      "description": "Create, validate, and manage Telco Engineering partner blueprints against telcoeng-blueprint-standards with JIRA integration and kube-compare-mcp connectivity",
+      "version": "0.1.1"
     }
   ]
 }

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -31,6 +31,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Snowflake](#snowflake-plugin)
 - [Sosreport](#sosreport-plugin)
 - [Teams](#teams-plugin)
+- [Telcoeng Blueprint Workflow](#telcoeng-blueprint-workflow-plugin)
 - [Test Coverage](#test-coverage-plugin)
 - [Testing](#testing-plugin)
 - [Utils](#utils-plugin)
@@ -394,6 +395,19 @@ Team structure knowledge and health analysis commands for OpenShift teams
 - **`/teams:list-teams`** - List all teams from the team component mapping
 
 See [plugins/teams/README.md](plugins/teams/README.md) for detailed documentation.
+
+### Telcoeng Blueprint Workflow Plugin
+
+Create, validate, and manage Telco Engineering partner blueprints against telcoeng-blueprint-standards with JIRA integration and kube-compare-mcp connectivity
+
+**Commands:**
+- **`/telcoeng-blueprint-workflow:fix` `<blueprint-path> [--partner <name>] [--auto] [--jira]`** - Generate fix proposals and diffs for non-compliant blueprint sections, with optional auto-apply and JIRA integration
+- **`/telcoeng-blueprint-workflow:generate` `<section-type> [--partner <name>] [--blueprint <path>] [--ocp-version <version>]`** - Generate standards-compliant paragraphs, tables, and sections for Telco Partner Blueprints
+- **`/telcoeng-blueprint-workflow:ingest` `<file-path> [--partner <name>] [--format word|pdf|markdown|gdocs]`** - Convert partner blueprints from Word/PDF/Google Docs into normalized Markdown aligned with telcoeng-blueprint-standards
+- **`/telcoeng-blueprint-workflow:search` `<query> [--dir <blueprints-directory>]`** - Search across normalized blueprints for patterns, configurations, and cross-references
+- **`/telcoeng-blueprint-workflow:validate` `<blueprint-path> [--partner <name>] [--cluster <kubeconfig>] [--jira]`** - Score a blueprint against telcoeng-blueprint-standards (0-100) with section-by-section compliance report
+
+See [plugins/telcoeng-blueprint-workflow/README.md](plugins/telcoeng-blueprint-workflow/README.md) for detailed documentation.
 
 ### Test Coverage Plugin
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -1790,6 +1790,72 @@
       "name": "marketplace-ops",
       "skills": [],
       "version": "0.1.2"
+    },
+    {
+      "commands": [
+        {
+          "argument_hint": "<blueprint-path> [--partner <name>] [--auto] [--jira]",
+          "description": "Generate fix proposals and diffs for non-compliant blueprint sections, with optional auto-apply and JIRA integration",
+          "name": "fix",
+          "synopsis": "/telcoeng-blueprint-workflow:fix <blueprint-path> [--partner <name>] [--auto] [--jira]"
+        },
+        {
+          "argument_hint": "<section-type> [--partner <name>] [--blueprint <path>] [--ocp-version <version>]",
+          "description": "Generate standards-compliant paragraphs, tables, and sections for Telco Partner Blueprints",
+          "name": "generate",
+          "synopsis": "/telcoeng-blueprint-workflow:generate <section-type> [--partner <name>] [--blueprint <path>] [--ocp-version <version>]"
+        },
+        {
+          "argument_hint": "<file-path> [--partner <name>] [--format word|pdf|markdown|gdocs]",
+          "description": "Convert partner blueprints from Word/PDF/Google Docs into normalized Markdown aligned with telcoeng-blueprint-standards",
+          "name": "ingest",
+          "synopsis": "/telcoeng-blueprint-workflow:ingest <file-path> [--partner <name>] [--format word|pdf|markdown|gdocs]"
+        },
+        {
+          "argument_hint": "<query> [--dir <blueprints-directory>]",
+          "description": "Search across normalized blueprints for patterns, configurations, and cross-references",
+          "name": "search",
+          "synopsis": "/telcoeng-blueprint-workflow:search <query> [--dir <blueprints-directory>]"
+        },
+        {
+          "argument_hint": "<blueprint-path> [--partner <name>] [--cluster <kubeconfig>] [--jira]",
+          "description": "Score a blueprint against telcoeng-blueprint-standards (0-100) with section-by-section compliance report",
+          "name": "validate",
+          "synopsis": "/telcoeng-blueprint-workflow:validate <blueprint-path> [--partner <name>] [--cluster <kubeconfig>] [--jira]"
+        }
+      ],
+      "description": "Create, validate, and manage Telco Engineering partner blueprints against telcoeng-blueprint-standards with JIRA integration and kube-compare-mcp connectivity",
+      "has_readme": true,
+      "hooks": [],
+      "name": "telcoeng-blueprint-workflow",
+      "skills": [
+        {
+          "description": "Dynamically reads telcoeng-blueprint-standards to extract the required section hierarchy for partner blueprints",
+          "id": "blueprint-structure",
+          "name": "Blueprint Structure"
+        },
+        {
+          "description": "Scores a blueprint against telcoeng-blueprint-standards using a weighted rubric (0-100)",
+          "id": "compliance-scoring",
+          "name": "Compliance Scoring"
+        },
+        {
+          "description": "Generates standards-compliant text snippets, tables, and sections for Telco Partner Blueprints",
+          "id": "content-generation",
+          "name": "Content Generation"
+        },
+        {
+          "description": "Documents RDS deviations, manages SUPPORTEX ticket references, and creates ECOPS JIRA tickets for blueprint compliance issues",
+          "id": "deviation-tracking",
+          "name": "Deviation Tracking"
+        },
+        {
+          "description": "Integrates with kube-compare-mcp for cluster-level validation against Telco RDS profiles",
+          "id": "kube-compare-integration",
+          "name": "Kube Compare Integration"
+        }
+      ],
+      "version": "0.1.1"
     }
   ]
 }

--- a/plugins/telcoeng-blueprint-workflow/.claude-plugin/plugin.json
+++ b/plugins/telcoeng-blueprint-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "telcoeng-blueprint-workflow",
+  "description": "Create, validate, and manage Telco Engineering partner blueprints against telcoeng-blueprint-standards with JIRA integration and kube-compare-mcp connectivity",
+  "version": "0.1.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/telcoeng-blueprint-workflow/README.md
+++ b/plugins/telcoeng-blueprint-workflow/README.md
@@ -1,0 +1,161 @@
+# Telco Blueprint Workflow Plugin
+
+End-to-end blueprint lifecycle management for Telco Engineering partner blueprints, aligned with `telcoeng-blueprint-standards`.
+
+## Features
+
+- **Document Ingestion** - Convert partner blueprints from Word/PDF/Google Docs into normalized Markdown matching the standards section hierarchy
+- **Compliance Validation** - Score blueprints (0-100) against `telcoeng-blueprint-standards` with section-by-section compliance reports
+- **Content Generation** - Generate standards-compliant S-BOM tables, networking sections, deviation lists, and full blueprint scaffolds
+- **Blueprint Search** - Search across normalized blueprints for patterns, configurations, and cross-references
+- **Automated Fix Proposals** - Generate concrete fix proposals as diffs for non-compliant sections, with optional auto-apply
+- **JIRA Integration** - Create and update ECOPS tickets for compliance findings and deviations
+- **Cluster Validation** - Validate live clusters against Telco RDS profiles via kube-compare-mcp
+
+## Prerequisites
+
+- Claude Code installed
+- `telcoeng-blueprint-standards` repository accessible (sibling directory or discoverable path)
+- Optional: `pandoc` or `pip install markitdown` for Word/PDF conversion
+- Optional: kube-compare-mcp server configured for cluster-level validation
+- Optional: Jira MCP server configured for ECOPS ticket integration
+
+## Installation
+
+Ensure you have the ai-helpers marketplace enabled, via [the instructions here](https://github.com/openshift-eng/ai-helpers#readme).
+
+```bash
+/plugin install telcoeng-blueprint-workflow@ai-helpers
+```
+
+## Available Commands
+
+### `/telcoeng-blueprint-workflow:ingest` - Document Ingestion & Normalization
+
+Convert partner blueprints from Word, PDF, or Google Docs into normalized Markdown aligned with `telcoeng-blueprint-standards`.
+
+```bash
+# Convert a Word document
+/telcoeng-blueprint-workflow:ingest ~/Documents/partner-blueprint.docx --partner acme-telecom
+
+# Normalize an existing Markdown file
+/telcoeng-blueprint-workflow:ingest ./existing-blueprint.md --partner softbank
+```
+
+See [commands/ingest.md](commands/ingest.md) for full documentation.
+
+---
+
+### `/telcoeng-blueprint-workflow:validate` - Compliance Checking & Validation
+
+Score a blueprint against `telcoeng-blueprint-standards` (0-100) with a section-by-section compliance report.
+
+```bash
+# Basic validation
+/telcoeng-blueprint-workflow:validate .work/blueprints/acme-telecom/blueprint.md
+
+# Validation with cluster check
+/telcoeng-blueprint-workflow:validate ./blueprint.md --cluster ~/.kube/config --partner samsung
+
+# Validation with JIRA ticket creation
+/telcoeng-blueprint-workflow:validate ./blueprint.md --partner softbank --jira
+```
+
+See [commands/validate.md](commands/validate.md) for full documentation.
+
+---
+
+### `/telcoeng-blueprint-workflow:generate` - Content Generation
+
+Generate standards-compliant paragraphs, tables, and sections for Telco Partner Blueprints.
+
+```bash
+# Generate S-BOM table
+/telcoeng-blueprint-workflow:generate sbom --partner acme-telecom --ocp-version 4.17
+
+# Generate full blueprint scaffold
+/telcoeng-blueprint-workflow:generate all --partner samsung --ocp-version 4.16
+
+# Generate and insert into existing blueprint
+/telcoeng-blueprint-workflow:generate deviations --blueprint .work/blueprints/softbank/blueprint.md
+```
+
+Supported section types: `metadata`, `intro`, `sbom`, `operators`, `support-exceptions`, `deviations`, `hbom`, `node-config`, `networking`, `operations`, `certification`, `all`.
+
+See [commands/generate.md](commands/generate.md) for full documentation.
+
+---
+
+### `/telcoeng-blueprint-workflow:search` - Blueprint Index & Search
+
+Search across normalized blueprints for patterns, configurations, and cross-references.
+
+```bash
+# Search for a specific configuration
+/telcoeng-blueprint-workflow:search "siteconfigv1"
+
+# Compare S-BOM across blueprints
+/telcoeng-blueprint-workflow:search "compare OCP versions across blueprints"
+
+# Search with custom directory
+/telcoeng-blueprint-workflow:search "BIOS settings" --dir ./blueprints/
+```
+
+See [commands/search.md](commands/search.md) for full documentation.
+
+---
+
+### `/telcoeng-blueprint-workflow:fix` - Automated Fix Proposals
+
+Compare non-compliant blueprints against standards and propose concrete fixes as diffs.
+
+```bash
+# Interactive fix session
+/telcoeng-blueprint-workflow:fix .work/blueprints/acme-telecom/blueprint.md --partner acme-telecom
+
+# Auto-apply all fixes
+/telcoeng-blueprint-workflow:fix ./blueprint.md --partner samsung --auto
+
+# Fix with JIRA tracking
+/telcoeng-blueprint-workflow:fix ./blueprint.md --partner softbank --jira
+```
+
+See [commands/fix.md](commands/fix.md) for full documentation.
+
+---
+
+## Typical Workflow
+
+```text
+1. Ingest    Partner sends Word doc  -->  /telcoeng-blueprint-workflow:ingest
+2. Validate  Check compliance        -->  /telcoeng-blueprint-workflow:validate
+3. Fix       Apply automated fixes   -->  /telcoeng-blueprint-workflow:fix
+4. Generate  Fill remaining gaps     -->  /telcoeng-blueprint-workflow:generate
+5. Search    Cross-reference others  -->  /telcoeng-blueprint-workflow:search
+6. Validate  Final compliance check  -->  /telcoeng-blueprint-workflow:validate
+```
+
+## Standards Resilience
+
+This plugin reads `telcoeng-blueprint-standards` dynamically at runtime. When standards change:
+
+- Section hierarchy updates automatically on next command run
+- Compliance rubric weights can be adjusted in `reference/compliance-rubric.md`
+- No hardcoded section names or compliance rules in commands or skills
+- If standards are unavailable, commands fall back to `reference/blueprint-sections.md` and warn about potentially stale data
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| [reference/blueprint-sections.md](reference/blueprint-sections.md) | Standards section hierarchy (pointer to canonical source) |
+| [reference/mcp-tools.md](reference/mcp-tools.md) | kube-compare-mcp and JIRA MCP tool signatures |
+| [reference/compliance-rubric.md](reference/compliance-rubric.md) | Scoring criteria and weights (configurable) |
+
+## Contributing
+
+Contributions welcome! Please submit pull requests to the [ai-helpers repository](https://github.com/openshift-eng/ai-helpers).
+
+## License
+
+Apache-2.0

--- a/plugins/telcoeng-blueprint-workflow/commands/fix.md
+++ b/plugins/telcoeng-blueprint-workflow/commands/fix.md
@@ -1,0 +1,196 @@
+---
+description: Generate fix proposals and diffs for non-compliant blueprint sections, with optional auto-apply and JIRA integration
+argument-hint: <blueprint-path> [--partner <name>] [--auto] [--jira]
+---
+
+## Name
+
+telcoeng-blueprint-workflow:fix
+
+## Synopsis
+
+```text
+/telcoeng-blueprint-workflow:fix <blueprint-path> [--partner <name>] [--auto] [--jira]
+```
+
+## Description
+
+The `fix` command compares a non-compliant blueprint against `telcoeng-blueprint-standards` and proposes concrete fixes as diffs. It automates the remediation cycle: validate → propose → apply → re-validate.
+
+This implements NOW #5 (Automated Fix Proposals and Diffs) from the prioritization matrix. It builds on the `validate` command's compliance report to generate actionable patches.
+
+### Key Features
+
+- Runs validation internally to identify all non-compliant sections
+- Generates specific fix proposals with before/after diffs
+- Presents proposals for user review and selective approval
+- Applies approved fixes and re-validates to confirm improvement
+- Optionally creates or updates ECOPS JIRA tickets for tracked issues
+- Saves a fix log for audit trail
+
+## Implementation
+
+### Phase 1: Run Validation
+
+1. Invoke the `validate` command internally on the provided `<blueprint-path>`
+2. If `--partner` is provided, pass it through after sanitizing: lowercase, allow only `[a-z0-9-]`, replace spaces/underscores with `-`, reject path traversal characters
+3. Capture the compliance report: overall score, section-by-section findings, and recommendations
+4. If the blueprint scores 90+ (Excellent), inform the user and exit — no fixes needed
+
+### Phase 2: Generate Fix Proposals
+
+For each non-compliant finding from the validation report:
+
+1. Invoke the `content-generation` skill using the Skill tool to generate compliant replacement content
+2. Invoke the `blueprint-structure` skill using the Skill tool to ensure the fix matches current standards
+3. For each fix proposal, produce:
+   - **Section**: The blueprint section being fixed
+   - **Issue**: What the validation found wrong
+   - **Current content**: The existing text (or "missing" if the section is absent)
+   - **Proposed fix**: The standards-compliant replacement
+   - **Impact**: How many compliance points this fix would recover
+   - **Diff**: A unified diff showing the exact changes
+
+Prioritize proposals by point impact (highest first).
+
+### Phase 3: Present Fix Proposals
+
+Display proposals to the user in order of impact:
+
+```text
+Fix Proposals for <partner-name> (Current Score: XX/100)
+
+## Proposal 1: Add missing S-BOM table (+5 points)
+Section: Software and Configuration > S-BOM
+Issue: S-BOM section exists but contains no version table
+
+--- current
++++ proposed
+@@ -1,2 +1,10 @@
+ ## Software Bill of Materials (S-BOM)
+-No content.
++| Component | Version | Minimum Patch Level |
++|-----------|---------|-------------------|
++| OpenShift Container Platform | <!-- TODO: version --> | <!-- TODO: patch level --> |
++| Advanced Cluster Management | <!-- TODO: version --> | <!-- TODO: patch level --> |
+
+Apply this fix? [y/n/edit]
+```
+
+For each proposal, allow:
+- **y**: Apply the fix as proposed
+- **n**: Skip this fix
+- **edit**: Let the user modify the proposed fix before applying
+
+If `--auto` is provided, apply all fixes without prompting (but still display them).
+
+### Phase 4: Apply Approved Fixes
+
+For each approved fix:
+
+1. Read the current blueprint file
+2. Locate the target section using heading matching
+3. Apply the proposed change:
+   - For missing sections: Insert at the correct position per standards hierarchy
+   - For incomplete sections: Replace the section content
+   - For malformed tables: Replace the table with the corrected version
+4. Write the updated blueprint back to disk
+5. Track applied fixes for the summary
+
+### Phase 5: Re-Validate
+
+1. Run validation again on the updated blueprint
+2. Compare the new score against the original score
+3. Display the improvement:
+   ```text
+   Score improved: 52/100 → 78/100 (+26 points)
+   Fixes applied: 4/6 proposals
+   Remaining issues: 2 (skipped by user)
+   ```
+
+### Phase 6: JIRA Integration (Optional)
+
+If `--jira` flag is provided:
+
+1. For each applied fix, check if an ECOPS ticket already exists
+2. If a ticket exists: Add a comment noting the fix was applied, with the diff
+3. If no ticket exists and fixes remain unapplied: Offer to create an ECOPS ticket
+4. Use the `jira` plugin with:
+   - Project: ECOPS
+   - Summary: `[Blueprint Fix] <partner-name> - <section> - <issue>`
+   - Description: Include the proposed fix content and diff
+   - Labels: blueprint, fix-proposal, <partner-name>
+5. Always ask for user confirmation before creating or updating tickets
+
+### Phase 7: Save Fix Log
+
+Save the complete fix session to `.work/blueprints/<partner-name>/fix-log.md`:
+
+```text
+# Fix Log — <partner-name>
+## Date: <timestamp>
+## Original Score: XX/100
+## Final Score: YY/100
+
+| # | Section | Issue | Proposed Fix | Status |
+|---|---------|-------|-------------|--------|
+| 1 | S-BOM | Missing version table | Added template table | Applied |
+| 2 | Deviations | No SUPPORTEX links | Added ticket references | Applied |
+| 3 | Networking | Missing NAD table | Generated NAD table | Skipped |
+
+## Applied Diffs
+<full diffs for all applied fixes>
+```
+
+## Return Value
+
+- **Original score**: Score before fixes
+- **New score**: Score after fixes
+- **Improvement**: Point difference
+- **Proposals generated**: Total number of fix proposals
+- **Proposals applied**: Number of fixes the user approved and applied
+- **Proposals skipped**: Number of fixes the user declined
+- **Fix log path**: `.work/blueprints/<partner-name>/fix-log.md`
+- **JIRA tickets**: Created or updated ticket IDs (if `--jira` was used)
+
+## Examples
+
+1. **Interactive fix session**:
+   ```text
+   /telcoeng-blueprint-workflow:fix .work/blueprints/acme-telecom/blueprint.md --partner acme-telecom
+   ```
+   Output: Displays proposals one by one, applies approved fixes, shows score improvement.
+
+2. **Auto-apply all fixes**:
+   ```text
+   /telcoeng-blueprint-workflow:fix ./blueprint.md --partner samsung --auto
+   ```
+   Output: Applies all generated fixes without prompting, displays summary.
+
+3. **Fix with JIRA ticket tracking**:
+   ```text
+   /telcoeng-blueprint-workflow:fix ./blueprint.md --partner softbank --jira
+   ```
+   Output: Applies fixes and creates/updates ECOPS tickets for each finding.
+
+4. **Fix a freshly ingested blueprint**:
+   ```text
+   /telcoeng-blueprint-workflow:fix .work/blueprints/partner-x/blueprint.md
+   ```
+
+## Arguments
+
+- `$1` (`<blueprint-path>`): Path to the blueprint Markdown file to fix.
+- `--partner <name>`: Partner name for report naming, file paths, and JIRA labels. If omitted, derived from file path or prompted.
+- `--auto`: Apply all fix proposals without interactive confirmation. Fixes are still displayed for review.
+- `--jira`: Enable JIRA integration to create or update ECOPS tickets for findings. Requires user confirmation per ticket.
+
+## Error Handling
+
+- **Blueprint not found**: Display error, suggest running `ingest` if the source is Word/PDF
+- **Blueprint not Markdown**: Inform user to run `ingest` first
+- **Already compliant (90+)**: Inform user, suggest minor improvements if any exist
+- **No fixable issues**: Some compliance gaps may require manual input (e.g., partner-specific data); list these separately
+- **Fix application failure**: Roll back the individual fix, continue with remaining proposals
+- **Standards not found**: Fall back to `reference/blueprint-sections.md`, warn about potentially stale fixes
+- **JIRA not configured**: Skip ticket operations, note in fix log

--- a/plugins/telcoeng-blueprint-workflow/commands/generate.md
+++ b/plugins/telcoeng-blueprint-workflow/commands/generate.md
@@ -1,0 +1,148 @@
+---
+description: Generate standards-compliant paragraphs, tables, and sections for Telco Partner Blueprints
+argument-hint: <section-type> [--partner <name>] [--blueprint <path>] [--ocp-version <version>]
+---
+
+## Name
+
+telcoeng-blueprint-workflow:generate
+
+## Synopsis
+
+```text
+/telcoeng-blueprint-workflow:generate <section-type> [--partner <name>] [--blueprint <path>] [--ocp-version <version>]
+```
+
+## Description
+
+The `generate` command produces standards-compliant text snippets for common blueprint sections. It reads the current standards to ensure generated content matches the required format, then interactively collects partner-specific data to produce ready-to-use content.
+
+This implements WOW #3 (Recommended Paragraph & Content Generation) from the prioritization matrix. It eliminates manual authoring of repetitive sections like S-BOM tables, deviation lists, and boilerplate text.
+
+### Key Features
+
+- Generates content for any standard blueprint section
+- Reads standards dynamically — format adapts when standards change
+- Collects partner-specific inputs interactively
+- Produces ready-to-use Markdown with TODO markers for missing data
+- Can insert generated content directly into an existing blueprint
+
+## Implementation
+
+### Phase 1: Load Content Templates
+
+1. Invoke the `content-generation` skill using the Skill tool to load templates and format patterns
+2. Invoke the `blueprint-structure` skill using the Skill tool to understand the target section's requirements
+
+### Phase 2: Identify Target Section
+
+Parse the `<section-type>` argument. Supported values:
+
+| Section Type | What It Generates |
+|-------------|-------------------|
+| `metadata` | Title, version history table, NDA notice, contacts table |
+| `intro` | Purpose statement, workload description, deployment scenarios |
+| `sbom` | Software Bill of Materials table with version columns |
+| `operators` | Operators table with version, channel, and role |
+| `support-exceptions` | Support Exceptions table with SUPPORTEX IDs |
+| `deviations` | RDS deviations list with explanations and impact |
+| `hbom` | Hardware Bill of Materials table |
+| `node-config` | Node types, labels, taints, resource partitioning |
+| `networking` | Network overview, CNI config, secondary networks, NAD table |
+| `operations` | LCM, backup/restore, observability, security, user management |
+| `certification` | CNF certification, hardware certification links |
+| `all` | Full blueprint scaffold with all sections |
+
+If the section type is not recognized, display the table above and prompt for selection.
+
+### Phase 3: Read Current Standards
+
+Read the corresponding section from `telcoeng-blueprint-standards/README.md` to extract:
+
+1. The exact heading hierarchy and format expected
+2. Example content and table structures from the standards
+3. Required disclaimers or boilerplate text
+
+### Phase 4: Collect Partner-Specific Inputs
+
+Interactively prompt the user for required data based on the section type:
+
+- For `sbom`: OCP version, partner product name/version, operators in use
+- For `hbom`: Server models, CPU, memory, storage, NICs
+- For `deviations`: RDS baseline, known deviations with rationale
+- For `networking`: Primary CNI, secondary network types, NAD count
+- For `metadata`: Partner name, document version, contacts
+- For `all`: Partner name, product, OCP version, deployment type (minimum required)
+
+Use the `--ocp-version` and `--partner` flags to pre-fill known values.
+
+Sanitize the partner name before using it in output paths: lowercase, allow only `[a-z0-9-]`, replace spaces/underscores with `-`, reject `/`, `\`, `..`, and absolute-path prefixes.
+
+### Phase 5: Generate Content
+
+Produce Markdown content that:
+
+1. Follows the exact format from the current standards
+2. Uses specific values where the user provided data
+3. Marks gaps with `<!-- TODO: description of what is needed -->` comments
+4. Includes appropriate links (Red Hat docs, SUPPORTEX tickets, RDS references)
+5. Uses standard Telco Engineering terminology
+
+### Phase 6: Present and Insert
+
+1. Display the generated content to the user for review
+2. If `--blueprint <path>` is provided:
+   - Locate the target section in the existing blueprint
+   - Show a diff preview of what will change
+   - Ask for confirmation before inserting
+   - Insert or replace the section content
+3. If no blueprint path is provided:
+   - Display the content for the user to copy
+   - Suggest saving to `.work/blueprints/<partner-name>/generated/<section-type>.md`
+
+## Return Value
+
+- **Generated content**: Markdown text for the requested section
+- **Completeness**: Complete / Partial / Template-only (based on how much data was provided)
+- **TODO count**: Number of items still needing user input
+- **Insertion status**: Whether content was inserted into an existing blueprint
+
+## Examples
+
+1. **Generate S-BOM table**:
+   ```text
+   /telcoeng-blueprint-workflow:generate sbom --partner acme-telecom --ocp-version 4.17
+   ```
+   Output: A complete S-BOM table pre-filled with OCP 4.17 components, with TODO markers for partner-specific software.
+
+2. **Generate full blueprint scaffold**:
+   ```text
+   /telcoeng-blueprint-workflow:generate all --partner samsung --ocp-version 4.16
+   ```
+   Output: Complete blueprint structure with all mandatory sections, pre-filled boilerplate, and TODO markers for partner data.
+
+3. **Generate and insert deviations into existing blueprint**:
+   ```text
+   /telcoeng-blueprint-workflow:generate deviations --blueprint .work/blueprints/softbank/blueprint.md
+   ```
+   Output: Generates an RDS deviations section and inserts it into the existing blueprint at the correct location.
+
+4. **Generate networking section**:
+   ```text
+   /telcoeng-blueprint-workflow:generate networking --partner acme-telecom
+   ```
+
+## Arguments
+
+- `$1` (`<section-type>`): The type of section to generate. See the table in Phase 2 for supported values. Use `all` for a full scaffold.
+- `--partner <name>`: Partner name used in generated content and file paths.
+- `--blueprint <path>`: Path to an existing blueprint to insert generated content into. Optional.
+- `--ocp-version <version>`: OpenShift version (e.g., 4.17) to pre-fill in generated tables. Optional.
+
+## Error Handling
+
+- **Unknown section type**: Display supported types table and prompt for selection
+- **Blueprint path not found**: Generate content to stdout instead of inserting
+- **Standards not found**: Fall back to `reference/blueprint-sections.md` for format reference
+- **Insufficient input**: Generate template with TODO markers rather than refusing
+- **Existing section conflict**: When inserting into a blueprint, warn if the section already has content and ask whether to replace or append

--- a/plugins/telcoeng-blueprint-workflow/commands/ingest.md
+++ b/plugins/telcoeng-blueprint-workflow/commands/ingest.md
@@ -1,0 +1,175 @@
+---
+description: Convert partner blueprints from Word/PDF/Google Docs into normalized Markdown aligned with telcoeng-blueprint-standards
+argument-hint: <file-path> [--partner <name>] [--format word|pdf|markdown|gdocs]
+---
+
+## Name
+
+telcoeng-blueprint-workflow:ingest
+
+## Synopsis
+
+```text
+/telcoeng-blueprint-workflow:ingest <file-path> [--partner <name>] [--format word|pdf|markdown|gdocs]
+```
+
+## Description
+
+The `ingest` command converts a partner blueprint document from Word, PDF, or Google Docs format into normalized Markdown that aligns with the `telcoeng-blueprint-standards` section hierarchy.
+
+This is the foundation layer of the blueprint workflow (WOW #1 from the prioritization matrix). All downstream commands (`validate`, `generate`, `fix`) operate on normalized Markdown, making ingestion the required first step for non-Markdown blueprints.
+
+### Key Features
+
+- Auto-detects input format based on file extension
+- Converts to raw Markdown using available tools (pandoc, MarkItDown, DocLing)
+- Maps extracted content to the standards-compliant section structure
+- Normalizes tables (S-BOM, H-BOM, deviation tables) into consistent Markdown format
+- Reports unmapped content that could not be placed into standard sections
+- Preserves original content — nothing is deleted, only reorganized
+
+## Implementation
+
+### Phase 1: Validate Input and Detect Format
+
+1. Check that the file exists at the provided path
+2. Detect format from extension (`.docx`, `.doc`, `.pdf`, `.md`) or from the `--format` flag
+3. If the file is already Markdown, skip to Phase 3
+4. Determine the partner name from `--partner` flag, file name, or prompt the user
+5. Sanitize partner name before using it in output paths:
+   - Lowercase and trim whitespace
+   - Allow only `[a-z0-9-]` characters; replace spaces and underscores with `-`
+   - Reject values containing `/`, `\`, `..`, or absolute-path prefixes
+   - Fail with a clear validation error if the sanitized name is empty or invalid
+
+### Phase 2: Convert to Raw Markdown
+
+Based on available tools, convert the document:
+
+**Priority order for conversion tools:**
+
+1. **pandoc** (most reliable for Word): `pandoc -f docx -t markdown --wrap=none <file>`
+2. **MarkItDown** (Microsoft, good for mixed formats): Python library, install with `pip install markitdown`
+3. **DocLing** (IBM Research, good for PDFs): Python library for document understanding
+
+Run the conversion and capture the raw Markdown output. If the first tool fails, try the next in priority order.
+
+**Post-conversion cleanup** (required for all tools):
+
+Remove pandoc and conversion artifacts that break Markdown rendering:
+- `{.underline}` — remove entirely
+- `{.mark}` — remove entirely
+- `{width="..." height="..."}` — remove image dimension attributes
+- `\[text\]` — unescape square brackets to `[text]`
+- `\'` — unescape apostrophes to `'`
+- Escaped pipes in tables — unescape `\|` to `|` within table cells
+- Grid tables — convert to standard pipe tables
+- Remove only converter-injected attribute suffixes attached to headings or images (e.g., `#{id}`, `{.class}`, `{width="..."}` at end-of-line). Do not remove brace content inside prose, code blocks, JSON/YAML snippets, or tables
+
+**Image and diagram handling**:
+
+Conversion tools extract embedded images to local paths (e.g., pandoc produces `![](media/imageN.ext)` references). Different tools (MarkItDown, DocLing) may use different extraction paths or filename patterns — check the conversion tool's output directory when locating images. For each image reference:
+1. If the image file was extracted alongside the Markdown, copy it to `.work/blueprints/<partner-name>/media/`
+2. If the image file is not available, replace the reference with a descriptive comment: `<!-- DIAGRAM: [description based on surrounding context] — source: original document -->`
+3. Never leave bare `![](media/imageN.ext)` references that point to nonexistent files
+
+**For Google Docs:**
+1. If a URL is provided, inform the user to export as `.docx` first
+2. If a downloaded `.docx` is provided, proceed with Word conversion
+
+### Phase 3: Load Standards Structure
+
+Invoke the `blueprint-structure` skill using the Skill tool to:
+
+1. Locate and read the current `telcoeng-blueprint-standards/README.md`
+2. Extract the required section hierarchy
+3. Get the list of mandatory sections and their expected content
+
+### Phase 4: Map Content to Standards Sections
+
+Analyze the raw Markdown and map content to the standards-compliant sections:
+
+1. **Heading matching**: Match existing headings in the document to standards section names (fuzzy match — case-insensitive, synonym support)
+2. **Content classification**: For content under non-standard headings, classify by content type:
+   - Tables with version columns → Software and Configuration (S-BOM)
+   - Tables with hardware specs → Hardware and Node Configuration (H-BOM)
+   - Network diagrams or VLAN references → Networking
+   - Upgrade procedures → Operations and Management > LCM
+   - SUPPORTEX references → Software and Configuration > Support Exceptions
+3. **Unmapped content**: Content that cannot be classified goes into an "Unmapped Content" appendix
+
+### Phase 5: Normalize Tables
+
+For each recognized table type, normalize to the standards format:
+
+- **S-BOM**: Ensure columns are Component | Version | Minimum Patch Level
+- **H-BOM**: Ensure columns are Component | Specification
+- **Support Exceptions**: Ensure columns are Support Exception ID | Required for | Status/Comments
+- **Operators**: Ensure columns are Operator | Version | Channel | Role
+- **NADs**: Ensure columns are NAD Name | Type | Parameters
+
+Preserve all original data — only restructure column order and headers.
+
+### Phase 6: Generate Output
+
+1. Assemble the normalized blueprint with all sections in the standards-prescribed order
+2. Insert `<!-- TODO: This section needs content -->` markers for empty mandatory sections
+3. Save to `.work/blueprints/<partner-name>/blueprint.md`
+4. Generate a summary report listing:
+   - Sections successfully mapped (with content)
+   - Sections empty (need content)
+   - Unmapped content (needs manual placement)
+   - Tables normalized (with before/after column mapping)
+
+### Phase 7: Present Results
+
+Display to the user:
+1. The output file path
+2. The mapping summary (how many sections mapped vs. empty)
+3. Any unmapped content that needs manual review
+4. Suggested next steps: run `validate` to check compliance, or `generate` to fill empty sections
+
+## Return Value
+
+- **Output file path**: `.work/blueprints/<partner-name>/blueprint.md`
+- **Mapping summary**: Sections mapped / empty / unmapped counts
+- **Unmapped content list**: Items that could not be automatically placed
+- **Conversion tool used**: Which tool performed the conversion
+
+## Examples
+
+1. **Convert a Word document**:
+   ```text
+   /telcoeng-blueprint-workflow:ingest ~/Documents/partner-blueprint.docx --partner acme-telecom
+   ```
+   Output:
+   ```text
+   Ingested: partner-blueprint.docx → .work/blueprints/acme-telecom/blueprint.md
+   Sections mapped: 5/7 | Empty: 2 | Unmapped content: 3 blocks
+   Next: Run /telcoeng-blueprint-workflow:validate .work/blueprints/acme-telecom/blueprint.md
+   ```
+
+2. **Convert a PDF**:
+   ```text
+   /telcoeng-blueprint-workflow:ingest ./samsung-vbsc-blueprint.pdf --partner samsung
+   ```
+
+3. **Normalize an existing Markdown file**:
+   ```text
+   /telcoeng-blueprint-workflow:ingest ./existing-blueprint.md --partner softbank
+   ```
+   Skips conversion, goes directly to section mapping and normalization.
+
+## Arguments
+
+- `$1` (`<file-path>`): Path to the blueprint document to ingest. Supports `.docx`, `.doc`, `.pdf`, `.md` extensions.
+- `--partner <name>`: Partner name for output directory naming. If omitted, derived from file name or prompted interactively.
+- `--format <type>`: Override format detection. Values: `word`, `pdf`, `markdown`, `gdocs`.
+
+## Error Handling
+
+- **File not found**: Display error with the provided path and suggest checking the path
+- **No conversion tool available**: List which tools are needed and provide installation commands (`pip install markitdown`, `brew install pandoc`)
+- **Conversion failure**: Show the error from the conversion tool, suggest trying a different format or tool
+- **Empty document**: Warn that the document appears empty, suggest checking the file
+- **Standards not found**: Fall back to `reference/blueprint-sections.md` for section hierarchy

--- a/plugins/telcoeng-blueprint-workflow/commands/search.md
+++ b/plugins/telcoeng-blueprint-workflow/commands/search.md
@@ -1,0 +1,120 @@
+---
+description: Search across normalized blueprints for patterns, configurations, and cross-references
+argument-hint: <query> [--dir <blueprints-directory>]
+---
+
+## Name
+
+telcoeng-blueprint-workflow:search
+
+## Synopsis
+
+```text
+/telcoeng-blueprint-workflow:search <query> [--dir <blueprints-directory>]
+```
+
+## Description
+
+The `search` command provides a central blueprint index by searching across all normalized blueprint documents for patterns, configurations, and cross-references. It enables queries like "which blueprints reference siteconfigv1?" or "show all BIOS settings across blueprints."
+
+This implements NOW #4 (Central Blueprint Index & Search) from the prioritization matrix. It treats the collection of normalized blueprints as a searchable knowledge base.
+
+### Key Features
+
+- Searches across multiple blueprint files simultaneously
+- Supports natural language queries and specific pattern matching
+- Returns results with source file, section, and surrounding context
+- Cross-references findings across blueprints for comparison
+- Identifies commonalities and differences between partner blueprints
+
+## Implementation
+
+### Phase 1: Locate Blueprint Files
+
+1. If `--dir` is provided, search that directory for `.md` files
+2. Otherwise, search in default locations:
+   - `.work/blueprints/*/blueprint.md` (ingested blueprints)
+   - Sibling directories matching `*blueprint*` patterns
+3. List all found blueprint files and their partner names
+4. If no blueprints found, inform the user and suggest running `ingest` first
+
+### Phase 2: Parse Search Query
+
+Interpret the user's query:
+
+1. **Specific pattern search**: If the query contains a specific term (e.g., "siteconfigv1", "SR-IOV", "SUPPORTEX-12345"), search for exact matches
+2. **Section-scoped search**: If the query references a section (e.g., "BIOS settings", "S-BOM versions"), scope the search to that section type
+3. **Comparison query**: If the query asks to compare (e.g., "compare networking across blueprints"), collect the relevant section from each blueprint
+4. **Natural language**: For general questions, search all content and rank by relevance
+
+### Phase 3: Search and Collect Results
+
+For each blueprint file:
+
+1. Read the file content
+2. Search for matches based on the parsed query
+3. For each match, extract:
+   - Blueprint file path and partner name
+   - Section heading where the match was found
+   - The matching text with surrounding context (2-3 lines before/after)
+   - Line number for reference
+
+### Phase 4: Present Results
+
+Display results grouped by blueprint:
+
+```text
+Found X matches across Y blueprints:
+
+## acme-telecom (blueprint.md)
+### Software and Configuration > S-BOM
+  Line 45: | OpenShift Container Platform | 4.17.3 | 4.17.2 |
+  Line 46: | Advanced Cluster Management | 2.11.1 | 2.11.0 |
+
+## samsung (blueprint.md)
+### Software and Configuration > S-BOM
+  Line 52: | OpenShift Container Platform | 4.16.8 | 4.16.5 |
+```
+
+For comparison queries, present a side-by-side or merged view.
+
+## Return Value
+
+- **Match count**: Total matches found
+- **Blueprint count**: Number of blueprints searched
+- **Results**: Grouped by blueprint with section and context
+- **Comparison table** (for comparison queries): Side-by-side view
+
+## Examples
+
+1. **Search for a specific configuration**:
+   ```text
+   /telcoeng-blueprint-workflow:search "siteconfigv1"
+   ```
+
+2. **Compare S-BOM across blueprints**:
+   ```text
+   /telcoeng-blueprint-workflow:search "compare OCP versions across blueprints"
+   ```
+
+3. **Find all BIOS settings**:
+   ```text
+   /telcoeng-blueprint-workflow:search "BIOS settings" --dir ./blueprints/
+   ```
+
+4. **Search for SUPPORTEX tickets**:
+   ```text
+   /telcoeng-blueprint-workflow:search "SUPPORTEX"
+   ```
+
+## Arguments
+
+- `$1` (`<query>`): The search query. Can be a specific term, section name, or natural language question.
+- `--dir <blueprints-directory>`: Directory containing blueprint Markdown files to search. Defaults to `.work/blueprints/`.
+
+## Error Handling
+
+- **No blueprints found**: Inform user, suggest running `ingest` to normalize documents first
+- **No matches**: Report zero results, suggest alternative search terms
+- **Large result set**: Limit to top 20 matches, offer to show more
+- **Binary or non-Markdown files**: Skip with a warning

--- a/plugins/telcoeng-blueprint-workflow/commands/validate.md
+++ b/plugins/telcoeng-blueprint-workflow/commands/validate.md
@@ -1,0 +1,189 @@
+---
+description: Score a blueprint against telcoeng-blueprint-standards (0-100) with section-by-section compliance report
+argument-hint: <blueprint-path> [--partner <name>] [--cluster <kubeconfig>] [--jira]
+---
+
+## Name
+
+telcoeng-blueprint-workflow:validate
+
+## Synopsis
+
+```text
+/telcoeng-blueprint-workflow:validate <blueprint-path> [--partner <name>] [--cluster <kubeconfig>] [--jira]
+```
+
+## Description
+
+The `validate` command is the Blueprint Advisor — it reads a blueprint document and the `telcoeng-blueprint-standards`, then produces a compliance score (0-100) with a detailed section-by-section breakdown.
+
+This implements WOW #2 (Automated Compliance Checking & Validation) from the prioritization matrix. It combines RAG-style analysis (standards + blueprint) with optional cluster-level validation via kube-compare-mcp.
+
+### Key Features
+
+- Scores compliance across 4 weighted categories (presence, completeness, RDS alignment, data quality)
+- Reads the standards document dynamically — adapts when standards change
+- Optionally validates against a live cluster using kube-compare-mcp
+- Creates ECOPS JIRA tickets for non-compliant findings (optional, via `--jira` flag)
+- Generates a detailed compliance report with actionable recommendations
+
+## Implementation
+
+### Phase 1: Load Scoring Framework
+
+1. Invoke the `compliance-scoring` skill using the Skill tool to load the weighted rubric from `reference/compliance-rubric.md`
+2. Load the four scoring categories and their point allocations
+
+### Phase 2: Load Standards Structure
+
+1. Invoke the `blueprint-structure` skill using the Skill tool
+2. Read the current `telcoeng-blueprint-standards/README.md` to extract the required section hierarchy
+3. Build the list of mandatory sections, required elements, and table schemas
+
+### Phase 3: Read the Blueprint
+
+1. Read the blueprint document at `<blueprint-path>`
+2. If the file is not Markdown, inform the user to run `ingest` first
+3. Parse the document structure: headings, sections, tables, bullet lists
+4. Determine the partner name from `--partner` flag, document title, or prompt
+5. Sanitize partner name: lowercase, allow only `[a-z0-9-]`, replace spaces/underscores with `-`, reject `/`, `\`, `..`, and absolute-path prefixes. Fail with a validation error if invalid
+
+### Phase 4: Score Section Presence (35 points)
+
+For each mandatory section from the standards:
+
+1. Search for the section heading in the blueprint (fuzzy match)
+2. Score: present with content = full points, present but empty = half points, absent = 0
+3. Record findings for the report
+
+### Phase 5: Score Content Completeness (30 points)
+
+For each present section, evaluate substantive content per the rubric criteria. Apply these strict rules:
+
+1. Check S-BOM for specific version numbers — OCP and RHCOS versions must be stated explicitly, not inferred from operator versions. Blank version fields score 0 for that row.
+2. Check H-BOM for specific hardware models and specs — each node type must be documented separately with vendor, model, CPU, memory, storage, NIC.
+3. Check architecture diagram is **renderable** in the Markdown — pandoc artifact comments or references to the source Word/PDF document do not count. Text descriptions without a renderable diagram score 1 at most.
+4. Check deployment scenarios are enumerated — if only one scenario applies, it must be explicitly stated.
+5. Check operations procedures are **actionable**, not strategic — "we plan to use ACM" without procedures scores 0. LCM must include specific upgrade paths, backup must describe what and how, monitoring must name the stack.
+6. Check networking has specific configurations — PTP details alone are insufficient, core networking config (CNI type, NADs, IP ranges) is required.
+7. Score each criterion per the rubric.
+
+### Phase 6: Score RDS Alignment (20 points)
+
+1. Invoke the `deviation-tracking` skill using the Skill tool
+2. **Detect RDS profile(s)**: Determine whether the blueprint covers a single profile (RAN-DU, Core, or Hub) or multiple profiles (e.g., Hub + Core). Use profile detection signals from the deviation-tracking skill:
+   - Hub signals: ACM, GitOps, Quay, Hub cluster, cluster management
+   - Core signals: 5G Core CNFs, multi-node MNO, CWL/CMWL workload clusters
+   - RAN-DU signals: DU workload, RT kernel, FlexRAN, Aerial SDK, SNO
+3. Check for explicit RDS baseline identification — must specify exact profile(s), OCP version, and link to the RDS document. For multi-profile blueprints, each profile must be named with its own RDS link. Vague references score 1 at most.
+4. Verify deviations are itemized with individual explanations. For multi-profile blueprints, each deviation must indicate which profile it applies to (Hub, Core, RAN-DU, or Shared).
+5. Verify SUPPORTEX tickets are linked (search for `SUPPORTEX-` pattern). For multi-profile blueprints, the SUPPORTEX table should include a Profile column.
+6. Verify deviation impact is assessed for each item
+7. **Profile-aware scoring**: A configuration that is baseline for one profile may be a deviation for another. For example, `realTimeKernel.enabled: false` is baseline for Core but a deviation for RAN-DU. For multi-profile blueprints, evaluate each profile independently and deduct points only for deviations not documented for the affected profile.
+
+### Phase 7: Detect Undocumented Deviations
+
+Scan the blueprint content for signals that indicate deviations exist but are not documented in the deviations section. Refer to the deviation detection patterns in the `deviation-tracking` skill, organized by RDS profile (RAN-DU, Core, Hub, Shared).
+
+For each detected undocumented deviation, add it to the compliance report as a gap. Undocumented deviations do not directly reduce the total score, but they may indirectly affect the "Deviations itemized" criterion (6 points) if the documented deviations list is incomplete relative to what exists in the blueprint. They are surfaced as actionable findings to guide the `fix` and `generate` commands.
+
+### Phase 8: Score Tables and Data Quality (15 points)
+
+1. Validate S-BOM table structure (Component | Version | Patch Level columns)
+2. Validate Operators table (Name | Version | Channel | Role)
+3. Validate Support Exceptions table (SUPPORTEX ID | Required For | Status)
+4. Validate Network Attachment Definitions table (NAD Name | Type | Parameters)
+
+### Phase 9: Cluster Validation (Optional)
+
+If `--cluster <kubeconfig>` is provided:
+
+1. Invoke the `kube-compare-integration` skill using the Skill tool
+2. Run cluster comparison against the appropriate RDS profile
+3. Cross-reference cluster deviations with documented blueprint deviations
+4. Flag undocumented deviations as additional compliance gaps
+5. Include cluster validation results in the report as a supplementary section
+
+### Phase 10: Generate Compliance Report
+
+1. Calculate total score (sum of all categories)
+2. Determine rating (Excellent/Good/Needs Work/Incomplete/Draft)
+3. Generate the full compliance report with:
+   - Overall score and rating
+   - Section-by-section breakdown with points and findings
+   - RDS alignment details
+   - Table quality assessment
+   - Cluster validation results (if performed)
+   - Prioritized recommendations (ordered by point impact)
+4. Save to `.work/blueprints/<partner-name>/compliance-report.md`
+
+### Phase 11: JIRA Integration (Optional)
+
+If `--jira` flag is provided:
+
+1. For each finding rated as "Missing" or "Fail", offer to create an ECOPS ticket
+2. Use the `jira` plugin's create command with:
+   - Project: ECOPS
+   - Summary: `[Blueprint] <partner-name> - <finding-description>`
+   - Labels: blueprint, compliance, <partner-name>
+3. Always ask for user confirmation before creating tickets
+4. Add ticket references to the compliance report
+
+## Return Value
+
+- **Overall score** (0-100)
+- **Rating** (Excellent/Good/Needs Work/Incomplete/Draft)
+- **Report file path**: `.work/blueprints/<partner-name>/compliance-report.md`
+- **Missing sections** count
+- **Top 3 recommendations**
+- **JIRA tickets created** (if `--jira` was used)
+
+## Examples
+
+1. **Basic validation**:
+   ```text
+   /telcoeng-blueprint-workflow:validate .work/blueprints/acme-telecom/blueprint.md
+   ```
+   Output:
+   ```text
+   Compliance Score: 72/100 — Needs Work
+
+   Section Presence:   28/35 (missing: Certification, Compute)
+   Content Completeness: 22/30 (S-BOM has TBD versions)
+   RDS Alignment:      12/20 (deviations not linked to SUPPORTEX)
+   Data Quality:       10/15 (NAD table missing)
+
+   Top recommendations:
+   1. Add Certification section with CNF and hardware certification status
+   2. Replace TBD versions in S-BOM with specific version numbers
+   3. Link each RDS deviation to a SUPPORTEX ticket
+
+   Report: .work/blueprints/acme-telecom/compliance-report.md
+   ```
+
+2. **Validation with cluster check**:
+   ```text
+   /telcoeng-blueprint-workflow:validate ./blueprint.md --cluster ~/.kube/config --partner samsung
+   ```
+
+3. **Validation with JIRA ticket creation**:
+   ```text
+   /telcoeng-blueprint-workflow:validate ./blueprint.md --partner softbank --jira
+   ```
+
+## Arguments
+
+- `$1` (`<blueprint-path>`): Path to the blueprint Markdown file to validate.
+- `--partner <name>`: Partner name for report naming and JIRA labels.
+- `--cluster <kubeconfig>`: Path to kubeconfig for cluster-level validation via kube-compare-mcp. Optional.
+- `--jira`: Enable JIRA ticket creation for non-compliant findings. Optional. Requires user confirmation per ticket.
+
+## Error Handling
+
+- **Blueprint not found**: Display error with path, suggest running `ingest` if the source is Word/PDF
+- **Blueprint not in Markdown**: Inform user to run `ingest` command first
+- **Standards not found**: Fall back to `reference/blueprint-sections.md`, warn about potentially stale data
+- **kube-compare-mcp not available**: Skip cluster validation, note in report, proceed with document-only scoring
+- **JIRA not configured**: Skip ticket creation, note in report, provide manual ticket creation guidance
+- **Empty blueprint**: Score 0/100 with rating "Draft", recommend using `generate` to scaffold content
+- **Skill invocation failure**: If a required skill (`compliance-scoring`, `blueprint-structure`, `deviation-tracking`) fails to load, fall back to built-in defaults (e.g., rubric weights 35/30/20/15) and warn the user that scoring may be incomplete

--- a/plugins/telcoeng-blueprint-workflow/reference/blueprint-sections.md
+++ b/plugins/telcoeng-blueprint-workflow/reference/blueprint-sections.md
@@ -1,0 +1,58 @@
+# Blueprint Section Reference
+
+This file is a **pointer** to the canonical source of truth: the `telcoeng-blueprint-standards` repository. Do NOT duplicate the standards here — always read the live document at runtime.
+
+## Standards Document Location
+
+The standards document is maintained at:
+
+- **Internal GitLab**: `gitlab.cee.redhat.com/telcoeng/telcoeng-blueprint-standards`
+- **Local clone** (if available): Look for `telcoeng-blueprint-standards/README.md` relative to the current workspace or in sibling directories
+
+To locate the standards at runtime, search in this order:
+
+1. `../telcoeng-blueprint-standards/README.md` (sibling directory)
+2. `../../telcoeng-blueprint-standards/README.md` (parent sibling)
+3. Search workspace for any directory named `telcoeng-blueprint-standards`
+
+## Required Section Hierarchy
+
+The following section hierarchy is extracted from the standards. **Always re-read the live document** to pick up changes — this list is for quick reference only.
+
+### Top-Level Sections (Mandatory)
+
+1. **Blueprint Document Metadata** — Title, Version History, NDA Notice, Contacts/Approvers
+2. **Authorship** — Collaborative authorship statement
+3. **Introduction and Architectural Overview** — Purpose, Workload, Solution Architecture, Deployment Scenarios, Infrastructure Components, Untested Features
+4. **Technical Deep Dive** — Core technical specifications
+   - Software and Configuration (S-BOM, Operators, Configuration Baseline, Support Exceptions, RDS Deviations)
+   - Hardware and Node Configuration (H-BOM, Node Types, Labels/Taints, Resource Partitioning, Kernel/BIOS)
+   - Compute
+   - Storage
+   - Networking (Network Overview, Primary CNI, Secondary Networks, IP Addressing, Load Balancing)
+5. **Operations and Management** — LCM, Backup/Restore, Observability, Security, User Management
+6. **Certification** — CNF Certification, Hardware Certification
+7. **Appendix** — Terminology, Configuration Examples, Diagrams, References
+
+### Critical Tables (Must Be Present and Complete)
+
+- **S-BOM Table**: Software component | Version | Minimum patch level
+- **Operators Table**: Operator name | Version | Channel (stable/eus) | Role
+- **Support Exceptions Table**: SUPPORTEX ID | Required for | Status/Comments
+- **RDS Deviations List**: Itemized deviations with explanation and tracking
+- **H-BOM Table**: Server model | CPU | Memory | Storage | NICs
+- **Network Attachment Definitions Table**: NAD name | Type | Parameters
+
+## Persona Requirements
+
+The standards define 7 target personas. Each blueprint section must satisfy:
+
+| Persona | Primary Need |
+|---------|-------------|
+| Platform/Operations/Workload Pillar Teams | Technical depth, RDS alignment, deviation tracking |
+| Verification Pillar Engineers | Precise configs, exact versions (S-BOM), specific hardware (H-BOM), YAML manifests |
+| Red Hat Field Teams | Executive architecture + technical depth for pre-sales |
+| NPSS Team | Compliance determines SLA eligibility; deviations affect support scope |
+| Partner Engineering Teams | Clear structure, RDS alignment guidance, production baselines |
+| CSP Architects | High-level architecture and operational considerations |
+| System Integrators | Tested baseline vs experimental features; deployment guidance |

--- a/plugins/telcoeng-blueprint-workflow/reference/compliance-rubric.md
+++ b/plugins/telcoeng-blueprint-workflow/reference/compliance-rubric.md
@@ -1,0 +1,82 @@
+# Compliance Scoring Rubric
+
+This rubric defines how blueprint compliance is scored (0-100). Weights are configurable — update this file when the standards add new mandatory sections.
+
+## Overall Score Composition
+
+| Category | Weight | Description |
+|----------|--------|-------------|
+| Section Presence | 35% | Are all mandatory sections present? |
+| Content Completeness | 30% | Are sections substantive (not just placeholders)? |
+| RDS Alignment | 20% | Are deviations documented? Are SUPPORTEX tickets linked? |
+| Tables and Data Quality | 15% | Are S-BOM, H-BOM, and other tables complete with specific values? |
+
+## Section Presence Scoring (35 points)
+
+Each mandatory section contributes equally. Missing a section scores 0 for that item.
+
+| Section | Points | Required Elements |
+|---------|--------|-------------------|
+| Document Metadata | 5 | Title, version history, NDA notice, contacts |
+| Introduction and Architectural Overview | 5 | Purpose, workload, architecture diagram, deployment scenarios |
+| Software and Configuration | 5 | S-BOM, operators, configuration baseline, support exceptions, deviations |
+| Hardware and Node Configuration | 5 | H-BOM, node types, labels/taints, resource partitioning, kernel/BIOS |
+| Networking | 5 | Network overview, primary CNI, secondary networks, IP addressing |
+| Operations and Management | 5 | LCM, backup/restore, observability, security, user management |
+| Certification | 5 | CNF certification, hardware certification |
+
+## Content Completeness Scoring (30 points)
+
+Sections must contain substantive content, not just headers or TODO placeholders. Strategic descriptions and aspirational text score 0 — content must be specific and actionable.
+
+| Criterion | Points | How to Assess |
+|-----------|--------|---------------|
+| S-BOM has specific versions (not "latest" or "TBD") | 6 | Check each row has concrete version numbers. OCP and RHCOS versions must be stated explicitly, not inferred from operator versions. Score is proportional: (valid_rows / total_rows) × 6 points, rounded to the nearest integer. |
+| H-BOM has specific hardware models and specs | 6 | Check server vendor, model, CPU arch/model, memory type/capacity, storage, NIC model, SR-IOV config. Each node type must be documented separately. |
+| Architecture diagram is present and renderable | 4 | The diagram must be viewable in the Markdown document itself (inline image or linked file). Pandoc artifact comments or references to external documents score 0. Text descriptions without a renderable diagram score 1 at most. |
+| Deployment scenarios are enumerated | 4 | Check for specific scenario types (5G Core, D-RAN, C-RAN, SNO, multi-node). If only one scenario applies, it must be explicitly stated. |
+| Operations procedures are actionable | 5 | LCM must include specific upgrade paths (z-stream, EUS-to-EUS), backup must describe what is backed up and how, monitoring must name the stack and alert targets. Strategic text ("we plan to use ACM") without procedures scores 0. |
+| Networking has specific configurations | 5 | CNI type must be named (e.g., OVNKubernetes), NADs must have parameters, IP ranges must be documented. PTP details alone are insufficient — core networking config is required. |
+
+## RDS Alignment Scoring (20 points)
+
+| Criterion | Points | How to Assess |
+|-----------|--------|---------------|
+| RDS baseline is identified | 4 | Must specify exact profile (RAN-DU, Core, or Hub), OCP version, and link to the RDS document. Vague references ("aligned with RDS") score 1 at most. |
+| Deviations are itemized | 6 | Each deviation listed separately with explanation. The scorer must also check for undocumented deviations by analyzing the blueprint content (see Undocumented Deviation Detection below). |
+| SUPPORTEX tickets are linked | 5 | SUPPORTEX-XXXXX format with active links. Each deviation must have a corresponding ticket. |
+| Deviation impact is assessed | 5 | Each deviation explains why it exists, what the impact is on platform stability and support coverage, and what mitigations are in place. |
+
+### Undocumented Deviation Detection
+
+During scoring, the validator must scan the blueprint for deviations that exist but are not documented. Refer to the deviation detection patterns in the `deviation-tracking` skill, which organizes signals by RDS profile (RAN-DU, Core, Hub, Shared). For multi-profile blueprints, evaluate each profile independently — a configuration baseline for one profile may be a deviation for another.
+
+Each detected undocumented deviation must be flagged in the compliance report as a gap requiring documentation and a SUPPORTEX ticket.
+
+## Tables and Data Quality Scoring (15 points)
+
+| Criterion | Points | How to Assess |
+|-----------|--------|---------------|
+| S-BOM table is well-formed | 4 | Has columns: Component, Version, Patch Level |
+| Operators table is complete | 3 | Has columns: Name, Version, Channel, Role |
+| Support Exceptions table is present | 4 | Has columns: SUPPORTEX ID, Required For, Status |
+| Network Attachment Definitions table exists | 4 | Has columns: NAD Name, Type, Parameters |
+
+## Score Interpretation
+
+| Score Range | Rating | Action |
+|-------------|--------|--------|
+| 90-100 | Excellent | Ready for review |
+| 75-89 | Good | Minor gaps — fix recommended |
+| 50-74 | Needs Work | Significant gaps — fix required before review |
+| 25-49 | Incomplete | Major sections missing — substantial work needed |
+| 0-24 | Draft | Early stage — use `generate` command to build out sections |
+
+## Updating This Rubric
+
+When `telcoeng-blueprint-standards` adds new mandatory sections:
+
+1. Add the section to the Section Presence table
+2. Adjust point distribution to maintain 35-point total by reducing points evenly across existing sections (rounding to maintain integer values)
+3. Add content completeness criteria if the section requires specific data
+4. Bump the plugin version (PATCH for weight adjustments, MINOR for new sections)

--- a/plugins/telcoeng-blueprint-workflow/reference/mcp-tools.md
+++ b/plugins/telcoeng-blueprint-workflow/reference/mcp-tools.md
@@ -1,0 +1,106 @@
+# MCP Tools Reference
+
+This document lists the MCP server tools used by this plugin for cluster validation and JIRA integration.
+
+## kube-compare-mcp Tools
+
+The `kube-compare-mcp` server wraps the `kube-compare` kubectl plugin for AI-assisted cluster validation against Telco Reference Design Specifications (RDS).
+
+**Prerequisites**: The kube-compare-mcp server must be configured and running. See `kube-compare-mcp` repository for setup.
+
+### kube_compare_resolve_rds
+
+Resolves available RDS profiles (RAN-DU, Core, Hub).
+
+**Usage**: Call before validation to determine which RDS profile applies to the blueprint's deployment scenario.
+
+```text
+Tool: kube_compare_resolve_rds
+Input: { "profile": "ran-du" }  // or "core", "hub"
+Returns: RDS reference configuration paths and metadata
+```
+
+### kube_compare_cluster_diff
+
+Compares a live cluster or manifests against an RDS reference configuration.
+
+**Usage**: Called by the `validate` command (Phase 7) to perform cluster-level compliance checks.
+
+```text
+Tool: kube_compare_cluster_diff
+Input: {
+  "reference": "<rds-profile>",
+  "cluster": "<kubeconfig-or-manifests-path>"
+}
+Returns: Structured diff showing deviations from RDS
+```
+
+### kube_compare_validate_rds
+
+Validates an RDS reference configuration itself for correctness.
+
+```text
+Tool: kube_compare_validate_rds
+Input: { "reference": "<rds-profile>" }
+Returns: Validation result with any configuration issues
+```
+
+### baremetal_bios_diff
+
+Compares BIOS settings against reference configurations.
+
+**Usage**: Relevant for the Hardware and Node Configuration section of blueprints (H-BOM, Kernel/BIOS settings).
+
+```text
+Tool: baremetal_bios_diff
+Input: {
+  "reference": "<bios-reference>",
+  "current": "<current-bios-settings>"
+}
+Returns: BIOS setting deviations
+```
+
+## JIRA Integration
+
+JIRA integration is handled through the existing `jira` plugin's MCP tools. This plugin delegates to the jira plugin for ticket operations.
+
+### Creating ECOPS Tickets
+
+Use the jira plugin's create command or MCP tools to create ECOPS tickets:
+
+```text
+Project: ECOPS
+Issue Type: Task or Bug
+Fields:
+  - Summary: "[Blueprint] <partner-name> - <issue-description>"
+  - Description: Compliance finding details, section reference, recommended fix
+  - Labels: ["blueprint", "compliance", "<partner-name>"]
+```
+
+### Querying Existing Tickets
+
+Search for blueprint-related ECOPS tickets using JQL:
+
+```text
+JQL: project = ECOPS AND labels = "blueprint" AND labels = "<partner-name>"
+```
+
+### SUPPORTEX Ticket References
+
+Support exception tickets follow the pattern `SUPPORTEX-XXXXX` and are tracked at:
+`https://issues.redhat.com/browse/SUPPORTEX-XXXXX`
+
+When documenting deviations, always link to the corresponding SUPPORTEX ticket.
+
+## RDSAnalyzer Integration
+
+The RDSAnalyzer CLI can be used as an additional validation layer:
+
+```text
+Flow: kube-compare (diffs) → RDSAnalyzer (rule evaluation) → Impact Reports
+Profiles: RAN-DU, Core, Hub
+Impact Levels: 4 levels (Critical, High, Medium, Low)
+Output: HTML/text reports
+```
+
+This tool is complementary to kube-compare-mcp and provides rule-based deviation impact assessment.

--- a/plugins/telcoeng-blueprint-workflow/skills/blueprint-structure/SKILL.md
+++ b/plugins/telcoeng-blueprint-workflow/skills/blueprint-structure/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: Blueprint Structure
+description: Dynamically reads telcoeng-blueprint-standards to extract the required section hierarchy for partner blueprints
+---
+
+# Blueprint Structure
+
+This skill provides the canonical section hierarchy that every Telco Partner Blueprint must follow. It reads the standards document **at runtime** to always reflect the latest requirements.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- Creating a new blueprint scaffold (`ingest` or `generate` commands)
+- Validating an existing blueprint's structure (`validate` command)
+- Mapping ingested content to the correct sections (`ingest` command)
+- Understanding what sections are mandatory vs. optional
+
+## Prerequisites
+
+- The `telcoeng-blueprint-standards` repository must be cloned locally
+- See `reference/blueprint-sections.md` for how to locate the standards document
+
+## Implementation Steps
+
+### Step 1: Locate the Standards Document
+
+Search for `telcoeng-blueprint-standards/README.md` in the following order:
+
+1. Sibling directory: `../telcoeng-blueprint-standards/README.md` relative to the current workspace
+2. Parent sibling: `../../telcoeng-blueprint-standards/README.md`
+3. Broader search: Find any directory named `telcoeng-blueprint-standards` under the user's project directories
+
+If the standards document cannot be found, inform the user and provide the GitLab URL:
+`gitlab.cee.redhat.com/telcoeng/telcoeng-blueprint-standards`
+
+### Step 2: Extract Section Hierarchy
+
+Read the standards document and extract all sections under the `# Telco Partner Blueprint` heading. Parse:
+
+1. **Top-level sections** (## headings): These are mandatory blueprint sections
+2. **Sub-sections** (### headings): These are required subsections within each top-level section
+3. **Bullet points under each section**: These are the required elements/content for that section
+
+Build a structured representation:
+
+```text
+Section: <name>
+  Required: true/false
+  Sub-sections:
+    - <sub-section-name>
+      Required elements:
+        - <element-1>
+        - <element-2>
+```
+
+### Step 3: Identify Critical Tables
+
+From the standards, identify all tables that must appear in a compliant blueprint:
+
+- S-BOM (Software Bill of Materials)
+- Operators and Versions
+- Support Exceptions (SUPPORTEX)
+- RDS Deviations
+- H-BOM (Hardware Bill of Materials)
+- Network Attachment Definitions
+
+For each table, extract the required columns from the standards examples.
+
+### Step 4: Extract Persona Requirements
+
+Read the `# Personas and Targeting` section to understand what each persona needs from the blueprint. Map persona requirements to specific sections.
+
+### Step 5: Return Structure Map
+
+Return the complete section hierarchy as a structured map that the calling command can use for:
+
+- **Scaffolding**: Generate empty sections with the correct headings and placeholders
+- **Validation**: Check if all required sections exist in a blueprint
+- **Mapping**: Match ingested content to the correct section
+
+## Return Value
+
+A structured section hierarchy containing:
+
+- All mandatory section names and their nesting
+- Required elements per section
+- Required table schemas (column names)
+- Persona-to-section mapping
+
+## Error Handling
+
+- **Standards not found**: Inform user, provide clone instructions, fall back to `reference/blueprint-sections.md` as a snapshot
+- **Standards format changed**: If the expected headings are not found, warn the user that the standards may have been restructured and suggest reviewing manually
+- **Partial read**: If some sections cannot be parsed, return what was found and flag the gaps

--- a/plugins/telcoeng-blueprint-workflow/skills/compliance-scoring/SKILL.md
+++ b/plugins/telcoeng-blueprint-workflow/skills/compliance-scoring/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: Compliance Scoring
+description: Scores a blueprint against telcoeng-blueprint-standards using a weighted rubric (0-100)
+---
+
+# Compliance Scoring
+
+This skill implements the compliance scoring engine that evaluates a blueprint document against the `telcoeng-blueprint-standards`. It produces a section-by-section compliance report with a total score from 0 to 100.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- The `validate` command needs to score a blueprint
+- The `fix` command needs to identify which sections need improvement
+- A user asks about blueprint compliance or readiness for review
+
+## Prerequisites
+
+- The blueprint document must be in Markdown format (use `ingest` command first if in Word/PDF)
+- The `blueprint-structure` skill must be invoked first to load the current section hierarchy
+- Read `reference/compliance-rubric.md` for the scoring weights and criteria
+
+## Implementation Steps
+
+### Step 1: Load Scoring Rubric
+
+Read `reference/compliance-rubric.md` to load the four scoring categories and their weights:
+
+1. Section Presence (35%)
+2. Content Completeness (30%)
+3. RDS Alignment (20%)
+4. Tables and Data Quality (15%)
+
+### Step 2: Score Section Presence (35 points)
+
+For each mandatory section from the blueprint-structure skill output, check if the section exists in the blueprint:
+
+1. Search for the section heading (## or ### level) in the document
+2. Allow minor heading variations (case-insensitive, synonyms like "SW BOM" for "S-BOM")
+3. Score: present = full points, absent = 0 points
+4. Record which sections are missing for the report
+
+### Step 3: Score Content Completeness (30 points)
+
+For each present section, evaluate whether it contains substantive content:
+
+1. **S-BOM check**: Does the table have rows with specific version numbers? Flag "TBD", "latest", or empty cells
+2. **H-BOM check**: Does the table have specific server models, CPU specs, memory amounts?
+3. **Architecture diagram**: Is there an image reference or diagram description?
+4. **Deployment scenarios**: Are specific scenarios enumerated (5G Core, D-RAN, C-RAN)?
+5. **Operations procedures**: Are LCM steps, backup procedures, monitoring setup described?
+6. **Networking configs**: Are CNI type, MTU, NAD parameters, IP ranges specified?
+
+Score each criterion per the rubric point values.
+
+### Step 4: Score RDS Alignment (20 points)
+
+Evaluate how well the blueprint documents its relationship to the Reference Design Specifications:
+
+1. **RDS baseline identified** (4 pts): Search for explicit RDS reference (e.g., "Telco 5G RAN 4.x RDS", "Reference Design Specification")
+2. **Deviations itemized** (6 pts): Check for a deviations section with individual bullet points or numbered items
+3. **SUPPORTEX tickets linked** (5 pts): Search for `SUPPORTEX-` pattern with issue tracker links
+4. **Deviation impact assessed** (5 pts): Each deviation should explain its rationale and impact
+
+### Step 5: Score Tables and Data Quality (15 points)
+
+Check the structure and completeness of required tables:
+
+1. **S-BOM table** (4 pts): Has columns for Component, Version, Patch Level
+2. **Operators table** (3 pts): Has columns for Name, Version, Channel, Role
+3. **Support Exceptions table** (4 pts): Has columns for SUPPORTEX ID, Required For, Status
+4. **Network Attachment Definitions** (4 pts): Has columns for NAD Name, Type, Parameters
+
+### Step 6: Calculate Total Score
+
+Sum all category scores. Apply the interpretation scale from the rubric:
+
+- 90-100: Excellent — ready for review
+- 75-89: Good — minor gaps
+- 50-74: Needs Work — significant gaps
+- 25-49: Incomplete — major sections missing
+- 0-24: Draft — early stage
+
+### Step 7: Generate Compliance Report
+
+Produce a structured report with:
+
+```text
+# Compliance Report: <blueprint-name>
+
+## Overall Score: XX/100 — <Rating>
+
+## Section Presence (XX/35)
+| Section | Status | Points |
+|---------|--------|--------|
+| ... | Present/Missing | X/5 |
+
+## Content Completeness (XX/30)
+| Criterion | Status | Points | Findings |
+|-----------|--------|--------|----------|
+| ... | Pass/Fail/Partial | X/Y | <details> |
+
+## RDS Alignment (XX/20)
+| Criterion | Status | Points | Findings |
+|-----------|--------|--------|----------|
+| ... | Pass/Fail | X/Y | <details> |
+
+## Tables and Data Quality (XX/15)
+| Table | Status | Points | Findings |
+|-------|--------|--------|----------|
+| ... | Well-formed/Missing/Incomplete | X/Y | <details> |
+
+## Recommendations
+1. <highest-impact recommendation>
+2. <second recommendation>
+...
+```
+
+Save the report to `.work/blueprints/<partner-name>/compliance-report.md`.
+
+## Return Value
+
+- **Total score** (0-100)
+- **Rating** (Excellent/Good/Needs Work/Incomplete/Draft)
+- **Category breakdown** (4 category scores)
+- **Missing sections** list
+- **Top recommendations** (ordered by impact)
+- **Report file path**
+
+## Error Handling
+
+- **Blueprint not in Markdown**: Inform user to run `ingest` command first
+- **Empty blueprint**: Score 0, recommend using `generate` command to scaffold
+- **Ambiguous section headings**: Use fuzzy matching, flag uncertain matches in the report
+- **Rubric file not found**: Fall back to hardcoded default weights (35/30/20/15) and warn user

--- a/plugins/telcoeng-blueprint-workflow/skills/content-generation/SKILL.md
+++ b/plugins/telcoeng-blueprint-workflow/skills/content-generation/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: Content Generation
+description: Generates standards-compliant text snippets, tables, and sections for Telco Partner Blueprints
+---
+
+# Content Generation
+
+This skill generates standards-compliant content for common blueprint sections. It produces recommended paragraphs, table templates, and section text that conform to `telcoeng-blueprint-standards`.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- The `generate` command needs to produce content for a specific blueprint section
+- The `fix` command needs to generate replacement text for non-compliant sections
+- A user needs a template for a specific table (S-BOM, H-BOM, Support Exceptions, etc.)
+- Drafting deprecation notices, best-practice guidance, or operator update text
+
+## Prerequisites
+
+- The `blueprint-structure` skill should be invoked first to understand the target section's requirements
+- The user should provide partner-specific details (partner name, product, OCP version, deployment type)
+- Read `reference/blueprint-sections.md` for the section hierarchy
+
+## Implementation Steps
+
+### Step 1: Identify Target Section
+
+Determine which section(s) to generate content for by first parsing `telcoeng-blueprint-standards/README.md` headings and section rules to derive the canonical section taxonomy at runtime. Do not rely on a fixed list — the standards document is authoritative.
+
+Common section types include (illustrative, not exhaustive): Document Metadata, S-BOM, H-BOM, Operators, Support Exceptions, RDS Deviations, Networking, Node Configuration, Operations and Management, and Certification. Always check the current standards for the complete and up-to-date list.
+
+### Step 2: Collect Required Inputs
+
+For each section type, prompt the user for the minimum required information:
+
+**For S-BOM**:
+- OpenShift version (e.g., 4.17)
+- Partner product name and version
+- Key operators in use
+
+**For H-BOM**:
+- Server model(s)
+- CPU type and count
+- Memory per node
+- Storage configuration
+- NIC models and speeds
+
+**For Networking**:
+- Primary CNI (typically OVNKubernetes)
+- Secondary network types (SR-IOV, MACVLAN)
+- Number of network attachment definitions
+
+**For RDS Deviations**:
+- Which RDS the blueprint aligns with
+- Known deviations from the partner's architecture
+
+### Step 3: Read Standards Examples
+
+Read the corresponding section from `telcoeng-blueprint-standards/README.md` to extract:
+
+1. The exact format expected (headings, bullet structure, table layout)
+2. Example content provided in the standards (e.g., sample SUPPORTEX table, sample deviations list)
+3. Required disclaimers or boilerplate text (NDA notice, audience statements)
+
+### Step 4: Generate Content
+
+Produce content that:
+
+1. **Follows the exact format** from the standards (heading levels, table columns, list structure)
+2. **Uses specific values** — never generate "TBD" or placeholder text where the user provided real data
+3. **Includes TODO markers** only for information the user did not provide, formatted as `<!-- TODO: <what is needed> -->`
+4. **References appropriate links** — Red Hat docs, SUPPORTEX tickets, RDS documentation
+5. **Matches the standards' tone** — technical, precise, using standard terminology (CNF, DU, CU, RAN, RDS)
+
+### Step 5: Present for Review
+
+Show the generated content to the user before insertion. Highlight:
+
+- Sections that are complete (all data provided)
+- Sections with TODO markers (data still needed)
+- Any assumptions made about the partner's architecture
+
+## Content Templates
+
+### S-BOM Table Template
+
+```markdown
+### Software Bill of Materials (S-BOM)
+
+| Component | Version | Minimum Patch Level |
+|-----------|---------|---------------------|
+| Red Hat OpenShift Container Platform | 4.X.Y | 4.X.Y |
+| Red Hat Advanced Cluster Management | 2.X.Y | 2.X.Y |
+| <!-- TODO: Add partner software components --> | | |
+```
+
+### Support Exceptions Table Template
+
+```markdown
+### Support Exceptions
+
+This design relies on the following support exceptions:
+
+| Support Exception ID | Required for | Status/Comments |
+|----------------------|--------------|-----------------|
+| [SUPPORTEX-XXXXX](https://issues.redhat.com/browse/SUPPORTEX-XXXXX) | [Partner Product] deviations vs OCP 4.X RAN RDS | Approved |
+```
+
+### H-BOM Table Template
+
+```markdown
+### Hardware Bill of Materials (H-BOM)
+
+| Component | Specification |
+|-----------|---------------|
+| Server Model | <!-- TODO: Server model --> |
+| CPU | <!-- TODO: CPU model and count --> |
+| Memory | <!-- TODO: Memory per node --> |
+| Storage | <!-- TODO: Storage type and capacity --> |
+| NIC | <!-- TODO: NIC model and speed --> |
+```
+
+### RDS Deviations Template
+
+When generating a deviations section, read the blueprint content to pre-populate known deviations. Each deviation must follow this structure:
+
+```markdown
+### Deviations from Red Hat Telco 5G OCP 4.X Reference Design Specification
+
+This solution deviates from the [Telco-5G-RAN 4.X Reference Design Specification](https://docs.openshift.com/container-platform/latest/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-ref-design-spec.html) in the following ways:
+
+* **[Deviation category]**: [Specific description of what differs]
+  * RDS expectation: [What the RDS specifies]
+  * Blueprint configuration: [What this blueprint does instead]
+  * Rationale: [Why this deviation is necessary]
+  * Impact: [Effect on platform resources, support scope, or stability]
+  * Tracked via: [SUPPORTEX-XXXXX](https://issues.redhat.com/browse/SUPPORTEX-XXXXX)
+```
+
+Load deviation detection patterns at runtime from the `deviation-tracking` skill (invoke it via the Skill tool) and from the current RDS reference configurations in `telcoeng-blueprint-standards`. The examples below are illustrative only — always defer to the loaded patterns, as RDS baselines change across OCP versions:
+
+- **RAN-DU examples**: Non-x86 architecture, non-RT kernel, GPU acceleration, custom kernel parameters
+- **Core examples**: Custom SCC capabilities, additional kernel modules, ODF internal mode, service mesh
+- **Hub examples**: Converged Hub with ODF on masters, Tech Preview operators, partner components
+- **Shared examples**: Additional cluster capabilities, etcd encryption, non-standard logging
+
+For multi-profile blueprints (e.g., Hub + Core), tag each deviation with its applicable profile. A configuration that is baseline for one profile may be a deviation for another (e.g., non-RT kernel is baseline for Core but a deviation for RAN-DU).
+
+When generating, scan the blueprint for detected patterns and pre-fill the deviations section with findings. Mark each with `<!-- TODO: Confirm rationale and file SUPPORTEX ticket -->` if the rationale is not clear from context.
+
+## Return Value
+
+- Generated Markdown content for the requested section(s)
+- List of TODO markers requiring user input
+- Confidence level (Complete / Partial / Template-only)
+
+## Error Handling
+
+- **Insufficient input**: Generate a template with TODO markers rather than refusing
+- **Unknown section type**: Refer to the standards document and attempt to generate based on the section's requirements
+- **Conflicting information**: Flag the conflict and ask the user to resolve before generating

--- a/plugins/telcoeng-blueprint-workflow/skills/deviation-tracking/SKILL.md
+++ b/plugins/telcoeng-blueprint-workflow/skills/deviation-tracking/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: Deviation Tracking
+description: Documents RDS deviations, manages SUPPORTEX ticket references, and creates ECOPS JIRA tickets for blueprint compliance issues
+---
+
+# Deviation Tracking
+
+This skill handles the documentation and tracking of deviations from Red Hat Reference Design Specifications (RDS) in partner blueprints. It manages SUPPORTEX ticket references and integrates with JIRA to create ECOPS tickets for unresolved deviations.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- The `validate` command checks RDS deviation documentation completeness
+- The `generate` command needs to produce a deviations section
+- The `fix` command needs to create JIRA tickets for undocumented deviations
+- A user needs to document a new deviation or update an existing one
+
+## Prerequisites
+
+- Understanding of which RDS profile the blueprint aligns with (RAN-DU, Core, or Hub)
+- Access to JIRA for SUPPORTEX and ECOPS ticket queries (via the `jira` plugin)
+- See `reference/mcp-tools.md` for JIRA integration patterns
+
+## Key Concepts
+
+### RDS Profiles
+
+Red Hat maintains Reference Design Specifications for different deployment types:
+
+- **RAN-DU**: Single Node OpenShift for Distributed Unit workloads
+- **Core**: Multi-node OpenShift for 5G Core workloads
+- **Hub**: Management cluster running ACM (OCP 4.19+)
+
+A blueprint may cover **multiple profiles** (e.g., Hub + Core when a partner documents both management and workload clusters in a single document). When multiple profiles apply:
+
+- Deviations must be evaluated against **each applicable RDS** independently
+- Each deviation must be tagged with its applicable profile (Hub, Core, RAN-DU, or Shared)
+- A SUPPORTEX table should include a **Profile** column indicating which cluster type the exception applies to
+- Scoring must account for both profiles — a configuration that is baseline for Core (e.g., non-RT kernel) may be a deviation for RAN-DU
+
+Each blueprint must identify which RDS profile(s) it aligns with and document all deviations per profile.
+
+### Deviation Types
+
+Common categories of deviations from RDS:
+
+1. **Workload specification** — Pod count, container count, traffic patterns
+2. **Exec probes** — Count and frequency exceeding RDS limits
+3. **ConfigMaps** — Usage patterns differing from RDS
+4. **Kernel arguments** — Additional kernel args not in RDS
+5. **Kernel modules** — Additional modules not validated in RDS
+6. **Sysctls** — Custom sysctl configurations
+7. **Cluster capabilities** — Enabling capabilities disabled in RDS
+8. **etcd encryption** — Enabling encryption not in baseline RDS
+
+### SUPPORTEX Tickets
+
+Formal support exceptions filed in JIRA under the SUPPORTEX project. Required when a deviation needs explicit Red Hat support approval.
+
+Format: `SUPPORTEX-XXXXX`
+Link: `https://issues.redhat.com/browse/SUPPORTEX-XXXXX`
+
+### ECOPS Tickets
+
+Operational compliance tickets filed in the ECOPS JIRA project. Used for tracking deviation analysis and resolution.
+
+Format: `ECOPS-XXXX`
+Link: `https://issues.redhat.com/browse/ECOPS-XXXX`
+
+## Implementation Steps
+
+### Step 1: Identify RDS Baseline
+
+From the blueprint, determine which RDS profile(s) the solution aligns with:
+
+1. Search for "Reference Design Specification" or "RDS" mentions
+2. Extract the OCP version and deployment type
+3. Detect profile signals to classify the blueprint:
+
+| Signal | Profile |
+|--------|---------|
+| DU workload, FlexRAN, Aerial SDK, RT kernel, SNO | RAN-DU |
+| 5G Core CNFs, multi-node MNO, CWL/CMWL clusters | Core |
+| ACM, GitOps, Quay, cluster management, Hub cluster | Hub |
+
+4. If both Hub and Core/RAN-DU signals are present, classify as **multi-profile** (e.g., Hub + Core)
+5. For multi-profile blueprints, identify which sections apply to which profile:
+   - Hub-specific: ACM configuration, GitOps, Quay registry, Hub operators, Hub georedundancy
+   - Core/RAN-specific: Workload CNFs, performance profiles, SR-IOV, worker node tuning
+   - Shared: S-BOM, cluster capabilities, security, monitoring, backup
+
+### Step 2: Extract Existing Deviations
+
+Parse the blueprint's deviations section (if present) and build an inventory:
+
+1. Find the "Deviations from the Reference Design Specifications" section
+2. Parse each deviation item (bullet points or numbered list)
+3. For each deviation, extract:
+   - Description of the deviation
+   - Reason/rationale
+   - Impact assessment (if provided)
+   - SUPPORTEX ticket reference (if linked)
+   - ECOPS ticket reference (if linked)
+
+### Step 3: Validate Deviation Documentation
+
+For each deviation, check:
+
+1. **Description is specific**: Not vague — names exact config, component, or parameter
+2. **Rationale is provided**: Explains WHY the deviation exists (partner requirement, architecture constraint)
+3. **Impact is assessed**: States the expected impact on platform resources or support scope
+4. **Ticket is linked**: SUPPORTEX or ECOPS ticket reference exists
+5. **Ticket status is current**: If possible, verify ticket status via JIRA (Approved, Pending, etc.)
+
+### Step 4: Identify Undocumented Deviations
+
+Scan the blueprint content itself for signals that indicate deviations exist but are not documented. This does not require kube-compare — it works from the blueprint text alone.
+
+**Content-based detection patterns:**
+
+Derive the canonical detection rules at runtime from the RDS reference configuration for the target profile. Load the current baseline from `telcoeng-blueprint-standards` and kube-compare RDS references — do not rely on a fixed rule set, as baselines change across OCP versions.
+
+Example detection signals (illustrative, not exhaustive):
+- Non-x86 CPU architecture, non-RT kernel on RAN workloads, GPU/DPU references
+- Kernel arguments, sysctls, or HugePages configurations not in the RDS baseline
+- Workload scale exceeding RDS limits, non-standard NICs, virtualized control planes
+- Additional cluster capabilities, etcd encryption, or operators beyond the baseline
+
+For each detected signal:
+1. Check if a corresponding deviation is documented in the deviations section
+2. If not documented, flag as an undocumented deviation in the compliance report
+3. Include the signal source (section, line) and the expected RDS behavior
+
+**kube-compare cross-reference** (when available):
+
+If kube-compare-mcp results are available, also cross-reference:
+
+1. Compare kube-compare cluster diff output against documented deviations
+2. Flag any deviations found by kube-compare that are NOT documented in the blueprint
+3. These are compliance gaps requiring either documentation or remediation
+
+### Step 5: Create JIRA Tickets (Optional)
+
+For undocumented or unresolved deviations, offer to create ECOPS tickets:
+
+1. Use the `jira` plugin's create command
+2. Set project to ECOPS
+3. Format the ticket:
+   - Summary: `[Blueprint] <partner-name> - <deviation-description>`
+   - Description: Include the deviation details, which RDS section it deviates from, and recommended action
+   - Labels: `blueprint`, `compliance`, `<partner-name>`
+
+Always ask for user confirmation before creating tickets.
+
+## Return Value
+
+- List of documented deviations with completeness status
+- List of undocumented deviations (gaps)
+- SUPPORTEX ticket references and their status
+- ECOPS ticket references and their status
+- Recommendations for improving deviation documentation
+
+## Error Handling
+
+- **No deviations section found**: Flag as a major compliance gap (points per `reference/compliance-rubric.md` — "Deviations are itemized" criterion)
+- **JIRA unavailable**: Document deviations locally, note that tickets need to be created manually
+- **Unknown RDS profile**: Ask user to specify which RDS the blueprint targets
+- **kube-compare results unavailable**: Skip cross-reference check, note in the report

--- a/plugins/telcoeng-blueprint-workflow/skills/kube-compare-integration/SKILL.md
+++ b/plugins/telcoeng-blueprint-workflow/skills/kube-compare-integration/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: Kube Compare Integration
+description: Integrates with kube-compare-mcp for cluster-level validation against Telco RDS profiles
+---
+
+# Kube Compare Integration
+
+This skill provides the bridge between blueprint document validation and live cluster validation using the `kube-compare-mcp` MCP server. It translates kube-compare results into blueprint compliance findings.
+
+## When to Use This Skill
+
+Use this skill when:
+
+- The `validate` command needs cluster-level validation (Phase 7)
+- The `status` command checks current cluster compliance
+- Cross-referencing blueprint deviations against actual cluster state
+- Validating that a deployed cluster matches its blueprint's specifications
+
+## Prerequisites
+
+- The `kube-compare-mcp` MCP server must be configured and running
+- A valid kubeconfig or manifest files for the target cluster
+- See `reference/mcp-tools.md` for the complete tool signatures
+
+## Implementation Steps
+
+### Step 1: Determine RDS Profile
+
+Based on the blueprint's deployment scenario, select the correct RDS profile:
+
+| Blueprint Deployment Type | RDS Profile |
+|--------------------------|-------------|
+| Single Node OpenShift / DU | ran-du |
+| Multi-node / 5G Core | core |
+| Management / ACM Hub | hub |
+
+Use the `kube_compare_resolve_rds` tool to confirm the profile is available and get its reference configuration paths.
+
+For multi-profile blueprints (e.g., Hub + Core), run `kube_compare_resolve_rds` separately for each profile and validate each cluster independently against its corresponding RDS. Cluster validation results should be reported per profile in the integration report.
+
+### Step 2: Run Cluster Comparison
+
+Invoke `kube_compare_cluster_diff` with the appropriate RDS profile:
+
+1. If a live cluster is available (kubeconfig provided): Compare against the live cluster
+2. If manifest files are available: Compare against the manifest files
+3. If neither is available: Skip this step and note in the report
+
+The tool returns structured diffs showing where the cluster deviates from the RDS reference.
+
+### Step 3: Parse Comparison Results
+
+Process the kube-compare output to extract:
+
+1. **Matching configurations**: Components that align with RDS (compliant)
+2. **Deviations**: Components that differ from RDS (need documentation)
+3. **Missing configurations**: RDS-required components not found in the cluster
+4. **Extra configurations**: Components present in the cluster but not in RDS
+
+### Step 4: Map Results to Blueprint Sections
+
+Translate kube-compare findings into blueprint section references:
+
+| kube-compare Finding | Blueprint Section |
+|---------------------|-------------------|
+| Operator version mismatch | Software and Configuration > Operators |
+| Missing CRD or CR | Software and Configuration > Configuration Baseline |
+| Network config deviation | Networking |
+| Node label/taint mismatch | Hardware and Node Configuration > Node Labels and Taints |
+| Resource partitioning diff | Hardware and Node Configuration > Resource Partitioning |
+| BIOS setting deviation | Hardware and Node Configuration > Kernel and BIOS Settings |
+
+### Step 5: Cross-Reference with Documented Deviations
+
+Compare kube-compare findings against the blueprint's documented deviations:
+
+1. For each kube-compare deviation, check if it appears in the blueprint's deviations section
+2. **Documented deviation**: Mark as acknowledged — no action needed
+3. **Undocumented deviation**: Flag as a compliance gap — needs documentation or remediation
+4. **Documented but not found**: The deviation may have been resolved — suggest removing from the blueprint
+
+### Step 6: Run BIOS Validation (Optional)
+
+If hardware BIOS settings are available, invoke `baremetal_bios_diff`:
+
+1. Compare current BIOS settings against the RDS reference
+2. Map deviations to the Hardware and Node Configuration section
+3. Flag any BIOS settings that should be documented as deviations
+
+### Step 7: Generate Integration Report
+
+Produce a summary that integrates with the main compliance report:
+
+```text
+## Cluster Validation Results
+
+### RDS Profile: <profile-name>
+### Cluster: <cluster-identifier>
+
+| Category | Compliant | Deviations | Missing |
+|----------|-----------|------------|---------|
+| Operators | X | Y | Z |
+| Network Config | X | Y | Z |
+| Node Config | X | Y | Z |
+| BIOS Settings | X | Y | Z |
+
+### Undocumented Deviations (Action Required)
+1. <deviation-description> — Blueprint section: <section>
+2. ...
+
+### Documented Deviations (Acknowledged)
+1. <deviation-description> — SUPPORTEX: <ticket>
+2. ...
+```
+
+## Return Value
+
+- Cluster compliance summary (compliant / deviations / missing counts)
+- List of undocumented deviations requiring blueprint updates
+- List of documented deviations confirmed by cluster state
+- Mapping of findings to blueprint sections
+- Integration report for inclusion in the main compliance report
+
+## Error Handling
+
+- **kube-compare-mcp not available**: Inform user, skip cluster validation, note in report
+- **Invalid kubeconfig**: Ask user for correct cluster credentials
+- **RDS profile not found**: List available profiles and ask user to select
+- **Timeout on large clusters**: Suggest running against specific namespaces or component subsets


### PR DESCRIPTION
**What this PR does / why we need it:**
Adds the telcoeng-blueprint-workflow plugin (v0.1.0) — five commands that automate the partner blueprint lifecycle against telcoeng-blueprint-standards:

- **Ingest**: Convert Word/PDF blueprints to normalized Markdown
- **Validate**: Score compliance (0-100) with section-by-section report
- **Generate**: Generate standards-compliant content (S-BOM, deviations, networking, etc.)
- **Fix**: Produce concrete fix proposals as diffs ranked by score impact
- **Search**: Query across normalized blueprints
- Supports RAN-DU, Core, Hub, and multi-profile (Hub+Core) blueprints. Reads standards dynamically at runtime, no hardcoded section names or compliance rules.

**Which issue(s) this PR fixes:**
N/A, this is a new plugin contribution.

**Special notes for your reviewer:**

- Plugin is Markdown-only (commands + skills + reference docs). No executable code.
- make lint passes with 0 errors/warnings.
- make update has been run — PLUGINS.md and docs/data.json are in sync.
- Tested against two real partner blueprints (single-profile RAN-DU and multi-profile Hub+Core).

**Checklist:**
 

- [ ] Subject and description added to both, commit and PR.
- [ ]  Relevant issues have been referenced.
- [ ] - [ ] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telco Blueprint Workflow plugin (v0.1.0) with five CLI commands: ingest, validate, generate, fix, and search; optional JIRA integration and live cluster validation via kube-compare.

* **Documentation**
  * Comprehensive user docs and references: README, command guides, compliance rubric, blueprint section reference, MCP/tooling guidance, and skill guides for structure, scoring, content generation, deviation tracking, and kube-compare.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->