### PR TITLE
Improve analyze-payload scoring precision with three targeted signals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,9 @@
   "owner": {
     "name": "openshift-eng"
   },
-  "allowCrossMarketplaceDependenciesOn": ["claude-plugins-official"],
+  "allowCrossMarketplaceDependenciesOn": [
+    "claude-plugins-official"
+  ],
   "plugins": [
     {
       "name": "git",
@@ -27,7 +29,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.39"
+      "version": "0.0.40"
     },
     {
       "name": "teams",

--- a/docs/data.json
+++ b/docs/data.json
@@ -607,7 +607,7 @@
           "name": "Trigger Payload Job"
         }
       ],
-      "version": "0.0.39"
+      "version": "0.0.40"
     },
     {
       "commands": [

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "author": {
     "name": "openshift"
   }

--- a/plugins/ci/skills/analyze-payload/SKILL.md
+++ b/plugins/ci/skills/analyze-payload/SKILL.md
@@ -199,6 +199,13 @@ Wait for all subagents to complete and collect their analysis results. For each 
 
 For each failed job, cross-reference the failure analysis from the subagent with the candidate PRs from the originating payload. Additionally, if a subagent traced the root cause to a PR outside the payload (e.g., an `openshift/release` PR that modified a CI step registry script), include that PR as a candidate — it is a regression like any other and should be scored and treated the same way as payload PRs.
 
+**Infrastructure and platform-specific failure triage**: Before scoring candidate PRs, check whether the failure is caused by cloud provider infrastructure rather than code changes. Key indicators:
+- **Cloud provider API errors**: Azure Graph API auth failures, AWS STS failures, GCP quota exhaustion — these are provider-side issues that resolve without code changes
+- **Single-platform failures**: If a failure occurs on only one cloud platform (e.g., only AKS) and the candidate PR doesn't directly modify platform-specific code, the causal chain requires stronger evidence
+- **Transient resolution**: If the same test passed on the same platform in a very recent payload with no relevant PR changes between the pass and failure
+
+Apply a negative adjustment: **Platform-specific failure without mechanism**: -20 (failure occurs only on one cloud platform and the causal chain from PR to platform-specific behavior requires multiple speculative steps)
+
 Score each (failed job, candidate PR) pair using the following weighted rubric:
 
 | Signal | Weight | Criteria |
@@ -209,8 +216,11 @@ Score each (failed job, candidate PR) pair using the following weighted rubric:
 | Multi-job correlation | +10 | The same PR is a candidate for failures in multiple independent jobs — the more jobs that point to the same PR, the stronger the signal |
 | Presubmit coverage gap | +10 | The failing job tests a scenario (upgrade, FIPS, SNO, techpreview, etc.) that wasn't covered by the PR's presubmit tests |
 | Single candidate | +10 | Only one PR landed in the originating payload that touches the affected component |
+| Test-introduction match | +40 | The candidate PR introduced a new test (visible in its diff) and that specific test is now failing. A PR that both creates a feature and its test, where the test immediately fails, is near-certain evidence of causation. |
 
-The maximum possible score is 130, but scores above 100 should be capped at 100. Record the numeric score for each (job, candidate PR) pair alongside the qualitative rationale.
+The maximum possible score is 170, but scores above 100 should be capped at 100. Record the numeric score for each (job, candidate PR) pair alongside the qualitative rationale.
+
+**Sub-component resolution**: For repos with 3+ PRs in the originating payload, examine each PR's changed file paths to identify sub-components. Score component exclusivity based on sub-component overlap rather than repo-level overlap. For example, in the `hypershift` repo, PRs modifying `control-plane-operator/` vs `hypershift-operator/` vs `test/` are distinct sub-components.
 
 #### 6.2: Propose Revert Candidates
 


### PR DESCRIPTION
## Summary
- Add cloud platform infrastructure triage with -20 negative adjustment for platform-specific failures without clear mechanism evidence (reduces false positives like Azure Graph API issues blamed on builder image changes)
- Add test-introduction match signal (+40) for PRs that introduce a test which immediately fails — near-certain causation evidence
- Add sub-component resolution for repos with 3+ PRs, scoring component exclusivity at sub-component level rather than whole-repo level (fixes persistent Case 008 weakness)

## Test plan
- [ ] Run eval suite against baseline (`2026-05-14-opus-4cases`) and compare scores
- [ ] Verify Case 008 (hypershift multi-PR) improves from 3/5 to 4-5/5 on analysis_quality
- [ ] Verify Case 012 (HyperShift builder FP) correctly applies -20 platform adjustment
- [ ] Verify no regressions on Cases 006, 007, 009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI plugin version to 0.0.40

* **Documentation**
  * Enhanced candidate scoring rubric with improved failure triage classification and new test-introduction matching signal for more accurate PR assessment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->