### PR TITLE
Add release-info plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -238,6 +238,12 @@
       "source": "./plugins/marketplace-ops",
       "description": "Maintenance commands for Claude Code plugin marketplaces",
       "version": "0.1.2"
+    },
+    {
+      "name": "release-info",
+      "source": "./plugins/release-info",
+      "description": "OCP release information: Product Pages schedules, PR-to-release tracing, and Cincinnati upgrade paths",
+      "version": "0.0.1"
     }
   ]
 }

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -35,6 +35,7 @@ rules:
   mcp-prohibited:
     allowlist:
     - gopls
+    - productpages
     enabled: true
     severity: error
   plugin-json-required:

--- a/docs/data.json
+++ b/docs/data.json
@@ -1790,6 +1790,31 @@
       "name": "marketplace-ops",
       "skills": [],
       "version": "0.1.2"
+    },
+    {
+      "commands": [],
+      "description": "OCP release information: Product Pages schedules, PR-to-release tracing, and Cincinnati upgrade paths",
+      "has_readme": true,
+      "hooks": [],
+      "name": "release-info",
+      "skills": [
+        {
+          "description": "Traces a GitHub PR to the first OCP z-stream release that shipped it. Auto-applies when asked which release contains a PR, when a PR or commit shipped, or to find a PR in a z-stream payload.",
+          "id": "pr-to-release-version",
+          "name": "PR to Release Version"
+        },
+        {
+          "description": "Generates a link to the interactive OpenShift update graph visualizer for a specific channel. Auto-applies when asked to show, visualize, or display the upgrade graph for an OCP version or channel.",
+          "id": "update-graph",
+          "name": "OCP Update Graph Visualizer"
+        },
+        {
+          "description": "Queries Cincinnati to find available OCP upgrade paths from a given version. Auto-applies when asked about upgrade paths, whether a version can upgrade to another, what updates are available, or if a z-stream is in a specific channel.",
+          "id": "upgrade-path",
+          "name": "OCP Upgrade Path"
+        }
+      ],
+      "version": "0.0.1"
     }
   ]
 }

--- a/plugins/release-info/.claude-plugin/plugin.json
+++ b/plugins/release-info/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "release-info",
+  "description": "OCP release information: Product Pages schedules, PR-to-release tracing, and Cincinnati upgrade paths",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/release-info/.mcp.json
+++ b/plugins/release-info/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "productpages": {
+      "type": "http",
+      "url": "https://productpages.redhat.com/mcp",
+      "headers": {
+        "X-MCP-Realm": "urn:mcp:realm:private-core"
+      }
+    }
+  }
+}

--- a/plugins/release-info/README.md
+++ b/plugins/release-info/README.md
@@ -1,0 +1,70 @@
+# release-info
+
+OCP release information plugin providing:
+
+- **Product Pages MCP** — queries Red Hat Product Pages for release schedules, milestones, GA dates, and program contacts
+- **PR to Release Version** — traces a GitHub PR to the first OCP z-stream release that shipped it
+- **Upgrade Path** — queries Cincinnati to find available OCP upgrade paths from a given version
+- **Update Graph Visualizer** — generates links to the interactive upgrade graph visualizer
+
+## Examples
+
+Ask in natural language — the plugin picks the right tool automatically.
+
+### Release schedules and milestones (Product Pages)
+
+- "When is the GA date for OCP 4.18?"
+- "What's the feature freeze date for 4.17?"
+- "Show me the full schedule for OCP 4.21"
+- "Who is the TPM for OpenShift Container Platform?"
+- "What releases are currently in development?"
+- "List all OCP releases under maintenance"
+
+### Tracing a PR to a release (pr-to-release-version)
+
+- "Which z-stream shipped PR https://github.com/openshift/hypershift/pull/7685 in 4.21?"
+- "Has PR #1893 from cluster-kube-apiserver-operator landed in any 4.17 z-stream?"
+- "When did the fix for OCPBUGS-76447 ship?"
+
+### Upgrade paths (upgrade-path)
+
+- "What upgrades are available from 4.16.3?"
+- "Can a cluster on 4.16.3 upgrade to 4.17.8?"
+- "Is 4.17.12 in the stable channel?"
+- "Show upgrade paths from 4.14.10 on arm64"
+- "What EUS upgrade options exist from 4.14.35?"
+
+### Upgrade graph visualization (update-graph)
+
+- "Show me the upgrade graph for 4.17"
+- "Visualize the fast channel for 4.16"
+- "Show the candidate graph for 4.18"
+
+### Combining tools
+
+- "My fix is in PR #7685 on openshift/hypershift. Has it shipped in 4.21, and can customers on 4.21.10 upgrade to get it?"
+- "When is 4.18 GA, and what does the current upgrade graph look like for the stable channel?"
+
+## Skills
+
+### product-pages (MCP)
+
+Connects to the Red Hat Product Pages MCP server, providing access to release schedules, milestones, lifecycle phases, and program contacts. Authentication is handled via browser-based OIDC flow on first use.
+
+**Prerequisites:** Red Hat SSO credentials (Kerberos/OIDC).
+
+### pr-to-release-version
+
+Determines which OCP z-stream release first shipped a given GitHub PR. Works for any repo that ships a component in the OCP release payload.
+
+**Prerequisites:** `oc`, `gh` (authenticated), `jq`, `curl`, and a pull secret with access to `quay.io/openshift-release-dev`.
+
+### upgrade-path
+
+Queries the Cincinnati update graph API to find available upgrade paths from a given OCP version. Supports channel selection, architecture filtering, and reachability checks to specific target versions.
+
+**Prerequisites:** `curl`, `jq` (no authentication needed).
+
+### update-graph
+
+Generates a direct link to the interactive OpenShift update graph visualizer pre-selecting the relevant channel. Supports stable, fast, candidate, and EUS channels.

