### PR TITLE
Bigquery ci-data command, test porting agent, several fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,9 @@
   "owner": {
     "name": "openshift-eng"
   },
-  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
+  "allowCrossMarketplaceDependenciesOn": [
+    "claude-plugins-official"
+  ],
   "plugins": [
     {
       "name": "git",
@@ -33,7 +35,7 @@
       "name": "teams",
       "source": "./plugins/teams",
       "description": "Team structure knowledge and health analysis commands for OpenShift teams",
-      "version": "0.0.13"
+      "version": "0.0.14"
     },
     {
       "name": "doc",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.39"
+      "version": "0.0.40"
     },
     {
       "name": "teams",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -189,7 +189,7 @@
       "name": "bigquery",
       "source": "./plugins/bigquery",
       "description": "BigQuery analysis utilities",
-      "version": "0.0.2"
+      "version": "0.0.4"
     },
     {
       "name": "workspaces",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -87,6 +87,7 @@ Tools for working with OpenShift CI and analyzing Prow job results
 - **`/ci:list-unstable-tests` `<version> <keywords> [sippy-url]`** - List unstable tests with pass rate below 95%
 - **`/ci:payload-experiment` `<payload-tag>`** - Open draft revert PRs for medium-confidence payload candidates and trigger payload jobs to experimentally determine which PR is causing failures
 - **`/ci:payload-revert` `<payload-tag>`** - Stage reverts for high-confidence payload candidates identified by analyze-payload
+- **`/ci:port-tests` `<count> [--from <subdir>] [--to <org/repo>]`** - Port tests from openshift-tests-private to openshift/origin
 - **`/ci:query-job-status` `<execution-id>`** - Query the status of a gangway job execution by ID
 - **`/ci:query-test-result` `<version> <keywords> [sippy-url]`** - Query test results from Sippy by version and test keywords
 - **`/ci:revert-pr` `<pr-url> <jira-ticket>`** - Revert a merged PR that is breaking CI or nightly payloads

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -87,7 +87,6 @@ Tools for working with OpenShift CI and analyzing Prow job results
 - **`/ci:list-unstable-tests` `<version> <keywords> [sippy-url]`** - List unstable tests with pass rate below 95%
 - **`/ci:payload-experiment` `<payload-tag>`** - Open draft revert PRs for medium-confidence payload candidates and trigger payload jobs to experimentally determine which PR is causing failures
 - **`/ci:payload-revert` `<payload-tag>`** - Stage reverts for high-confidence payload candidates identified by analyze-payload
-- **`/ci:port-tests` `<count> [--from <subdir>] [--to <org/repo>]`** - Port tests from openshift-tests-private to openshift/origin
 - **`/ci:query-job-status` `<execution-id>`** - Query the status of a gangway job execution by ID
 - **`/ci:query-test-result` `<version> <keywords> [sippy-url]`** - Query test results from Sippy by version and test keywords
 - **`/ci:revert-pr` `<pr-url> <jira-ticket>`** - Revert a merged PR that is breaking CI or nightly payloads
@@ -397,11 +396,11 @@ Team structure knowledge and health analysis commands for OpenShift teams
 - **`/teams:coderabbit-inheritance-scanner` `[--dry-run]`** - Scan openshift org repos for .coderabbit.yaml/.coderabbit.yml files missing inheritance
 - **`/teams:coderabbit-rules-from-pr-reviews` `<repo> [--count N]`** - Analyze PR review comments to propose CodeRabbit rules for a repository
 - **`/teams:health-check-jiras` `--project <project> [--component comp1 comp2 ...] [--team <team-name>] [--status status1 status2 ...] [--include-closed] [--limit N]`** - Query and summarize JIRA bugs for a specific project with counts by component
-- **`/teams:health-check-regressions` `<release> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`** - Query and summarize regression data for OpenShift releases with counts and metrics
+- **`/teams:health-check-regressions` `<view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`** - Query and summarize regression data for OpenShift releases with counts and metrics
 - **`/teams:health-check` `<release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]`** - Analyze and grade component health based on regression and JIRA bug metrics
 - **`/teams:list-components` `[--team <team-name>]`** - List all OCPBUGS components, optionally filtered by team
 - **`/teams:list-jiras` `<project> [--component comp1 comp2 ...] [--status status1 status2 ...] [--include-closed] [--limit N]`** - Query and list raw JIRA bug data for a specific project
-- **`/teams:list-regressions` `<release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`** - Fetch and list raw regression data for OpenShift releases
+- **`/teams:list-regressions` `<view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`** - Fetch and list raw regression data for OpenShift releases
 - **`/teams:list-teams`** - List all teams from the team component mapping
 
 See [plugins/teams/README.md](plugins/teams/README.md) for detailed documentation.

--- a/docs/data.json
+++ b/docs/data.json
@@ -748,7 +748,7 @@
           "name": "Summarize JIRAs"
         }
       ],
-      "version": "0.0.13"
+      "version": "0.0.14"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -644,13 +644,13 @@
           "argument_hint": "<view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
           "description": "Query and summarize regression data for OpenShift releases with counts and metrics",
           "name": "health-check-regressions",
-          "synopsis": "/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
+          "synopsis": "/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
         },
         {
           "argument_hint": "<release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]",
           "description": "Analyze and grade component health based on regression and JIRA bug metrics",
           "name": "health-check",
-          "synopsis": "/teams:health-check <release> [--components comp1 comp2 ...] [--project JIRAPROJECT]"
+          "synopsis": "/teams:health-check <release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]"
         },
         {
           "argument_hint": "[--team <team-name>]",

--- a/docs/data.json
+++ b/docs/data.json
@@ -430,6 +430,12 @@
           "synopsis": "/ci:payload-revert <payload-tag>"
         },
         {
+          "argument_hint": "<count> [--from <subdir>] [--to <org/repo>]",
+          "description": "Port tests from openshift-tests-private to openshift/origin",
+          "name": "port-tests",
+          "synopsis": "/ci:port-tests <count> [--from <subdir>] [--to <org/repo>]"
+        },
+        {
           "argument_hint": "<execution-id>",
           "description": "Query the status of a gangway job execution by ID",
           "name": "query-job-status",

--- a/docs/data.json
+++ b/docs/data.json
@@ -1604,9 +1604,14 @@
           "description": "Comprehensive analysis of BigQuery usage patterns, costs, and query performance",
           "id": "analyze-usage",
           "name": "Analyze BigQuery Usage"
+        },
+        {
+          "description": "Safely query and report on OpenShift CI prow job and test data in BigQuery with cost controls, dry-run validation, and local caching of results",
+          "id": "ci-data-analyst",
+          "name": "CI Data Analyst"
         }
       ],
-      "version": "0.0.2"
+      "version": "0.0.4"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -612,7 +612,7 @@
           "name": "Trigger Payload Job"
         }
       ],
