### PR TITLE
Add generate-api-stubs skill to openshift plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,7 +95,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "name": "openshift-tls-profile",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,7 +95,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.6"
+      "version": "0.0.7"
     },
     {
       "name": "openshift-tls-profile",

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -3,6 +3,7 @@
 This document lists all available Claude Code plugins and their commands in the ai-helpers repository.
 
 - [Agendas](#agendas-plugin)
+- [Agentic Docs](#agentic-docs-plugin)
 - [Operator Dashboard](#operator-dashboard-plugin)
 - [Bigquery](#bigquery-plugin)
 - [Ci](#ci-plugin)
@@ -46,6 +47,15 @@ A plugin to create various meeting agendas
 - **`/agendas:outcome-refinement`** - Analyze the list of JIRA outcome issues to prepare an outcome refinement meeting agenda.
 
 See [plugins/agendas/README.md](plugins/agendas/README.md) for detailed documentation.
+
+### Agentic Docs Plugin
+
+Create and maintain AI-optimized documentation for OpenShift
+
+**Commands:**
+- **`/agentic-docs:component`** - Create lean tier-2 agentic documentation for an OpenShift component repository
+
+See [plugins/agentic-docs/README.md](plugins/agentic-docs/README.md) for detailed documentation.
 
 ### Operator Dashboard Plugin
 
@@ -401,6 +411,7 @@ Team structure knowledge and health analysis commands for OpenShift teams
 - **`/teams:list-components` `[--team <team-name>]`** - List all OCPBUGS components, optionally filtered by team
 - **`/teams:list-jiras` `<project> [--component comp1 comp2 ...] [--status status1 status2 ...] [--include-closed] [--limit N]`** - Query and list raw JIRA bug data for a specific project
 - **`/teams:list-regressions` `<view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`** - Fetch and list raw regression data for OpenShift releases
+- **`/teams:list-repos` `[--refresh]`** - Report on repository purpose and approvers for github.com/openshift
 - **`/teams:list-teams`** - List all teams from the team component mapping
 
 See [plugins/teams/README.md](plugins/teams/README.md) for detailed documentation.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -321,6 +321,7 @@ OpenShift development utilities and helpers
 - **`/openshift:create-cluster` `[release-image] [platform] [options]`** - Extract OpenShift installer from release image and create an OCP cluster
 - **`/openshift:destroy-cluster` `[install-dir]`** - Destroy an OpenShift cluster created by create-cluster command
 - **`/openshift:expand-test-case` `[test-idea-or-file-or-commands] [format]`** - Expand basic test ideas or existing oc commands into comprehensive test scenarios with edge cases in oc CLI or Ginkgo format
+- **`/openshift:generate-api` `[api-repo-path] [--client-go [client-go-path]]`** - Generate OpenShift API stubs with automatic error detection and fixing, optionally updating client-go
 - **`/openshift:ironic-status`** - Check status of Ironic baremetal nodes in OpenShift cluster
 - **`/openshift:new-e2e-test` `[test-specification]`** - Write and validate new OpenShift E2E tests using Ginkgo framework
 - **`/openshift:node-kernel-conntrack` `<node> <image> [--command <cmd>] [--filter <params>]`** - Get connection tracking entries from Kubernetes node

--- a/docs/data.json
+++ b/docs/data.json
@@ -671,6 +671,12 @@
           "synopsis": "/teams:list-regressions <view> [--components comp1 comp2 ...] [--start YYYY-MM-DD] [--end YYYY-MM-DD]"
         },
         {
+          "argument_hint": "[--refresh]",
+          "description": "Report on repository purpose and approvers for github.com/openshift",
+          "name": "list-repos",
+          "synopsis": "/teams:list-repos"
+        },
+        {
           "argument_hint": "",
           "description": "List all teams from the team component mapping",
           "name": "list-teams",
@@ -718,6 +724,11 @@
           "name": "CodeRabbit Rules from PR Reviews - Fetch Comments"
         },
         {
+          "description": "Helper skill to find repository approvers and ownership information",
+          "id": "find-repo-owner",
+          "name": "Find Repository Owner"
+        },
+        {
           "description": "Fetch OpenShift release dates and metadata from Sippy API",
           "id": "get-release-dates",
           "name": "Get Release Dates"
@@ -736,6 +747,11 @@
           "description": "Fetch and analyze component health regressions for OpenShift releases",
           "id": "list-regressions",
           "name": "List Regressions"
+        },
+        {
+          "description": "Generate cached report of OpenShift repository purpose and approvers",
+          "id": "list-repos",
+          "name": "OpenShift Repository Report"
         },
         {
           "description": "List all teams from the team component mapping",
@@ -1175,6 +1191,11 @@
       "name": "openshift",
       "skills": [
         {
+          "description": "Run `make generate` in openshift/api repository to generate client code, deepcopy methods, informers, and listers. Automatically troubleshoot and fix common errors including working directory issues, missing markers, and import path problems. Use when the user needs to generate OpenShift API stubs, run make generate, or troubleshoot code generation errors in openshift/api. Make sure to use this skill whenever the user mentions running make generate, generating stubs, fixing code generation errors, or working with openshift/api types.",
+          "id": "generate-api-stubs",
+          "name": "Generate API Stubs"
+        },
+        {
           "description": "Generates and displays OVN-Kubernetes network topology diagrams showing logical switches, routers, ports with IP/MAC addresses in Mermaid format",
           "id": "generating-ovn-topology",
           "name": "generating-ovn-topology"
@@ -1185,7 +1206,7 @@
           "name": "OpenShift Node Kernel Inspection"
         }
       ],
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     {
       "commands": [

--- a/docs/data.json
+++ b/docs/data.json
@@ -1131,6 +1131,12 @@
           "synopsis": "/openshift:expand-test-case [test-idea-or-file-or-commands] [format]"
         },
         {
+          "argument_hint": "[api-repo-path] [--client-go [client-go-path]]",
+          "description": "Generate OpenShift API stubs with automatic error detection and fixing, optionally updating client-go",
+          "name": "generate-api",
+          "synopsis": "/openshift:generate-api [api-repo-path] [--client-go [client-go-path]]"
+        },
+        {
           "argument_hint": "",
           "description": "Check status of Ironic baremetal nodes in OpenShift cluster",
           "name": "ironic-status",
@@ -1191,7 +1197,7 @@
       "name": "openshift",
       "skills": [
         {
-          "description": "Run `make generate` in openshift/api repository to generate client code, deepcopy methods, informers, and listers. Automatically troubleshoot and fix common errors including working directory issues, missing markers, and import path problems. Use when the user needs to generate OpenShift API stubs, run make generate, or troubleshoot code generation errors in openshift/api. Make sure to use this skill whenever the user mentions running make generate, generating stubs, fixing code generation errors, or working with openshift/api types.",
+          "description": "Run `make generate` in openshift/api repository to generate client code, deepcopy methods, informers, and listers. Automatically troubleshoot and fix common errors including working directory issues, missing markers, and import path problems. Also handles multi-repo workflow with openshift/client-go, updating vendoring and regenerating clients. Use when the user needs to generate OpenShift API stubs, run make generate, update client-go vendoring, troubleshoot code generation errors in openshift/api or openshift/client-go, or mentions working with openshift/api types and client-go together.",
           "id": "generate-api-stubs",
           "name": "Generate API Stubs"
         },
@@ -1206,7 +1212,7 @@
           "name": "OpenShift Node Kernel Inspection"
         }
       ],
-      "version": "0.0.6"
+      "version": "0.0.7"
     },
     {
       "commands": [

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/commands/generate-api.md
+++ b/plugins/openshift/commands/generate-api.md
@@ -1,0 +1,116 @@
+---
+description: Generate OpenShift API stubs with automatic error detection and fixing, optionally updating client-go
+argument-hint: "[api-repo-path] [--client-go [client-go-path]]"
+---
+
+## Name
+openshift:generate-api
+
+## Synopsis
+```
+/openshift:generate-api [api-repo-path] [--client-go [client-go-path]]
+```
+
+## Description
+
+The `openshift:generate-api` command automates running code generation in the openshift/api repository and optionally regenerates openshift/client-go. It handles the common pain points of API stub generation: working directory validation, GOPATH structure requirements, missing tools, and iterative error fixing.
+
+The command uses an iterative fix-and-retry loop (up to 5 attempts) to automatically resolve common generation errors before escalating to the user.
+
+### What It Generates
+
+In openshift/api:
+- **Deepcopy methods** (`zz_generated.deepcopy.go`)
+- **Swagger documentation** (`zz_generated.swagger_doc_generated.go`)
+- **OpenAPI definitions** (`zz_generated.openapi.go`)
+- **CRD manifests**
+- **Protobuf bindings** (if `protoc` is available)
+
+In openshift/client-go (with `--client-go`):
+- **Typed clients** for all API resources
+- **Informers** and **listers**
+- **Apply configurations**
+
+## Implementation
+
+1. **Working Directory Validation**
+   - Verify the openshift/api repository is located at `$GOPATH/src/github.com/openshift/api`
+   - If not, offer to create a symlink or adjust GOPATH
+   - Run `${CLAUDE_PLUGIN_ROOT}/scripts/check_working_directory.sh` for validation
+
+2. **Run Code Generation**
+   - Execute `make update-codegen-crds` (the primary generation target in openshift/api)
+   - Capture output and check exit code
+   - Set `GOPATH` and optionally `PROTO_OPTIONAL=1` if protoc is unavailable
+
+3. **Error Detection and Auto-Fix**
+   - Run `${CLAUDE_PLUGIN_ROOT}/scripts/detect_generation_errors.py` on failures
+   - Automatically fix recognized patterns (missing markers, vendor sync, missing tools)
+   - Retry generation after each fix (max 5 iterations)
+
+4. **Validation**
+   - Run `${CLAUDE_PLUGIN_ROOT}/scripts/validate_generated_code.sh`
+   - Verify generated files exist, are non-empty, and compile
+
+5. **Client-Go Workflow** (when `--client-go` is specified)
+   - Validate client-go working directory (same GOPATH structure requirement)
+   - Add `go mod edit -replace github.com/openshift/api=<local-api-path>` to client-go's go.mod
+   - Run `go mod vendor` to sync vendor directory
+   - Execute `make generate` in client-go
+   - Apply the same iterative error detection and fixing
+   - Validate generated client code
+   - Warn user to remove the replace directive before pushing
+
+6. **Report Results**
+   - Show files modified in each repository
+   - Summarize errors encountered and fixes applied
+   - Provide `git diff --stat` for review
+   - Suggest next steps
+
+## Examples
+
+### Example 1: Generate from current directory
+```
+/openshift:generate-api
+```
+Runs generation in the current directory (must be openshift/api).
+
+### Example 2: Generate from a specific path
+```
+/openshift:generate-api ~/code/api
+```
+Runs generation using the openshift/api repository at the given path.
+
+### Example 3: Generate API and update client-go
+```
+/openshift:generate-api ~/code/api --client-go ~/code/client-go
+```
+Generates API stubs, then updates client-go vendoring to use the local API and regenerates client code.
+
+### Example 4: Generate API and auto-detect client-go
+```
+/openshift:generate-api --client-go
+```
+Generates API stubs in the current directory, then searches common locations for client-go.
+
+## Arguments
+
+- **api-repo-path** (optional): Path to the openshift/api repository. Defaults to the current working directory.
+- **--client-go** (optional): Also update and regenerate openshift/client-go. Optionally accepts a path to the client-go repository; if omitted, searches common locations (`~/code/client-go`, `$GOPATH/src/github.com/openshift/client-go`).
+
+## Common Issues
+
+### GOPATH Structure
+Code generators require repositories at `$GOPATH/src/github.com/openshift/<repo>`. The command detects this automatically and offers to create symlinks.
+
+### Missing protoc
+Protobuf generation requires `protoc 23.x`. If unavailable, the command sets `PROTO_OPTIONAL=1` to skip protobuf generation. Other generated code proceeds normally.
+
+### Branch Compatibility
+When using `--client-go`, both repositories must be on compatible branches. If client-go references API packages that don't exist in your local API branch, you'll see import errors during vendoring.
+
+## See Also
+
+- [openshift/api repository](https://github.com/openshift/api/)
+- [openshift/client-go repository](https://github.com/openshift/client-go/)
+- [Kubernetes Code Generator](https://github.com/kubernetes/code-generator)

--- a/plugins/openshift/skills/generate-api-stubs/SKILL.md
+++ b/plugins/openshift/skills/generate-api-stubs/SKILL.md
@@ -1,0 +1,438 @@
+---
+name: Generate API Stubs
+description: Run `make generate` in openshift/api repository to generate client code, deepcopy methods, informers, and listers. Automatically troubleshoot and fix common errors including working directory issues, missing markers, and import path problems. Also handles multi-repo workflow with openshift/client-go, updating vendoring and regenerating clients. Use when the user needs to generate OpenShift API stubs, run make generate, update client-go vendoring, troubleshoot code generation errors in openshift/api or openshift/client-go, or mentions working with openshift/api types and client-go together.
+tools: [Bash, Read, Write, Edit]
+---
+
+# Generate API Stubs
+
+Automate running `make generate` in the openshift/api repository with intelligent error detection and automatic fixing.
+
+## When to Use This Skill
+
+Use this skill when:
+- User asks to "run make generate" in openshift/api
+- User mentions generating stubs, client code, deepcopy methods, informers, or listers
+- User reports errors with code generation in openshift/api
+- User is making changes to API types and needs to regenerate derived code
+- User mentions issues with "goroot src directory" or GOPATH-related errors
+- User asks to "update client-go vendoring" or "regenerate client-go"
+- User mentions working with both openshift/api and openshift/client-go together
+
+## Prerequisites
+
+- Must be in openshift/api repository (or user provides path to it)
+- Go toolchain installed (`go version` works)
+- Internet access to download code-generator tools if needed
+- Write permissions in the repository directory
+
+## Implementation Workflow
+
+This skill uses an iterative loop with a maximum of 5 attempts to successfully generate API stubs.
+
+### Phase 1: Working Directory Validation
+
+Before attempting generation, validate the working directory location:
+
+1. **Check current location**:
+   - Run `${CLAUDE_PLUGIN_ROOT}/scripts/check_working_directory.sh` from the openshift/api repository
+   - This script validates that the repository is in the correct Go workspace structure
+
+2. **Common issue - GOPATH structure requirement**:
+   - Kubernetes code-generators require the repository to be at `$GOPATH/src/github.com/openshift/api`
+   - Default Go workspace: `~/go/src/github.com/openshift/api`
+   - **Why**: Code generators use import path detection that requires this specific directory structure
+
+3. **If validation fails**, guide the user with options:
+   - **Option A**: Clone to the correct location:
+     ```bash
+     mkdir -p ~/go/src/github.com/openshift
+     git clone https://github.com/openshift/api ~/go/src/github.com/openshift/api
+     cd ~/go/src/github.com/openshift/api
+     ```
+   - **Option B**: Create a symlink (if current directory has work):
+     ```bash
+     mkdir -p ~/go/src/github.com/openshift
+     ln -s $PWD ~/go/src/github.com/openshift/api
+     cd ~/go/src/github.com/openshift/api
+     ```
+   - **Option C**: Set up temporary GOPATH:
+     ```bash
+     # If repo is at /home/user/repos/api
+     export GOPATH=/home/user/repos
+     # Now the import path github.com/openshift/api resolves correctly
+     ```
+
+4. **Document the context**: Explain to the user why this directory structure matters and which option was chosen.
+
+### Phase 2: Run make generate
+
+Execute the code generation:
+
+1. **Capture output**:
+   ```bash
+   make generate > /tmp/make-generate-output.log 2>&1
+   echo "Exit code: $?" >> /tmp/make-generate-output.log
+   ```
+
+2. **Check exit code**:
+   - If exit code = 0: Proceed to Phase 4 (Validation)
+   - If exit code ≠ 0: Proceed to Phase 3 (Error Diagnosis)
+
+3. **Save iteration state**: Track how many attempts have been made to prevent infinite loops.
+
+### Phase 3: Error Diagnosis and Auto-Fix
+
+When `make generate` fails, diagnose and fix the issue:
+
+1. **Run error detection**:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect_generation_errors.py /tmp/make-generate-output.log
+   ```
+   This returns JSON with `error_type`, `suggested_fix`, and `files_to_check`.
+
+2. **Match against known patterns** (see `${CLAUDE_PLUGIN_ROOT}/references/common_errors.md` for full catalog):
+
+   **Pattern 1: Missing deepcopy-gen markers**
+   - Signature: `Types need DeepCopy methods` or `missing deepcopy-gen markers`
+   - Fix: Add `// +k8s:deepcopy-gen=true` comment above the type definition
+   - Example:
+     ```go
+     // +k8s:deepcopy-gen=true
+     type MyAPIType struct {
+         // ...
+     }
+     ```
+
+   **Pattern 2: Missing genclient markers**
+   - Signature: `type X does not have genclient marker` or needs client generation
+   - Fix: Add `// +genclient` above resource types (not list types or subresources)
+   - Example:
+     ```go
+     // +genclient
+     // +k8s:deepcopy-gen=true
+     type MyResource struct {
+         // ...
+     }
+     ```
+
+   **Pattern 3: Import path resolution errors**
+   - Signature: `cannot resolve import path` or `package not found`
+   - Fixes to try in order:
+     1. Run `go mod tidy` to sync dependencies
+     2. Verify GOPATH is set: `go env GOPATH`
+     3. Return to Phase 1 (working directory validation)
+
+   **Pattern 4: Missing code-generator tools**
+   - Signature: `deepcopy-gen: command not found`, `client-gen: not found`, etc.
+   - Fix: Check Makefile for tool installation targets:
+     ```bash
+     # Most openshift/api repos have update-codegen-crds or similar
+     make update-codegen-crds
+     ```
+   - Alternative: Manual tool installation:
+     ```bash
+     go install k8s.io/code-generator/cmd/deepcopy-gen@latest
+     go install k8s.io/code-generator/cmd/client-gen@latest
+     ```
+
+   **Pattern 5: GOPATH/GOROOT not set correctly**
+   - Signature: `cannot find package in any of GOPATH/GOROOT`
+   - Fix: Return to Phase 1, the working directory is wrong
+
+   **Pattern 6: Permission errors**
+   - Signature: `permission denied` writing generated files
+   - Fix: Check write permissions, may need to adjust file ownership
+
+   **Pattern 7: Stale generated code**
+   - Signature: Conflicts between existing generated code and new generation
+   - Fix: Remove old generated files and retry:
+     ```bash
+     find . -name 'zz_generated.*.go' -delete
+     rm -rf ./generated/
+     ```
+
+3. **Apply the fix**:
+   - If pattern is recognized: Apply fix automatically and explain what was done
+   - If pattern is NOT recognized: Show the user the error output, explain what you see, and ask for guidance
+
+4. **After applying fix**: Return to Phase 2 to retry `make generate`
+
+5. **Track attempted fixes**: Maintain a list of fixes already tried to avoid repeating the same fix in a loop.
+
+### Phase 4: Validation
+
+After successful generation (exit code 0), validate the results:
+
+1. **Run validation script**:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/validate_generated_code.sh
+   ```
+
+2. **Validation checks**:
+   - Expected generated files exist:
+     - `zz_generated.deepcopy.go` files in API type directories
+     - `generated/clientset/` directory
+     - `generated/informers/` directory
+     - `generated/listers/` directory
+   - Generated code compiles: `go build ./...`
+   - No obvious errors in generated files (import cycles, syntax errors)
+
+3. **Validation outcomes**:
+   - If validation passes: Proceed to Phase 5 (Report Results)
+   - If validation fails: Treat as an error and return to Phase 3 with the validation failure as the error
+
+### Phase 5: Report Results
+
+Provide a comprehensive summary of what was done:
+
+1. **List modified files**:
+   ```bash
+   git status --short
+   ```
+
+2. **Show diff summary**:
+   ```bash
+   git diff --stat
+   ```
+
+3. **Report structure**:
+   ```markdown
+   ## Generation Results
+
+   **Working Directory**: <path used>
+   **Attempts**: <number of iterations>
+   **Status**: ✓ Success
+
+   ### Files Modified:
+   - <list of changed files>
+
+   ### Errors Encountered and Fixed:
+   1. <error 1>: <fix applied>
+   2. <error 2>: <fix applied>
+
+   ### Validation:
+   - ✓ deepcopy methods generated
+   - ✓ Client code generated
+   - ✓ Informers generated
+   - ✓ Listers generated
+   - ✓ Code compiles successfully
+
+   ### Next Steps:
+   1. Review the generated code changes
+   2. Run tests: `make test` or `make verify`
+   3. If updating client-go is needed, proceed to Phase 6 (Multi-Repository Workflow)
+   4. Commit the changes: `git add . && git commit -m "Generate API stubs"`
+   ```
+
+4. **If warnings exist**, include them in a "Warnings" section.
+
+## Error Handling
+
+### Maximum Iteration Limit
+
+- **Maximum 5 iterations** of the fix-and-retry loop
+- If limit is reached without success:
+  1. Report all attempted fixes
+  2. Show current error state
+  3. Display the last error output
+  4. Recommend manual intervention with specific guidance
+
+### Infinite Loop Prevention
+
+- Track which fixes have been attempted
+- Never apply the exact same fix twice
+- If the same error pattern appears after a fix, escalate to user for guidance
+
+### Unrecognized Errors
+
+When encountering an error pattern not in the catalog:
+
+1. Show the full error output to the user
+2. Explain what you understand about the error
+3. Provide diagnostic information:
+   - Current working directory
+   - GOPATH value
+   - Go version
+   - Available code-generator tools
+4. Ask the user for guidance on how to proceed
+5. If the user provides a fix, apply it and add it to your notes for future reference
+
+## Phase 6: Multi-Repository Workflow (Optional)
+
+After successfully generating API stubs in openshift/api, you may need to update openshift/client-go to use the local API changes. This is common during development when client-go needs to regenerate clients based on unreleased API changes.
+
+### When to Use Multi-Repo Workflow
+
+Use this phase when:
+- User mentions "client-go" after API generation
+- User says to "update vendoring" or "regenerate client-go"
+- User asks to test API changes in client-go
+- This is part of a multi-repo change workflow
+
+### Step 1: Locate openshift/client-go Repository
+
+1. **Check if client-go exists locally**:
+   ```bash
+   # Common locations
+   ls -d ~/go/src/github.com/openshift/client-go 2>/dev/null || \
+   ls -d ~/code/client-go 2>/dev/null
+   ```
+
+2. **If not found**, ask user for the location or offer to clone:
+   ```bash
+   mkdir -p ~/go/src/github.com/openshift
+   git clone https://github.com/openshift/client-go ~/go/src/github.com/openshift/client-go
+   ```
+
+3. **Validate working directory** (same GOPATH structure requirement):
+   - Must be at `$GOPATH/src/github.com/openshift/client-go`
+   - Use the same working directory validation approach as Phase 1
+   - Create symlink if needed
+
+### Step 2: Update Vendoring to Point to Local API
+
+Use `go mod replace` to point client-go at the local API directory:
+
+1. **Determine the local API path**:
+   ```bash
+   API_PATH=$(cd /path/to/openshift/api && pwd)
+   # Example: /home/user/go/src/github.com/openshift/api
+   ```
+
+2. **Add replace directive to go.mod**:
+   ```bash
+   cd ~/go/src/github.com/openshift/client-go
+   go mod edit -replace github.com/openshift/api=$API_PATH
+   ```
+
+3. **Verify the replace directive**:
+   ```bash
+   grep "github.com/openshift/api" go.mod
+   # Should show: replace github.com/openshift/api => /path/to/local/api
+   ```
+
+4. **Update dependencies**:
+   ```bash
+   go mod tidy
+   go mod vendor  # If client-go uses vendoring
+   ```
+
+### Step 3: Run Client-Go Generation
+
+Apply the same iterative generation workflow to client-go:
+
+1. **Check Makefile for generation target**:
+   ```bash
+   grep -E "^(generate|update):" Makefile
+   ```
+   Common targets: `make generate`, `make update-codegen`, `make update`
+
+2. **Run generation** using Phases 2-4:
+   - Execute make target (Phase 2)
+   - Detect and fix errors (Phase 3)
+   - Validate generated code (Phase 4)
+
+3. **Common client-go specific issues**:
+   - **Import path errors**: If generation can't find openshift/api types, verify the `replace` directive is correct
+   - **Stale generated code**: May need to clean old generated files first
+   - **Version mismatches**: Ensure code-generator tool versions match between api and client-go
+
+### Step 4: Validate Client-Go Changes
+
+After successful generation:
+
+1. **Check what was generated**:
+   ```bash
+   git status --short
+   git diff --stat
+   ```
+
+2. **Verify compilation**:
+   ```bash
+   go build ./...
+   ```
+
+3. **Run tests** (if applicable):
+   ```bash
+   make test-unit
+   go test ./...
+   ```
+
+### Step 5: Report Multi-Repo Results
+
+Provide a comprehensive summary of both repositories:
+
+```markdown
+## Multi-Repository Generation Results
+
+### openshift/api
+**Status**: ✓ Successfully generated
+**Files modified**: <count> files
+**Key changes**: <summary>
+
+### openshift/client-go
+**Status**: ✓ Successfully generated
+**Vendoring**: Updated to use local API at <path>
+**Files modified**: <count> files
+**Key changes**: <summary>
+
+### Next Steps:
+1. Review changes in both repositories
+2. Run integration tests if available
+3. Commit changes in both repos:
+   - api: `git commit -m "Generate API stubs"`
+   - client-go: `git commit -m "Regenerate clients for API changes"`
+4. When ready to push: Remove go.mod replace directive in client-go before pushing
+```
+
+### Important Notes
+
+**Before pushing client-go**:
+- **Remove the replace directive** from go.mod:
+  ```bash
+  go mod edit -dropreplace github.com/openshift/api
+  ```
+- This is critical - you can't push with a replace pointing to a local path
+- Only use replace directives during local development
+
+**Workflow variations**:
+- Some repos use `go mod vendor`, others use modules directly
+- Check for a `vendor/` directory to determine vendoring strategy
+- If vendoring is used, run `go mod vendor` after `go mod tidy`
+
+## Output Format
+
+### Primary Output
+- Generated Go source files (*.go) in the repository
+- Modified files: types, client code, informers, listers, deepcopy methods
+- (Multi-repo): Updated go.mod with replace directive and regenerated client-go files
+
+### Secondary Output
+- Summary report (markdown format) showing:
+  - Working directory used
+  - Number of retry attempts
+  - Errors encountered and fixes applied
+  - Validation results
+  - Git diff summary
+  - Suggested next steps
+  - (Multi-repo): Status of both api and client-go repositories
+
+## Integration with Parent
+
+This skill can be invoked:
+
+1. **Directly by user**: "run make generate in openshift/api"
+2. **From other commands**: Commands that modify API types can invoke this skill to regenerate code
+3. **As part of workflows**: Future PR preparation workflows can include this skill
+
+When invoked from another command or skill, the invoking context should provide:
+- Path to openshift/api repository (if not current directory)
+- Whether to auto-commit results or leave them staged
+
+## Examples
+
+### Example 1: Successful generation from correct directory
+
+```bash
+User: "run make generate in openshift/api"

--- a/plugins/openshift/skills/generate-api-stubs/references/common_errors.md
+++ b/plugins/openshift/skills/generate-api-stubs/references/common_errors.md
@@ -1,0 +1,496 @@
+# Common Code Generation Errors
+
+This document catalogs common error patterns encountered when running `make generate` in openshift/api, along with their signatures, root causes, and fixes.
+
+## Error Pattern: Missing Deepcopy Markers
+
+**Signature:**
+```
+Types need DeepCopy methods
+missing deepcopy-gen markers
+DeepCopy method not found for type X
+```
+
+**Root Cause:**
+Kubernetes code-generator requires explicit markers to indicate which types should have DeepCopy methods generated. Without the marker, the generator skips the type.
+
+**Fix:**
+Add the `// +k8s:deepcopy-gen=true` comment above the type definition.
+
+**Example:**
+
+Input (before):
+```go
+package v1
+
+type MyAPIType struct {
+    Name string `json:"name"`
+    Value int   `json:"value"`
+}
+```
+
+Output (after):
+```go
+package v1
+
+// +k8s:deepcopy-gen=true
+type MyAPIType struct {
+    Name string `json:"name"`
+    Value int   `json:"value"`
+}
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: Missing GenClient Markers
+
+**Signature:**
+```
+type X does not have genclient marker
+genclient marker required for client generation
+missing genclient annotation
+```
+
+**Root Cause:**
+To generate client code for a Kubernetes resource, the type must be marked with `// +genclient`. This tells the generator that this type represents a top-level API resource (not a list type or subresource).
+
+**Fix:**
+Add `// +genclient` comment above resource type definitions. Note: Do NOT add this to list types (e.g., `MyResourceList`) or embedded types.
+
+**Example:**
+
+Input (before):
+```go
+package v1
+
+// +k8s:deepcopy-gen=true
+type MyResource struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    
+    Spec   MyResourceSpec   `json:"spec"`
+    Status MyResourceStatus `json:"status,omitempty"`
+}
+```
+
+Output (after):
+```go
+package v1
+
+// +genclient
+// +k8s:deepcopy-gen=true
+type MyResource struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    
+    Spec   MyResourceSpec   `json:"spec"`
+    Status MyResourceStatus `json:"status,omitempty"`
+}
+```
+
+**Auto-fixable:** Yes (with caution - must verify it's a resource type, not a list)
+
+---
+
+## Error Pattern: Import Path Resolution
+
+**Signature:**
+```
+cannot resolve import path "github.com/openshift/api/..."
+package github.com/openshift/api/... not found
+cannot find package "github.com/openshift/api/..."
+```
+
+**Root Cause:**
+Go's import path resolution can't find the openshift/api package. This usually means:
+1. The repository is not in the correct GOPATH location
+2. go.mod is out of sync with dependencies
+3. GOPATH is not set correctly
+
+**Fix (try in order):**
+1. Run `go mod tidy` to sync dependencies
+2. Verify GOPATH: `echo $GOPATH` and `go env GOPATH`
+3. Check repository location matches `$GOPATH/src/github.com/openshift/api`
+4. If location is wrong, see working directory validation section
+
+**Example:**
+
+```bash
+# Verify GOPATH
+$ go env GOPATH
+/home/user/go
+
+# Check current location
+$ pwd
+/home/user/repos/api  # WRONG - should be /home/user/go/src/github.com/openshift/api
+
+# Fix by moving or symlinking
+$ mkdir -p ~/go/src/github.com/openshift
+$ ln -s /home/user/repos/api ~/go/src/github.com/openshift/api
+$ cd ~/go/src/github.com/openshift/api
+```
+
+**Auto-fixable:** Partially (can run `go mod tidy`, directory fix requires user action)
+
+---
+
+## Error Pattern: Code Generator Tool Not Found
+
+**Signature:**
+```
+deepcopy-gen: command not found
+client-gen: not found
+informer-gen: command not found
+lister-gen: No such file or directory
+controller-gen: command not found
+```
+
+**Root Cause:**
+The Kubernetes code-generator tools are not installed or not in PATH. These tools must be available for `make generate` to work.
+
+**Fix:**
+Check if the Makefile has a tool installation target, or install manually:
+
+```bash
+# Check for Make targets
+make help | grep -i tool
+make help | grep -i codegen
+
+# If there's an install target, use it
+make install-tools
+# or
+make update-codegen-crds
+
+# Manual installation
+go install k8s.io/code-generator/cmd/deepcopy-gen@latest
+go install k8s.io/code-generator/cmd/client-gen@latest
+go install k8s.io/code-generator/cmd/informer-gen@latest
+go install k8s.io/code-generator/cmd/lister-gen@latest
+go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: GOPATH Not Set
+
+**Signature:**
+```
+GOPATH is not set
+cannot find package in any of GOPATH/GOROOT
+GOROOT not found
+```
+
+**Root Cause:**
+The GOPATH environment variable is not set, or is set incorrectly. Code generators rely on GOPATH to resolve import paths.
+
+**Fix:**
+1. Check GOPATH: `go env GOPATH`
+2. If empty, set it: `export GOPATH=$(go env GOPATH)` or `export GOPATH=$HOME/go`
+3. Verify repository is in `$GOPATH/src/github.com/openshift/api`
+
+**Example:**
+
+```bash
+# Check if GOPATH is set
+$ go env GOPATH
+/home/user/go
+
+# If empty, set it
+$ export GOPATH=$HOME/go
+
+# Verify
+$ echo $GOPATH
+/home/user/go
+
+# Ensure repo is in correct location
+$ pwd
+/home/user/go/src/github.com/openshift/api  # Correct location
+```
+
+**Auto-fixable:** No (requires environment setup or directory relocation)
+
+---
+
+## Error Pattern: Permission Denied
+
+**Signature:**
+```
+permission denied
+cannot create directory: Permission denied
+cannot write file: Permission denied
+```
+
+**Root Cause:**
+The user doesn't have write permissions in the repository directory or for specific generated files.
+
+**Fix:**
+1. Check file ownership: `ls -la`
+2. Check directory permissions: `ls -ld .`
+3. Fix ownership if needed: `sudo chown -R $USER:$USER .`
+4. Fix permissions: `chmod -R u+w .`
+
+**Auto-fixable:** No (requires manual permission fixes)
+
+---
+
+## Error Pattern: Stale Generated Code
+
+**Signature:**
+```
+conflict with existing generated code
+generated code is out of date
+Please run update-codegen
+stale generated files detected
+```
+
+**Root Cause:**
+Old generated code conflicts with new generation. This can happen when:
+- Generator version changed
+- API types were modified
+- Generated files were manually edited
+
+**Fix:**
+Remove old generated files and regenerate:
+
+```bash
+# Remove all generated deepcopy files
+find . -name 'zz_generated.*.go' -delete
+
+# Remove generated directories
+rm -rf ./generated/
+
+# Re-run generation
+make generate
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: go.mod Issues
+
+**Signature:**
+```
+go.mod is malformed
+go.sum mismatch
+missing go.sum entry for module
+```
+
+**Root Cause:**
+The go.mod or go.sum files are out of sync with the actual dependencies.
+
+**Fix:**
+```bash
+# Tidy up dependencies
+go mod tidy
+
+# Verify modules
+go mod verify
+
+# Download missing modules
+go mod download
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: Compilation Errors in Source
+
+**Signature:**
+```
+syntax error: unexpected X
+undefined: TypeName
+type X is not defined
+```
+
+**Root Cause:**
+There are syntax errors or undefined types in the source code before generation runs. Code generation requires valid Go source files.
+
+**Fix:**
+1. Fix the syntax error or undefined type in the source file
+2. Ensure all imports are correct
+3. Run `go build ./...` to verify source compiles
+4. Then retry `make generate`
+
+**Auto-fixable:** No (requires manual code fixes)
+
+---
+
+## Error Pattern: Wrong Working Directory
+
+**Signature:**
+```
+Makefile not found
+no such file or directory: Makefile
+make: *** No rule to make target 'generate'
+```
+
+**Root Cause:**
+Not in the openshift/api repository root, or in wrong subdirectory.
+
+**Fix:**
+```bash
+# Find the repository root
+git rev-parse --show-toplevel
+
+# Change to repository root
+cd $(git rev-parse --show-toplevel)
+
+# Verify Makefile exists
+ls -l Makefile
+
+# Run make generate
+make generate
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: Missing Package-Level Markers
+
+**Signature:**
+```
+package X is missing groupName marker
+package needs +k8s:deepcopy-gen=package
+```
+
+**Root Cause:**
+Package-level markers are required in `doc.go` files to configure code generation for the entire package.
+
+**Fix:**
+Create or update `doc.go` in the package directory:
+
+```go
+// Package v1 contains API Schema definitions for the myapi v1 API group
+// +k8s:deepcopy-gen=package
+// +k8s:openapi-gen=true
+// +groupName=myapi.openshift.io
+package v1
+```
+
+**Auto-fixable:** Yes
+
+---
+
+## Error Pattern: API Version Mismatch
+
+**Signature:**
+```
+API version mismatch
+apiVersion field does not match package
+GroupVersion mismatch
+```
+
+**Root Cause:**
+The `apiVersion` in the type's JSON tags doesn't match the package's declared group and version.
+
+**Fix:**
+Ensure the GroupVersion is correctly defined in `register.go`:
+
+```go
+var (
+    GroupVersion = schema.GroupVersion{
+        Group:   "myapi.openshift.io",
+        Version: "v1",
+    }
+)
+```
+
+And types reference it correctly:
+
+```go
+type MyResource struct {
+    metav1.TypeMeta `json:",inline"`  // Will be set to myapi.openshift.io/v1
+    // ...
+}
+```
+
+**Auto-fixable:** No (requires understanding of API group/version structure)
+
+---
+
+## Error Pattern: Namespace Scope Marker Mismatch
+
+**Signature:**
+```
+resource must specify namespaced marker
+cluster-scoped resource with namespace field
+```
+
+**Root Cause:**
+The `// +genclient:nonNamespaced` marker doesn't match the resource's actual scope.
+
+**Fix:**
+For cluster-scoped resources, add:
+```go
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen=true
+type MyClusterResource struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    // ...
+}
+```
+
+For namespaced resources, omit `nonNamespaced`:
+```go
+// +genclient
+// +k8s:deepcopy-gen=true
+type MyNamespacedResource struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    // ...
+}
+```
+
+**Auto-fixable:** No (requires understanding of resource scope)
+
+---
+
+## Error Pattern: ReadOnly Subresource Issues
+
+**Signature:**
+```
+status subresource must be read-only
+spec/status separation required
+```
+
+**Root Cause:**
+OpenShift APIs should separate spec (desired state) and status (observed state), with status being a read-only subresource.
+
+**Fix:**
+Ensure proper structure and add subresource marker:
+
+```go
+// +genclient
+// +genclient:subresource:status
+// +k8s:deepcopy-gen=true
+type MyResource struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    
+    Spec   MyResourceSpec   `json:"spec"`
+    Status MyResourceStatus `json:"status,omitempty"`
+}
+```
+
+**Auto-fixable:** Partially (can add marker, but structure must be manually verified)
+
+---
+
+## Usage Notes
+
+When using this reference:
+
+1. **Match error output against signatures** - Use regex or substring matching
+2. **Try auto-fixable errors first** - These have high success rates
+3. **For non-auto-fixable errors** - Provide the fix steps to the user with explanation
+4. **Chain multiple fixes** - Some errors require multiple fixes in sequence
+5. **Track attempted fixes** - Don't apply the same fix twice in a row

--- a/plugins/openshift/skills/generate-api-stubs/scripts/check_working_directory.sh
+++ b/plugins/openshift/skills/generate-api-stubs/scripts/check_working_directory.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Validates that current directory is in correct Go workspace location for openshift/api
+# Returns 0 if valid, 1 if invalid
+# Prints diagnostic information and suggestions if invalid
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get GOPATH
+GOPATH="${GOPATH:-$(go env GOPATH)}"
+if [ -z "$GOPATH" ]; then
+    echo -e "${RED}Error: GOPATH is not set and 'go env GOPATH' returned empty${NC}" >&2
+    echo "Solution: Set GOPATH environment variable or ensure Go is properly installed" >&2
+    exit 1
+fi
+
+# Expected location
+EXPECTED_PATH="$GOPATH/src/github.com/openshift/api"
+CURRENT_DIR="$(pwd)"
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo -e "${RED}Error: Not in a git repository${NC}" >&2
+    echo "Current directory: $CURRENT_DIR" >&2
+    exit 1
+fi
+
+# Check if this is the openshift/api repository
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+if [[ ! "$REMOTE_URL" =~ openshift/api ]]; then
+    echo -e "${YELLOW}Warning: This doesn't appear to be the openshift/api repository${NC}" >&2
+    echo "Remote URL: $REMOTE_URL" >&2
+    echo "Expected: *openshift/api*" >&2
+fi
+
+# Check if current directory matches expected GOPATH structure
+if [ "$CURRENT_DIR" = "$EXPECTED_PATH" ]; then
+    echo -e "${GREEN}✓ Working directory is correct${NC}"
+    echo "Location: $CURRENT_DIR"
+    echo "GOPATH: $GOPATH"
+    exit 0
+fi
+
+# Check if current directory is a symlink to the expected path
+REAL_CURRENT_DIR="$(realpath "$CURRENT_DIR")"
+REAL_EXPECTED_PATH="$(realpath "$EXPECTED_PATH" 2>/dev/null || echo "$EXPECTED_PATH")"
+if [ "$REAL_CURRENT_DIR" = "$REAL_EXPECTED_PATH" ]; then
+    echo -e "${GREEN}✓ Working directory is correct (via symlink)${NC}"
+    echo "Location: $CURRENT_DIR"
+    echo "Real path: $REAL_CURRENT_DIR"
+    echo "GOPATH: $GOPATH"
+    exit 0
+fi
+
+# Working directory is incorrect
+echo -e "${RED}✗ Working directory is incorrect for code generation${NC}" >&2
+echo "" >&2
+echo "Current directory: $CURRENT_DIR" >&2
+echo "Expected directory: $EXPECTED_PATH" >&2
+echo "GOPATH: $GOPATH" >&2
+echo "" >&2
+echo -e "${YELLOW}Why this matters:${NC}" >&2
+echo "Kubernetes code-generators use import path detection that requires repositories" >&2
+echo "to be located at GOPATH/src/<import-path>. For openshift/api, the import path" >&2
+echo "is 'github.com/openshift/api', so it must be at:" >&2
+echo "  \$GOPATH/src/github.com/openshift/api" >&2
+echo "" >&2
+echo -e "${YELLOW}Suggested fixes:${NC}" >&2
+echo "" >&2
+echo "Option A - Clone to correct location:" >&2
+echo "  mkdir -p $GOPATH/src/github.com/openshift" >&2
+echo "  git clone https://github.com/openshift/api $EXPECTED_PATH" >&2
+echo "  cd $EXPECTED_PATH" >&2
+echo "" >&2
+echo "Option B - Create symlink (preserves current work):" >&2
+echo "  mkdir -p $GOPATH/src/github.com/openshift" >&2
+echo "  ln -s $CURRENT_DIR $EXPECTED_PATH" >&2
+echo "  cd $EXPECTED_PATH" >&2
+echo "" >&2
+echo "Option C - Adjust GOPATH (temporary solution):" >&2
+# Try to infer what GOPATH should be
+if [[ "$CURRENT_DIR" =~ (.*)/src/github.com/openshift/api$ ]]; then
+    INFERRED_GOPATH="${BASH_REMATCH[1]}"
+    echo "  export GOPATH=$INFERRED_GOPATH" >&2
+    echo "  # This will make the current directory resolve correctly" >&2
+else
+    echo "  # Cannot infer GOPATH from current directory structure" >&2
+    echo "  # Current directory doesn't follow the src/github.com/openshift/api pattern" >&2
+fi
+
+exit 1

--- a/plugins/openshift/skills/generate-api-stubs/scripts/detect_generation_errors.py
+++ b/plugins/openshift/skills/generate-api-stubs/scripts/detect_generation_errors.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Parses make generate output and identifies error patterns.
+Returns JSON with error classification and suggested fixes.
+"""
+
+import sys
+import json
+import re
+from pathlib import Path
+
+# Error pattern definitions
+ERROR_PATTERNS = [
+    {
+        "name": "missing_deepcopy_markers",
+        "signatures": [
+            r"Types need DeepCopy methods",
+            r"missing deepcopy-gen markers",
+            r"DeepCopy.*not found",
+            r"must have deepcopy",
+        ],
+        "error_type": "missing_markers",
+        "suggested_fix": "Add // +k8s:deepcopy-gen=true comment above type definitions",
+        "auto_fixable": True,
+    },
+    {
+        "name": "missing_genclient_markers",
+        "signatures": [
+            r"does not have genclient marker",
+            r"genclient.*required",
+            r"missing.*genclient",
+        ],
+        "error_type": "missing_markers",
+        "suggested_fix": "Add // +genclient comment above resource type definitions (not lists or subresources)",
+        "auto_fixable": True,
+    },
+    {
+        "name": "import_path_resolution",
+        "signatures": [
+            r"cannot resolve import path",
+            r"package.*not found",
+            r"no such package",
+            r"cannot find package",
+        ],
+        "error_type": "import_error",
+        "suggested_fix": "Run 'go mod tidy' or verify GOPATH is correctly set",
+        "auto_fixable": True,
+    },
+    {
+        "name": "tool_not_found",
+        "signatures": [
+            r"deepcopy-gen.*command not found",
+            r"client-gen.*not found",
+            r"informer-gen.*not found",
+            r"lister-gen.*not found",
+            r"openapi-gen.*not found",
+            r"controller-gen.*not found",
+            r"protoc.*command not found",
+            r"protobuf requires protoc",
+        ],
+        "error_type": "missing_tool",
+        "suggested_fix": "Install missing code-generator tools or run tool installation make target",
+        "auto_fixable": True,
+    },
+    {
+        "name": "gopath_not_set",
+        "signatures": [
+            r"GOPATH.*not set",
+            r"GOPATH.*to be set",
+            r"requires GOPATH",
+            r"cannot find package in any of.*GOPATH",
+            r"GOROOT.*not found",
+        ],
+        "error_type": "environment",
+        "suggested_fix": "Verify GOPATH is set and repository is in correct location ($GOPATH/src/github.com/openshift/api)",
+        "auto_fixable": False,
+    },
+    {
+        "name": "permission_denied",
+        "signatures": [
+            r"permission denied",
+            r"cannot create.*Permission denied",
+        ],
+        "error_type": "permissions",
+        "suggested_fix": "Check file permissions and ownership in the repository directory",
+        "auto_fixable": False,
+    },
+    {
+        "name": "stale_generated_code",
+        "signatures": [
+            r"conflict.*generated",
+            r"generated.*out of date",
+            r"Please run.*update-codegen",
+        ],
+        "error_type": "stale_code",
+        "suggested_fix": "Remove old generated files (find . -name 'zz_generated.*.go' -delete) and retry",
+        "auto_fixable": True,
+    },
+    {
+        "name": "vendor_out_of_sync",
+        "signatures": [
+            r"inconsistent vendoring",
+            r"not marked as replaced in vendor/modules\.txt",
+            r"To sync the vendor directory, run:\s+go mod vendor",
+        ],
+        "error_type": "dependency",
+        "suggested_fix": "Run 'go mod vendor' to sync vendor directory with go.mod",
+        "auto_fixable": True,
+    },
+    {
+        "name": "go_mod_issues",
+        "signatures": [
+            r"go.mod.*malformed",
+            r"go.sum.*mismatch",
+            r"missing go.sum entry",
+        ],
+        "error_type": "dependency",
+        "suggested_fix": "Run 'go mod tidy' to fix go.mod and go.sum",
+        "auto_fixable": True,
+    },
+    {
+        "name": "compilation_error",
+        "signatures": [
+            r"syntax error",
+            r"undefined:",
+            r"type.*not defined",
+        ],
+        "error_type": "compilation",
+        "suggested_fix": "Fix syntax or type errors in source files before generating",
+        "auto_fixable": False,
+    },
+]
+
+
+def extract_file_references(output):
+    """Extract file paths mentioned in error output."""
+    file_patterns = [
+        r"([a-zA-Z0-9_/.-]+\.go):\d+:\d+:",  # file.go:line:col:
+        r"([a-zA-Z0-9_/.-]+\.go):",  # file.go:
+        r"in\s+([a-zA-Z0-9_/.-]+\.go)",  # in file.go
+    ]
+
+    files = set()
+    for pattern in file_patterns:
+        matches = re.finditer(pattern, output)
+        for match in matches:
+            files.add(match.group(1))
+
+    return sorted(list(files))
+
+
+def extract_type_references(output):
+    """Extract type names mentioned in errors."""
+    type_patterns = [
+        r"type\s+([A-Z][a-zA-Z0-9_]*)",
+        r"struct\s+([A-Z][a-zA-Z0-9_]*)",
+    ]
+
+    types = set()
+    for pattern in type_patterns:
+        matches = re.finditer(pattern, output)
+        for match in matches:
+            types.add(match.group(1))
+
+    return sorted(list(types))
+
+
+def detect_error_pattern(output):
+    """Detect which error pattern matches the output."""
+    for pattern in ERROR_PATTERNS:
+        for signature in pattern["signatures"]:
+            if re.search(signature, output, re.IGNORECASE):
+                return pattern
+
+    return None
+
+
+def analyze_output(output):
+    """Analyze make generate output and return error classification."""
+    # Check if generation was successful
+    if "Exit code: 0" in output or re.search(r"generated.*successfully", output, re.IGNORECASE):
+        return {
+            "status": "success",
+            "error_type": None,
+            "error_pattern": None,
+            "suggested_fix": None,
+            "auto_fixable": False,
+            "files_to_check": [],
+            "types_mentioned": [],
+        }
+
+    # Detect error pattern
+    pattern = detect_error_pattern(output)
+
+    if pattern:
+        return {
+            "status": "error",
+            "error_type": pattern["error_type"],
+            "error_pattern": pattern["name"],
+            "suggested_fix": pattern["suggested_fix"],
+            "auto_fixable": pattern["auto_fixable"],
+            "files_to_check": extract_file_references(output),
+            "types_mentioned": extract_type_references(output),
+        }
+    else:
+        # Unknown error pattern
+        return {
+            "status": "error",
+            "error_type": "unknown",
+            "error_pattern": "unrecognized",
+            "suggested_fix": "Unknown error - manual review required",
+            "auto_fixable": False,
+            "files_to_check": extract_file_references(output),
+            "types_mentioned": extract_type_references(output),
+            "error_sample": output[:500] if len(output) > 500 else output,
+        }
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: detect_generation_errors.py <output_file>", file=sys.stderr)
+        print("   or: cat output.log | detect_generation_errors.py -", file=sys.stderr)
+        sys.exit(1)
+
+    # Read input
+    if sys.argv[1] == "-":
+        output = sys.stdin.read()
+    else:
+        output_file = Path(sys.argv[1])
+        if not output_file.exists():
+            print(f"Error: File not found: {output_file}", file=sys.stderr)
+            sys.exit(1)
+        output = output_file.read_text()
+
+    # Analyze
+    result = analyze_output(output)
+
+    # Output JSON
+    print(json.dumps(result, indent=2))
+
+    # Exit code based on status
+    sys.exit(0 if result["status"] == "success" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/openshift/skills/generate-api-stubs/scripts/validate_generated_code.sh
+++ b/plugins/openshift/skills/generate-api-stubs/scripts/validate_generated_code.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Validates that code generation succeeded
+# Checks for expected generated files and basic compilation
+# Returns 0 if all checks pass, 1 otherwise
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+VALIDATION_FAILED=0
+
+echo "Validating generated code..."
+echo ""
+
+# Check 1: Deepcopy files exist
+echo -n "Checking for deepcopy generated files... "
+DEEPCOPY_FILES=$(find . -name 'zz_generated.deepcopy.go' 2>/dev/null | wc -l)
+if [ "$DEEPCOPY_FILES" -gt 0 ]; then
+    echo -e "${GREEN}✓${NC} Found $DEEPCOPY_FILES deepcopy file(s)"
+else
+    echo -e "${RED}✗${NC} No zz_generated.deepcopy.go files found"
+    VALIDATION_FAILED=1
+fi
+
+# Check 2: Generated directory exists
+echo -n "Checking for generated/ directory... "
+if [ -d "generated" ]; then
+    echo -e "${GREEN}✓${NC} generated/ directory exists"
+else
+    echo -e "${YELLOW}⚠${NC} generated/ directory not found (may be expected for some repos)"
+fi
+
+# Check 3: Client code
+echo -n "Checking for generated clientset... "
+if [ -d "generated/clientset" ] || find . -type d -name "clientset" 2>/dev/null | grep -q .; then
+    echo -e "${GREEN}✓${NC} Clientset generated"
+else
+    echo -e "${YELLOW}⚠${NC} No clientset found (may not be required)"
+fi
+
+# Check 4: Informers
+echo -n "Checking for generated informers... "
+if [ -d "generated/informers" ] || find . -type d -name "informers" 2>/dev/null | grep -q .; then
+    echo -e "${GREEN}✓${NC} Informers generated"
+else
+    echo -e "${YELLOW}⚠${NC} No informers found (may not be required)"
+fi
+
+# Check 5: Listers
+echo -n "Checking for generated listers... "
+if [ -d "generated/listers" ] || find . -type d -name "listers" 2>/dev/null | grep -q .; then
+    echo -e "${GREEN}✓${NC} Listers generated"
+else
+    echo -e "${YELLOW}⚠${NC} No listers found (may not be required)"
+fi
+
+# Check 6: OpenAPI schema
+echo -n "Checking for OpenAPI generated code... "
+if find . -name '*openapi_generated.go' 2>/dev/null | grep -q .; then
+    echo -e "${GREEN}✓${NC} OpenAPI schema generated"
+else
+    echo -e "${YELLOW}⚠${NC} No OpenAPI schema found (may not be required)"
+fi
+
+# Check 7: Verify generated files are not empty
+echo -n "Checking generated files are not empty... "
+EMPTY_FILES=$(find . -name 'zz_generated.*.go' -type f -empty 2>/dev/null)
+if [ -z "$EMPTY_FILES" ]; then
+    echo -e "${GREEN}✓${NC} All generated files have content"
+else
+    echo -e "${RED}✗${NC} Found empty generated files:"
+    echo "$EMPTY_FILES"
+    VALIDATION_FAILED=1
+fi
+
+# Check 8: Basic Go compilation
+echo -n "Checking if generated code compiles... "
+if go build ./... > /tmp/validation-build.log 2>&1; then
+    echo -e "${GREEN}✓${NC} Code compiles successfully"
+else
+    echo -e "${RED}✗${NC} Compilation failed"
+    echo "Build errors:"
+    cat /tmp/validation-build.log
+    VALIDATION_FAILED=1
+fi
+
+# Check 9: No obvious errors in generated files
+echo -n "Checking for import cycles or syntax errors... "
+if go list ./... > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} No import cycles detected"
+else
+    echo -e "${RED}✗${NC} Found import cycles or package errors"
+    go list ./... 2>&1 | head -20
+    VALIDATION_FAILED=1
+fi
+
+# Summary
+echo ""
+if [ $VALIDATION_FAILED -eq 0 ]; then
+    echo -e "${GREEN}✓ Validation passed${NC}"
+    echo "All generated code checks completed successfully."
+    exit 0
+else
+    echo -e "${RED}✗ Validation failed${NC}"
+    echo "Some validation checks did not pass. Review the errors above."
+    exit 1
+fi


### PR DESCRIPTION
New skill to automate running `make generate` in openshift/api with iterative error detection and auto-fixing. Includes multi-repo workflow support for updating openshift/client-go vendoring and regeneration.

Bumps openshift plugin version to 0.0.6.

## What this PR does / why we need it:

## Which issue(s) this PR fixes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Agentic Docs plugin for AI-optimized OpenShift documentation access
  * Added /teams:list-repos command and a repository-owner lookup utility for teams
  * Added OpenShift API stub generation command with automated detection/fix/validation workflows

* **Documentation**
  * New guidance and troubleshooting for API generation and client-go regeneration

* **Updates**
  * OpenShift plugin version bumped to 0.0.7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->