--- a/plugins/release-info/skills/pr-to-release-version/SKILL.md
+++ b/plugins/release-info/skills/pr-to-release-version/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: PR to Release Version
+description: "Traces a GitHub PR to the first OCP z-stream release that shipped it. Auto-applies when asked which release contains a PR, when a PR or commit shipped, or to find a PR in a z-stream payload."
+---
+
+# PR to Release Version
+
+Determines which OCP z-stream release first shipped a given GitHub PR. Works for PRs from any repo that ships a component in the OCP release payload.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- Asked which OCP release contains a specific PR
+- Asked when a PR or commit was shipped
+- Tracing a bug fix to a z-stream release
+- Checking if a PR landed in a specific OCP version
+
+## How to Run
+
+Run the script at `${CLAUDE_PLUGIN_ROOT}/skills/pr-to-release-version/pr-to-release-version.sh`:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/pr-to-release-version/pr-to-release-version.sh" <pr-url-or-number> <minor-version> [--repo <org/repo>]
+```
+
+### Examples
+
+```bash
+# Full PR URL (repo extracted automatically)
+bash "${CLAUDE_PLUGIN_ROOT}/skills/pr-to-release-version/pr-to-release-version.sh" https://github.com/openshift/hypershift/pull/7685 4.21
+
+# PR number with explicit repo
+bash "${CLAUDE_PLUGIN_ROOT}/skills/pr-to-release-version/pr-to-release-version.sh" 7685 4.21 --repo openshift/hypershift
+
+# Different repo
+bash "${CLAUDE_PLUGIN_ROOT}/skills/pr-to-release-version/pr-to-release-version.sh" https://github.com/openshift/cluster-kube-apiserver-operator/pull/1893 4.17
+```
+
+### Input
+
+- **PR**: A GitHub PR URL or number. If using a number, `--repo` is required.
+- **Minor version**: The user must provide the target OCP minor version (e.g., `4.17`). If not provided, ask for it before running. A PR can ship in multiple streams via cherrypicks, so this cannot be inferred.
+
+### Output
+
+The script prints a structured result to stdout and progress to stderr:
+
+```text
+PR: #7685 (OCPBUGS-76447: Add UserAgent telemetry to CPO Azure SDK clients)
+Merged: 2026-04-28 to release-4.21
+Component: hypershift
+First z-stream: 4.21.13
+Payload commit: 6202ab927f91ca188e621b62c802d8f3e5de1c48
+Verification: https://github.com/openshift/hypershift/compare/6202ab92...6202ab92
+```
+
+Report the result to the user. If the script exits with an error, report the error message.
+
+### Prerequisites
+
+The script requires `oc`, `gh` (authenticated), `jq`, and `curl`. It also needs a pull secret with access to `quay.io/openshift-release-dev`. The script auto-discovers pull secrets from: `$PULL_SECRET`, `~/pull-secret.txt`, `~/pull-secret.json`, `~/.docker/config.json`, `$XDG_RUNTIME_DIR/containers/auth.json`, `~/.config/containers/auth.json`.
+
+### How It Works
+
+1. Gets the PR merge commit via `gh pr view`
+2. Maps the repo to an OCP payload component using `oc adm release info` image annotations
+3. Binary searches across accepted z-streams (~6 iterations for ~60 releases) using `gh api compare` to find the first z-stream that includes the merge commit

--- a/plugins/release-info/skills/pr-to-release-version/pr-to-release-version.sh
+++ b/plugins/release-info/skills/pr-to-release-version/pr-to-release-version.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_CONTROLLER="https://amd64.ocp.releases.ci.openshift.org"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <pr-url-or-number> <minor-version> [--repo <org/repo>]
+
+Examples:
+  $(basename "$0") 7685 4.21 --repo openshift/hypershift
+  $(basename "$0") https://github.com/openshift/cluster-kube-apiserver-operator/pull/1893 4.17
+
+Arguments:
+  pr-url-or-number  GitHub PR URL or number
+  minor-version     OCP minor version (e.g., 4.17, 4.21)
+  --repo            Required when using a PR number instead of a full URL
+EOF
+  exit 1
+}
+
+die() { echo "Error: $*" >&2; exit 1; }
+info() { echo "$*" >&2; }
+
+# --- Argument parsing ---
+[[ $# -lt 2 ]] && usage
+
+PR_INPUT="$1"
+MINOR="$2"
+shift 2
+
+REPO=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) [[ $# -lt 2 ]] && die "--repo requires an argument"; REPO="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+if [[ "$PR_INPUT" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  REPO="${BASH_REMATCH[1]}"
+  PR_NUMBER="${BASH_REMATCH[2]}"
+else
+  PR_NUMBER="$PR_INPUT"
+  [[ -z "$REPO" ]] && die "--repo is required when using a PR number"
+fi
+
+[[ "$MINOR" =~ ^4\.[0-9]+$ ]] || die "minor version must be like 4.17, got: $MINOR"
+
+# --- Tool validation ---
+for cmd in oc gh jq curl; do
+  command -v "$cmd" &>/dev/null || die "$cmd is required but not found"
+done
+
+# --- Pull secret discovery ---
+PULL_SECRET_PATH=""
+for f in "${PULL_SECRET:-}" "$HOME/pull-secret.txt" "$HOME/pull-secret.json" "$HOME/.docker/config.json" "${XDG_RUNTIME_DIR:-}/containers/auth.json" "$HOME/.config/containers/auth.json"; do
+  [[ -n "$f" ]] && [[ -f "$f" ]] && PULL_SECRET_PATH="$f" && break
+done
+[[ -z "$PULL_SECRET_PATH" ]] && die "No pull secret found. Set \$PULL_SECRET or place one at ~/pull-secret.txt"
+
+# --- Step 1: PR info ---
+info "Fetching PR #${PR_NUMBER} from ${REPO}..."
+PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeCommit,state,mergedAt,baseRefName,title)
+PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+[[ "$PR_STATE" != "MERGED" ]] && die "PR #${PR_NUMBER} is ${PR_STATE}, not merged"
+
+MERGE_SHA=$(echo "$PR_JSON" | jq -r '.mergeCommit.oid')
+MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt')
+PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+PR_BASE=$(echo "$PR_JSON" | jq -r '.baseRefName')
+
+info "PR #${PR_NUMBER}: ${PR_TITLE}"
+info "Merged: ${MERGED_AT} to ${PR_BASE} (${MERGE_SHA:0:12})"
+
+# --- Step 2: Component mapping ---
+info "Fetching release stream tags..."
+TAGS_JSON=$(curl -sf "${RELEASE_CONTROLLER}/api/v1/releasestream/4-stable/tags") \
+  || die "Failed to fetch release stream from ${RELEASE_CONTROLLER}"
+
+LATEST_PULLSPEC=$(echo "$TAGS_JSON" | jq -r --arg m "${MINOR}." \
+  '[.tags[] | select(.name | startswith($m))] | .[0].pullSpec')
+[[ -z "$LATEST_PULLSPEC" || "$LATEST_PULLSPEC" == "null" ]] && die "No releases found for ${MINOR}"
+
+info "Building repo-to-component mapping from ${LATEST_PULLSPEC}..."
+REPO_URL="https://github.com/${REPO}"
+COMPONENT=$(oc adm release info "$LATEST_PULLSPEC" -a "$PULL_SECRET_PATH" --output=json | \
+  jq -r --arg repo "$REPO_URL" \
+  '[.references.spec.tags[] |
+    select(.annotations["io.openshift.build.source-location"] == $repo)] |
+    .[0].name')
+[[ -z "$COMPONENT" || "$COMPONENT" == "null" ]] && die "${REPO} is not a component in the OCP ${MINOR} payload"
+
+info "Component: ${COMPONENT}"
+
+# --- Step 3: Enumerate z-streams ---
+ZSTREAMS=$(echo "$TAGS_JSON" | jq -c --arg m "${MINOR}." \
+  '[.tags[] | select(.name | startswith($m)) | select(.phase == "Accepted")] |
+   reverse | [.[] | {name: .name, pullSpec: .pullSpec}]')
+ZSTREAM_COUNT=$(echo "$ZSTREAMS" | jq 'length')
+[[ "$ZSTREAM_COUNT" -eq 0 ]] && die "No accepted z-streams found for ${MINOR}"
+
+info "Found ${ZSTREAM_COUNT} accepted z-streams"
+
+# --- Step 4: Binary search ---
+check_inclusion() {
+  local pullspec="$1"
+  local payload_commit
+  payload_commit=$(oc adm release info "$pullspec" -a "$PULL_SECRET_PATH" --output=json | \
+    jq -r --arg c "$COMPONENT" \
+    '.references.spec.tags[] | select(.name == $c) | .annotations["io.openshift.build.commit.id"]')
+
+  if [[ -z "$payload_commit" || "$payload_commit" == "null" ]]; then
+    echo "skip"
+    return
+  fi
+
+  echo "$payload_commit"
+}
+
+compare_commits() {
+  local payload_commit="$1"
+  gh api "repos/${REPO}/compare/${MERGE_SHA}...${payload_commit}" --jq '.status' 2>/dev/null || echo "error"
+}
+
+lo=0
+hi=$((ZSTREAM_COUNT - 1))
+result_idx=-1
+result_commit=""
+
+while [[ $lo -le $hi ]]; do
+  mid=$(( (lo + hi) / 2 ))
+  zname=$(echo "$ZSTREAMS" | jq -r ".[$mid].name")
+  zpull=$(echo "$ZSTREAMS" | jq -r ".[$mid].pullSpec")
+
+  payload_commit=$(check_inclusion "$zpull")
+  if [[ "$payload_commit" == "skip" ]]; then
+    info "Checking ${zname}... component not found, skipping"
+    lo=$((mid + 1))
+    continue
+  fi
+
+  status=$(compare_commits "$payload_commit")
+  case "$status" in
+    identical|ahead)
+      info "Checking ${zname}... included"
+      result_idx=$mid
+      result_commit="$payload_commit"
+      hi=$((mid - 1))
+      ;;
+    behind)
+      info "Checking ${zname}... not included"
+      lo=$((mid + 1))
+      ;;
+    diverged)
+      info "Checking ${zname}... diverged (commit not on release branch)"
+      lo=$((mid + 1))
+      ;;
+    *)
+      info "Checking ${zname}... error comparing commits"
+      lo=$((mid + 1))
+      ;;
+  esac
+done
+
+# --- Step 5: Report ---
+echo ""
+if [[ $result_idx -lt 0 ]]; then
+  echo "PR: #${PR_NUMBER} (${PR_TITLE})"
+  echo "Merged: ${MERGED_AT} to ${PR_BASE}"
+  echo "Component: ${COMPONENT}"
+  echo "Result: NOT YET SHIPPED in any ${MINOR} z-stream"
+  exit 0
+fi
+
+FIRST_ZSTREAM=$(echo "$ZSTREAMS" | jq -r ".[$result_idx].name")
+info "→ First shipped in ${FIRST_ZSTREAM}"
+echo ""
+echo "PR: #${PR_NUMBER} (${PR_TITLE})"
+echo "Merged: ${MERGED_AT} to ${PR_BASE}"
+echo "Component: ${COMPONENT}"
+echo "First z-stream: ${FIRST_ZSTREAM}"
+echo "Payload commit: ${result_commit}"
+echo "Verification: https://github.com/${REPO}/compare/${MERGE_SHA}...${result_commit}"

--- a/plugins/release-info/skills/update-graph/SKILL.md
+++ b/plugins/release-info/skills/update-graph/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: OCP Update Graph Visualizer
+description: "Generates a link to the interactive OpenShift update graph visualizer for a specific channel. Auto-applies when asked to show, visualize, or display the upgrade graph for an OCP version or channel."
+---
+
+# OCP Update Graph Visualizer
+
+Generates a direct link to the interactive OpenShift update graph visualizer at `ctron.github.io/openshift-update-graph`, pre-selecting the relevant channel.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- Asked to show or visualize the OCP upgrade graph
+- Asked to display upgrade paths graphically
+- Following up on upgrade path queries with a visual
+- Asked "show me the graph for 4.17"
+
+## How to Respond
+
+Construct the URL using the pattern:
+
+```text
+https://ctron.github.io/openshift-update-graph#<channel>
+```
+
+### Channel Format
+
+Channels follow the pattern `<type>-<minor>`:
+- `stable-4.17` — production-ready releases
+- `fast-4.17` — early access before stable promotion
+- `candidate-4.17` — release candidates
+- `eus-4.14` — Extended Update Support
+
+### Examples
+
+| User asks | URL |
+|-----------|-----|
+| "Show me the upgrade graph for 4.17" | `https://ctron.github.io/openshift-update-graph#stable-4.17` |
+| "Visualize fast channel for 4.16" | `https://ctron.github.io/openshift-update-graph#fast-4.16` |
+| "Show candidate graph for 4.18" | `https://ctron.github.io/openshift-update-graph#candidate-4.18` |
+| "EUS upgrade graph for 4.14" | `https://ctron.github.io/openshift-update-graph#eus-4.14` |
+
+### Behavior
+
+1. Default to `stable` channel unless the user specifies otherwise
+2. Present the link to the user and suggest they open it in a browser
+3. If the user was just querying upgrade paths with the `upgrade-path` skill, include the matching graph link automatically
+4. The visualizer supports Classic, Layered DAG, and Tangled Tree views — mention this if the user wants different perspectives on the graph

