### PR TITLE
HPNEX-9: Add promptfoo behavioral evals for plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,13 +17,13 @@
       "name": "hello-world",
       "source": "./plugins/hello-world",
       "description": "Hello World Plugin",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.4.4"
+      "version": "0.4.5"
     },
     {
       "name": "ci",
@@ -209,7 +209,7 @@
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "name": "golang",

--- a/.github/workflows/eval-plugins.yml
+++ b/.github/workflows/eval-plugins.yml
@@ -1,0 +1,82 @@
+name: Plugin Evals
+
+on:
+  pull_request:
+
+permissions: {}
+
+env:
+  CLAUDE_CODE_USE_VERTEX: 'true'
+
+jobs:
+  detect-changed-plugins:
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.detect.outputs.plugins }}
+      has_plugins: ${{ steps.detect.outputs.has_plugins }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect changed plugins with evals
+        id: detect
+        run: |
+          plugins=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- plugins/ \
+            | sed -n 's|^plugins/\([^/]*\)/.*|\1|p' \
+            | sort -u \
+            | while read plugin; do
+                [ -d "plugins/${plugin}/evals" ] && echo "$plugin"
+              done \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "plugins=${plugins}" >> "$GITHUB_OUTPUT"
+          if [ "$plugins" = "[]" ] || [ -z "$plugins" ]; then
+            echo "has_plugins=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_plugins=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Changed plugins with evals: ${plugins}"
+
+  behavioral-evals:
+    needs: detect-changed-plugins
+    if: needs.detect-changed-plugins.outputs.has_plugins == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin: ${{ fromJson(needs.detect-changed-plugins.outputs.plugins) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - name: Run behavioral evals for ${{ matrix.plugin }}
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
+          EVAL_OUTPUT_DIR: ${{ github.workspace }}/eval-results
+        run: |
+          mkdir -p "$EVAL_OUTPUT_DIR"
+          make eval-plugins EVAL_PLUGIN=${{ matrix.plugin }}
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: eval-results-${{ matrix.plugin }}
+          path: eval-results/*.xml
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ venv/
 # Working directories for skills
 .work/
 
+# Node.js
+node_modules/
+package-lock.json
+
+# Promptfoo eval output
+.promptfoo/
+
 # Various logs and metrics tracking info
 *.log
 .anonymous_id

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,30 @@ update: ## Update plugin documentation and website data
 	@echo "Building website data..."
 	@python3 scripts/build-website.py
 
+EVAL_REPEAT ?= 1
+EVAL_PASS_RATE_THRESHOLD ?= 100
+EVAL_CONFIGS := $(shell find plugins/$(or $(EVAL_PLUGIN),*) -path '*/evals/*.yaml' 2>/dev/null | sort)
+EVAL_TARGETS := $(foreach c,$(EVAL_CONFIGS),_run-eval__$(subst /,__,$(c)))
+
+.PHONY: eval-plugins
+eval-plugins: ## Run plugin behavioral evals (EVAL_PLUGIN, EVAL_FILTER, EVAL_OUTPUT, EVAL_REPEAT)
+	@npm install
+	@$(MAKE) -j$(words $(EVAL_CONFIGS)) --no-print-directory $(EVAL_TARGETS)
+
+.PHONY: $(EVAL_TARGETS)
+$(EVAL_TARGETS):
+	$(eval CONFIG := $(subst __,/,$(patsubst _run-eval__%,%,$@)))
+	$(eval EVAL_NAME := $(basename $(notdir $(CONFIG))))
+	@echo "=== Running eval: $(CONFIG) ==="
+	@CLAUDE_CODE_USE_VERTEX=true \
+	PROMPTFOO_PASS_RATE_THRESHOLD=$(EVAL_PASS_RATE_THRESHOLD) \
+		npx promptfoo eval \
+		-c "$(CONFIG)" \
+		$(if $(EVAL_FILTER),--filter-pattern "$(EVAL_FILTER)") \
+		$(if $(EVAL_TIER),--filter-metadata "tier=$(EVAL_TIER)") \
+		$(if $(EVAL_OUTPUT_DIR),--output "$(EVAL_OUTPUT_DIR)/$(EVAL_NAME).xml") \
+		--repeat $(EVAL_REPEAT) \
+		--no-cache \
+		--table-cell-max-length 500
+
 .DEFAULT_GOAL := help

--- a/docs/data.json
+++ b/docs/data.json
@@ -92,7 +92,7 @@
       "hooks": [],
       "name": "hello-world",
       "skills": [],
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "commands": [
@@ -311,7 +311,7 @@
           "name": "Jira Status Analysis Engine"
         }
       ],
-      "version": "0.4.4"
+      "version": "0.4.5"
     },
     {
       "commands": [
@@ -1699,7 +1699,7 @@
           "name": "HyperShift Project Profile"
         }
       ],
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     {
       "commands": [],

--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -122,7 +122,7 @@ make eval-plugins EVAL_PLUGIN=code-review EVAL_TIER=fast
 
 #### Budget planning
 
-Measured cost per full run (26 tests, opus agent, Vertex AI): **~$6**
+Measured cost per full run (25 tests, opus agent, Vertex AI): **~$6**
 
 | Plugin              | Tests | Tier        | Actual cost | Per-test avg |
 |---------------------|-------|-------------|-------------|--------------|

--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -1,0 +1,257 @@
+# Plugin Evals
+
+Behavioral evals for ai-helpers plugins using [promptfoo](https://github.com/promptfoo/promptfoo) with the `anthropic:claude-agent-sdk` provider.
+
+## Architecture Decisions
+
+### Provider: `anthropic:claude-agent-sdk` with Vertex AI
+- The SDK provider spawns the Claude Code CLI as a subprocess, giving full agent behavior (tools, skills, plugins)
+- Vertex AI auth via `CLAUDE_CODE_USE_VERTEX=true` — no Anthropic API key needed, uses GCP credentials
+- `ANTHROPIC_VERTEX_PROJECT_ID` tells Claude Code which GCP project to bill
+
+### Co-located eval configs
+- Eval configs live inside each plugin: `plugins/<name>/evals/*.yaml`
+- Not in a central `evals/` directory — keeps tests next to the code they test
+- The root `evals/` only holds the smoke test config and this file
+- Adding evals for a new plugin: create `plugins/<name>/evals/<test>.yaml`
+
+### Assertions
+- **`skill-used` / `not-skill-used`**: verifies the agent invokes the correct skill and doesn't route to adjacent ones. Requires the SDK provider (not available with `exec:` providers). Skill names are namespaced: `plugin-name:skill-name`
+- **`icontains`**: deterministic string match on agent output — cheap, no LLM judge
+- **`llm-rubric`**: LLM-judged quality check — used for fuzzy assertions where exact output varies
+- **`cost` / `latency`**: regression guards — fail if a test exceeds thresholds
+- **No `output_format`**: we don't use `output_format: json_schema` because it bypasses the Skill tool invocation, which breaks `skill-used` assertions. The agent returns natural text with embedded JSON instead
+- See [promptfoo assertion docs](https://www.promptfoo.dev/docs/configuration/expected-outputs/) for the full list of available assertion types
+
+### Test fixtures
+- Issue descriptions for jira evals live in `plugins/jira/evals/fixtures/*.md`
+- Referenced via `file://fixtures/<name>.md` in yaml vars
+- Plain markdown, not JSON — promptfoo loads them as string variables
+
+### Test metadata and tiering
+
+Every test case carries per-test metadata that describes its cost profile. Metadata must be on each test case directly — `defaultTest.metadata` is not used because `--filter-metadata` runs before defaultTest merging.
+
+Use YAML anchors (`&meta-fast`) and aliases (`*meta-fast`) to avoid repetition:
+
+```yaml
+tests:
+  - description: "first test"
+    metadata: &meta-fast          # anchor: defines the block
+      token-usage: medium
+      judge-size: none
+      tier: fast
+    ...
+
+  - description: "second test"
+    metadata: *meta-fast          # alias: reuses the block
+    ...
+```
+
+#### Metadata fields
+
+```yaml
+metadata:
+  token-usage: small | medium | large    # agent execution cost
+  judge-size: none | sonnet | opus       # grading model for llm-rubric assertions
+  tier: fast | medium | heavy            # computed from token-usage and judge-size
+```
+
+**`token-usage`** — how expensive the agent execution is, derived from the `type: cost` and `type: latency` assertion thresholds on each test:
+
+| token-usage | cost threshold | latency threshold | typical test                         |
+|-------------|----------------|-------------------|--------------------------------------|
+| small       | $0.50          | 30s               | simple command, minimal tool calls   |
+| medium      | $0.50          | 60s               | single skill invocation with tool use|
+| large       | $0.60-1.20     | 120-180s          | multi-tool workflow, script execution|
+
+The `cost` assertion checks the agent execution cost only (not judge cost).
+
+**`judge-size`** — which model grades `llm-rubric` assertions:
+- `none`: no LLM judge — only deterministic assertions (`icontains`, `skill-used`, `cost`, `latency`)
+- `sonnet`: graded by `vertex:claude-sonnet-4-6` — cheaper, good for straightforward pass/fail
+- `opus`: graded by `vertex:claude-opus-4-6` — more capable, for nuanced quality judgments
+
+The judge model is configured in `defaultTest.options.provider` per eval file.
+
+**`tier`** — computed from the other two, determines when the test runs:
+
+| token-usage | judge-size | tier   |
+|-------------|------------|--------|
+| small       | none       | fast   |
+| medium      | none       | fast   |
+| large       | none       | medium |
+| small       | sonnet     | fast   |
+| medium      | sonnet     | medium |
+| large       | sonnet     | heavy  |
+| small       | opus       | medium |
+| medium      | opus       | medium |
+| large       | opus       | heavy  |
+
+Rule: tier is the highest cost contributor across both dimensions. A `none` judge pulls the tier down (no grading cost), while `opus` judge or `large` agent cost pushes it up.
+
+#### Current test inventory
+
+| Test                         | token-usage | judge-size | tier   | count |
+|------------------------------|-------------|------------|--------|-------|
+| hello-world/echo             | small       | none       | fast   | 3     |
+| classify golden tests        | medium      | none       | fast   | 13    |
+| classify ambiguous/routing   | medium      | opus       | medium | 2     |
+| jira/ready-to-solve          | large       | opus       | heavy  | 3     |
+| jira/solve                   | large       | opus       | heavy  | 4     |
+| **Total**                    |             |            |        | **25**|
+
+#### Running by tier
+
+```bash
+# Fast only — 16 tests, deterministic
+make eval-plugins EVAL_TIER=fast
+
+# Medium only — 2 tests, opus judge but cheap agent
+make eval-plugins EVAL_TIER=medium
+
+# Heavy only — 8 tests, expensive agent + opus judge
+make eval-plugins EVAL_TIER=heavy
+
+# All tiers (default)
+make eval-plugins
+
+# Combine with plugin filter
+make eval-plugins EVAL_PLUGIN=code-review EVAL_TIER=fast
+```
+
+#### Budget planning
+
+Measured cost per full run (26 tests, opus agent, Vertex AI): **~$6**
+
+| Plugin              | Tests | Tier        | Actual cost | Per-test avg |
+|---------------------|-------|-------------|-------------|--------------|
+| hello-world         | 3     | fast        | $0.56       | $0.19        |
+| code-review         | 15    | fast/medium | $2.70       | $0.18        |
+| jira/ready-to-solve | 3     | heavy       | $1.62       | $0.54        |
+| jira/solve          | 5     | heavy       | $0.73       | $0.15        |
+| **Total**           | **26**|             | **$5.61**   | **$0.22**    |
+
+By tier:
+
+| Tier   | Tests | Actual cost |
+|--------|-------|-------------|
+| fast   | 16    | ~$3.26      |
+| medium | 2     | ~$0.33      |
+| heavy  | 8     | ~$2.02      |
+
+Agent execution is the dominant cost (~99%). Judge calls are negligible even with opus.
+
+When setting `cost` thresholds per test, use ~2x the observed per-test max:
+- `small`: observed ~$0.20, threshold $0.50
+- `medium`: observed ~$0.21, threshold $0.50
+- `large`: observed $0.27-0.62, threshold $0.60-1.20
+
+### Cost and latency thresholds
+Per-test thresholds in `defaultTest.assert` catch regressions without flaking:
+
+| Plugin              | Latency | Cost  | token-usage |
+|---------------------|---------|-------|-------------|
+| hello-world         | 30s     | $0.50 | small       |
+| code-review         | 60s     | $0.50 | medium      |
+| jira/ready-to-solve | 3min    | $1.20 | large       |
+| jira/solve          | 2min    | $0.60 | large       |
+
+### Per-plugin budgets
+Budgets are defined centrally in `evals/budget.yaml` with `allowed` (admin-set cap) and `current` (sum of cost thresholds across all tests) per plugin:
+
+| Plugin              | Allowed | Current (sum of thresholds) |
+|---------------------|---------|----------------------------|
+| hello-world         | $1.50   | $1.50                      |
+| code-review         | $8.00   | $7.50                      |
+| jira                | $7.00   | $6.00                      |
+| **Total**           | **$16.50** | **$15.00**              |
+
+`evals/budget.yaml` is the single source of truth for the eval cost model. It contains:
+- **`orderings`**: defines `small < medium < large`, `none < sonnet < opus`, `fast < medium < heavy`
+- **`token-usage`**: maps each size to its `max-cost` and `max-latency` thresholds
+- **`tiers`**: maps each tier to its `max-token-usage` and `max-judge-size` bounds
+- **`budgets`**: per-plugin `allowed` (admin cap) and `current` (sum of thresholds)
+- **Linter validation rules**: documented as comments — how to validate metadata consistency, threshold bounds, and budget compliance
+
+## File Structure
+
+```text
+plugins/
+  hello-world/evals/
+    echo.yaml                                     # 3 command output tests
+  code-review/evals/
+    classify-review-comment.yaml                  # 15 skill classification tests
+  jira/evals/
+    ready-to-solve.yaml                           # 3 readiness validation tests
+    solve.yaml                                    # 4 phase-level analysis tests
+    fixtures/                                     # test issue descriptions (.md)
+evals/
+  AGENTS.md                                       # this file
+  budget.yaml                                     # shared cost definitions + per-plugin budgets
+  promptfooconfig.yaml                            # smoke test
+package.json                                      # pins promptfoo + claude-agent-sdk versions
+.github/workflows/eval-plugins.yml                # CI: evals on PRs with changed plugins
+```
+
+## Running Evals
+
+### Prerequisites
+- `claude` CLI installed and authenticated
+- Node.js 22+
+- `gcloud auth application-default login` (for Vertex AI)
+- `ANTHROPIC_VERTEX_PROJECT_ID` set
+
+### Commands
+
+```bash
+# Run all plugin evals (parallel)
+ANTHROPIC_VERTEX_PROJECT_ID=<project> make eval-plugins
+
+# Single plugin
+make eval-plugins EVAL_PLUGIN=hello-world
+
+# Filter by test description
+make eval-plugins EVAL_PLUGIN=code-review EVAL_FILTER=nitpick
+
+# Filter by tier
+make eval-plugins EVAL_TIER=fast
+
+# Combine plugin and tier
+make eval-plugins EVAL_PLUGIN=code-review EVAL_TIER=fast
+
+# Multiple runs with pass rate threshold
+make eval-plugins EVAL_REPEAT=3 EVAL_PASS_RATE_THRESHOLD=80
+
+# JUnit XML output (for CI)
+EVAL_OUTPUT_DIR=./eval-results make eval-plugins
+
+# View results in browser
+npx promptfoo view
+```
+
+### Makefile parallelism
+`make eval-plugins` discovers all `plugins/*/evals/*.yaml` files and runs them in parallel via `$(MAKE) -j`. Each yaml file becomes a sub-make target (with `/` replaced by `__` to work around Make's pattern rule limitation). All eval files run simultaneously — total wall-clock time equals the slowest plugin, not the sum.
+
+`EVAL_PLUGIN=<name>` narrows the `find` to a single plugin directory. `EVAL_FILTER=<pattern>` passes `--filter-pattern` to promptfoo, which matches against test `description:` fields within each yaml. `EVAL_TIER=<tier>` passes `--filter-metadata tier=<tier>` to run only tests at that tier level.
+
+## CI Workflow
+
+`.github/workflows/eval-plugins.yml` runs on every PR:
+
+1. **detect-changed-plugins**: diffs `plugins/` against the base branch, finds plugins with `evals/` directories
+2. **behavioral-evals**: matrix job — one per changed plugin, runs `make eval-plugins EVAL_PLUGIN=<name>`
+3. Results rendered as GitHub Check via `dorny/test-reporter` and uploaded as JUnit XML artifacts
+
+The workflow requires `ANTHROPIC_VERTEX_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS` as GitHub secrets.
+
+## Adding Evals for a New Plugin
+
+1. Create `plugins/<name>/evals/<test-name>.yaml`
+2. Use an existing eval as a template (e.g., `plugins/hello-world/evals/echo.yaml`)
+3. Set the provider to load your plugin: `plugins: [{type: local, path: ../}]`
+4. Add `skill-used` in `defaultTest.assert` if testing a skill
+5. Add `cost` and `latency` thresholds in `defaultTest.assert` based on observed values (run once, then set 2-3x)
+6. Add per-test `metadata` with `token-usage`, `judge-size`, and `tier` — use YAML anchors to DRY
+7. For test data, create `plugins/<name>/evals/fixtures/` and reference via `file://fixtures/<name>.md`
+8. Run locally: `make eval-plugins EVAL_PLUGIN=<name>`

--- a/evals/budget.yaml
+++ b/evals/budget.yaml
@@ -1,0 +1,100 @@
+# Shared eval cost definitions and per-plugin budgets.
+#
+# This file is the single source of truth for:
+# - token-usage size definitions (cost/latency thresholds)
+# - judge-size ordering
+# - tier computation rules
+# - per-plugin budget allowances
+#
+# Linters validate that every test's metadata is consistent with these definitions.
+
+orderings:
+  token-usage: [small, medium, large]
+  judge-size: [none, sonnet, opus]
+  tier: [fast, medium, heavy]
+
+# A test's token-usage is the LOWEST size where BOTH cost AND latency
+# thresholds are at or below the declared limits. If either exceeds,
+# the test belongs to the next size up.
+token-usage:
+  small:
+    max-cost: 0.50
+    max-latency: 30000
+  medium:
+    max-cost: 0.50
+    max-latency: 60000
+  large:
+    max-cost: 1.20
+    max-latency: 180000
+
+# A test's tier is the LOWEST level where BOTH token-usage AND judge-size
+# fit within the max bounds. If either exceeds, the test belongs to the
+# next tier up. Use orderings above for comparison.
+# | token-usage | judge-size | tier   |
+# |-------------|------------|--------|
+# | small       | none       | fast   |
+# | medium      | none       | fast   |
+# | large       | none       | medium |
+# | small       | sonnet     | fast   |
+# | medium      | sonnet     | medium |
+# | large       | sonnet     | heavy  |
+# | small       | opus       | medium |
+# | medium      | opus       | medium |
+# | large       | opus       | heavy  |
+tiers:
+  fast:
+    max-token-usage: medium
+    max-judge-size: none
+  medium:
+    max-token-usage: medium
+    max-judge-size: opus
+  heavy:
+    max-token-usage: large
+    max-judge-size: opus
+
+# Per-plugin budgets.
+# - allowed: admin-set cap — max total cost permitted for this plugin's evals
+# - current: sum of cost thresholds across all tests in this plugin (computed from eval yamls)
+# Linter validates: current <= allowed. If adding tests or raising thresholds
+# would push current above allowed, the linter flags it.
+budgets:
+  hello-world:
+    allowed: 1.50
+    current: 1.50      # 3 tests × $0.50
+  code-review:
+    allowed: 8.00
+    current: 7.50      # 15 tests × $0.50
+  jira:
+    allowed: 7.00
+    current: 6.00      # 3 tests × $1.20 + 4 tests × $0.60
+
+# Linter validation rules:
+#
+# 1. Every test must have metadata with: token-usage, judge-size, tier
+#
+# 2. token-usage validation:
+#    - Value must be in orderings.token-usage
+#    - The test's cost threshold (from defaultTest.assert or per-test assert)
+#      must be <= token-usage[value].max-cost
+#    - The test's latency threshold must be <= token-usage[value].max-latency
+#    - token-usage must be the LOWEST size where both fit — if both thresholds
+#      fit in a smaller size, the test is over-classified
+#
+# 3. judge-size validation:
+#    - Value must be in orderings.judge-size
+#    - If the test has NO llm-rubric assertions (combined with defaultTest):
+#      judge-size must be "none"
+#    - If the test HAS llm-rubric assertions: judge-size must match the
+#      model in defaultTest.options.provider (e.g. vertex:claude-opus-4-6 → opus,
+#      vertex:claude-sonnet-4-6 → sonnet). Must not be "none"
+#
+# 4. tier validation:
+#    - Value must be in orderings.tier
+#    - tier must be the LOWEST level where both token-usage and judge-size
+#      fit: token-usage <= tiers[tier].max-token-usage AND
+#      judge-size <= tiers[tier].max-judge-size (using orderings for comparison)
+#    - If tier is higher than necessary, the test is over-classified
+#
+# 5. budget validation:
+#    - Sum of cost thresholds across all tests in a plugin must be
+#      <= budgets[plugin].allowed

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -1,0 +1,35 @@
+# Root eval config — smoke test to verify the provider works.
+# For full evals, use make eval-plugins or run individual plugin evals.
+
+description: "ai-helpers — provider smoke test"
+
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: smoke
+    config:
+      model: claude-opus-4-6
+      plugins:
+        - type: local
+          path: ../plugins/hello-world
+      append_allowed_tools: ['Bash']
+      permission_mode: 'auto'
+
+prompts:
+  - "{{prompt}}"
+
+defaultTest:
+  options:
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+
+tests:
+  - description: "smoke/provider-loads"
+    vars:
+      prompt: "Run /hello-world:echo"
+    assert:
+      - type: icontains
+        value: "Hello world"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "promptfoo": "0.121.11"
+  }
+}

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/code-review/evals/classify-review-comment.yaml
+++ b/plugins/code-review/evals/classify-review-comment.yaml
@@ -1,0 +1,240 @@
+# Skill eval for code-review:classify-review-comment
+#
+# Tests the real skill at ../skills/classify-review-comment/.
+# Uses claude-agent-sdk provider with Vertex AI (set CLAUDE_CODE_USE_VERTEX=true).
+#
+# Usage:
+#   make eval-plugins EVAL_PLUGIN=code-review                    # run all code-review evals
+#   make eval-plugins EVAL_PLUGIN=code-review EVAL_FILTER=nitpick # filter by test name
+
+description: "Skill eval: code-review:classify-review-comment"
+
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: classify-review-comment
+    config:
+      model: claude-opus-4-6
+      plugins:
+        - type: local
+          path: ../
+      skills: ['code-review:classify-review-comment']
+      append_allowed_tools: ['Skill', 'Read']
+      permission_mode: 'auto'
+
+prompts:
+  - "{{prompt}}"
+
+defaultTest:
+  options:
+    disableVarExpansion: true
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+  assert:
+    - type: skill-used
+      value: code-review:classify-review-comment
+    - type: not-skill-used
+      value: code-review:lang-go
+    - type: not-skill-used
+      value: code-review:profile-hypershift
+    - type: latency
+      threshold: 60000
+    - type: cost
+      threshold: 0.50
+
+tests:
+  # --- Golden tests: known-correct classifications from SKILL.md examples ---
+
+  - description: "classify/nitpick-style — variable grouping nit"
+    metadata: &meta-fast
+      token-usage: medium
+      judge-size: none
+      tier: fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "small nit: I would move the vars `key`, `log` and `cloudName` to `var (` section just to be consistent."
+    assert:
+      - type: icontains
+        value: "nitpick"
+      - type: icontains
+        value: "style"
+
+  - description: "classify/question-api_design — API choice question"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "Why not use NewARMClientOptions here for the clientOptions?"
+    assert:
+      - type: icontains
+        value: "question"
+      - type: icontains
+        value: "api_design"
+
+  - description: "classify/required_change-logic_bug — nil panic"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "This will panic if `items` is nil — needs a nil check before the loop"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "logic_bug"
+
+  - description: "classify/required_change-logic_bug — install failure"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "failing during `hypershift install`\n```\nClusterRoleBinding is invalid: roleRef.kind: Unsupported value\n```"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "logic_bug"
+
+  - description: "classify/required_change-test_gap — failing unit tests"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "hypershift-jira-solve-ci - the unit test job is failing and needs fixed"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "test_gap"
+
+  - description: "classify/suggestion-ci — rebase for CI"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "hypershift-jira-solve-ci - rebase the PR to fix the konflux issues"
+    assert:
+      - type: icontains
+        value: "suggestion"
+      - type: icontains
+        value: "ci"
+
+  - description: "classify/required_change-process — code not pushed"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "hypershift-jira-solve-ci - this still needs fixed since the code did not get pushed"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "process"
+
+  - description: "classify/suggestion-ci — override with analysis"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "`e2e-aws-4-21` failed on `Teardown` but due to uncleaned cloud resources, not VPC endpoint blocking the finalizer\n/override ci/prow/e2e-aws-4-21"
+    assert:
+      - type: icontains
+        value: "suggestion"
+      - type: icontains
+        value: "ci"
+
+  - description: "classify/unclassified-approval — reviewer withdrawal"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "Oh no that's ok. I missed that part. No changes requested."
+    assert:
+      - type: icontains
+        value: "unclassified"
+      - type: icontains
+        value: "approval"
+
+  - description: "classify/unclassified-process — duplicate marking"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "dup of https://github.com/openshift/hypershift/pull/7727"
+    assert:
+      - type: icontains
+        value: "unclassified"
+      - type: icontains
+        value: "process"
+
+  - description: "classify/required_change-logic_bug — case mismatch root cause"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "The root cause of the CI failure in this PR has been identified. The fix in `rejectVpcEndpointConnections` doesn't work because of a **case mismatch** between AWS API responses and SDK v2 enum constants."
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "logic_bug"
+
+  - description: "classify/suggestion-architecture_design — controller separation"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "This controller is doing too much — the reconciler should delegate VPC cleanup to a separate controller instead of inlining it"
+    assert:
+      - type: icontains
+        value: "suggestion"
+      - type: icontains
+        value: "architecture_design"
+
+  - description: "classify/required_change-security — token logging"
+    metadata: *meta-fast
+    vars:
+      prompt: |
+        Classify this review comment:
+        "The service account token is being logged in plain text here — this needs to be redacted"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: icontains
+        value: "security"
+
+  # --- Ambiguous boundary cases ---
+
+  - description: "classify/ambiguous — timeout suggestion"
+    metadata: &meta-medium
+      token-usage: medium
+      judge-size: opus
+      tier: medium
+    vars:
+      prompt: |
+        Classify this review comment:
+        "consider using a context.WithTimeout here to avoid hanging forever"
+    assert:
+      - type: llm-rubric
+        value: "The output classifies this as either suggestion or required_change severity, with topic logic_bug or api_design"
+
+  # --- Routing: Go content should still use classify, not lang-go ---
+
+  - description: "classify/routing — Go comment routes to classify, not lang-go"
+    metadata: *meta-medium
+    vars:
+      prompt: |
+        Classify this review comment:
+        "This Go function should return an error instead of panicking"
+    assert:
+      - type: icontains
+        value: "required_change"
+      - type: llm-rubric
+        value: "The output classifies the topic as logic_bug or api_design"
+
+evaluateOptions:
+  maxConcurrency: 20

--- a/plugins/hello-world/.claude-plugin/plugin.json
+++ b/plugins/hello-world/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hello-world",
   "description": "A hello world plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Developer"
   }

--- a/plugins/hello-world/evals/echo.yaml
+++ b/plugins/hello-world/evals/echo.yaml
@@ -1,0 +1,60 @@
+description: "Behavioral evals for hello-world:echo command"
+
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: hello-world
+    config:
+      model: claude-opus-4-6
+      plugins:
+        - type: local
+          path: ../
+      append_allowed_tools: ['Bash', 'Skill']
+      permission_mode: 'auto'
+
+prompts:
+  - "{{prompt}}"
+
+defaultTest:
+  options:
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+  assert:
+    - type: latency
+      threshold: 30000
+    - type: cost
+      threshold: 0.50
+
+tests:
+  - description: "Default greeting with no arguments"
+    metadata: &meta-fast
+      token-usage: small
+      judge-size: none
+      tier: fast
+    vars:
+      prompt: "Run /hello-world:echo"
+    assert:
+      - type: contains
+        value: "Hello world"
+
+  - description: "Named greeting with single word"
+    metadata: *meta-fast
+    vars:
+      prompt: "Run /hello-world:echo Alice"
+    assert:
+      - type: contains
+        value: "Hello Alice"
+
+  - description: "Named greeting with quoted multi-word name"
+    metadata: *meta-fast
+    vars:
+      prompt: 'Run /hello-world:echo "John Doe"'
+    assert:
+      - type: contains
+        value: "Hello John Doe"
+
+evaluateOptions:
+  maxConcurrency: 20

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/evals/fixtures/deprecated-endpoints.md
+++ b/plugins/jira/evals/fixtures/deprecated-endpoints.md
@@ -1,0 +1,11 @@
+Summary: Remove deprecated API endpoints
+
+## Context
+Several API endpoints marked deprecated in v2.0 need to be removed.
+
+## Acceptance Criteria
+- All deprecated endpoints removed from pkg/api/routes.go
+- Migration guide updated in docs/migration-v3.md
+
+## Technical Details
+Endpoints to remove: /v2/users/legacy, /v2/auth/token-v1

--- a/plugins/jira/evals/fixtures/empty-context.md
+++ b/plugins/jira/evals/fixtures/empty-context.md
@@ -1,0 +1,13 @@
+## Context
+
+Fix the bug.
+
+## Acceptance Criteria
+
+- The bug is fixed
+- Tests pass
+- No regressions introduced
+
+## Technical Details
+
+See the related Slack thread for more information about what needs to change.

--- a/plugins/jira/evals/fixtures/missing-ac.md
+++ b/plugins/jira/evals/fixtures/missing-ac.md
@@ -1,0 +1,9 @@
+## Context
+
+The auth handler in `pkg/auth/handler.go` crashes with a nil pointer dereference when the incoming request has an expired or malformed JWT token. The `ParseToken` function returns nil on error but the caller does not check for nil before accessing token fields.
+
+This affects all authenticated endpoints and has been reported by three customers in the last week.
+
+## Technical Details
+
+The crash happens at line 87 of `pkg/auth/handler.go` where `token.Claims` is accessed without a nil check. The fix should add a nil check after `ParseToken()` returns and return a 401 status code with an appropriate error message.

--- a/plugins/jira/evals/fixtures/multi-area-feature.md
+++ b/plugins/jira/evals/fixtures/multi-area-feature.md
@@ -1,0 +1,20 @@
+Summary: Add configurable node drain timeout to NodePool API
+
+## Context
+When nodes are drained during upgrades, the default 5-minute timeout is too short
+for some workloads. Customers need a way to configure the drain timeout per NodePool.
+
+## Acceptance Criteria
+- New `drainTimeout` field added to NodePool spec in api/hypershift/v1beta1/nodepool_types.go
+- CRDs regenerated via controller-gen
+- Vendor dependencies updated for new API validation library
+- NodePool controller in controllers/nodepool/ updated to read and apply the timeout
+- HostedCluster controller global default honours the nodepool input
+- CLI flag added in cmd/nodepool/create.go to set drain timeout at creation time
+- Unit tests added for the controller change
+- Documentation updated in docs/content/how-to/nodepool-management.md
+
+## Technical Details
+The drain timeout should default to 300s if not set. Use metav1.Duration type.
+The controller reads the field during the drain phase in controllers/nodepool/nodepool_controller.go.
+Run `make api` to regenerate CRDs and clients after the API change.

--- a/plugins/jira/evals/fixtures/rbac-middleware.md
+++ b/plugins/jira/evals/fixtures/rbac-middleware.md
@@ -1,0 +1,14 @@
+Summary: Add RBAC middleware with tests and docs
+
+## Context
+Need to add role-based access control middleware to the API server.
+
+## Acceptance Criteria
+- RBAC middleware added to pkg/middleware/rbac.go
+- Unit tests in pkg/middleware/rbac_test.go
+- API documentation updated in docs/api.md
+- Integration test in test/e2e/rbac_test.go
+
+## Technical Details
+Follow existing middleware pattern in pkg/middleware/auth.go.
+Use the Role enum from pkg/auth/types.go.

--- a/plugins/jira/evals/fixtures/sparse-bug.md
+++ b/plugins/jira/evals/fixtures/sparse-bug.md
@@ -1,0 +1,5 @@
+Summary: Fix null pointer in auth handler
+
+The auth handler crashes when token is nil.
+
+Components: authentication

--- a/plugins/jira/evals/fixtures/well-groomed.md
+++ b/plugins/jira/evals/fixtures/well-groomed.md
@@ -1,0 +1,22 @@
+## Context
+
+The HTTP client in `pkg/api/client.go` creates connections without any timeout configuration. When upstream services become unresponsive, goroutines pile up waiting indefinitely on HTTP responses, causing memory leaks and eventual OOM kills in production.
+
+This was observed in the `api-server` pod during the 2024-12-15 incident where the identity-provider service went down for 20 minutes, causing 3000+ goroutine leaks.
+
+## Acceptance Criteria
+
+- All HTTP client calls in `pkg/api/client.go` use a `context.WithTimeout` with a 30-second default timeout
+- The timeout value is configurable via environment variable `HTTP_CLIENT_TIMEOUT`
+- Existing unit tests are updated to verify timeout behavior
+- A new integration test validates that requests are cancelled after the timeout period
+- No goroutine leaks under sustained load (verify with `runtime.NumGoroutine()` in test)
+
+## Technical Details
+
+The `http.Client` struct at line 42 of `pkg/api/client.go` is created with zero-value fields, meaning no timeout. The fix should:
+
+1. Wrap all outgoing calls with `context.WithTimeout(ctx, timeout)`
+2. Use the existing `pkg/config` package to read the timeout from env
+3. Follow the pattern established in `pkg/webhook/client.go` which already has proper timeouts
+4. Update `TestClientGet` and `TestClientPost` in `pkg/api/client_test.go`

--- a/plugins/jira/evals/ready-to-solve.yaml
+++ b/plugins/jira/evals/ready-to-solve.yaml
@@ -1,0 +1,75 @@
+description: "Behavioral evals for jira:ready-to-solve skill"
+
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: jira-ready-to-solve
+    config:
+      model: claude-opus-4-6
+      plugins:
+        - type: local
+          path: ../
+      skills: ['jira:ready-to-solve']
+      append_allowed_tools: ['Skill', 'Read', 'Bash']
+      permission_mode: 'auto'
+
+prompts:
+  - |
+    Use the ready-to-solve skill to validate this issue description in --dry-run mode.
+    Do NOT call any Jira APIs — just run the check_sections.py script on the description below.
+
+    Here is the issue description:
+
+    {{description}}
+
+defaultTest:
+  options:
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+  assert:
+    - type: skill-used
+      value: jira:ready-to-solve
+    - type: latency
+      threshold: 180000
+    - type: cost
+      threshold: 1.20
+
+tests:
+  - description: "ready-to-solve/well-groomed — passes all checks"
+    metadata: &meta-heavy
+      token-usage: large
+      judge-size: opus
+      tier: heavy
+    vars:
+      description: file://fixtures/well-groomed.md
+    assert:
+      - type: icontains
+        value: "pass"
+      - type: llm-rubric
+        value: "The response indicates the issue passes readiness validation with all required sections present and adequate content"
+
+  - description: "ready-to-solve/missing-ac — fails readiness"
+    metadata: *meta-heavy
+    vars:
+      description: file://fixtures/missing-ac.md
+    assert:
+      - type: icontains
+        value: "fail"
+      - type: llm-rubric
+        value: "The response identifies that the issue is missing an Acceptance Criteria section"
+
+  - description: "ready-to-solve/short-context — fails readiness"
+    metadata: *meta-heavy
+    vars:
+      description: file://fixtures/empty-context.md
+    assert:
+      - type: icontains
+        value: "fail"
+      - type: llm-rubric
+        value: "The response identifies that the Context section is too short or lacks adequate content"
+
+evaluateOptions:
+  maxConcurrency: 20

--- a/plugins/jira/evals/solve.yaml
+++ b/plugins/jira/evals/solve.yaml
@@ -1,0 +1,99 @@
+description: "Behavioral evals for jira:solve command — phase-level analysis tests"
+
+providers:
+  - id: anthropic:claude-agent-sdk
+    label: jira-solve
+    config:
+      model: claude-opus-4-6
+      plugins:
+        - type: local
+          path: ../
+      append_allowed_tools: ['Skill', 'Read', 'Grep', 'Glob']
+      permission_mode: 'default'
+
+prompts:
+  - "{{prompt}}"
+
+defaultTest:
+  options:
+    provider:
+      id: vertex:claude-opus-4-6
+      config:
+        projectId: "{{ env.ANTHROPIC_VERTEX_PROJECT_ID }}"
+        region: global
+        temperature: 0
+  assert:
+    - type: latency
+      threshold: 120000
+    - type: cost
+      threshold: 0.60
+
+tests:
+  - description: "solve/missing-ac — flags for grooming"
+    metadata: &meta-heavy
+      token-usage: large
+      judge-size: opus
+      tier: heavy
+    vars:
+      issue: file://fixtures/sparse-bug.md
+      prompt: |
+        I want to solve this Jira issue using /jira:solve. Before I run it,
+        analyze whether this issue is ready. Here's the issue content:
+
+        {{issue}}
+
+        Is this issue ready for /jira:solve? What's missing?
+    assert:
+      - type: icontains
+        value: "acceptance criteria"
+      - type: llm-rubric
+        value: "The response identifies that the issue lacks sufficient detail for implementation — specifically missing acceptance criteria, technical details, or both"
+
+  - description: "solve/plan-quality — reasonable implementation approach"
+    metadata: *meta-heavy
+    vars:
+      issue: file://fixtures/well-groomed.md
+      prompt: |
+        Analyze this issue and outline the implementation approach you would take
+        for /jira:solve. Do NOT actually implement anything — just describe the plan.
+
+        {{issue}}
+    assert:
+      - type: llm-rubric
+        value: "The plan references the specific files mentioned (pkg/api/client.go, pkg/webhook/client.go), identifies the need for context.WithTimeout, and mentions test updates"
+      - type: not-icontains
+        value: "git push"
+      - type: not-icontains
+        value: "gh pr create"
+
+  - description: "solve/ci-flag — understands --ci behavior"
+    metadata: *meta-heavy
+    vars:
+      prompt: |
+        If I run /jira:solve OCPBUGS-99999 origin --ci, how does the behavior
+        differ from running it without --ci? List the key differences.
+    assert:
+      - type: llm-rubric
+        value: "Response mentions at least two of: no user approval prompts, proceeds with assumptions instead of asking for grooming, skips PR description review"
+
+  - description: "solve/no-destructive — does not attempt destructive actions"
+    metadata: *meta-heavy
+    vars:
+      issue: file://fixtures/deprecated-endpoints.md
+      prompt: |
+        Analyze this issue for /jira:solve readiness and describe what steps
+        you would take.
+
+        {{issue}}
+
+        Just analyze — do NOT make any changes.
+    assert:
+      - type: llm-rubric
+        value: "Response provides analysis or plan only, does not attempt to execute any git or file modification commands"
+      - type: not-icontains
+        value: "git checkout"
+      - type: not-icontains
+        value: "git push"
+
+evaluateOptions:
+  maxConcurrency: 20


### PR DESCRIPTION
## Summary

Add a [promptfoo](https://github.com/promptfoo/promptfoo)-based eval framework for testing plugin skills and commands. Uses the `anthropic:claude-agent-sdk` provider with Vertex AI auth, which spawns the Claude Code CLI as a subprocess for full agent behavior (tools, skills, plugins).

### Design decisions
- **Co-located evals**: configs live inside each plugin (`plugins/<name>/evals/*.yaml`), not in a central directory
- **SDK provider over exec**: enables `skill-used` / `not-skill-used` assertions that verify skill routing
- **No `output_format`**: structured output bypasses Skill tool invocation, breaking `skill-used` assertions — we use `icontains` + `llm-rubric` instead
- **Test fixtures**: issue descriptions loaded from `file://fixtures/<name>.md` — plain markdown, not JSON
- **Parallel execution**: `make eval-plugins` runs all eval files simultaneously via `$(MAKE) -j` — wall-clock time equals the slowest plugin, not the sum
- **Centralized budget**: `evals/budget.yaml` defines token-usage sizes, tier computation rules, and per-plugin budget caps
- See `evals/AGENTS.md` for full architecture documentation

### Behavioral evals (3 plugins, 25 test cases)
- **hello-world** (3 tests): command output validation
- **code-review** (15 tests): classify-review-comment skill with `skill-used`, `not-skill-used`, and `icontains` golden test assertions
- **jira** (7 tests): ready-to-solve deterministic validation + solve phase-level analysis with `llm-rubric` judging

### Assertion types used
- `skill-used` / `not-skill-used` — skill routing verification
- `icontains` / `not-icontains` — deterministic output matching
- `llm-rubric` — LLM-judged quality (graded by `vertex:claude-opus-4-6`)
- `cost` / `latency` — regression guards with per-plugin thresholds

### Test metadata and tiering

Every test carries per-test metadata for filtering by cost profile via `--filter-metadata`:

```yaml
metadata:
  token-usage: small | medium | large    # agent execution cost
  judge-size: none | sonnet | opus       # grading model for llm-rubric
  tier: fast | medium | heavy            # computed from the other two
```

Tier computation:

| token-usage | judge-size | tier   |
|-------------|------------|--------|
| small       | none       | fast   |
| medium      | none       | fast   |
| large       | none       | medium |
| small       | sonnet     | fast   |
| medium      | sonnet     | medium |
| large       | sonnet     | heavy  |
| small       | opus       | medium |
| medium      | opus       | medium |
| large       | opus       | heavy  |

Current inventory:

| Test                       | token-usage | judge-size | tier   | count |
|----------------------------|-------------|------------|--------|-------|
| hello-world/echo           | small       | none       | fast   | 3     |
| classify golden tests      | medium      | none       | fast   | 13    |
| classify ambiguous/routing | medium      | opus       | medium | 2     |
| jira/ready-to-solve        | large       | opus       | heavy  | 3     |
| jira/solve                 | large       | opus       | heavy  | 4     |
| **Total**                  |             |            |        | **25**|

### Cost and latency thresholds

| Plugin              | Latency | Cost  | token-usage |
|---------------------|---------|-------|-------------|
| hello-world         | 30s     | $0.50 | small       |
| code-review         | 60s     | $0.50 | medium      |
| jira/ready-to-solve | 3min    | $1.20 | large       |
| jira/solve          | 2min    | $0.60 | large       |

### Per-plugin budgets (`evals/budget.yaml`)

`allowed` = admin-set cap. `current` = sum of cost thresholds across all tests.

| Plugin              | Allowed | Current |
|---------------------|---------|---------|
| hello-world         | $1.50   | $1.50   |
| code-review         | $8.00   | $7.50   |
| jira                | $7.00   | $6.00   |
| **Total**           | **$16.50** | **$15.00** |

Measured actual cost per full run: **~$6** (thresholds are 2x safety margin over actuals)

### Makefile targets
All eval files run in parallel by default via `$(MAKE) -j`.
```bash
make eval-plugins                                              # all plugins (parallel)
make eval-plugins EVAL_PLUGIN=hello-world                      # single plugin
make eval-plugins EVAL_PLUGIN=code-review EVAL_FILTER=nitpick  # filter by test name
make eval-plugins EVAL_TIER=fast                               # filter by tier
make eval-plugins EVAL_PLUGIN=jira EVAL_TIER=heavy             # combine plugin + tier
make eval-plugins EVAL_REPEAT=3 EVAL_PASS_RATE_THRESHOLD=80   # multiple runs
EVAL_OUTPUT_DIR=./results make eval-plugins                    # JUnit XML output
```

### CI workflow
GH Actions runs on every PR:
- Detects changed plugins with `evals/` directories
- Runs behavioral evals per plugin as parallel matrix jobs
- Renders results as GitHub Check via `dorny/test-reporter`
- Uploads JUnit XML results as artifacts

## Test plan

- [x] `make eval-plugins EVAL_PLUGIN=hello-world` — 3/3 passed
- [x] `make eval-plugins EVAL_PLUGIN=code-review` — 15/15 passed
- [x] `make eval-plugins EVAL_PLUGIN=jira` — 7/7 passed
- [x] `make eval-plugins` full parallel run — 25/25 passed
- [x] `make eval-plugins EVAL_PLUGIN=jira EVAL_FILTER=commit-strategy EVAL_REPEAT=10 EVAL_PASS_RATE_THRESHOLD=95` — 10/10 passed
- [x] `make eval-plugins EVAL_TIER=fast` — 16/16 passed (tier filtering works)
- [x] `make eval-plugins EVAL_PLUGIN=code-review EVAL_TIER=medium` — 2/2 passed
- [x] `EVAL_OUTPUT_DIR=./eval-results make eval-plugins` — JUnit XML files generated
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated CI-driven behavioral plugin evaluations with per-plugin runs, JUnit reporting, and per-plugin artifacts.
  * Local make-based harness to run plugin evals in parallel with configurable repeat and pass-rate controls.

* **Documentation**
  * Comprehensive eval guide covering provider/configuration, test metadata/tiering, budgets/thresholds, and how to add plugin evals.
  * Added behavioral test suites and reusable fixtures for multiple plugins.

* **Chores**
  * Updated ignore patterns and added pinned dev dependencies for eval tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->