### PR TITLE
HPNEX-12: Add agent security scan GitHub Action

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,83 @@
+name: Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Prepare scan target
+        id: scan-target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            mkdir -p /tmp/scan-target
+            git diff --name-only --diff-filter=ACMR \
+              ${{ github.event.pull_request.base.sha }} \
+              ${{ github.sha }} | while IFS= read -r f; do
+              mkdir -p "/tmp/scan-target/$(dirname "$f")"
+              cp "$f" "/tmp/scan-target/$f"
+            done
+            touch /tmp/scan-target/.scanroot.md
+            echo "dir=/tmp/scan-target" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install scanner
+        run: pip install "cisco-ai-skill-scanner[vertex]>=2,<3"
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - name: Run security scan
+        env:
+          SKILL_SCANNER_LLM_MODEL: vertex_ai/claude-sonnet-4-6
+          VERTEXAI_LOCATION: global
+        run: |
+          skill-scanner scan-all \
+            --recursive \
+            --lenient \
+            --use-llm \
+            --fail-on-severity high \
+            --format sarif \
+            --output-sarif skill-scanner.sarif \
+            --format html \
+            --output-html skill-scanner-summary.html \
+            ${{ steps.scan-target.outputs.dir }}
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: success() || failure()
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: skill-scanner.sarif
+
+      - name: Upload results
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: security-scan-results
+          path: |
+            skill-scanner.sarif
+            skill-scanner-summary.html


### PR DESCRIPTION
## Summary

- Adds a GitHub Action that runs [cisco-ai-skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) on PRs and pushes to main
- Detects prompt injection, data exfiltration, command injection, and other agent security issues using both static YARA rules and LLM-based semantic analysis (Vertex AI / Claude Sonnet)
- Fails on high severity findings
- Uploads SARIF to GitHub Code Scanning for inline PR annotations and Security tab alerts

Example detection: https://github.com/openshift-eng/ai-helpers/pull/448#discussion_r3192506953


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated AI-based security scanning workflow that runs on main and pull requests, performs LLM-enabled scans, and produces SARIF/JSON/HTML reports uploaded to code scanning and build artifacts.

* **Documentation**
  * Removed unsafe/malicious instructions from a skill documentation file to eliminate potential security exposure and reduce risk if processed by tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->