### PR TITLE
fix: register ai-sbom plugin in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -225,6 +225,12 @@
       "source": "./plugins/console",
       "description": "OpenShift Console dynamic plugin development utilities",
       "version": "0.0.1"
+    },
+    {
+      "name": "ai-sbom",
+      "source": "./plugins/ai-sbom",
+      "description": "Generate AI Software Bill of Materials (SBOM) declarations for PR descriptions",
+      "version": "0.0.1"
     }
   ]
 }

--- a/docs/data.json
+++ b/docs/data.json
@@ -1738,6 +1738,21 @@
         }
       ],
       "version": "0.0.1"
+    },
+    {
+      "commands": [],
+      "description": "Generate AI Software Bill of Materials (SBOM) declarations for PR descriptions",
+      "has_readme": true,
+      "hooks": [],
+      "name": "ai-sbom",
+      "skills": [
+        {
+          "description": "Generate an AI SBOM declaration for a PR description. Use this skill when the user asks to generate an AI SBOM, create an ai-assisted block, fill out their AI assistance section, or prepare a PR description with AI provenance. Also use when the user says 'what skills did I use' or 'summarize my AI usage'.",
+          "id": "generate",
+          "name": "AI SBOM Generate"
+        }
+      ],
+      "version": "0.0.1"
     }
   ]
 }

--- a/plugins/ai-sbom/.claude-plugin/plugin.json
+++ b/plugins/ai-sbom/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-sbom",
+  "description": "Generate AI Software Bill of Materials (SBOM) declarations for PR descriptions",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/plugin.json` to the ai-sbom plugin so it's discoverable by the marketplace installer
- Add ai-sbom entry to `.claude-plugin/marketplace.json`
- Regenerate `docs/data.json` via `make update`

The ai-sbom plugin directory was merged in #441 but was missing the registration files, so `claude plugin install ai-sbom@ai-helpers` failed with "Plugin not found."

## Test plan
- [ ] `claude plugin marketplace update ai-helpers`
- [ ] `claude plugin install ai-sbom@ai-helpers` succeeds
- [ ] `/ai-sbom:generate` skill is available in sessions

## AI Assistance

```ai-assisted
Tool: Claude Code 2.1.126
Model: claude-opus-4-6

Skills used:
- superpowers:brainstorming@5.0.7 (anthropics/claude-plugins-official@a01a135f) — Collaborative design and spec creation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI Software Bill of Materials (SBOM) plugin (v0.0.1) with a generate skill for creating SBOM declarations and managing software component information in pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->