--- a/plugins/release-info/skills/upgrade-path/SKILL.md
+++ b/plugins/release-info/skills/upgrade-path/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: OCP Upgrade Path
+description: "Queries Cincinnati to find available OCP upgrade paths from a given version. Auto-applies when asked about upgrade paths, whether a version can upgrade to another, what updates are available, or if a z-stream is in a specific channel."
+---
+
+# OCP Upgrade Path
+
+Queries the Cincinnati update graph API to find available upgrade paths from a given OCP version.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- Asked what upgrades are available from a specific OCP version
+- Asked whether a cluster can upgrade from version X to version Y
+- Checking if a z-stream is reachable via upgrade from a given version
+- Checking which channel a release is in (candidate, fast, stable)
+- Asked about OCP upgrade compatibility
+
+## How to Run
+
+Run the script at `${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh`:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh" <version> [--channel <channel>] [--arch <arch>] [--to <target>]
+```
+
+### Examples
+
+```bash
+# All upgrades from 4.16.3 in stable-4.16
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh" 4.16.3
+
+# Cross-minor upgrades via fast channel
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh" 4.16.3 --channel fast-4.17
+
+# Check if a specific target is reachable
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh" 4.16.3 --channel stable-4.17 --to 4.17.8
+
+# ARM architecture
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upgrade-path/upgrade-path.sh" 4.16.3 --arch arm64
+```
+
+### Input
+
+- **version** (required): Source OCP version (e.g., `4.16.3`)
+- **--channel** (optional): Cincinnati channel. Defaults to `stable-<minor>` derived from the version. Common channels: `candidate-4.X`, `fast-4.X`, `stable-4.X`, `eus-4.X`
+- **--arch** (optional): Cluster architecture. Defaults to `amd64`. Options: `amd64`, `arm64`, `s390x`, `ppc64le`, `multi`
+- **--to** (optional): Check reachability to a specific target version
+
+### Output
+
+Tab-separated list of available target versions with their payload pullspec and errata URL.
+
+When `--to` is used, reports whether the specific upgrade path exists.
+
+### Prerequisites
+
+Requires `curl` and `jq`. No authentication needed — queries the public Cincinnati API.
+
+### Complementary Tools
+
+After finding that a fix shipped in a z-stream (via `pr-to-release-version`), use this skill to verify customers can actually upgrade to that release.
+
+After querying upgrade paths, suggest the interactive graph visualizer for the relevant channel: `https://ctron.github.io/openshift-update-graph#<channel>`

