### PR TITLE
Fix 403 when posting lint comments on fork PRs

### DIFF
--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run skillsaw
-        uses: stbenjam/skillsaw@d475638873e09327262ae82f5657d390a91a3c8a # v0
+        uses: stbenjam/skillsaw@eee9ebe1e1e26cdc66a2b26f1f5e0e1b62a9e0b6 # v0
         with:
           strict: true
           verbose: true

--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -1,7 +1,7 @@
 name: Lint Plugins
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run skillsaw
         uses: stbenjam/skillsaw@d475638873e09327262ae82f5657d390a91a3c8a # v0

--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -1,7 +1,7 @@
 name: Lint Plugins
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main
@@ -11,13 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run skillsaw
         uses: stbenjam/skillsaw@d475638873e09327262ae82f5657d390a91a3c8a # v0

--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run skillsaw
-        uses: stbenjam/skillsaw@eee9ebe1e1e26cdc66a2b26f1f5e0e1b62a9e0b6 # v0
+        uses: stbenjam/skillsaw@eee9ebea0f33517bfb3c4d0413471c5165becc7e # v0
         with:
           strict: true
           verbose: true

--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -1,0 +1,20 @@
+name: Lint Review
+
+on:
+  workflow_run:
+    workflows: ["Lint Plugins"]
+    types: [completed]
+
+jobs:
+  review:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Post review comments
+        uses: stbenjam/skillsaw/review@d475638873e09327262ae82f5657d390a91a3c8a # v0

--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Post review comments
-        uses: stbenjam/skillsaw/review@eee9ebe1e1e26cdc66a2b26f1f5e0e1b62a9e0b6 # v0
+        uses: stbenjam/skillsaw/review@eee9ebea0f33517bfb3c4d0413471c5165becc7e # v0

--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -1,3 +1,8 @@
+# Separate workflow for posting lint review comments on PRs.
+# The lint workflow runs with a read-only token (safe for fork PRs that
+# execute custom linter rules via subprocess). This workflow triggers
+# after it completes, downloads the report artifact, and posts comments
+# with a write-capable token — without ever checking out untrusted code.
 name: Lint Review
 
 on:

--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Post review comments
-        uses: stbenjam/skillsaw/review@d475638873e09327262ae82f5657d390a91a3c8a # v0
+        uses: stbenjam/skillsaw/review@eee9ebe1e1e26cdc66a2b26f1f5e0e1b62a9e0b6 # v0


### PR DESCRIPTION
## Summary
- Keep `pull_request` trigger (read-only token, safe for fork PRs that may run custom linter rules via subprocess)
- Add a new `lint-review.yml` workflow that triggers on `workflow_run` completion and uses skillsaw's `review/` action to post PR comments with a write-capable token
- Remove `pull-requests: write` from the lint job since it no longer posts comments directly
- Depends on https://github.com/stbenjam/skillsaw/pull/140 (skillsaw support for artifact-based review)

## Why not `pull_request_target`?
`.skillsaw-custom.py` runs `subprocess.run(["python3", ...])` on scripts from the checked-out repo. With `pull_request_target`, a malicious fork PR could replace those scripts and get arbitrary code execution with a write token.

## Test plan
- [ ] Merge skillsaw PR first, update SHA references
- [ ] Verify fork PRs get inline lint review comments without 403
- [ ] Verify push-to-main lint still works
- [ ] Verify linter text output is visible in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened permissions for the pull-request linting job to reduce granted access.
  * Added a separate lint-review workflow that runs after lint checks on pull requests and posts automated review comments.
  * Improves visibility and reliability of lint feedback during pull request reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->