### PR TITLE
Add CI check requiring OWNERS file for new plugins

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -91,10 +91,57 @@ rules:
     enabled: true
     severity: error
 
+  # Every plugin must have an OWNERS file
+  plugin-owners-required:
+    enabled: true
+    severity: error
+    legacy-exceptions:
+      - agendas
+      - ai-operator-dashboard-generator
+      - ai-sbom
+      - bigquery
+      - ci
+      - code-review
+      - compliance
+      - console
+      - container-image
+      - doc
+      - etcd
+      - git
+      - golang
+      - gwapi
+      - hcp
+      - hello-world
+      - jira
+      - lvms
+      - marketplace-ops
+      - metrics
+      - must-gather
+      - native-notifications
+      - node
+      - node-tuning
+      - olm
+      - olm-team
+      - openshift
+      - openshift-tls-profile
+      - origin
+      - ote-migration
+      - rds-analyzer
+      - session
+      - snowflake
+      - sosreport
+      - teams
+      - test-coverage
+      - testing
+      - utils
+      - workspaces
+      - yaml
+
 # Load custom rules from these files
 custom-rules:
   - ".skillsaw/plugindocs_rule.py"
   - ".skillsaw/promptfoo_budget_rule.py"
+  - ".skillsaw/owners_rule.py"
 
 # Exclude patterns (glob format)
 # Use exclude: [] to disable all excludes including defaults

--- a/.skillsaw/owners_rule.py
+++ b/.skillsaw/owners_rule.py
@@ -1,0 +1,67 @@
+"""
+Require an OWNERS file in each plugin directory.
+"""
+
+from typing import List
+
+from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
+from skillsaw.lint_target import PluginNode
+
+
+class PluginOwnersRequiredRule(Rule):
+    """Every plugin must have a non-empty OWNERS file."""
+
+    config_schema = {
+        "legacy-exceptions": {
+            "type": "list",
+            "default": [],
+            "description": "Plugin names to exclude from the OWNERS file requirement",
+        },
+    }
+
+    @property
+    def rule_id(self) -> str:
+        return "plugin-owners-required"
+
+    @property
+    def description(self) -> str:
+        return "Every plugin must have a non-empty OWNERS file in its root directory."
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+        excluded = set(self.config.get("legacy-exceptions", []))
+
+        for node in context.lint_tree.find(PluginNode):
+            plugin_name = node.path.name
+            owners_path = node.path / "OWNERS"
+            has_owners = owners_path.exists() and owners_path.stat().st_size > 0
+
+            if plugin_name in excluded:
+                if has_owners:
+                    violations.append(
+                        self.violation(
+                            f"Plugin '{plugin_name}' has an OWNERS file but is still in the exclude list — remove it from the exclusion",
+                            file_path=owners_path,
+                        )
+                    )
+                continue
+
+            if not owners_path.exists():
+                violations.append(
+                    self.violation(
+                        f"Plugin '{plugin_name}' is missing an OWNERS file",
+                        file_path=node.path / ".claude-plugin" / "plugin.json",
+                    )
+                )
+            elif not has_owners:
+                violations.append(
+                    self.violation(
+                        f"Plugin '{plugin_name}' has an empty OWNERS file",
+                        file_path=owners_path,
+                    )
+                )
+
+        return violations


### PR DESCRIPTION
New plugins need to have someone who claims ownership.  Old plugins that get owners added, will fail until the exception is removed.  We should work to getting this list down to 0, but for now let's make sure we don't add new ones that don't have ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced enforcement rule requiring all plugins to maintain OWNERS files for proper accountability and maintenance tracking.
  * Added support for legacy exceptions to allow exempting specific plugins from this requirement during transition.

* **Chores**
  * Added new test plugin with metadata and command documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->