### PR TITLE
feat(code-review): add --html flag for pre-commit review reports

### DIFF
--- a/plugins/code-review/commands/pre-commit-review.md
+++ b/plugins/code-review/commands/pre-commit-review.md
@@ -1,6 +1,6 @@
 ---
 description: "Automated pre-commit code quality review with language-aware analysis and project-specific profiles"
-argument-hint: "[--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]"
+argument-hint: "[--language <lang>] [--profile <name>] [--skip-build] [--skip-tests] [--html <path>]"
 ---
 
 ## Name
@@ -8,7 +8,7 @@ code-review:pre-commit-review
 
 ## Synopsis
 ```
-/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests]
+/code-review:pre-commit-review [--language <lang>] [--profile <name>] [--skip-build] [--skip-tests] [--html <path>]
 ```
 
 ## Description
@@ -31,6 +31,7 @@ The two layers compose: `--language go --profile hypershift` applies both Go idi
   - `--profile <name>`: Project profile skill to load (e.g., `hypershift`)
   - `--skip-build`: Skip build verification step
   - `--skip-tests`: Skip unit test coverage review step
+  - `--html <path>`: Generate an HTML report file at the specified path (e.g., `--html ./review.html`). The text report is still produced; the HTML report is generated as an additional output.
 - If `--language` is not specified, auto-detect the primary language from the file extensions of changed files:
   - `.go` -> `go`
   - `.py` -> `python`
@@ -56,6 +57,15 @@ This step is language-agnostic.
 ### Step 2 — Launch Parallel Review Sub-Agents
 
 After identifying changed files, launch the following reviews concurrently. Launch ALL sub-agents in parallel (single message with multiple Task tool calls) for maximum speed. Each sub-agent should be given `subagent_type: "general-purpose"`. Do NOT set the `model` parameter — let sub-agents inherit the parent model, as these analysis tasks require a capable model. Pass each sub-agent the list of changed files, the loaded language skill content (if any), and the loaded profile skill content (if any) in its prompt.
+
+**If `--html` is specified**, instruct each sub-agent to return its findings in a structured format. Each finding must include:
+- **Finding text**: A clear description of the issue and recommended fix.
+- **Severity**: One of `Blocking`, `Medium`, or `Low`.
+- **File path and line number(s)**: The specific `file:line` reference (e.g., `path/to/file.go:42` or `path/to/file.go:42-50`). Use `N/A` if not applicable.
+- **Agent name**: The name of the sub-agent producing the finding (e.g., `Idiomatic Go`, `Unit Test Coverage`, `DRY Compliance`, `SOLID Compliance`, or the profile SME agent name).
+- **Agent verdict**: The sub-agent's overall verdict for its review area (e.g., `PASS`, `RECOMMENDATIONS`, `JUSTIFIED`, `FAIL`).
+
+Each sub-agent should return its output as plain text with the structured findings clearly delimited so the parent agent can parse them. The plain text narrative is still included for the text report.
 
 #### Sub-agent: Unit Test Coverage
 Skip if `--skip-tests` is specified.
@@ -139,6 +149,101 @@ After all sub-agents and build verification complete, aggregate findings into a 
 9. **Required Actions**: Issues that must be fixed before committing (blocking).
 10. **Recommended Improvements**: Suggestions that are not blocking but would improve code quality.
 