-      "version": "0.0.39"
+      "version": "0.0.40"
     },
     {
       "commands": [
@@ -644,13 +644,13 @@
           "argument_hint": "<view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
           "description": "Query and summarize regression data for OpenShift releases with counts and metrics",
           "name": "health-check-regressions",
-          "synopsis": "/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
+          "synopsis": "/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
         },
         {
           "argument_hint": "<release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]",
           "description": "Analyze and grade component health based on regression and JIRA bug metrics",
           "name": "health-check",
-          "synopsis": "/teams:health-check <release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]"
+          "synopsis": "/teams:health-check <release> [--components comp1 comp2 ...] [--project JIRAPROJECT]"
         },
         {
           "argument_hint": "[--team <team-name>]",

--- a/docs/data.json
+++ b/docs/data.json
@@ -430,12 +430,6 @@
           "synopsis": "/ci:payload-revert <payload-tag>"
         },
         {
-          "argument_hint": "<count> [--from <subdir>] [--to <org/repo>]",
-          "description": "Port tests from openshift-tests-private to openshift/origin",
-          "name": "port-tests",
-          "synopsis": "/ci:port-tests <count> [--from <subdir>] [--to <org/repo>]"
-        },
-        {
           "argument_hint": "<execution-id>",
           "description": "Query the status of a gangway job execution by ID",
           "name": "query-job-status",
@@ -477,6 +471,11 @@
       "hooks": [],
       "name": "ci",
       "skills": [
+        {
+          "description": "Add a Component Readiness triage record link to a JIRA issue description",
+          "id": "add-jira-triage-link",
+          "name": "Add JIRA Triage Link"
+        },
         {
           "description": "Analyze and compare disruption across one or more Prow CI job runs by examining interval data, audit logs, pod logs, and CPU metrics",
           "id": "analyze-disruption",
@@ -642,10 +641,10 @@
           "synopsis": "/teams:health-check-jiras --project <project> [--component comp1 comp2 ...] [--status status1 status2 ...] [--include-closed] [--limit N]"
         },
         {
-          "argument_hint": "<release> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
+          "argument_hint": "<view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
           "description": "Query and summarize regression data for OpenShift releases with counts and metrics",
           "name": "health-check-regressions",
-          "synopsis": "/teams:health-check-regressions <release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
+          "synopsis": "/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
         },
         {
           "argument_hint": "<release> [--components comp1 comp2 ...] [--team <team-name>] [--project JIRAPROJECT]",
@@ -666,10 +665,10 @@
           "synopsis": "/teams:list-jiras <project> [--component comp1 comp2 ...] [--status status1 status2 ...] [--include-closed] [--limit N]"
         },
         {
-          "argument_hint": "<release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
+          "argument_hint": "<view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]",
           "description": "Fetch and list raw regression data for OpenShift releases",
           "name": "list-regressions",
-          "synopsis": "/teams:list-regressions <release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
+          "synopsis": "/teams:list-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
         },
         {
           "argument_hint": "",

--- a/plugins/bigquery/.claude-plugin/plugin.json
+++ b/plugins/bigquery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bigquery",
   "description": "BigQuery cost analysis and optimization utilities",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/bigquery/skills/ci-data-analyst/SKILL.md
+++ b/plugins/bigquery/skills/ci-data-analyst/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: CI Data Analyst
+description: Safely query and report on OpenShift CI prow job and test data in BigQuery with cost controls, dry-run validation, and local caching of results
+---
+
+# CI Data Analyst
+
+An agent for querying and analyzing OpenShift CI data stored in BigQuery. Covers prow job runs, junit test results, job variants, and related tables. Prioritizes cost safety: every query is dry-run first, costs are estimated, and the user confirms before execution.
+
+## When to Use This Skill
+
+- Investigating test failures, flakes, or regressions across CI jobs
+- Querying prow job pass/fail rates over time
+- Analyzing test results by variant (platform, architecture, network, upgrade, etc.)
+- Exploring CI data patterns (e.g. which jobs run a test, how often a test fails)
+- Any ad-hoc BigQuery analysis against OpenShift CI datasets
+
+## Prerequisites
+
+- `bq` CLI installed and authenticated (`gcloud auth login`)
+- BigQuery read access to the `openshift-gce-devel` project
+
+## Core Principles
+
+### 1. Cost Safety Is Non-Negotiable
+
+The junit table alone is massive. Every query MUST go through this flow:
+
+1. **Show the query** to the user before doing anything
+2. **Dry-run** to get bytes scanned: `bq query --project_id=openshift-gce-devel --dry_run --use_legacy_sql=false '<query>'`
+3. **Calculate cost**: bytes / 10^12 * $6.25 (on-demand pricing)
+4. **If cost > $1.00**: show the estimated cost and bytes scanned, ask user to confirm before executing
+5. **If cost <= $1.00**: proceed, but still report the cost in results
+6. **Never loop or repeat queries.** Run once, cache locally, analyze from the cached data.
+
+### 2. Always Use Partition Filters
+
+Both key tables are partitioned by day:
+- `junit`: partitioned on `modified_time`
+- `jobs`: partitioned on `prowjob_start`
+
+**Every query MUST include a filter on the partition column** to avoid full-table scans. Use tight date ranges:
+
+```sql
+WHERE modified_time >= DATETIME("2026-05-01")
+  AND modified_time < DATETIME("2026-05-08")
+```
+
+### 3. Cache Results Locally
+
+After executing a query, save the results to `.work/ci-data-analyst/` as JSON or CSV. Reference cached files for follow-up analysis instead of re-querying. Name files descriptively (e.g. `test-failures-apiserver-readyz-2026-05-01-to-2026-05-07.json`).
+
+## Project and Dataset Reference
+
+**Project**: `openshift-gce-devel` (always use this, pass `--project_id=openshift-gce-devel` to all bq commands)
+
+### Engineering Dataset: `ci_analysis_us`
+
+The primary dataset for engineering prow jobs. Key tables:
+
+#### `ci_analysis_us.junit`
+Junit test results. Massive table. Partitioned by DAY on `modified_time`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| prowjob_build_id | STRING | Join key to jobs table |
+| file_path | STRING | Artifact path of the junit XML |
+| test_name | STRING | Full test name |
+| testsuite | STRING | Test suite name |
+| success_val | INTEGER | 1 = pass, 0 = fail |
+| success | BOOLEAN | Pass/fail |
+| skipped | BOOLEAN | Whether test was skipped |
+| flake_count | INTEGER | >0 means this row is part of a flake |
+| modified_time | DATETIME | **Partition column** - always filter on this |
+| branch | STRING | Release branch (e.g. "release-4.18") |
+| prowjob_name | STRING | Name of the prow job run |
+| duration_ms | INTEGER | Test execution time |
+| test_id | STRING | Stable test identifier |
+| failure_message | STRING | Failure message from junit XML |
+| failure_content | STRING | Failure body from junit XML |
+| start_time | DATETIME | Test start time |
+| end_time | DATETIME | Test end time |
+| platform | STRING | **LEGACY - do not use for filtering** |
+| arch | STRING | **LEGACY - do not use for filtering** |
+| network | STRING | **LEGACY - do not use for filtering** |
+| upgrade | STRING | **LEGACY - do not use for filtering** |
+
+**IMPORTANT**: The `platform`, `arch`, `network`, `upgrade` columns on the junit table are legacy and unmaintained. Do NOT use them for filtering or grouping. Instead, join to `jobs` and then to `job_variants` for accurate variant data. See "Variant Joins" below.
+
+#### `ci_analysis_us.jobs`
+Prow job **runs** (invocations). Each row is a single execution of a job. Partitioned by DAY on `prowjob_start`.
+
+**Important terminology**: When users say "job" they typically mean a distinct `prowjob_job_name` (e.g. `periodic-ci-openshift-release-master-nightly-4.19-e2e-aws-ovn`). The `jobs` table contains individual **runs** of those jobs, each with a unique `prowjob_build_id`. A single "job" has many runs over time. Use `prowjob_job_name` to group/identify jobs, and `prowjob_build_id` to identify specific runs.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| prowjob_build_id | STRING | Primary key, join key to junit |
+| prowjob_job_name | STRING | Canonical job name (join key to job_variants) |
+| prowjob_url | STRING | Link to prow job |
+| prowjob_state | STRING | "success", "failure", "error", "aborted" |
+| prowjob_start | DATETIME | **Partition column** |
+| prowjob_completion | DATETIME | When job finished |
+| prowjob_type | STRING | "periodic", "presubmit", "postsubmit" |
+| org | STRING | GitHub org |
+| repo | STRING | GitHub repo |
+| pr_number | STRING | PR number (presubmits) |
+| base_ref | STRING | Base branch |
+| is_release_verify | BOOLEAN | Whether this is a release verification job |
+
+#### `ci_analysis_us.job_variants`
+Maps job names to their variant classifications. Not partitioned (small table).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| job_name | STRING | Join to `jobs.prowjob_job_name` |
+| variant_name | STRING | e.g. "Platform", "Architecture", "Network", "Upgrade" |
+| variant_value | STRING | e.g. "aws", "amd64", "ovn", "upgrade-micro" |
+
+### Variant Reference
+
+The `job_variants` table maps each job name to multiple variant dimensions. These are the primary way to categorize and filter jobs. The most important variants for analysis:
+
+#### Release & Upgrade Variants
+
+| Variant | Description | Key Values |
+|---------|-------------|------------|
+| **Release** | The OCP version being tested | `4.18`, `4.19`, `4.20`, `4.21`, `4.22`, `4.23`, `5.0`, `5.1` |
+| **Upgrade** | Type of upgrade being tested | `none` (no upgrade), `micro` (z-stream), `minor` (y-stream), `major` (x-stream), `multi` (multi-hop), `micro-downgrade` |
+| **FromRelease** | Source version for upgrade jobs | `4.17`, `4.18`, etc. |
+
+- **Release** is the target version. For upgrade jobs, this is what the cluster upgrades *to*.
+- **Upgrade=none** means a fresh install job, not an upgrade.
+- Use Release to scope queries to a specific OCP version (e.g. "4.19 regressions").
+
+#### Platform & Infrastructure Variants
+
+| Variant | Description | Key Values |
+|---------|-------------|------------|
+| **Platform** | Cloud/infra provider | `aws`, `azure`, `gcp`, `vsphere`, `metal`, `openstack`, `nutanix`, `alibaba`, `kubevirt`, `libvirt`, `none`, `ovirt`, `rosa`, `aro`, `external-aws`, `external-oci`, `external-vsphere`, `osd-gcp` |
+| **Architecture** | CPU architecture | `amd64`, `arm64`, `multi`, `ppc64le`, `s390x` |
+| **Topology** | Cluster topology | `ha` (standard 3+3), `single` (SNO), `compact` (3-node), `external`, `microshift`, `two-node-arbiter`, `two-node-fencing` |
+| **Installer** | Installation method | `ipi`, `upi`, `agent`, `assisted`, `hypershift`, `aro` |
+
+#### Network Variants
+
+| Variant | Description | Key Values |
+|---------|-------------|------------|
+| **Network** | CNI plugin | `ovn`, `sdn` (legacy), `cilium` |
+| **NetworkStack** | IP stack | `ipv4`, `ipv6`, `dual` |
+| **NetworkAccess** | Connectivity constraints | `default`, `disconnected`, `proxy`, `nat-instance` |
+
+#### Job Classification Variants
+
+| Variant | Description | Key Values |
+|---------|-------------|------------|
+| **JobTier** | How important the job is to release gating | `blocking` (blocks payloads), `informing` (signals, doesn't block), `candidate`, `standard`, `rare`, `excluded`, `hidden` |
+| **Owner** | Team/org that owns the job | `eng`, `qe`, `aro`, `cnf`, `perfscale`, etc. |
+| **Suite** | Test suite | `parallel`, `serial`, `etcd-scaling`, `unknown` |
+
+#### Configuration Variants
+
+| Variant | Description | Key Values |
+|---------|-------------|------------|
+| **Procedure** | Special test procedures | `none`, `serial`, `cert-rotation-shutdown`, `cpu-partitioning`, `etcd-scaling`, `ipsec`, `on-cluster-layering`, etc. |
+| **SecurityMode** | FIPS mode | `default`, `fips` |
+| **FeatureSet** | Feature gate mode | `default`, `techpreview` |
+| **CGroupMode** | CGroup version | `v1`, `v2` |
+| **ContainerRuntime** | Container runtime | `runc`, `crun` |
+| **OS** | Node OS | `rhcos9`, `rhcos10`, `rhcos9-10` |
+| **Aggregation** | Whether results are aggregated | `none`, `aggregated` |
+
+#### Common Filtering Patterns
+
+When filtering by variant, remember each dimension is a separate LEFT JOIN:
+
+```sql
+-- Find all 4.19 upgrade-from-4.18 failures on AWS
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_release
+  ON jobs.prowjob_job_name = jv_release.job_name AND jv_release.variant_name = 'Release'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_upgrade
+  ON jobs.prowjob_job_name = jv_upgrade.job_name AND jv_upgrade.variant_name = 'Upgrade'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_from
+  ON jobs.prowjob_job_name = jv_from.job_name AND jv_from.variant_name = 'FromRelease'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_platform
+  ON jobs.prowjob_job_name = jv_platform.job_name AND jv_platform.variant_name = 'Platform'
+WHERE jv_release.variant_value = '4.19'
+  AND jv_upgrade.variant_value = 'minor'
+  AND jv_from.variant_value = '4.18'
+  AND jv_platform.variant_value = 'aws'
+```
+
+**Tip**: To exclude aggregated results (which are synthetic rollups, not real job runs), filter `Aggregation != 'aggregated'` or `prowjob_name NOT LIKE '%aggregated%'`.
+
+#### `ci_analysis_us.job_labels`
+Labels/annotations applied to job runs. Partitioned by DAY on `prowjob_start`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| prowjob_build_id | STRING | Join key to jobs/junit |
+| prowjob_start | DATETIME | **Partition column** |
+| label | STRING | e.g. "InfraFailure" |
+| symptom_id | STRING | Triage symptom ID |
+
+### QE Dataset: `ci_analysis_qe`
+
+Smaller dataset for QE prow jobs. Has the same table structure as `ci_analysis_us` (jobs, junit, job_variants, job_labels). QE jobs are slowly being migrated to the engineering system.
+
+**Always default to `ci_analysis_us`** unless the user explicitly asks about QE data. Never assume QE dataset.
+
+## Query Patterns
+
+### Deduplicating Junit Results (CRITICAL)
+
+The junit table directly models junit XML. A "flake" (test fails then passes on retry) appears as **two separate rows**: one with `success_val=0` and one with `success_val=1`. Raw queries will double-count test runs unless deduplicated.
+
+**Always use this deduplication pattern** (from sippy):
+
+```sql
+WITH deduped AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER(
+      PARTITION BY file_path, test_name, testsuite
+      ORDER BY
+        CASE
+          WHEN flake_count > 0 THEN 0
+          WHEN success_val > 0 THEN 1
+          ELSE 2
+        END
+    ) AS row_num,
+    CASE WHEN flake_count > 0 THEN 0 ELSE success_val END AS adjusted_success_val,
+    CASE WHEN flake_count > 0 THEN 1 ELSE 0 END AS adjusted_flake_count
+  FROM `openshift-gce-devel.ci_analysis_us.junit`
+  WHERE modified_time >= DATETIME("2026-05-01")
+    AND modified_time < DATETIME("2026-05-08")
+    AND skipped = false
+    AND test_name LIKE '%your test pattern%'
+)
+SELECT * FROM deduped WHERE row_num = 1
+```
+
+**Priority order**: flakes (0) > passes (1) > failures (2). This means:
+- If a test flaked, it's counted as a flake (not a failure)
+- `adjusted_success_val`: 0 for flakes (they didn't cleanly pass), original value otherwise
+- `adjusted_flake_count`: 1 for flakes, 0 otherwise
+
+**When to skip deduplication**: Only when you specifically want to see raw pass/fail pairs (e.g. debugging a specific flake's failure message). In all aggregation/counting queries, always deduplicate.
+
+### Variant Joins
+
+To get accurate variant data for test results, join through the jobs table to job_variants:
+
+```sql
+SELECT
+  junit.test_name,
+  junit.modified_time,
+  jv_platform.variant_value AS platform,
+  jv_arch.variant_value AS architecture,
+  jv_network.variant_value AS network,
+  jv_upgrade.variant_value AS upgrade
+FROM `openshift-gce-devel.ci_analysis_us.junit` junit
+INNER JOIN `openshift-gce-devel.ci_analysis_us.jobs` jobs
+  ON junit.prowjob_build_id = jobs.prowjob_build_id
+  AND jobs.prowjob_start >= DATETIME("2026-05-01")
+  AND jobs.prowjob_start < DATETIME("2026-05-08")
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_platform
+  ON jobs.prowjob_job_name = jv_platform.job_name AND jv_platform.variant_name = 'Platform'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_arch
+  ON jobs.prowjob_job_name = jv_arch.job_name AND jv_arch.variant_name = 'Architecture'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_network
+  ON jobs.prowjob_job_name = jv_network.job_name AND jv_network.variant_name = 'Network'
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_variants` jv_upgrade
+  ON jobs.prowjob_job_name = jv_upgrade.job_name AND jv_upgrade.variant_name = 'Upgrade'
+WHERE junit.modified_time >= DATETIME("2026-05-01")
+  AND junit.modified_time < DATETIME("2026-05-08")
+```
+
+Each variant dimension gets its own LEFT JOIN with a unique alias. Common variant names: `Platform`, `Architecture`, `Network`, `Upgrade`, `Release`, `Topology`, `Installer`, `Suite`.
+
+To discover all available variant names and values:
+```sql
+SELECT variant_name, ARRAY_AGG(DISTINCT variant_value ORDER BY variant_value) AS variant_values
+FROM `openshift-gce-devel.ci_analysis_us.job_variants`
+WHERE variant_value != ""
+GROUP BY variant_name
+```
+
+### Filtering Out Infrastructure Failures
+
+To exclude jobs that failed due to infrastructure issues (not real test failures), filter using job_labels:
+
+```sql
+LEFT JOIN `openshift-gce-devel.ci_analysis_us.job_labels` jl
+  ON junit.prowjob_build_id = jl.prowjob_build_id
+  AND jl.prowjob_start >= DATETIME("2026-05-01")
+  AND jl.prowjob_start < DATETIME("2026-05-08")
+  AND jl.label = 'InfraFailure'
+WHERE jl.label IS NULL  -- exclude infra failures
+```
+
+### Job Pass Rate Analysis
+
+```sql
+SELECT
+  jobs.prowjob_job_name,
+  COUNT(DISTINCT jobs.prowjob_build_id) AS total_runs,
+  COUNT(DISTINCT IF(jobs.prowjob_state = 'success', jobs.prowjob_build_id, NULL)) AS successful_runs
+FROM `openshift-gce-devel.ci_analysis_us.jobs` jobs
+WHERE jobs.prowjob_start >= DATETIME("2026-05-01")
+  AND jobs.prowjob_start < DATETIME("2026-05-08")
+  AND jobs.prowjob_type = 'periodic'
+GROUP BY jobs.prowjob_job_name
+ORDER BY total_runs DESC
+```
+
+## Execution Workflow
+
+For every user request:
+
+### Step 1: Understand the Question
+Parse what the user wants to know. Identify:
+- Which table(s) are needed
+- What date range to use (ask if not specified, suggest a narrow range)
+- Whether deduplication is needed (yes for any junit aggregation)
+- Which variants matter
+
+### Step 2: Build the Query
+Construct the SQL following the patterns above. Always include:
+- Partition column filter with a tight date range
+- Deduplication CTE if querying junit for aggregation
+- Variant joins if variant-level breakdown is needed
+- `--use_legacy_sql=false` flag
+
+### Step 3: Show the Query
+Present the query to the user so they can review it.
+
+### Step 4: Dry Run
+```bash
+bq query --project_id=openshift-gce-devel --dry_run --use_legacy_sql=false '<query>'
+```
+
+Parse the output to extract bytes to be processed.
+
+### Step 5: Confirm Cost
+Calculate: `bytes / 1,000,000,000,000 * 6.25 = cost in USD`
+
+- **<= $1.00**: Report cost and proceed
+- **> $1.00**: Show cost and bytes scanned, ask user for confirmation before running
+- **> $10.00**: Strongly recommend narrowing date range or filters before proceeding
+
+### Step 6: Execute and Cache
+```bash
+bq query --project_id=openshift-gce-devel --use_legacy_sql=false --format=json --max_rows=10000 '<query>' > .work/ci-data-analyst/<descriptive-name>.json
+```
+
+Report total rows returned and the file where results are cached.
+
+### Step 7: Analyze and Report
+Parse the cached results and present findings. Include:
+- Summary statistics
+- Notable patterns
+- Links to specific prow jobs when relevant (prowjob_url)
+- Suggestions for follow-up queries if warranted
+
+## Query Optimization Tips
+
+- **Narrow date ranges first**: Start with 7 days. Widen only if needed.
+- **Use test_id over test_name LIKE**: If the user provides a test_id, use exact match. LIKE with wildcards on test_name forces a full column scan.
+- **Select only needed columns**: Don't SELECT * on the junit table.
+- **Filter early**: Put the most selective filters in the WHERE clause.
+- **Avoid repeated queries**: Cache results and analyze locally.
+- **Consider the jobs table first**: If you only need job-level data (no test results), query jobs directly -- it's much smaller than junit.
+
+## Error Handling
+
+- **"BigQuery not enabled"**: Pass `--project_id=openshift-gce-devel` explicitly
+- **Authentication errors**: Ask user to run `! gcloud auth login`
+- **Timeout on large queries**: Suggest narrowing the date range
+- **No results**: Verify the test name / job name exists, check the date range, verify the branch
+
+## Example Interactions
+
+**User**: "How often is the kube-apiserver readyz test failing this week?"
+
+1. Build deduped query filtering junit on test_name LIKE '%readyz%' for the past 7 days
+2. Show query, dry run (~1TB for a week on junit)
+3. Show cost estimate, get confirmation
+4. Execute, cache to `.work/ci-data-analyst/readyz-failures-2026-05-01-to-2026-05-07.json`
+5. Report: X total runs, Y failures, Z flakes, pass rate = N%
+6. Break down by job name or variant if helpful
+
+**User**: "Which periodic jobs on AWS have the worst pass rate this month?"
+
+1. Query jobs table joined to job_variants for Platform=aws, prowjob_type=periodic
+2. No junit needed, just job pass/fail -- much cheaper
+3. Dry run, report cost, execute
+4. Report top failing jobs with pass rates

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -3,6 +3,6 @@
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
   "version": "0.0.39",
   "author": {
-    "name": "openshift"
+    "name": "github.com/openshift-eng"
   }
 }

--- a/plugins/ci/agents/test-porter.md
+++ b/plugins/ci/agents/test-porter.md
@@ -84,9 +84,13 @@ If a directory with the same name exists in origin, use it. If no match, create 
 2. If no equivalent and the helper is small (< 50 lines), copy it to the destination
 4. Copy fixture files (YAML, JSON) to the corresponding `testdata/` directory
 
-### Compilation Verification
+### Compilation and Verification
 
-Always run `go build ./test/extended/...` in the origin repo after porting. Iterate on failures. 
+After porting, run these in order in the origin repo and iterate on failures:
+
+1. `go build ./test/extended/...` — fix compile errors first
+2. `make update-bindata` — regenerate bindata for any new fixture files
+3. `make verify` — fix any linting, formatting, or generated-file issues
 
 ## PR Creation
 

--- a/plugins/ci/agents/test-porter.md
+++ b/plugins/ci/agents/test-porter.md
@@ -22,18 +22,20 @@ The `gh` CLI must be authenticated.
 
 You handle every phase of the test porting lifecycle. The user will tell you what to do in natural language:
 
-1. **Port tests** — find `// port=yes` tests, adapt them, create a PR
+1. **Port tests** — find `// port=yes` tests, adapt them, create a PR (noting AI assistance in the description)
 2. **Check PR status** — look at CI results, summarize what's passing/failing
 3. **Fix CI failures** — read build errors or test failures, push fixes
-4. **Respond to review comments** — read PR review comments, make requested changes, push updates
-5. **Check test results** — query whether ported tests are showing up and passing in CI
-6. **Escalate** — tag a human reviewer when the PR is ready or when you're stuck
+4. **Respond to CodeRabbit** — address automated review feedback, push fixes
+5. **Hand off for human review** — once CI is green and CodeRabbit is addressed, notify humans the PR is ready
+6. **Respond to human review** — make requested improvements or drop tests as reviewers direct
+7. **Check test results** — query whether ported tests are showing up and passing in CI
+8. **Escalate** — tag a human reviewer when you're stuck
 
 ## Porting Rules
 
 ### Test Selection
 
-- **Only port tests marked `// port=yes`** — never `port=no`, `port=maybe`, `port=complete`
+- **Only port tests marked `// port=yes`** — never `port=no`, `port=maybe`, `port=complete`, `port=skipped`
 
 ### Code Adaptation
 
@@ -101,7 +103,18 @@ Ported tests:
 git push origin "$BRANCH"
 ```
 
-Create the PR with `gh pr create`. Include a summary table of ported and skipped tests.
+Create the PR with `gh pr create`. The PR description **must** include:
+
+1. A summary table of ported and skipped tests
+2. The following workflow notice at the top of the description:
+
+```markdown
+> **AI-Ported Tests** — These tests were ported from `openshift-tests-private` with AI assistance.
+> The AI agent will respond to CodeRabbit review feedback, verify CI is passing, and then
+> hand off the PR for human review. Human reviewers may request improvements or ask that
+> specific tests be dropped — the agent will act on that feedback. Tests that cannot be
+> made to pass or that reviewers deem unsuitable will be removed from the PR.
+```
 
 ## Source Annotation Updates
 
@@ -109,7 +122,10 @@ Do **not** mark tests as `port=complete` when the PR is first created. Only upda
 - The origin PR has been **merged**, or
 - The user explicitly tells you to mark them complete
 
-When updating, create a branch and PR against `openshift/openshift-tests-private` (the upstream repo, not a fork). The PR should reference the merged origin PR and list which tests were marked complete.
+Mark tests as `// port=skipped` when:
+- A human reviewer requests the test be **dropped** from the PR during review
+
+When updating, create a branch and PR against `openshift/openshift-tests-private` (the upstream repo, not a fork). The PR should reference the origin PR and list which tests were marked complete or skipped (and why, for skipped tests).
 
 ## CI Monitoring and Fixes
 
@@ -157,17 +173,42 @@ When reporting CI status to the user, summarize:
 
 ## Review Handling
 
-When asked to respond to review comments:
+### CodeRabbit Review
+
+CodeRabbit will automatically review the PR. Respond to its feedback proactively:
+
+1. Read CodeRabbit's review comments using `gh api repos/{owner}/{repo}/pulls/{number}/comments`
+2. Address valid suggestions (style fixes, missing error handling, etc.) by pushing fix commits
+3. For suggestions that don't apply to ported tests or conflict with origin conventions, reply explaining why
+4. After addressing CodeRabbit feedback and CI is green, post a PR comment indicating the PR is ready for human review
+
+### Human Review
+
+Humans are the final authority on ported tests. When a human reviewer comments:
 
 1. Use `gh api repos/{owner}/{repo}/pulls/{number}/comments` to read review comments
 2. Use `gh pr view <PR> --comments` for conversation-level comments
-3. Make the requested changes
-4. Push a new commit addressing the feedback
-5. Reply to the review comment if the change was non-obvious
+3. **Improvement requests**: make the requested changes and push a new commit
+4. **Drop requests**: if a reviewer asks to drop a test, remove it from the PR entirely — remove the test code, any helper functions or fixtures only used by that test, and push a commit noting which test was dropped and why. Mark dropped tests as `// port=skipped` in the source repo (not `port=complete`)
+5. Reply to each review comment confirming what action was taken
+6. After addressing all feedback, post a summary comment listing changes made
 
-## Escalation
+## Escalation and Handoff
 
-When the PR is ready for human review, or when you've exhausted your fix attempts:
+### Ready for Human Review
+
+When CodeRabbit feedback is addressed and CI is passing, hand off the PR:
+
+1. Post a PR comment summarizing the state:
+   - Which tests were ported and are passing
+   - Any CodeRabbit feedback that was addressed
+   - Any tests that were dropped during CI fixes (and why)
+2. Tag the user or a specified reviewer
+3. Note that reviewers can request improvements or ask to drop tests, and the agent will act on that feedback
+
+### Stuck or Exhausted Fix Attempts
+
+When you've exhausted your fix attempts:
 - Tag the user or a specified reviewer on the PR with a comment summarizing the state
 - List what's passing, what's failing, and what you've tried
 

--- a/plugins/ci/agents/test-porter.md
+++ b/plugins/ci/agents/test-porter.md
@@ -10,7 +10,7 @@ You are the OpenShift Test Porter — an agent that ports Ginkgo e2e tests from 
 ## Repos
 
 - **Source**: `openshift-tests-private` (branch: `porting-prep`) — tests annotated with `// port=yes|no|maybe|complete`
-- **Destination**: `openshift/origin` — PRs created here (or on a fork like `dgoodwin/origin`)
+- **Destination**: `openshift/origin` — PRs created here (or on a fork like `your-fork/origin`)
 
 You need both repos cloned locally. Ask the user for paths if you can't find them. Common locations:
 - `~/go/src/github.com/openshift/openshift-tests-private`
@@ -60,7 +60,7 @@ Keep `e2e`, `g` (ginkgo), and `o` (gomega) imports as-is.
 - Keep sig tags, feature tags, severity tags, and variant tags
 - Add `[apigroup:xxx]` tags if needed by origin
 
-Example: `Author:huirwang-High-53223-Verify ACL audit logs` becomes `[OTP] Verify ACL audit logs`
+Example: `Author:jsmith-High-53223-Verify ACL audit logs` becomes `[OTP] Verify ACL audit logs`
 
 ### Destination Package Mapping
 

--- a/plugins/ci/agents/test-porter.md
+++ b/plugins/ci/agents/test-porter.md
@@ -1,0 +1,180 @@
+---
+name: test-porter
+description: |
+  Automated Ginkgo e2e test porting agent. Ports tests from openshift-tests-private to openshift/origin, creates PRs, monitors CI, responds to review feedback, pushes fixes, and escalates to humans when needed. Use this agent for any task related to porting tests between these repos.
+color: yellow
+---
+
+You are the OpenShift Test Porter — an agent that ports Ginkgo e2e tests from `openshift-tests-private` to `openshift/origin`, then shepherds the resulting PRs through CI and review.
+
+## Repos
+
+- **Source**: `openshift-tests-private` (branch: `porting-prep`) — tests annotated with `// port=yes|no|maybe|complete`
+- **Destination**: `openshift/origin` — PRs created here (or on a fork like `dgoodwin/origin`)
+
+You need both repos cloned locally. Ask the user for paths if you can't find them. Common locations:
+- `~/go/src/github.com/openshift/openshift-tests-private`
+- `~/go/src/github.com/openshift/origin`
+
+The `gh` CLI must be authenticated.
+
+## What You Can Do
+
+You handle every phase of the test porting lifecycle. The user will tell you what to do in natural language:
+
+1. **Port tests** — find `// port=yes` tests, adapt them, create a PR
+2. **Check PR status** — look at CI results, summarize what's passing/failing
+3. **Fix CI failures** — read build errors or test failures, push fixes
+4. **Respond to review comments** — read PR review comments, make requested changes, push updates
+5. **Check test results** — query whether ported tests are showing up and passing in CI
+6. **Escalate** — tag a human reviewer when the PR is ready or when you're stuck
+
+## Porting Rules
+
+### Test Selection
+
+- **Only port tests marked `// port=yes`** — never `port=no`, `port=maybe`, `port=complete`
+
+### Code Adaptation
+
+Replace the `compat_otp` compatibility layer with `exutil` equivalents:
+
+| Source (openshift-tests-private) | Destination (origin) |
+|----------------------------------|----------------------|
+| `compat_otp.NewCLI(...)` | `exutil.NewCLI(...)` |
+| `compat_otp.NewCLIWithoutNamespace(...)` | `exutil.NewCLIWithoutNamespace(...)` |
+| `compat_otp.By(...)` | `g.By(...)` |
+| `compat_otp.FixturePath(...)` | `exutil.FixturePath(...)` |
+| `compat_otp.KubeConfigPath()` | Remove — `exutil.NewCLI` doesn't take this |
+| `import compat_otp "..."` | `import exutil "github.com/openshift/origin/test/extended/util"` |
+| `import "github.com/openshift/openshift-tests-private/test/extended/util"` | `import exutil "github.com/openshift/origin/test/extended/util"` |
+
+Keep `e2e`, `g` (ginkgo), and `o` (gomega) imports as-is.
+
+### Test Name Adaptation
+
+- Remove the `Author:xxx-` prefix
+- Add an `[OTP]` tag to the test name
+- Keep sig tags, feature tags, severity tags, and variant tags
+- Add `[apigroup:xxx]` tags if needed by origin
+
+Example: `Author:huirwang-High-53223-Verify ACL audit logs` becomes `[OTP] Verify ACL audit logs`
+
+### Destination Package Mapping
+
+Map source subdirectory and sig tag to the appropriate `origin/test/extended/` package:
+
+- `[sig-network]` → `networking/`
+- `[sig-storage]` → `storage/`
+- `[sig-auth]` → `authentication/` or `authorization/`
+- `[sig-apps]` → `deployments/` or `apps/`
+- `[sig-api-machinery]` → `apiserver/`
+- `[sig-cluster-lifecycle]` → `cluster/`
+- `[sig-imageregistry]` → `image_registry/`
+- `[sig-node]` → `node/`
+- `[sig-instrumentation]` → `prometheus/`
+
+If a directory with the same name exists in origin, use it. If no match, create a new package and register it in `test/extended/include.go` with a blank import.
+
+### Helper Functions and Fixtures
+
+1. First look for an equivalent in origin's existing utilities
+2. If no equivalent and the helper is small (< 50 lines), copy it to the destination
+4. Copy fixture files (YAML, JSON) to the corresponding `testdata/` directory
+
+### Compilation Verification
+
+Always run `go build ./test/extended/...` in the origin repo after porting. Iterate on failures. 
+
+## PR Creation
+
+When creating a PR on origin:
+
+```bash
+BRANCH="port-tests-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH"
+git add -A
+git commit -m "Port $COUNT tests from openshift-tests-private [OTP]
+
+Ported tests:
+- <list each test name and source file>"
+git push origin "$BRANCH"
+```
+
+Create the PR with `gh pr create`. Include a summary table of ported and skipped tests.
+
+## Source Annotation Updates
+
+Do **not** mark tests as `port=complete` when the PR is first created. Only update `// port=yes` to `// port=complete` when:
+- The origin PR has been **merged**, or
+- The user explicitly tells you to mark them complete
+
+When updating, create a branch and PR against `openshift/openshift-tests-private` (the upstream repo, not a fork). The PR should reference the merged origin PR and list which tests were marked complete.
+
+## CI Monitoring and Fixes
+
+CI jobs on `openshift/origin` PRs can take up to 5 hours to complete after a push. There are typically 15-20 Prow jobs per PR. Don't panic about individual job failures — they're common and often unrelated to the ported tests.
+
+### Checking CI Status
+
+Use `gh pr checks <PR> --repo openshift/origin` to get a summary. This shows each job's name, state (pass/fail/pending), and Prow URL. Example output:
+
+```
+ci/prow/e2e-aws-csi          fail   https://prow.ci.openshift.org/view/gs/...
+ci/prow/e2e-gcp-ovn          pass   https://prow.ci.openshift.org/view/gs/...
+ci/prow/unit                  pass   https://prow.ci.openshift.org/view/gs/...
+```
+
+Ignore the `tide` check — it reflects merge eligibility, not test results.
+
+If jobs are still `pending`, tell the user how many are complete vs pending and suggest checking back later.
+
+### Triaging Failures
+
+A failing job does **not** necessarily mean the ported test is at fault. When a job fails:
+
+1. Open the Prow URL for the failed job
+2. Look at the **junit** test results in the job artifacts to find which specific tests failed
+3. Determine whether any of the failing tests are:
+   - **Our ported test** (contains `[OTP]` in the name) — this is a real problem, investigate and fix
+   - **Other tests that started failing after our change** — could indicate our code broke something, investigate
+   - **Tests that commonly fail on this job regardless of the PR** (known flakes) — likely not our fault
+
+If a failure is clearly a known flake unrelated to our changes, note it but don't try to fix it.
+
+### Fixing CI Failures
+
+1. Read the failing test output and the relevant code
+2. Push a fix commit to the PR branch
+3. After 3 failed fix attempts on the same issue, stop and tell the user you need help — explain what you've tried and what's failing
+
+### Overall CI Health Assessment
+
+When reporting CI status to the user, summarize:
+- Total jobs: N passed, N failed, N pending
+- For each failure: job name, whether it's related to our ported test, and brief reason
+- Overall verdict: "CI looks healthy" / "has failures but unrelated to our tests" / "our test is failing, needs a fix"
+
+## Review Handling
+
+When asked to respond to review comments:
+
+1. Use `gh api repos/{owner}/{repo}/pulls/{number}/comments` to read review comments
+2. Use `gh pr view <PR> --comments` for conversation-level comments
+3. Make the requested changes
+4. Push a new commit addressing the feedback
+5. Reply to the review comment if the change was non-obvious
+
+## Escalation
+
+When the PR is ready for human review, or when you've exhausted your fix attempts:
+- Tag the user or a specified reviewer on the PR with a comment summarizing the state
+- List what's passing, what's failing, and what you've tried
+
+## General Behavior
+
+- Never force-push
+- Never merge PRs — leave them open for human review
+- Create separate commits for each logical change (initial port, CI fixes, review feedback)
+- Be concise in PR descriptions and commit messages
+- When uncertain about a porting decision, explain the tradeoff and ask the user

--- a/plugins/ci/commands/analyze-regression.md
+++ b/plugins/ci/commands/analyze-regression.md
@@ -899,6 +899,16 @@ Parse and analyze the JSON output from scripts using your own reasoning capabili
    - Triage: https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/<triage_id>
    ```
 
+   Then add the triage record link to the JIRA description using the `add-jira-triage-link` skill:
+
+   ```bash
+   jira_key="<existing_jira_key>"
+   link_script="plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py"
+   python3 "$link_script" "$jira_key" --triage-id "$triage_id" --format json
+   ```
+
+   If successful, note that the triage link was added to the JIRA description. If it was already present, note that. If JIRA credentials are not set, skip this step silently (the triage itself already succeeded).
+
    **Note**: The triage-regression script automatically fetches the existing triage and merges its regressions with the new ones, so you only need to pass the regression IDs you want to add.
 
    **Scenario B: JIRA bug found but not triaged to any regression** (from step 5 or step 11)
@@ -952,6 +962,15 @@ Parse and analyze the JSON output from scripts using your own reasoning capabili
    - JIRA: https://redhat.atlassian.net/browse/OCPBUGS-67890
    - Triage: https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/<triage_id>
    ```
+
+   Then add the triage record link to the JIRA description using the `add-jira-triage-link` skill:
+
+   ```bash
+   link_script="plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py"
+   python3 "$link_script" "OCPBUGS-67890" --triage-id "$triage_id" --format json
+   ```
+
+   If successful, note that the triage link was added to the JIRA description. If JIRA credentials are not set, skip this step silently.
 
    **Scenario C: No related triage or bug found**
 
@@ -1031,6 +1050,15 @@ Parse and analyze the JSON output from scripts using your own reasoning capabili
    - Release Blocker: Approved
    - Triage: https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/<triage_id>
    ```
+
+   Then add the triage record link to the JIRA description using the `add-jira-triage-link` skill:
+
+   ```bash
+   link_script="plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py"
+   python3 "$link_script" "<new_bug_key>" --triage-id "$triage_id" --format json
+   ```
+
+   If successful, note that the triage link was added to the JIRA description. If JIRA credentials are not set, skip this step silently.
 
    **Scenario D: Regression is already triaged**
 
@@ -1265,6 +1293,7 @@ Uses the `triage-regression` skill with authentication via the `oc-auth` skill (
   - `fetch-related-triages`: Finds existing triages and untriaged regressions related to a regression
   - `fetch-jira-issue`: Fetches JIRA issue details and classifies progress
   - `triage-regression`: Creates or updates triage records linking regressions to JIRA bugs
+  - `add-jira-triage-link`: Adds the triage record link to the JIRA issue description after triaging
   - `set-release-blocker`: Sets the Release Blocker field to "Approved" on filed JIRA bugs
   - `oc-auth`: Provides authentication tokens for sippy-auth API
   - `prow-job-analyze-install-failure`: Analyzes GCS artifacts for individual failed install runs (used only when test name contains "install should succeed")
@@ -1291,6 +1320,7 @@ Uses the `triage-regression` skill with authentication via the `oc-auth` skill (
 - Related Skill: `fetch-related-triages` - Finds existing triages and untriaged regressions related to a regression (`plugins/ci/skills/fetch-related-triages/SKILL.md`)
 - Related Skill: `fetch-jira-issue` - Fetches JIRA issue details and classifies progress (`plugins/ci/skills/fetch-jira-issue/SKILL.md`)
 - Related Skill: `triage-regression` - Creates or updates triage records (`plugins/ci/skills/triage-regression/SKILL.md`)
+- Related Skill: `add-jira-triage-link` - Adds triage record link to JIRA issue description (`plugins/ci/skills/add-jira-triage-link/SKILL.md`)
 - Related Skill: `set-release-blocker` - Sets Release Blocker field on JIRA bugs (`plugins/ci/skills/set-release-blocker/SKILL.md`)
 - Related Skill: `oc-auth` - Authentication tokens for sippy-auth (`plugins/ci/skills/oc-auth/SKILL.md`)
 - Related Skill: `prow-job-analyze-install-failure` - Deep per-run install failure analysis via GCS artifacts (`plugins/ci/skills/prow-job-analyze-install-failure/SKILL.md`)

--- a/plugins/ci/commands/analyze-regression.md
+++ b/plugins/ci/commands/analyze-regression.md
@@ -37,6 +37,27 @@ When calling Python skill scripts via the Bash tool, always run the script direc
 
 Parse and analyze the JSON output from scripts using your own reasoning capabilities rather than shell pipelines.
 
+**Obtaining the DPCR authentication token from mounted kubeconfig**
+
+The triage and bug filing steps (step 14) require a Bearer token from the DPCR cluster (`api.cr.j7t7.p1.openshiftapps.com:6443`). When running in a container with `~/.kube` mounted (read-only), the token is extracted directly from the mounted kubeconfig using `oc`:
+
+```bash
+# Find the oc context for the DPCR cluster from the mounted kubeconfig
+DPCR_CONTEXT=$(oc config get-contexts -o name 2>/dev/null | while read -r ctx; do
+  server=$(oc config view -o jsonpath="{.clusters[?(@.name=='$(oc config view -o jsonpath="{.contexts[?(@.name=='$ctx')].context.cluster}" 2>/dev/null)')].cluster.server}" 2>/dev/null || echo "")
+  server_clean=$(echo "$server" | sed -E 's|^https?://||')
+  if [ "$server_clean" = "api.cr.j7t7.p1.openshiftapps.com:6443" ]; then
+    echo "$ctx"
+    break
+  fi
+done)
+
+# Extract the token from the DPCR context
+TOKEN=$(oc whoami -t --context="$DPCR_CONTEXT" 2>/dev/null)
+```
+
+This works because `oc` reads from `~/.kube/config` which is bind-mounted from the host. The token stored in the kubeconfig was obtained when the user previously ran `oc login` to the DPCR cluster on the host. If the token is expired, instruct the user to re-authenticate on the host: `oc login https://api.cr.j7t7.p1.openshiftapps.com:6443`.
+
 1. **Load CI Context**: Read all documentation files in `plugins/ci/docs/` for context on tests, jobs, and CI conventions. These contain important notes on specific test frameworks, job ownership, and debugging guidance that should inform the analysis.
 
    ```bash
@@ -1259,15 +1280,23 @@ Uses the `triage-regression` skill with authentication via the `oc-auth` skill (
    - Component Readiness API
    - Check firewall and VPN settings if needed
 
-3. **JIRA_USERNAME** and **JIRA_API_TOKEN** (optional): Required for JIRA progress analysis on triaged regressions
+3. **JIRA_URL**, **JIRA_USERNAME**, and **JIRA_API_TOKEN** (optional): Required for JIRA progress analysis and bug filing
 
    - Set environment variables:
      ```bash
+     export JIRA_URL="https://redhat.atlassian.net"
      export JIRA_USERNAME="your.email@redhat.com"
      export JIRA_API_TOKEN="your-api-token"
      ```
    - Obtain your API token from: https://id.atlassian.com/manage-profile/security/api-tokens
-   - If either is not set, JIRA progress analysis will be skipped but other analysis continues
+   - If not set, JIRA progress analysis and bug filing will be skipped but other analysis continues
+
+4. **Kubeconfig with DPCR cluster context** (optional): Required for triaging regressions
+
+   - The kubeconfig (`~/.kube/config`) must contain a context for the DPCR cluster (`api.cr.j7t7.p1.openshiftapps.com:6443`)
+   - When running in a container, mount the host kubeconfig: `-v "$HOME/.kube:/home/claude/.kube:ro,Z"`
+   - The token is extracted via `oc whoami -t` from the mounted kubeconfig
+   - If the token is expired, re-authenticate on the host: `oc login https://api.cr.j7t7.p1.openshiftapps.com:6443`
 
 ## Notes
 

--- a/plugins/ci/commands/analyze-regression.md
+++ b/plugins/ci/commands/analyze-regression.md
@@ -53,6 +53,10 @@ DPCR_CONTEXT=$(oc config get-contexts -o name 2>/dev/null | while read -r ctx; d
 done)
 
 # Extract the token from the DPCR context
+if [ -z "$DPCR_CONTEXT" ]; then
+  echo "ERROR: Could not find a DPCR cluster context in kubeconfig. Set DPCR_CONTEXT manually or run: oc login https://api.cr.j7t7.p1.openshiftapps.com:6443"
+  exit 1
+fi
 TOKEN=$(oc whoami -t --context="$DPCR_CONTEXT" 2>/dev/null)
 ```
 

--- a/plugins/ci/skills/add-jira-triage-link/SKILL.md
+++ b/plugins/ci/skills/add-jira-triage-link/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: Add JIRA Triage Link
+description: Add a Component Readiness triage record link to a JIRA issue description
+---
+
+# Add JIRA Triage Link
+
+This skill adds a Component Readiness triage record link to a JIRA issue description so that anyone viewing the bug can monitor the on-going status of all regressions triaged to it.
+
+## When to Use This Skill
+
+Use this skill after creating or updating a triage record via the `triage-regression` skill. The link gives bug viewers a way to see all regressions associated with the bug in Component Readiness.
+
+## Prerequisites
+
+1. **JIRA_USERNAME** and **JIRA_API_TOKEN** environment variables must be set
+2. **Python 3.6+**
+
+## Implementation Steps
+
+### Step 1: Run the Script
+
+```bash
+script_path="plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py"
+
+python3 "$script_path" OCPBUGS-12345 \
+  --triage-id 456 \
+  --format json
+```
+
+**Arguments**:
+- `issue_key`: JIRA issue key (e.g., OCPBUGS-12345)
+
+**Required Options**:
+- `--triage-id <id>`: Triage record ID from Component Readiness
+
+**Options**:
+- `--format json|text`: Output format (default: text)
+
+### Step 2: Parse the Output
+
+```bash
+output=$(python3 "$script_path" OCPBUGS-12345 --triage-id 456 --format json)
+success=$(echo "$output" | jq -r '.success')
+
+if [ "$success" = "true" ]; then
+  already=$(echo "$output" | jq -r '.already_present')
+  if [ "$already" = "true" ]; then
+    echo "Triage link already in description"
+  else
+    echo "Triage link added"
+  fi
+fi
+```
+
+## Script Output Format
+
+### JSON Format (--format json)
+
+**Success (link added)**:
+```json
+{
+  "success": true,
+  "issue_key": "OCPBUGS-12345",
+  "triage_url": "https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/456",
+  "already_present": false
+}
+```
+
+**Success (link already present)**:
+```json
+{
+  "success": true,
+  "issue_key": "OCPBUGS-12345",
+  "triage_url": "https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/456",
+  "already_present": true
+}
+```
+
+**Error**:
+```json
+{
+  "success": false,
+  "error": "Failed to update description: HTTP 403: ...",
+  "issue_key": "OCPBUGS-12345"
+}
+```
+
+## Notes
+
+- The script is idempotent — if the triage link is already in the description, it skips the update
+- Uses Atlassian Document Format (ADF) to append a horizontal rule and the triage link section
+- Appends to the existing description without modifying existing content
+- Requires JIRA API v3 write access to the issue
+
+## See Also
+
+- Related Skill: `triage-regression` (creates triage records that produce the triage ID)
+- Related Skill: `set-release-blocker` (similar pattern for updating JIRA issue fields)
+- Related Command: `/ci:analyze-regression` (calls this skill after triaging)

--- a/plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py
+++ b/plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py
@@ -16,6 +16,7 @@ import argparse
 import base64
 import json
 import os
+import re
 import sys
 import urllib.request
 import urllib.error
@@ -43,7 +44,8 @@ def _description_contains_triage_link(description: Any, triage_url: str) -> bool
     if description is None:
         return False
     text = json.dumps(description)
-    return triage_url in text
+    pattern = re.escape(triage_url) + r"(?!\w)"
+    return re.search(pattern, text) is not None
 
 
 def _build_triage_section(triage_id: int) -> List[Dict[str, Any]]:
@@ -113,7 +115,7 @@ def add_triage_link(issue_key: str, triage_id: int, token: str, username: str) -
             "already_present": True,
         }
 
-    if description is None:
+    if not isinstance(description, dict) or not isinstance(description.get("content"), list):
         description = {"type": "doc", "version": 1, "content": []}
 
     triage_nodes = _build_triage_section(triage_id)

--- a/plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py
+++ b/plugins/ci/skills/add-jira-triage-link/add_jira_triage_link.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Add a Component Readiness triage record link to a JIRA issue description.
+
+Appends a section to the issue description with a link to the triage record UI
+so that anyone viewing the bug can monitor the on-going status of all
+regressions triaged to it.
+
+Usage:
+    python3 add_jira_triage_link.py OCPBUGS-12345 --triage-id 456
+
+Requires JIRA_API_TOKEN and JIRA_USERNAME environment variables.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Any, Dict, List
+
+JIRA_BASE_URL = "https://redhat.atlassian.net"
+TRIAGE_UI_BASE = "https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages"
+
+
+def _get_auth_header(username: str, token: str) -> str:
+    credentials = base64.b64encode(f"{username}:{token}".encode()).decode()
+    return f"Basic {credentials}"
+
+
+def _fetch_description(issue_key: str, auth: str) -> Dict[str, Any]:
+    url = f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}?fields=description"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Authorization", auth)
+    req.add_header("Accept", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _description_contains_triage_link(description: Any, triage_url: str) -> bool:
+    if description is None:
+        return False
+    text = json.dumps(description)
+    return triage_url in text
+
+
+def _build_triage_section(triage_id: int) -> List[Dict[str, Any]]:
+    triage_url = f"{TRIAGE_UI_BASE}/{triage_id}"
+    return [
+        {
+            "type": "rule",
+        },
+        {
+            "type": "paragraph",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Component Readiness Triage Record",
+                    "marks": [{"type": "strong"}],
+                },
+            ],
+        },
+        {
+            "type": "paragraph",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Monitor the on-going status of all regressions triaged to this bug: ",
+                },
+                {
+                    "type": "text",
+                    "text": triage_url,
+                    "marks": [
+                        {
+                            "type": "link",
+                            "attrs": {"href": triage_url},
+                        }
+                    ],
+                },
+            ],
+        },
+    ]
+
+
+def add_triage_link(issue_key: str, triage_id: int, token: str, username: str) -> dict:
+    auth = _get_auth_header(username, token)
+    triage_url = f"{TRIAGE_UI_BASE}/{triage_id}"
+
+    try:
+        issue_data = _fetch_description(issue_key, auth)
+    except urllib.error.HTTPError as e:
+        return {
+            "success": False,
+            "error": f"Failed to fetch issue: HTTP {e.code}",
+            "issue_key": issue_key,
+        }
+    except urllib.error.URLError as e:
+        return {
+            "success": False,
+            "error": f"Failed to fetch issue: {e.reason}",
+            "issue_key": issue_key,
+        }
+
+    description = issue_data.get("fields", {}).get("description")
+
+    if _description_contains_triage_link(description, triage_url):
+        return {
+            "success": True,
+            "issue_key": issue_key,
+            "triage_url": triage_url,
+            "already_present": True,
+        }
+
+    if description is None:
+        description = {"type": "doc", "version": 1, "content": []}
+
+    triage_nodes = _build_triage_section(triage_id)
+    description["content"].extend(triage_nodes)
+
+    url = f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}"
+    payload = json.dumps({"fields": {"description": description}}).encode("utf-8")
+    req = urllib.request.Request(url, data=payload, method="PUT")
+    req.add_header("Authorization", auth)
+    req.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            pass
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        return {
+            "success": False,
+            "error": f"Failed to update description: HTTP {e.code}: {error_body}",
+            "issue_key": issue_key,
+        }
+    except urllib.error.URLError as e:
+        return {
+            "success": False,
+            "error": f"Failed to update description: {e.reason}",
+            "issue_key": issue_key,
+        }
+
+    return {
+        "success": True,
+        "issue_key": issue_key,
+        "triage_url": triage_url,
+        "already_present": False,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Add a Component Readiness triage record link to a JIRA issue description",
+    )
+    parser.add_argument("issue_key", help="JIRA issue key (e.g., OCPBUGS-12345)")
+    parser.add_argument(
+        "--triage-id",
+        type=int,
+        required=True,
+        help="Triage record ID from Component Readiness",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("JIRA_API_TOKEN")
+    if not token:
+        print("Error: JIRA_API_TOKEN environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    username = os.environ.get("JIRA_USERNAME")
+    if not username:
+        print("Error: JIRA_USERNAME environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    result = add_triage_link(args.issue_key, args.triage_id, token, username)
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        if result["success"]:
+            if result.get("already_present"):
+                print(f"Triage link already present in {result['issue_key']}")
+            else:
+                print(f"Triage link added to {result['issue_key']}")
+            print(f"  {result['triage_url']}")
+        else:
+            print(f"Failed to add triage link to {result['issue_key']}")
+            print(f"  Error: {result['error']}")
+
+    sys.exit(0 if result["success"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/teams/.claude-plugin/plugin.json
+++ b/plugins/teams/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "teams",
   "description": "Team structure knowledge and health analysis commands for OpenShift teams",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/teams/commands/health-check-regressions.md
+++ b/plugins/teams/commands/health-check-regressions.md
@@ -1,6 +1,6 @@
 ---
 description: Query and summarize regression data for OpenShift releases with counts and metrics
-argument-hint: <release> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+argument-hint: <view> [--components comp1 comp2 ...] [--team <team-name>] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
 ---
 
 ## Name
@@ -10,13 +10,13 @@ teams:health-check-regressions
 ## Synopsis
 
 ```
-/teams:health-check-regressions <release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
-/teams:health-check-regressions <release> --team <team-name> [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+/teams:health-check-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+/teams:health-check-regressions <view> --team <team-name> [--start YYYY-MM-DD] [--end YYYY-MM-DD]
 ```
 
 ## Description
 
-The `teams:health-check-regressions` command queries regression data for a specified OpenShift release and generates summary statistics. It leverages the `list-regressions` command to fetch raw regression data and then presents counts, percentages, and timing metrics to help understand regression trends at a glance.
+The `teams:health-check-regressions` command queries regression data for a specified view (e.g., "4.22-main") and generates summary statistics. A view represents a specific regression tracking context within a release — multiple views can exist per release (e.g., "4.22-main", "4.22-main-mass-failure"). The release is derived from the view name automatically. It leverages the `list-regressions` command to fetch raw regression data filtered to the specified view and then presents counts, percentages, and timing metrics to help understand regression trends at a glance.
 
 By default, the command analyzes:
 - All regressions within the release development window
@@ -42,9 +42,10 @@ This command is useful for:
    - Run: `python3 --version`
    - Verify version 3.6 or later is available
 
-2. **Parse Arguments**: Extract release version and optional filters from arguments
+2. **Parse Arguments**: Extract view name and optional filters from arguments
 
-   - Release format: "X.Y" (e.g., "4.17", "4.21")
+   - View format: "X.Y-suffix" (e.g., "4.22-main", "4.17-main")
+   - The release is derived from the view name (e.g., "4.22" from "4.22-main")
    - Optional filters:
      - `--components`: Space-separated list of component search strings (fuzzy match)
      - `--team`: Team name (looks up all components for that team)
@@ -73,7 +74,8 @@ This command is useful for:
 4. **Fetch Release Dates**: Run the get_release_dates.py script to get development window dates
 
    - Script location: `plugins/teams/skills/get-release-dates/get_release_dates.py`
-   - Pass release as `--release` argument
+   - Derive the release from the view name (e.g., "4.22" from "4.22-main")
+   - Pass derived release as `--release` argument
    - Extract `development_start` and `ga` dates from JSON output
    - Convert timestamps to simple date format (YYYY-MM-DD)
    - Use these dates if `--start` and `--end` are not explicitly provided
@@ -81,7 +83,7 @@ This command is useful for:
 5. **Execute Python Script**: Run the list_regressions.py script with appropriate arguments
 
    - Script location: `plugins/teams/skills/list-regressions/list_regressions.py`
-   - Pass release as `--release` argument
+   - Pass view as `--view` argument (the script derives the release internally)
    - Pass resolved component names as `--components` argument
    - Pass `development_start` date as `--start` argument (if available)
      - Always applied (for both GA'd and in-development releases)
@@ -117,7 +119,7 @@ This command is useful for:
 8. **Error Handling**: Handle common error scenarios
 
    - Network connectivity issues
-   - Invalid release format
+   - Invalid view format
    - API errors (404, 500, etc.)
    - Empty results
    - No matches for component filter
@@ -129,7 +131,7 @@ The command outputs a **Regression Summary Report** with the following informati
 
 ### Overall Summary
 
-- **Release**: OpenShift release version
+- **View**: View name (e.g., "4.22-main")
 - **Development Window**: Start and end dates (or "In Development" if no GA date)
 - **Total Regressions**: `summary.total`
 - **Filtered Infrastructure Regressions**: `summary.filtered_suspected_infra_regressions`
@@ -170,32 +172,33 @@ For each component (from `components.*.summary`):
 ### Additional Information
 
 - **Filters Applied**: Lists any component or date filters used
-- **Data Scope**: Notes which regressions are included based on date filtering
+- **Data Scope**: Notes which regressions are included based on view and date filtering
+  - Regressions are filtered to the specified view (open/closed status comes from the view)
   - For GA'd releases: Regressions within development window (start to GA)
   - For in-development releases: Regressions from development start onwards
 
 ## Examples
 
-1. **Summarize all regressions for a release**:
+1. **Summarize all regressions for a view**:
 
    ```
-   /teams:health-check-regressions 4.17
+   /teams:health-check-regressions 4.17-main
    ```
 
-   Fetches and summarizes all regressions for release 4.17, automatically applying development window date filtering.
+   Fetches and summarizes all regressions for the 4.17-main view, automatically applying development window date filtering.
 
 2. **Filter by specific component (exact match)**:
 
    ```
-   /teams:health-check-regressions 4.21 --components Monitoring
+   /teams:health-check-regressions 4.21-main --components Monitoring
    ```
 
-   Shows summary statistics for only the Monitoring component in release 4.21.
+   Shows summary statistics for only the Monitoring component in the 4.21-main view.
 
 3. **Filter by fuzzy search**:
 
    ```
-   /teams:health-check-regressions 4.21 --components network
+   /teams:health-check-regressions 4.21-main --components network
    ```
 
    Finds all components containing "network" (case-insensitive) and shows summary statistics for all matches (e.g., "Networking / ovn-kubernetes", "Networking / DNS", etc.).
@@ -203,7 +206,7 @@ For each component (from `components.*.summary`):
 4. **Filter by multiple search strings**:
 
    ```
-   /teams:health-check-regressions 4.21 --components etcd kube-
+   /teams:health-check-regressions 4.21-main --components etcd kube-
    ```
 
    Finds all components containing "etcd" OR "kube-" and shows combined summary statistics.
@@ -211,7 +214,7 @@ For each component (from `components.*.summary`):
 5. **Specify custom date range**:
 
    ```
-   /teams:health-check-regressions 4.17 --start 2024-05-17 --end 2024-10-29
+   /teams:health-check-regressions 4.17-main --start 2024-05-17 --end 2024-10-29
    ```
 
    Summarizes regressions within a specific date range:
@@ -221,10 +224,10 @@ For each component (from `components.*.summary`):
 6. **In-development release**:
 
    ```
-   /teams:health-check-regressions 4.21
+   /teams:health-check-regressions 4.22-main
    ```
 
-   Summarizes regressions for an in-development release:
+   Summarizes regressions for an in-development release view:
    - Automatically fetches development_start date
    - No end date filtering (release not yet GA'd)
    - Shows current state of regression management
@@ -232,7 +235,7 @@ For each component (from `components.*.summary`):
 7. **Filter by team**:
 
    ```
-   /teams:health-check-regressions 4.21 --team "API Server"
+   /teams:health-check-regressions 4.21-main --team "API Server"
    ```
 
    Summarizes regressions for all components owned by the "API Server" team:
@@ -243,16 +246,17 @@ For each component (from `components.*.summary`):
 8. **Team summary with custom date range**:
 
    ```
-   /teams:health-check-regressions 4.17 --team "Networking" --start 2024-05-17 --end 2024-10-29
+   /teams:health-check-regressions 4.17-main --team "Networking" --start 2024-05-17 --end 2024-10-29
    ```
 
    Summarizes regressions for the Networking team within a specific date range
 
 ## Arguments
 
-- `$1` (required): Release version
-  - Format: "X.Y" (e.g., "4.17", "4.21")
-  - Must be a valid OpenShift release number
+- `$1` (required): View name
+  - Format: "X.Y-suffix" (e.g., "4.22-main", "4.17-main")
+  - The release is derived from the view name (e.g., "4.22" from "4.22-main")
+  - Multiple views can exist per release (e.g., "4.22-main", "4.22-main-mass-failure")
 
 - `$2+` (optional): Filter flags
   - `--components <search1> [search2 ...]`: Filter by component names using fuzzy search

--- a/plugins/teams/commands/list-regressions.md
+++ b/plugins/teams/commands/list-regressions.md
@@ -336,7 +336,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 
 ## See Also
 
-- Skill Documentation: `plugins/component-health/skills/list-regressions/SKILL.md`
+- Skill Documentation: `plugins/teams/skills/list-regressions/SKILL.md`
 - Script: `plugins/teams/skills/list-regressions/list_regressions.py`
 - Related Command: `/teams:summarize-regressions` (for summary statistics)
 - Related Command: `/teams:analyze` (for health grading and analysis)

--- a/plugins/teams/commands/list-regressions.md
+++ b/plugins/teams/commands/list-regressions.md
@@ -1,6 +1,6 @@
 ---
 description: Fetch and list raw regression data for OpenShift releases
-argument-hint: <release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+argument-hint: <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
 ---
 
 ## Name
@@ -10,12 +10,12 @@ teams:list-regressions
 ## Synopsis
 
 ```
-/teams:list-regressions <release> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+/teams:list-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
 ```
 
 ## Description
 
-The `teams:list-regressions` command fetches regression data for a specified OpenShift release and returns raw regression details without performing any summarization or analysis. It provides complete regression information including test names, timestamps, triages, and metadata.
+The `teams:list-regressions` command fetches regression data for a specified view (e.g., "4.22-main") and returns raw regression details without performing any summarization or analysis. A view represents a specific regression tracking context within a release — multiple views can exist per release. The release is derived from the view name automatically. Open/closed status for each regression is determined by the view's own tracking (not the regression's global status). It provides complete regression information including test names, timestamps, triages, and metadata.
 
 This command is useful for:
 
@@ -33,9 +33,10 @@ This command is useful for:
    - Run: `python3 --version`
    - Verify version 3.6 or later is available
 
-2. **Parse Arguments**: Extract release version and optional filters from arguments
+2. **Parse Arguments**: Extract view name and optional filters from arguments
 
-   - Release format: "X.Y" (e.g., "4.17", "4.21")
+   - View format: "X.Y-suffix" (e.g., "4.22-main", "4.17-main")
+   - The release is derived from the view name (e.g., "4.22" from "4.22-main")
    - Optional filters:
      - `--components`: Space-separated list of component search strings (fuzzy match)
      - `--start`: Start date for filtering (YYYY-MM-DD)
@@ -46,7 +47,7 @@ This command is useful for:
 
    - Run list_components.py to get all available components:
      ```bash
-     python3 plugins/component-health/skills/list-components/list_components.py --release <release>
+     python3 plugins/teams/skills/list-components/list_components.py --release <release>
      ```
    - If `--components` was provided:
      - For each search string, find all components containing that string (case-insensitive)
@@ -59,15 +60,15 @@ This command is useful for:
 
 4. **Fetch Release Dates** (if date filtering needed): Run the get_release_dates.py script
 
-   - Script location: `plugins/component-health/skills/get-release-dates/get_release_dates.py`
+   - Script location: `plugins/teams/skills/get-release-dates/get_release_dates.py`
    - Pass release as `--release` argument
    - Extract `development_start` and `ga` dates from JSON output
    - Use these dates for `--start` and `--end` parameters if not explicitly provided
 
 5. **Execute Python Script**: Run the list_regressions.py script
 
-   - Script location: `plugins/component-health/skills/list-regressions/list_regressions.py`
-   - Pass release as `--release` argument
+   - Script location: `plugins/teams/skills/list-regressions/list_regressions.py`
+   - Pass view as `--view` argument (the script derives the release internally)
    - Pass resolved component names as `--components` argument
    - Pass `--start` date if filtering by start date
    - Pass `--end` date if filtering by end date
@@ -204,18 +205,18 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 
 ## Examples
 
-1. **List all regressions for a release**:
+1. **List all regressions for a view**:
 
    ```
-   /teams:list-regressions 4.17
+   /teams:list-regressions 4.17-main
    ```
 
-   Fetches all regression data for release 4.17, including all components.
+   Fetches all regression data for the 4.17-main view, including all components.
 
 2. **Filter by specific component (exact match)**:
 
    ```
-   /teams:list-regressions 4.21 --components Monitoring
+   /teams:list-regressions 4.21-main --components Monitoring
    ```
 
    Returns regression data for only the Monitoring component.
@@ -223,7 +224,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 3. **Filter by fuzzy search**:
 
    ```
-   /teams:list-regressions 4.21 --components network
+   /teams:list-regressions 4.21-main --components network
    ```
 
    Finds all components containing "network" (case-insensitive):
@@ -236,7 +237,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 4. **Filter by multiple search strings**:
 
    ```
-   /teams:list-regressions 4.21 --components etcd kube-
+   /teams:list-regressions 4.21-main --components etcd kube-
    ```
 
    Finds all components containing "etcd" OR "kube-":
@@ -249,7 +250,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 5. **Filter by development window** (GA'd release):
 
    ```
-   /teams:list-regressions 4.17 --start 2024-05-17 --end 2024-10-29
+   /teams:list-regressions 4.17-main --start 2024-05-17 --end 2024-10-29
    ```
 
    Fetches regressions within the development window:
@@ -259,26 +260,27 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 6. **Filter for in-development release**:
 
    ```
-   /teams:list-regressions 4.21 --start 2025-09-02
+   /teams:list-regressions 4.22-main --start 2025-09-02
    ```
 
-   Fetches regressions for an in-development release:
+   Fetches regressions for an in-development release view:
    - Excludes regressions closed before development started
    - No end date (release still in development)
 
 7. **Combine fuzzy component search and date filters**:
 
    ```
-   /teams:list-regressions 4.21 --components network --start 2025-09-02
+   /teams:list-regressions 4.21-main --components network --start 2025-09-02
    ```
 
    Returns regressions for all networking components from the development window.
 
 ## Arguments
 
-- `$1` (required): Release version
-  - Format: "X.Y" (e.g., "4.17", "4.21")
-  - Must be a valid OpenShift release number
+- `$1` (required): View name
+  - Format: "X.Y-suffix" (e.g., "4.22-main", "4.17-main")
+  - The release is derived from the view name (e.g., "4.22" from "4.22-main")
+  - Multiple views can exist per release (e.g., "4.22-main", "4.22-main-mass-failure")
 
 - `$2+` (optional): Filter flags
   - `--components <search1> [search2 ...]`: Filter by component names using fuzzy search
@@ -316,7 +318,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
    - Check firewall and VPN settings if needed
 
 3. **API Configuration**: The API endpoint must be configured in the script
-   - Location: `plugins/component-health/skills/list-regressions/list_regressions.py`
+   - Location: `plugins/teams/skills/list-regressions/list_regressions.py`
    - The script should have the correct API base URL
 
 ## Notes
@@ -335,7 +337,7 @@ Each regression object (in `components.*.open` or `components.*.closed` arrays) 
 ## See Also
 
 - Skill Documentation: `plugins/component-health/skills/list-regressions/SKILL.md`
-- Script: `plugins/component-health/skills/list-regressions/list_regressions.py`
+- Script: `plugins/teams/skills/list-regressions/list_regressions.py`
 - Related Command: `/teams:summarize-regressions` (for summary statistics)
 - Related Command: `/teams:analyze` (for health grading and analysis)
 - Related Skill: `get-release-dates` (for fetching development window dates)

--- a/plugins/teams/skills/analyze-regressions/SKILL.md
+++ b/plugins/teams/skills/analyze-regressions/SKILL.md
@@ -43,21 +43,22 @@ Use this skill when you need to:
 
 ### Step 1: Parse Arguments
 
-Extract the release version and optional component filter from the command arguments:
+Extract the view name and optional component filter from the command arguments:
 
-- **Release format**: "X.Y" (e.g., "4.17", "4.21")
+- **View format**: "X.Y-suffix" (e.g., "4.22-main", "4.17-main")
+- The release is derived from the view name (e.g., "4.22" from "4.22-main")
 - **Components** (optional): List of component names to filter by
 
 **Example argument parsing**:
 
 ```
-/teams:analyze-regressions 4.17
-/teams:analyze-regressions 4.21 --components Monitoring etcd
+/teams:analyze-regressions 4.17-main
+/teams:analyze-regressions 4.21-main --components Monitoring etcd
 ```
 
 ### Step 2: Fetch Release Dates
 
-Run the `get_release_dates.py` script to determine the development window for the release:
+Derive the release from the view name (e.g., "4.17" from "4.17-main"), then run the `get_release_dates.py` script to determine the development window:
 
 ```bash
 python3 plugins/teams/skills/get-release-dates/get_release_dates.py \
@@ -98,7 +99,7 @@ Run the `list_regressions.py` script with the appropriate arguments:
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17 \
+  --view 4.17-main \
   --start 2024-05-17 \
   --end 2024-10-29 \
   --short
@@ -106,7 +107,7 @@ python3 plugins/teams/skills/list-regressions/list_regressions.py \
 
 **Parameter rules**:
 
-- `--release`: Always required (from Step 1)
+- `--view`: Always required (from Step 1). The release is derived from the view name internally.
 - `--components`: Optional, only if specified by user (from Step 1)
 - `--start`: Use `development_start` date from Step 2 (if not null)
   - **Always applied** for both GA'd and in-development releases
@@ -120,21 +121,21 @@ python3 plugins/teams/skills/list-regressions/list_regressions.py \
   - Only includes summary statistics
   - Prevents truncation problems with large datasets
 
-**Example for GA'd release** (4.17):
+**Example for GA'd release** (4.17-main):
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17 \
+  --view 4.17-main \
   --start 2024-05-17 \
   --end 2024-10-29 \
   --short
 ```
 
-**Example for in-development release** (4.21 with null GA):
+**Example for in-development release** (4.22-main with null GA):
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.22-main \
   --start 2025-09-02 \
   --short
 ```
@@ -143,7 +144,7 @@ python3 plugins/teams/skills/list-regressions/list_regressions.py \
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.21-main \
   --components Monitoring etcd \
   --start 2025-09-02 \
   --short
@@ -469,7 +470,7 @@ Opening in your default browser...
 2. **Invalid Release Format**
 
    - **Symptom**: Empty results or error response
-   - **Solution**: Verify the release format (e.g., "4.17", not "v4.17" or "4.17.0")
+   - **Solution**: Verify the view format (e.g., "4.17-main", not "4.17" or "v4.17")
 
 3. **Release Dates Not Found**
 
@@ -500,7 +501,7 @@ Enable verbose output by examining stderr:
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17 \
+  --view 4.17-main \
   --short 2>&1 | tee debug.log
 ```
 
@@ -567,45 +568,48 @@ The HTML report should include:
 ### Example 1: Grade Overall Release Health
 
 ```
-/teams:analyze-regressions 4.17
+/teams:analyze-regressions 4.17-main
 ```
 
 **Execution flow**:
 
-1. Fetch release dates for 4.17
-2. Run list_regressions.py with --start and --end (GA'd release)
-3. Display overall health grade
-4. Display per-component scorecard
-5. Highlight components needing attention
-6. Offer HTML report generation
+1. Derive release "4.17" from view "4.17-main"
+2. Fetch release dates for 4.17
+3. Run list_regressions.py with --view 4.17-main --start and --end (GA'd release)
+4. Display overall health grade
+5. Display per-component scorecard
+6. Highlight components needing attention
+7. Offer HTML report generation
 
 ### Example 2: Grade Specific Components
 
 ```
-/teams:analyze-regressions 4.21 --components Monitoring etcd
+/teams:analyze-regressions 4.22-main --components Monitoring etcd
 ```
 
 **Execution flow**:
 
-1. Fetch release dates for 4.21 (may have null GA)
-2. Run list_regressions.py with --components and --start only (in-development)
-3. Display health grades for Monitoring and etcd only
-4. Compare the two components
-5. Identify which needs more attention
+1. Derive release "4.22" from view "4.22-main"
+2. Fetch release dates for 4.22 (may have null GA)
+3. Run list_regressions.py with --view --components and --start only (in-development)
+4. Display health grades for Monitoring and etcd only
+5. Compare the two components
+6. Identify which needs more attention
 
 ### Example 3: Grade Single Component
 
 ```
-/teams:analyze-regressions 4.21 --components "kube-apiserver"
+/teams:analyze-regressions 4.21-main --components "kube-apiserver"
 ```
 
 **Execution flow**:
 
-1. Fetch release dates for 4.21
-2. Run list_regressions.py with single component filter
-3. Display detailed health metrics for kube-apiserver
-4. Show open vs closed breakdown
-5. List count of open untriaged regressions (if any)
+1. Derive release "4.21" from view "4.21-main"
+2. Fetch release dates for 4.21
+3. Run list_regressions.py with --view and single component filter
+4. Display detailed health metrics for kube-apiserver
+5. Show open vs closed breakdown
+6. List count of open untriaged regressions (if any)
 
 ## Health Grade Calculation Details
 

--- a/plugins/teams/skills/list-regressions/SKILL.md
+++ b/plugins/teams/skills/list-regressions/SKILL.md
@@ -58,29 +58,29 @@ plugins/teams/skills/list-regressions/list_regressions.py
 Execute the script with appropriate arguments:
 
 ```bash
-# Basic usage - all regressions for a release
+# Basic usage - all regressions for a view
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17
+  --view 4.17-main
 
 # Filter by specific components
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.21-main \
   --components Monitoring "kube-apiserver"
 
 # Filter by multiple components
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.21-main \
   --components Monitoring etcd "kube-apiserver"
 
 # Filter by development window (GA'd release - both start and end)
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17 \
+  --view 4.17-main \
   --start 2024-05-17 \
   --end 2024-10-01
 
 # Filter by development window (in-development release - start only)
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.22-main \
   --start 2025-09-02
 ```
 
@@ -293,16 +293,17 @@ Enable verbose output by examining stderr:
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17 2>&1 | tee debug.log
+  --view 4.17 2>&1 | tee debug.log
 ```
 
 ## Script Arguments
 
 ### Required Arguments
 
-- `--release`: Release version to query
-  - Format: `"X.Y"` (e.g., "4.17", "4.16")
-  - Must be a valid OpenShift release number
+- `--view`: View name to query
+  - Format: `"X.Y-suffix"` (e.g., "4.22-main", "4.17-main")
+  - The release is derived from the view name automatically
+  - Multiple views can exist per release (e.g., "4.22-main", "4.22-main-mass-failure")
 
 ### Optional Arguments
 
@@ -501,46 +502,46 @@ The script outputs JSON with summaries and regressions grouped by component:
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.17
+  --view 4.17-main
 ```
 
-**Expected Output**: JSON containing all regressions for release 4.17
+**Expected Output**: JSON containing all regressions for the 4.17-main view
 
 ### Example 2: Filter by Component
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.21-main \
   --components Monitoring etcd
 ```
 
-**Expected Output**: JSON containing regressions for only Monitoring and etcd components in release 4.21
+**Expected Output**: JSON containing regressions for only Monitoring and etcd components in the 4.21-main view
 
 ### Example 3: Filter by Single Component
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.21 \
+  --view 4.21-main \
   --components "kube-apiserver"
 ```
 
-**Expected Output**: JSON containing regressions for the kube-apiserver component in release 4.21
+**Expected Output**: JSON containing regressions for the kube-apiserver component in the 4.21-main view
 
 ### Example 4: Filter by Exact Test Name
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.22 \
+  --view 4.22-main \
   --test-name "[Monitor:kubelet-container-restarts][sig-architecture] platform pods in ns/openshift-machine-config-operator should not exit an excessive amount of times"
 ```
 
-**Expected Output**: JSON containing all regressions (across all components and variants) for this exact test in release 4.22. Useful for finding the same test failing in different variant combinations.
+**Expected Output**: JSON containing all regressions (across all components and variants) for this exact test in the 4.22-main view. Useful for finding the same test failing in different variant combinations.
 
 ### Example 5: Filter by Test Name Substring
 
 ```bash
 python3 plugins/teams/skills/list-regressions/list_regressions.py \
-  --release 4.22 \
+  --view 4.22-main \
   --test-name-contains "openshift-machine-config-operator"
 ```
 

--- a/plugins/teams/skills/list-regressions/list_regressions.py
+++ b/plugins/teams/skills/list-regressions/list_regressions.py
@@ -3,23 +3,24 @@
 Script to fetch regression data for OpenShift components.
 
 Usage:
-    python3 list_regressions.py --release <release> [--components comp1 comp2 ...] [--short]
-    python3 list_regressions.py --release <release> --team "Team Name" [--short]
-    python3 list_regressions.py --release <release> --test-name "exact test name"
-    python3 list_regressions.py --release <release> --test-name-contains "substring"
+    python3 list_regressions.py --view <view> [--components comp1 comp2 ...] [--short]
+    python3 list_regressions.py --view <view> --team "Team Name" [--short]
+    python3 list_regressions.py --view <view> --test-name "exact test name"
+    python3 list_regressions.py --view <view> --test-name-contains "substring"
 
 Example:
-    python3 list_regressions.py --release 4.17
-    python3 list_regressions.py --release 4.21 --components Monitoring etcd
-    python3 list_regressions.py --release 4.21 --team "API Server"
-    python3 list_regressions.py --release 4.21 --short
-    python3 list_regressions.py --release 4.22 --test-name "[Monitor:kubelet-container-restarts]..."
-    python3 list_regressions.py --release 4.22 --test-name-contains "openshift-machine-config-operator"
+    python3 list_regressions.py --view 4.17-main
+    python3 list_regressions.py --view 4.21-main --components Monitoring etcd
+    python3 list_regressions.py --view 4.21-main --team "API Server"
+    python3 list_regressions.py --view 4.21-main --short
+    python3 list_regressions.py --view 4.22-main --test-name "[Monitor:kubelet-container-restarts]..."
+    python3 list_regressions.py --view 4.22-main --test-name-contains "openshift-machine-config-operator"
 """
 
 import argparse
 import os
 import json
+import re
 import sys
 import urllib.request
 import urllib.error
@@ -90,6 +91,56 @@ def calculate_hours_between(start_timestamp: str, end_timestamp: str) -> int:
     
     time_diff = end_time - start_time
     return round(time_diff.total_seconds() / 3600)
+
+
+def extract_release_from_view(view: str) -> str:
+    match = re.match(r'(\d+\.\d+)', view)
+    if not match:
+        raise ValueError(f"Cannot extract release from view name '{view}'. Expected format like '4.22-main'.")
+    return match.group(1)
+
+
+def filter_by_view(data: list, view_name: str) -> list:
+    """
+    Filter regressions to only those present in the specified view, and replace
+    top-level opened/closed fields with view-specific timestamps.
+
+    Args:
+        data: List of regression dictionaries
+        view_name: View name to filter by (e.g., "4.22-main")
+
+    Returns:
+        Filtered list of regressions with view-specific open/closed status
+    """
+    filtered = []
+    for regression in data:
+        views = regression.get('views', [])
+        matching_view = None
+        for v in views:
+            if v.get('view_name') == view_name:
+                matching_view = v
+                break
+
+        if matching_view is None:
+            continue
+
+        regression['opened'] = matching_view.get('opened_at', regression.get('opened'))
+
+        closed_at = matching_view.get('closed_at')
+        if isinstance(closed_at, dict):
+            if closed_at.get('Valid') is True:
+                regression['closed'] = closed_at.get('Time')
+            else:
+                regression['closed'] = None
+        elif matching_view.get('active') is True:
+            regression['closed'] = None
+        else:
+            regression['closed'] = closed_at
+
+        filtered.append(regression)
+
+    print(f"Filtered to {len(filtered)} regressions for view: {view_name}", file=sys.stderr)
+    return filtered
 
 
 def fetch_regressions(release: str) -> dict:
@@ -300,9 +351,9 @@ def remove_unnecessary_fields(regressions: list) -> list:
         List of regression dictionaries with unnecessary fields removed
     """
     for regression in regressions:
-        # Remove links and test_id to reduce response size
         regression.pop('links', None)
         regression.pop('test_id', None)
+        regression.pop('views', None)
     
     return regressions
 
@@ -615,31 +666,31 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # List all regressions for release 4.17
-  %(prog)s --release 4.17
+  # List all regressions for a view
+  %(prog)s --view 4.17-main
 
   # Filter by specific components
-  %(prog)s --release 4.21 --components Monitoring "kube-apiserver"
+  %(prog)s --view 4.21-main --components Monitoring "kube-apiserver"
 
   # Filter by multiple components
-  %(prog)s --release 4.21 --components Monitoring etcd "kube-apiserver"
+  %(prog)s --view 4.21-main --components Monitoring etcd "kube-apiserver"
 
   # Short output mode (summaries only, no regression data)
-  %(prog)s --release 4.17 --short
+  %(prog)s --view 4.17-main --short
 
   # Find all regressions for a specific test (across all variants)
-  %(prog)s --release 4.22 --test-name "exact test name here"
+  %(prog)s --view 4.22-main --test-name "exact test name here"
 
   # Find regressions with test names containing a substring
-  %(prog)s --release 4.22 --test-name-contains "openshift-machine-config-operator"
+  %(prog)s --view 4.22-main --test-name-contains "openshift-machine-config-operator"
         """
     )
-    
+
     parser.add_argument(
-        '--release',
+        '--view',
         type=str,
         required=True,
-        help='Release version (e.g., "4.17", "4.16")'
+        help='View name (e.g., "4.22-main", "4.17-main"). Release is derived from this.'
     )
     
     parser.add_argument(
@@ -707,6 +758,14 @@ Examples:
         print("Error: --test-name and --test-name-contains are mutually exclusive. Use one or the other.", file=sys.stderr)
         return 1
 
+    # Extract release from view name
+    try:
+        release = extract_release_from_view(args.view)
+        print(f"Derived release '{release}' from view '{args.view}'", file=sys.stderr)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
     # If team is specified, look up components for that team
     components_to_filter = args.components
     team_name = None
@@ -724,8 +783,8 @@ Examples:
             return 1
 
     try:
-        # Fetch regressions
-        regressions = fetch_regressions(args.release)
+        # Fetch regressions using derived release
+        regressions = fetch_regressions(release)
 
         # Filter by components (always called to remove empty component names)
         if isinstance(regressions, list):
@@ -734,6 +793,10 @@ Examples:
         # Filter by test name if specified
         if isinstance(regressions, list) and (args.test_name or args.test_name_contains):
             regressions = filter_by_test_name(regressions, args.test_name, args.test_name_contains)
+
+        # Filter by view and apply view-specific open/closed status
+        if isinstance(regressions, list):
+            regressions = filter_by_view(regressions, args.view)
 
         # Simplify time field structures (closed, last_failure)
         if isinstance(regressions, list):


### PR DESCRIPTION
Apologies for the mixed bag here, these are changes I've been accumulating for several weeks. 

Updates a couple commands for the new way sippy represents views on regressions.

Adds an agent for porting OTP tests to origin, still in development and not yet automated.

Adds a very helpful bigquery ci-data plugin that knows how to dedupe test junit flakes, join in variant info, and understands cost concerns with these tables. Queries are dry-run and will prompt the user for confirmation if the cost is over $5. Requires bigquery creds which most will not have outside TRT.

Improve the analyze-regression command to better pull dpcr and jira creds when running in a pod. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Add JIRA Triage Link" CI skill
  * Added "CI Data Analyst" BigQuery skill
  * Added "test-porter" agent to assist e2e test porting

* **Improvements**
  * Teams commands and docs now accept view names (e.g., 4.22-main) instead of release versions

* **Documentation**
  * Expanded CI and Teams docs with usage, prerequisites, and examples

* **Chores**
  * Bumped CI, Teams, and BigQuery plugin versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->