### PR TITLE
CNTRLPLANE-3370: feat(jira): comment on Jira ticket when not-ready-to-solve label is applied

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     {
       "name": "ci",

--- a/docs/data.json
+++ b/docs/data.json
@@ -300,7 +300,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.4.1"
+      "version": "0.4.2"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/ready-to-solve.md
+++ b/plugins/jira/commands/ready-to-solve.md
@@ -71,9 +71,20 @@ plugins/jira/skills/ready-to-solve/SKILL.md
    - Re-run validation (steps 2-4) on the updated description to confirm the issue now passes
    - If the user declines, skip the update and report the original validation result
 
-6. **Apply Label**: Unless `--dry-run`, update the issue labels via `mcp__atlassian__jira_update_issue`. Fetch current labels first, remove the stale opposite label, add the new label, and PUT the full array in a single call.
+6. **Comment on Result**: If `--dry-run` is NOT set, post or update a Jira comment reflecting the validation result:
+   - **On FAIL**: Post a comment (or edit the existing automated comment) summarizing the failed checks. The comment includes:
+     - A header indicating this is an automated readiness check
+     - A table of check results with severity labels (REQUIRED / WARNING) — only failed and warning checks are shown
+     - AI qualitative assessment verdicts and reasoning for FAIL/WARNING dimensions
+     - Human-readable guidance on what to fix
+     - A note that `/jira:ready-to-solve {issue-key} --fix` can auto-fix some issues (for Claude Code users)
+     - If `--fix` was attempted but didn't fully resolve all failures, a note indicating auto-fix was tried
+   - **On PASS**: If a previous automated failure comment exists, edit it to a brief "PASSED" message. If no previous comment exists, no comment is posted.
+   - **Duplicate prevention**: Automated comments are identified by a marker prefix (`**Automated Readiness Check`). Existing automated comments are edited in place — never duplicated.
 
-7. **Report**: Display a structured markdown report with per-check results, AI assessments, overall verdict, and label applied.
+7. **Apply Label**: Unless `--dry-run`, update the issue labels via `mcp__atlassian__jira_update_issue`. Fetch current labels first, remove the stale opposite label, add the new label, and PUT the full array in a single call.
+
+8. **Report**: Display a structured markdown report with per-check results, AI assessments, overall verdict, and label applied.
 
 ## Return Value
 
@@ -109,6 +120,6 @@ plugins/jira/skills/ready-to-solve/SKILL.md
 
 ## Arguments:
 - $1: Jira issue key (required). Examples: `OCPBUGS-12345`, `HOSTEDCP-999`, `GCP-456`.
-- `--dry-run`: Optional. Skip label application, only report results.
+- `--dry-run`: Optional. Skip label application and comment posting, only report results.
 - `--verbose`: Optional. Show full per-check details including matched section content.
 - `--fix`: Optional. When validation fails, generate a revised description fixing the failing checks, show the proposed changes, and update the issue upon user confirmation.

--- a/plugins/jira/skills/ready-to-solve/SKILL.md
+++ b/plugins/jira/skills/ready-to-solve/SKILL.md
@@ -150,7 +150,110 @@ curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" -H "Content-Type: application/json" \
 
 6. **If declined**: Skip the update and proceed to label application and reporting with the original validation result.
 
-### Phase 6: Apply Jira Label
+### Phase 6: Comment on Result
+
+Skip if `--dry-run` is set.
+
+Post or update a Jira comment reflecting the validation result so the ticket author knows the outcome without running the check themselves.
+
+#### Step 1: Check for existing automated comment
+
+Fetch existing comments and search for one whose body starts with `**Automated Readiness Check`. Save its `comment_id` if found.
+
+```python
+comments = mcp__atlassian__jira_get_comments(page_id="{issue_key}")
+```
+
+Iterate through the returned comments. If any comment body starts with `**Automated Readiness Check`, store its `comment_id` for editing in Step 3.
+
+#### Step 2a: Build FAIL comment body
+
+Skip if verdict is PASS — go to Step 2b.
+
+Build the comment body from the check results (Phase 2) and AI assessment (Phase 3):
+
+```markdown
+**Automated Readiness Check — FAILED**
+
+This issue does not yet meet the requirements for automated solving. Please update the issue description to address the REQUIRED items below.
+
+**Failed Checks:**
+
+| Check | Severity | Details |
+|-------|----------|---------|
+| {check_name} | REQUIRED | {details} |
+| {check_name} | WARNING | {details} |
+
+**AI Assessment:**
+
+| Dimension | Verdict | Reasoning |
+|-----------|---------|-----------|
+| {dimension_name} | FAIL/WARNING | {justification} |
+
+---
+*These checks can also be auto-fixed by running `/jira:ready-to-solve {issue-key} --fix` in Claude Code.*
+```
+
+**Filtering rules:**
+- Only include deterministic checks that FAILED or have WARNINGs (skip passed checks)
+- Show severity column (REQUIRED / WARNING) so authors know what blocks vs. what is advisory
+- Only include AI dimensions that returned FAIL or WARNING (skip PASS)
+- If all AI dimensions passed, omit the AI Assessment table entirely
+- If `--fix` was attempted but the issue still fails, replace the footer with:
+  ```
+  *Auto-fix was attempted but could not fully resolve all issues. Please address the remaining items manually.*
+  ```
+
+#### Step 2b: Build PASS comment body
+
+Only reached if verdict is PASS AND an existing automated comment was found in Step 1. If no existing comment was found, skip to Phase 7 — no comment is needed for a first-time PASS.
+
+```markdown
+**Automated Readiness Check — PASSED**
+
+All checks passed. This issue is ready for `/jira:solve`.
+```
+
+#### Step 3: Post or edit the comment
+
+If an existing automated comment was found (Step 1), edit it:
+
+```python
+mcp__atlassian__jira_edit_comment(
+    issue_key="{issue_key}",
+    comment_id="{comment_id}",
+    body=comment_body
+)
+```
+
+If no existing comment was found and the verdict is FAIL, post a new one:
+
+```python
+mcp__atlassian__jira_add_comment(
+    issue_key="{issue_key}",
+    body=comment_body
+)
+```
+
+If no existing comment was found and the verdict is PASS, do nothing.
+
+**CLI fallback for adding:**
+```bash
+curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST "https://redhat.atlassian.net/rest/api/2/issue/{issue_key}/comment" \
+  -d '{"body": "...comment_body..."}'
+```
+
+**CLI fallback for editing:**
+```bash
+curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X PUT "https://redhat.atlassian.net/rest/api/2/issue/{issue_key}/comment/{comment_id}" \
+  -d '{"body": "...comment_body..."}'
+```
+
+### Phase 7: Apply Jira Label
 
 Skip if `--dry-run` is set.
 
@@ -178,7 +281,7 @@ jira issue edit PROJ-123 -l "ready-to-solve"
 
 Note: The `labels` field in Jira REST API replaces the entire array, so always include all existing labels plus the new one.
 
-### Phase 7: Generate Report
+### Phase 8: Generate Report
 
 Output format:
 
@@ -221,6 +324,7 @@ Output format:
 | Python not available | "Python 3 is required. Check: `which python3`" |
 | `check_sections.py` fails | Display script error, proceed with AI-only assessment, note in report |
 | Description is null/empty | Automatic FAIL: "Issue has no description. Add Context and Acceptance Criteria sections." |
+| Comment post/edit fails | Display warning but still proceed with label application and report. Non-fatal. |
 | Label update fails | Display warning but still show report. Non-fatal. |
 | Description update fails (`--fix`) | Display error, report original validation result. Non-fatal. |
 | User declines fix (`--fix`) | Skip update, proceed with original validation result. |

--- a/plugins/jira/skills/ready-to-solve/SKILL.md
+++ b/plugins/jira/skills/ready-to-solve/SKILL.md
@@ -158,55 +158,25 @@ Post or update a Jira comment reflecting the validation result so the ticket aut
 
 #### Step 1: Check for existing automated comment
 
-Fetch existing comments and search for one whose body starts with `**Automated Readiness Check`. Save its `comment_id` if found.
+Fetch the issue with comments included and search for one whose body starts with `**Automated Readiness Check`. Save its `comment_id` if found.
 
 ```python
-comments = mcp__atlassian__jira_get_comments(page_id="{issue_key}")
+issue = mcp__atlassian__jira_get_issue(issue_key="{issue_key}")
 ```
 
-Iterate through the returned comments. If any comment body starts with `**Automated Readiness Check`, store its `comment_id` for editing in Step 3.
+Iterate through the comments in the returned issue payload. If any comment body starts with `**Automated Readiness Check`, store its `comment_id` for editing in Step 3.
 
-#### Step 2a: Build FAIL comment body
+#### Step 2: Build comment body
 
-Skip if verdict is PASS — go to Step 2b.
-
-Build the comment body from the check results (Phase 2) and AI assessment (Phase 3):
-
-```markdown
-**Automated Readiness Check — FAILED**
-
-This issue does not yet meet the requirements for automated solving. Please update the issue description to address the REQUIRED items below.
-
-**Failed Checks:**
-
-| Check | Severity | Details |
-|-------|----------|---------|
-| {check_name} | REQUIRED | {details} |
-| {check_name} | WARNING | {details} |
-
-**AI Assessment:**
-
-| Dimension | Verdict | Reasoning |
-|-----------|---------|-----------|
-| {dimension_name} | FAIL/WARNING | {justification} |
-
----
-*These checks can also be auto-fixed by running `/jira:ready-to-solve {issue-key} --fix` in Claude Code.*
-```
-
-**Filtering rules:**
-- Only include deterministic checks that FAILED or have WARNINGs (skip passed checks)
-- Show severity column (REQUIRED / WARNING) so authors know what blocks vs. what is advisory
-- Only include AI dimensions that returned FAIL or WARNING (skip PASS)
-- If all AI dimensions passed, omit the AI Assessment table entirely
+**On FAIL**: Reuse the same report format defined in Phase 8 (Generate Report), filtered to only show failed and warning checks. Wrap it with:
+- Header: `**Automated Readiness Check — FAILED**` followed by "Please update the issue description to address the REQUIRED items below."
+- Footer: `*These checks can also be auto-fixed by running '/jira:ready-to-solve {issue-key} --fix' in Claude Code.*`
 - If `--fix` was attempted but the issue still fails, replace the footer with:
-  ```
+  ```text
   *Auto-fix was attempted but could not fully resolve all issues. Please address the remaining items manually.*
   ```
 
-#### Step 2b: Build PASS comment body
-
-Only reached if verdict is PASS AND an existing automated comment was found in Step 1. If no existing comment was found, skip to Phase 7 — no comment is needed for a first-time PASS.
+**On PASS**: If an existing automated comment was found in Step 1, use a brief body. If no existing comment was found, skip to Phase 7 — no comment is needed for a first-time PASS.
 
 ```markdown
 **Automated Readiness Check — PASSED**


### PR DESCRIPTION
## Summary

- When `/jira:ready-to-solve` determines an issue is not ready, post a Jira comment summarizing which checks failed with severity labels (REQUIRED vs WARNING)
- Comment includes human-readable guidance on what to fix, plus a note about `--fix` for Claude Code users
- When `--fix` was attempted but didn't fully resolve, the comment notes that auto-fix was tried
- When a previously-failing issue passes, the old failure comment is edited to a brief "PASSED" message
- Existing automated comments are edited in place — never duplicated
- Comment is skipped on `--dry-run`

## Motivation

When `not-ready-to-solve` is applied without explanation, ticket authors don't know what needs fixing. This was observed on issues like [CNTRLPLANE-596](https://redhat.atlassian.net/browse/CNTRLPLANE-596) where the label was applied but the reason wasn't clear.

## Test plan

- [ ] Run `/jira:ready-to-solve <issue-key>` on an issue missing required sections — verify comment is posted with failed checks and severity labels
- [ ] Run `/jira:ready-to-solve <issue-key>` on a well-groomed issue — verify NO comment is posted (no prior failure comment to edit)
- [ ] Run `/jira:ready-to-solve <issue-key> --dry-run` on a failing issue — verify NO comment is posted
- [ ] Run `/jira:ready-to-solve <issue-key>` twice on the same failing issue — verify the existing comment is edited, not duplicated
- [ ] Run `/jira:ready-to-solve <issue-key> --fix` where fix partially fails — verify comment notes auto-fix was attempted
- [ ] Fix a previously-failing issue manually, re-run `/jira:ready-to-solve <issue-key>` — verify the failure comment is edited to show PASSED
- [ ] Run `make lint` — passes

## AI Assistance

```ai-assisted
Tool: Claude Code 2.1.126
Model: claude-opus-4-6

Skills used:
- superpowers:writing-plans@5.0.7 (anthropics/claude-plugins-official@a01a135f) — Implementation planning
- superpowers:executing-plans@5.0.7 (anthropics/claude-plugins-official@a01a135f) — Plan execution
- personal-claude-skills:grill-with-docs@0.1.0 (bryan-cox/personal-claude-skills@cd96dea7) — Documentation-based knowledge drilling
```