### PR TITLE
workspaces: print configured paths in gather/list output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -194,7 +194,7 @@
       "name": "workspaces",
       "source": "./plugins/workspaces",
       "description": "Manage isolated git worktree workspaces for multi-repo development",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "gwapi",

--- a/docs/data.json
+++ b/docs/data.json
@@ -1612,7 +1612,7 @@
       "hooks": [],
       "name": "workspaces",
       "skills": [],
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "commands": [

--- a/plugins/workspaces/.claude-plugin/plugin.json
+++ b/plugins/workspaces/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workspaces",
   "description": "Manage isolated git worktree workspaces for multi-repo development",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/workspaces/commands/create.md
+++ b/plugins/workspaces/commands/create.md
@@ -56,6 +56,10 @@ ${CLAUDE_PLUGIN_ROOT}/commands/create/gather.sh
 
 ## Step 2: Parse workspace description
 
+**Read configured paths**: From Step 1 output, note the `=== CONFIG ===` section values:
+- `REPOS_ROOT` — use this path when doing any direct git operations on repos (e.g., `git worktree add`)
+- `WORKSPACES_ROOT` — use this path when referencing workspace locations
+
 **Check for custom rules**: From Step 1 output, check if `=== CUSTOM_PROMPT ===` section is present:
 
 - **If present**: Apply the aliases and auto-detect rules defined in that section

--- a/plugins/workspaces/commands/create/gather.sh
+++ b/plugins/workspaces/commands/create/gather.sh
@@ -27,6 +27,11 @@ if [ ! -d "${CLAUDE_WORKSPACES_ROOT}/.template" ]; then
 fi
 
 echo ""
+echo "=== CONFIG ==="
+echo "REPOS_ROOT: ${CLAUDE_GIT_REPOS_ROOT}"
+echo "WORKSPACES_ROOT: ${CLAUDE_WORKSPACES_ROOT}"
+
+echo ""
 echo "=== REPOS ==="
 # Use portable find syntax (GNU -printf not available on macOS/BSD)
 find "${CLAUDE_GIT_REPOS_ROOT}/" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | tr '\n' ' ' | sed 's/ $/\n/'

--- a/plugins/workspaces/commands/delete.md
+++ b/plugins/workspaces/commands/delete.md
@@ -48,6 +48,10 @@ ${CLAUDE_PLUGIN_ROOT}/commands/delete/list.sh
 
 3. Verify the output shows `CONFIGURATION SAVED` before proceeding to Step 2
 
+**Read configured paths**: From the output, note the `=== CONFIG ===` section values:
+- `REPOS_ROOT` — use this path when doing any direct git operations on repos
+- `WORKSPACES_ROOT` — use this path when referencing workspace locations
+
 Match user's input against the workspace list:
 - **Exact match found**: Proceed to Step 2
 - **Partial matches found**: Use AskUserQuestion to let user select from matches

--- a/plugins/workspaces/commands/delete/list.sh
+++ b/plugins/workspaces/commands/delete/list.sh
@@ -17,6 +17,11 @@ echo "$PREFLIGHT_OUTPUT"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/../create/preflight.sh" > /dev/null 2>&1
 
+echo ""
+echo "=== CONFIG ==="
+echo "REPOS_ROOT: ${CLAUDE_GIT_REPOS_ROOT}"
+echo "WORKSPACES_ROOT: ${CLAUDE_WORKSPACES_ROOT}"
+
 echo "=== WORKSPACES ==="
 for dir in "${CLAUDE_WORKSPACES_ROOT}"/*/; do
     [ -d "$dir" ] || continue


### PR DESCRIPTION
<!--

** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:

Agents had no way to know the configured REPOS_ROOT from script output, causing them to guess default paths (e.g. ~/git-repos/) when doing direct git operations. Now gather.sh and list.sh emit a CONFIG section with REPOS_ROOT and WORKSPACES_ROOT, and the skill instructions tell the agent to use those values.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified steps in workspace creation and deletion guides to explicitly read and note configured repository and workspace paths from command output.

* **New Features**
  * Workspace create/delete commands now print configuration values (repository and workspace root paths) during execution for easier reference.

* **Chores**
  * Plugin version bumped to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->