--- a/plugins/release-info/skills/upgrade-path/upgrade-path.sh
+++ b/plugins/release-info/skills/upgrade-path/upgrade-path.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UPSTREAM="${UPSTREAM:-https://api.openshift.com/api/upgrades_info/graph}"
+ARCH="${ARCH:-amd64}"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $(basename "$0") <version> [--channel <channel>] [--arch <arch>] [--to <target-version>]
+
+Query Cincinnati for available upgrade paths from a given OCP version.
+
+Examples:
+  $(basename "$0") 4.16.3
+  $(basename "$0") 4.16.3 --channel fast-4.17
+  $(basename "$0") 4.16.3 --channel stable-4.17 --to 4.17.8
+  $(basename "$0") 4.16.3 --arch arm64
+
+Arguments:
+  version              Source OCP version (e.g., 4.16.3)
+  --channel <channel>  Graph channel (default: stable-<minor> derived from version)
+  --arch <arch>        Cluster architecture (default: amd64)
+  --to <target>        Filter results to show only a specific target version
+EOF
+  exit 1
+}
+
+die() { echo "Error: $*" >&2; exit 1; }
+info() { echo "$*" >&2; }
+
+[[ $# -lt 1 ]] && usage
+
+VERSION="$1"
+shift
+
+CHANNEL=""
+TARGET=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel) [[ $# -lt 2 ]] && die "--channel requires an argument"; CHANNEL="$2"; shift 2 ;;
+    --arch) [[ $# -lt 2 ]] && die "--arch requires an argument"; ARCH="$2"; shift 2 ;;
+    --to) [[ $# -lt 2 ]] && die "--to requires an argument"; TARGET="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be like 4.16.3, got: $VERSION"
+
+if [[ -z "$CHANNEL" ]]; then
+  MINOR="${VERSION%.*}"
+  CHANNEL="stable-${MINOR}"
+fi
+
+for cmd in curl jq; do
+  command -v "$cmd" &>/dev/null || die "$cmd is required but not found"
+done
+
+OUTPUT=$(mktemp)
+trap 'rm -f "$OUTPUT"' EXIT
+
+info "Querying Cincinnati: channel=${CHANNEL} arch=${ARCH} from=${VERSION}"
+
+if ! curl --silent --location --fail --header 'Accept:application/json' \
+  "${UPSTREAM}?channel=${CHANNEL}&arch=${ARCH}" -o "$OUTPUT"; then
+  die "Failed to fetch graph from ${UPSTREAM} (channel=${CHANNEL})"
+fi
+
+NODE_COUNT=$(jq '.nodes | length' "$OUTPUT")
+EDGE_COUNT=$(jq '.edges | length' "$OUTPUT")
+info "Graph: ${NODE_COUNT} nodes, ${EDGE_COUNT} edges"
+
+SOURCE_EXISTS=$(jq -r --arg v "$VERSION" '[.nodes[] | select(.version == $v)] | length' "$OUTPUT")
+if [[ "$SOURCE_EXISTS" -eq 0 ]]; then
+  echo "Version ${VERSION} not found in channel ${CHANNEL}"
+  echo ""
+  echo "Available versions in ${CHANNEL}:"
+  jq -r '[.nodes[].version] | sort_by(split(".") | map(tonumber))[]' "$OUTPUT" | tail -10
+  exit 1
+fi
+
+if [[ -n "$TARGET" ]]; then
+  RESULT=$(jq -r --arg src "$VERSION" --arg tgt "$TARGET" '
+    (.nodes | to_entries | map({key: (.key | tostring), value: .value}) | from_entries) as $idx |
+    [.edges[] |
+      select($idx[(.[0] | tostring)].version == $src) |
+      select($idx[(.[1] | tostring)].version == $tgt) |
+      $idx[(.[1] | tostring)]
+    ] | if length > 0 then
+      .[0] | "REACHABLE: " + .version + "\t" + .payload + "\t" + (.metadata.url // "-")
+    else
+      "NOT REACHABLE: No direct upgrade path from " + $src + " to " + $tgt + " in channel " + "'"${CHANNEL}"'"
+    end
+  ' "$OUTPUT")
+  echo "$RESULT"
+else
+  echo "Available upgrades from ${VERSION} in ${CHANNEL}:"
+  echo ""
+  jq -r --arg src "$VERSION" '
+    (.nodes | to_entries | map({key: (.key | tostring), value: .value}) | from_entries) as $idx |
+    [.edges[] |
+      select($idx[(.[0] | tostring)].version == $src)[1] |
+      tostring | $idx[.]
+    ] | sort_by(.version | split(".") | map(tonumber))[] |
+    .version + "\t" + .payload + "\t" + (.metadata.url // "-")
+  ' "$OUTPUT"
+fi
+
+TOTAL=$(jq -r --arg src "$VERSION" '
+  (.nodes | to_entries | map({key: (.key | tostring), value: .value}) | from_entries) as $idx |
+  [.edges[] | select($idx[(.[0] | tostring)].version == $src)] | length
+' "$OUTPUT")
+info ""
+info "Total: ${TOTAL} available upgrade(s) from ${VERSION}"
+info "Graph visualizer: https://ctron.github.io/openshift-update-graph#${CHANNEL}"


### PR DESCRIPTION
## Summary

- Adds `release-info` plugin with four capabilities for OCP release lifecycle queries:
  - **Product Pages MCP** server for schedules, milestones, GA dates, and contacts
  - **pr-to-release-version** skill to trace a GitHub PR to its first shipped z-stream
  - **upgrade-path** skill to query Cincinnati for available upgrade paths between versions
  - **update-graph** skill to generate links to the interactive upgrade graph visualizer

## Examples

Ask in natural language — the plugin picks the right tool automatically.

### Release schedules and milestones (Product Pages)

- "When is the GA date for OCP 4.18?"
- "What's the feature freeze date for 4.17?"
- "Show me the full schedule for OCP 4.21"
- "Who is the TPM for OpenShift Container Platform?"
- "What releases are currently in development?"

### Tracing a PR to a release (pr-to-release-version)

- "Which z-stream shipped PR https://github.com/openshift/hypershift/pull/7685 in 4.21?"
- "Has PR #1893 from cluster-kube-apiserver-operator landed in any 4.17 z-stream?"
- "When did the fix for OCPBUGS-76447 ship?"

### Upgrade paths (upgrade-path)

- "What upgrades are available from 4.16.3?"
- "Can a cluster on 4.16.3 upgrade to 4.17.8?"
- "Is 4.17.12 in the stable channel?"
- "Show upgrade paths from 4.14.10 on arm64"

### Upgrade graph visualization (update-graph)

- "Show me the upgrade graph for 4.17"
- "Visualize the fast channel for 4.16"

### Combining tools

- "My fix is in PR #7685 on openshift/hypershift. Has it shipped in 4.21, and can customers on 4.21.10 upgrade to get it?"
- "When is 4.18 GA, and what does the current upgrade graph look like for the stable channel?"

## Test plan

- [ ] Enable the plugin and verify Product Pages MCP tools are available after auth
- [ ] Run `pr-to-release-version` with a known merged PR and verify correct z-stream output
- [ ] Run `upgrade-path` with a known version and verify Cincinnati results
- [ ] Ask for upgrade graph visualization and verify correct `ctron.github.io` URL is generated
- [ ] Verify `make lint` passes with zero errors and warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced `release-info` plugin with three capabilities: trace GitHub PRs to their first shipped OCP z-stream release, query OpenShift upgrade paths and available updates, and generate links to the interactive OCP update graph visualizer.

* **Documentation**
  - Added comprehensive documentation for the release-info plugin and its skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->