### PR TITLE
Add Task template to gcp-hcp skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     {
       "name": "ci",

--- a/docs/data.json
+++ b/docs/data.json
@@ -311,7 +311,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.4.3"
+      "version": "0.4.4"
     },
     {
       "commands": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/skills/gcp-hcp/CLAUDE.md
+++ b/plugins/jira/skills/gcp-hcp/CLAUDE.md
@@ -10,6 +10,7 @@ content from the upstream sources and reconcile any changes.
 |-------------------------------------------|--------------------------------------------|
 | Story Template structure                  | docs/jira-story-template.md               |
 | Story Sizing Guide (within story section) | docs/jira-story-template.md               |
+| Task Template structure                   | docs/jira-task-template.md                |
 | Priority Scheme (OJA-PRIS-001)            | *See note below*                           |
 | Epic Template structure                   | docs/jira-epic-template.md                |
 | Feature Template structure                | docs/jira-feature-template.md             |

--- a/plugins/jira/skills/gcp-hcp/CLAUDE.md
+++ b/plugins/jira/skills/gcp-hcp/CLAUDE.md
@@ -22,6 +22,7 @@ When this skill needs updating (upstream templates changed, new sections added):
 
 1. Fetch the latest content from each upstream file:
    - https://raw.githubusercontent.com/openshift-online/gcp-hcp/main/docs/jira-story-template.md
+   - https://raw.githubusercontent.com/openshift-online/gcp-hcp/main/docs/jira-task-template.md
    - https://raw.githubusercontent.com/openshift-online/gcp-hcp/main/docs/jira-epic-template.md
    - https://raw.githubusercontent.com/openshift-online/gcp-hcp/main/docs/jira-feature-template.md
    - https://raw.githubusercontent.com/openshift-online/gcp-hcp/main/docs/definition-of-done.md

--- a/plugins/jira/skills/gcp-hcp/SKILL.md
+++ b/plugins/jira/skills/gcp-hcp/SKILL.md
@@ -297,6 +297,47 @@ When splitting a large story, consider these approaches:
 
 ---
 
+### Task Template
+
+Source: [jira-task-template.md](https://github.com/openshift-online/gcp-hcp/blob/main/docs/jira-task-template.md)
+
+A finite piece of work to be completed. Great for tracking post-meeting follow-ups & action items. Fits within a single sprint.
+
+#### When to Use a Task
+
+**Use a Task for:**
+- Post-meeting follow-ups and action items
+- Finite pieces of work that fit within a single sprint
+- Specific, well-scoped work items that don't require user story format
+- Discrete deliverables or activities
+
+**Use a Story instead for:**
+- User-facing features or capabilities requiring user story format ("As a... I want... so that...")
+
+#### Context / Background
+
+[Why this work is needed, relevant history, links to meeting notes or related tickets]
+
+#### Requirements
+
+[What needs to be delivered or accomplished]
+
+#### Technical Approach
+
+[Proposed solution, major steps, or approach to completing this work]
+
+#### Dependencies
+
+[Blocking items: other tickets, required access/permissions, or external dependencies]
+
+#### Acceptance Criteria
+
+- [ ] [Specific testable outcome 1]
+- [ ] [Specific testable outcome 2]
+- [ ] [Specific testable outcome 3]
+
+---
+
 ### Epic Template
 
 Source: [jira-epic-template.md](https://github.com/openshift-online/gcp-hcp/blob/main/docs/jira-epic-template.md)

--- a/plugins/jira/skills/gcp-hcp/SKILL.md
+++ b/plugins/jira/skills/gcp-hcp/SKILL.md
@@ -21,6 +21,8 @@ This skill provides GCP HCP (Hypershift on GKE) team-specific conventions for cr
   - [JIRA Templates](#jira-templates)
     - [Story Template](#story-template)
       - [Story Sizing Guide](#story-sizing-guide)
+    - [Task Template](#task-template)
+      - [When to Use a Task](#when-to-use-a-task)
     - [Epic Template](#epic-template)
     - [Feature Template](#feature-template)
   - [Definition of Done](#definition-of-done)


### PR DESCRIPTION
## Summary
Update gcp-hcp skill to include the new Task template structure

## Description

Adds the Task template section to the `jira:gcp-hcp` skill, following the new template created in openshift-online/gcp-hcp.

### What's Changed

- **SKILL.md**: Added Task Template section with structure and usage guidance
- **CLAUDE.md**: Added `docs/jira-task-template.md` to upstream sources table

### Task Definition

Tasks are finite pieces of work that fit within a single sprint, great for tracking post-meeting follow-ups and action items.

## Related

- **Upstream PR**: https://github.com/openshift-online/gcp-hcp/pull/55
- **Jira**: https://redhat.atlassian.net/browse/GCP-607

## Notes

This PR references the upstream template file. The gcp-hcp PR should be merged first to ensure the upstream file exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Task Template to Jira conventions, with guidance on when to use Tasks and required sections (Context/Background, Requirements, Technical Approach, Dependencies, Acceptance Criteria).
  * Updated the table of contents and added an upstream Task Template mapping plus a sync step to fetch and update the template.
  * Minor numeric/formatting artifact introduced near the new section.
* **Chores**
  * Bumped Jira plugin version to 0.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->