### PR TITLE
Migrate lint workflow to skillsaw GitHub Action

### DIFF
--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -11,20 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Pull skillsaw Docker image
-        run: docker pull ghcr.io/stbenjam/skillsaw:main
 
       - name: Run skillsaw
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/workspace \
-            -w /workspace \
-            ghcr.io/stbenjam/skillsaw:main \
-            -v --strict
+        uses: stbenjam/skillsaw@63a422d073e055a8b03f5b83584451a419b7669b # v0
+        with:
+          strict: true
+          verbose: true


### PR DESCRIPTION
## Summary
- Replaces the Docker-based linting workflow with the [skillsaw](https://github.com/stbenjam/skillsaw) GitHub Action
- Posts inline PR review comments on violations with automatic cleanup when issues are fixed
- Simpler workflow config — no Docker build step needed

Example: in-line comments https://github.com/openshift-eng/ai-helpers/pull/456#discussion_r3208775087


## What changed
The `lint-plugins.yml` workflow now uses `stbenjam/skillsaw@v0` instead of building and running a Docker container. The action installs skillsaw via pip, runs the linter, and posts results as individual PR comments.

## Test plan
- [x] Verified inline comments appear on violations
- [x] Verified comments are resolved when violations are fixed
- [x] Verified summary comment appears for violations outside the diff
- [x] Verified summary comment is deleted when violations are fixed
- [x] Clean run with no violations exits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Lint Plugins CI workflow with enhanced permissions to support additional pull request operations.
  * Transitioned linting mechanism from manual Docker commands to GitHub Action-based approach with stricter validation enforcement and verbose output reporting.
  * Refined workflow checkout configuration for improved integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->