+#### Step 4a — Generate HTML Report (only if `--html <path>` is specified)
+
+After generating the text report above, produce an HTML report file at the path specified by `--html`. The text report is always produced regardless of this flag.
+
+##### Detect GitHub context
+
+Run the following commands to gather context for links in the HTML report:
+
+1. Run `gh pr view --json number,url,headRefName,baseRefName 2>/dev/null` to get the PR number, URL, head branch name, and base branch. Parse `owner/repo` from the URL (e.g., `https://github.com/openshift/hypershift/pull/123` yields `openshift/hypershift`).
+2. Run `git rev-parse --short HEAD` to get the abbreviated commit SHA.
+3. Run `git rev-parse HEAD` to get the full commit SHA (used for blob links if no PR exists).
+
+If `gh pr view` fails (no PR exists yet), set `pr_number` to `null`. The report will omit PR file links and use blob links only.
+
+##### Compute file anchors for PR links
+
+For each file in the "Files Reviewed" list, compute the GitHub PR file tab anchor hash by running:
+
+```
+echo -n "<filepath>" | shasum -a 256 | cut -d' ' -f1
+```
+
+This produces the SHA-256 hash used in the `#diff-<hash>` fragment for PR file links. Store the hash for each file path.
+
+##### Generate the HTML file
+
+Use the **Write** tool to create the HTML file at the user-specified path. The HTML must follow this exact structure and styling:
+
+**Document head:**
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pre-Commit Review — {PR_TITLE_OR_BRANCH}</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  code { font-size: 0.82rem; }
+  .loc { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.82rem; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 0.4rem; }
+  .dot-pass { background: #198754; }
+  .dot-warn { background: #ffc107; }
+</style>
+</head>
+```
+
+Use Bootstrap 5.3 light theme only (no dark theme). The container uses `max-width: 1200px`.
+
+**Page structure (in this exact order):**
+
+1. **Header**: `<h1>Pre-Commit Code Review</h1>` followed by a subtitle paragraph with PR/branch context and today's date. Below that, a verdict badge (`text-bg-success` for PASS, `text-bg-warning` for PASS WITH RECOMMENDATIONS, `text-bg-danger` for FAIL).
+
+2. **Summary Grid**: A 4-column card grid (`row g-3 mb-4`) showing:
+   - Files Reviewed (count)
+   - Build (PASS/FAIL/SKIPPED, colored appropriately)
+   - Blocking Issues (count, `text-success` if 0, `text-danger` otherwise)
+   - Recommendations (count, `text-warning` if > 0, `text-success` if 0)
+
+3. **Files Reviewed section**: `<h2 class="h5 border-bottom border-secondary pb-2 mb-2">Files Reviewed</h2>` with intro text. Inside a card, organize files into columns by category (Source, Tests, Docs, Config, etc.) using `<div class="row">` with `col-md-4` columns. Each file is a list item with a colored dot and a link:
+   - If a PR exists: link to `https://github.com/{owner}/{repo}/pull/{pr_number}/files#diff-{sha256_hash}` with `target="_blank"`.
+   - If no PR exists: link to `https://github.com/{owner}/{repo}/blob/{commit_sha}/{filepath}` with `target="_blank"`.
+   - Dot colors: `#0d6efd` for source, `#198754` (use `dot-pass` class) for tests, `#bc8cff` for docs, `#6c757d` for config/other.
+
+4. **Review Agents summary table**: `<h2 class="h5 ...">Review Agents</h2>` with intro text describing how many agents reviewed the change. Inside a card, a `<table class="table table-sm mb-0">` with columns: Agent, Verdict, Findings. Each agent name is an anchor link (`<a href="#agent-id">`) pointing to its detail section below. Verdict is a Bootstrap badge. Do NOT put badges on the detail section headers — only in this summary table.
+
+5. **All Recommendations (Consolidated) table**: `<h2 class="h5 ..." id="all-recommendations">All Recommendations (Consolidated)</h2>` with intro text. A responsive table with columns: #, Severity, File:Line, Recommendation, Agent. Number findings sequentially starting at 1. Severity uses badges (`text-bg-danger` for Blocking, `text-bg-warning` for Medium, `text-bg-secondary` for Low). File:Line references are clickable links to blob view: `https://github.com/{owner}/{repo}/blob/{short_sha}/{filepath}#L{line}`. The Agent column contains anchor links back to the detail section. De-duplicate findings that appear in multiple agents (note both agents in the Agent column).
+
+6. **Review Agent Output in Detail**: `<h2 class="h4 border-bottom border-dark pb-2 mt-5 mb-2">Review Agent Output in Detail</h2>` with intro text. Then one `<h3>` section per agent, each with:
+   - An `id` attribute for anchor linking from the summary table (e.g., `id="build-verification"`, `id="unit-test-coverage"`, `id="idiomatic-go"`, `id="dry-compliance"`, `id="solid-compliance"`, and kebab-case IDs for profile SME agents).
+   - `class="h5 border-bottom border-secondary pb-2 mb-2"` on the `<h3>`. No badges on these headers.
+   - A `<p class="text-secondary small mb-3">` intro sentence describing what the agent checks.
+   - A card with the agent's detailed output. Use tables, pass/fail dots, and narrative text as appropriate for each agent type.
+   - Findings that appear in the consolidated recommendations table are rendered inside `<div class="alert alert-light border small mb-0">` boxes with the text `Finding (#N):` where N matches the consolidated table number.
+   - Design notes and warnings use `<div class="alert alert-warning border small ...">` boxes.
+
+7. **Footer**: `<footer class="text-center text-secondary small border-top border-secondary pt-3 mt-4">` with text like "Generated by Claude Code — N review agents + build command — PR link". If a PR exists, link to it. If not, show the branch name.
+
+**Document closing:**
+```html
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+```
+
+##### Fallback when no PR context is available
+
+If `gh pr view` failed (no PR exists):
+- Use the branch name from `git rev-parse --abbrev-ref HEAD` for the subtitle.
+- Use blob links (`https://github.com/{owner}/{repo}/blob/{commit_sha}/{filepath}`) instead of PR file links everywhere.
+- Detect `owner/repo` from the git remote: `git remote get-url origin` and parse it from the URL (handles both HTTPS and SSH formats).
+- The footer shows the branch name instead of a PR link.
+
+After writing the file, inform the user of the path where the HTML report was saved.
+
 ### Critical Rules
 
 - **Never approve without build verification** unless `--skip-build` is explicitly specified.
@@ -187,8 +292,15 @@ After all sub-agents and build verification complete, aggregate findings into a 
    ```
    Applies Rust idiomatic checks with no project-specific profile.
 
+6. **Go review with HyperShift profile and HTML report**:
+   ```
+   /code-review:pre-commit-review --language go --profile hypershift --html ./review.html
+   ```
+   Applies Go idiomatic checks plus HyperShift project conventions, and writes an HTML report to `./review.html`.
+
 ## Arguments:
 - `--language <lang>`: Language skill to load. Currently shipped: `go`. Planned: `python`, `rust`, `typescript`, `java`. If omitted, auto-detected from changed file extensions.
 - `--profile <name>`: Project profile skill to load. Loads `skills/profile-<name>/SKILL.md` for project-specific conventions. If omitted, no profile-specific checks are applied.
 - `--skip-build`: Skip the build verification step (Step 3). Useful for documentation-only changes or when build infrastructure is not available locally.
 - `--skip-tests`: Skip the unit test coverage review step (Unit Test Coverage sub-agent). Useful when changes do not affect testable code.
+- `--html <path>`: Generate an HTML report file at the specified path in addition to the text report. The HTML report uses Bootstrap 5.3 styling with clickable file/line links to GitHub, a consolidated recommendations table, and detailed per-agent output sections. Requires `gh` CLI for PR context; falls back to blob links if no PR exists.


### PR DESCRIPTION
## Summary

- Adds `--html <path>` flag to `/code-review:pre-commit-review` that generates an HTML report alongside the text output
- Sub-agents receive an instruction to format findings as structured data when HTML output is requested
- The lead agent collects all sub-agent results and renders a styled HTML report at the specified path

## Test plan

- [ ] Run `/code-review:pre-commit-review --html /tmp/report.html` and verify HTML file is generated
- [ ] Run without `--html` flag and verify behavior is unchanged
- [ ] Verify HTML report contains all review sections (tests, idiomatic, DRY, SOLID, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `code-review:pre-commit-review` command documentation to add `--html <path>` option for generating Bootstrap-styled HTML reports.
  * Documented HTML report features including GitHub PR context integration, summary cards, verdict tables, and consolidated recommendations with deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->