### PR TITLE
fetch-payloads: resolve stale Pending jobs against Prow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.40"
+      "version": "0.0.41"
     },
     {
       "name": "teams",

--- a/docs/data.json
+++ b/docs/data.json
@@ -612,7 +612,7 @@
           "name": "Trigger Payload Job"
         }
       ],
-      "version": "0.0.40"
+      "version": "0.0.41"
     },
     {
       "commands": [

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/fetch-payloads/fetch_payloads.py
+++ b/plugins/ci/skills/fetch-payloads/fetch_payloads.py
@@ -41,6 +41,17 @@ def release_stream_name(version: str, stream: str, architecture: str) -> str:
     return name
 
 
+GCSWEB_BASE = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
+PROW_VIEW_PREFIX = "https://prow.ci.openshift.org/view/gs/"
+
+PROW_STATE_MAP = {
+    "success": "Succeeded",
+    "failure": "Failed",
+    "aborted": "Failed",
+    "error": "Failed",
+}
+
+
 def fetch_json(url: str, timeout: int = 30) -> dict:
     """Fetch JSON from a URL."""
     try:
@@ -55,6 +66,28 @@ def fetch_json(url: str, timeout: int = 30) -> dict:
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+
+def try_fetch_json(url: str, timeout: int = 10) -> dict | None:
+    """Fetch JSON from a URL, returning None on any failure."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def resolve_prow_state(prow_url: str) -> str | None:
+    """Query the actual Prow job state via its GCS prowjob.json artifact."""
+    if not prow_url or not prow_url.startswith(PROW_VIEW_PREFIX):
+        return None
+    gcs_path = prow_url[len(PROW_VIEW_PREFIX):]
+    prowjob_url = f"{GCSWEB_BASE}/{gcs_path}/prowjob.json"
+    data = try_fetch_json(prowjob_url)
+    if not data:
+        return None
+    prow_state = data.get("status", {}).get("state", "")
+    return PROW_STATE_MAP.get(prow_state)
 
 
 def fetch_tags(architecture: str, version: str, stream: str) -> list:
@@ -154,15 +187,34 @@ def main():
     payloads = []
     for tag in tags:
         name = tag.get("name", "")
+        phase = tag.get("phase", "Unknown")
         details = fetch_release_details(architecture, stream_name, name)
         all_results = details.get("results", {})
         filtered_results = {
             k: v for k, v in all_results.items()
             if k in ("blockingJobs", "asyncJobs")
         }
+
+        # The release controller can leave jobs as Pending after the payload
+        # reaches a terminal state. Cross-check against Prow to get the real
+        # state so the analysis skill doesn't skip completed jobs.
+        if phase in ("Accepted", "Rejected"):
+            blocking = filtered_results.get("blockingJobs", {})
+            for job_name, job_info in blocking.items():
+                if job_info.get("state") != "Pending":
+                    continue
+                resolved = resolve_prow_state(job_info.get("url", ""))
+                if resolved:
+                    print(
+                        f"  {job_name}: release controller says Pending, "
+                        f"Prow says {resolved}",
+                        file=sys.stderr,
+                    )
+                    job_info["state"] = resolved
+
         payloads.append({
             "tag": name,
-            "phase": tag.get("phase", "Unknown"),
+            "phase": phase,
             "url": release_page_url(architecture, stream_name, name),
             "results": filtered_results,
         })


### PR DESCRIPTION
## Summary
- The release controller can leave blocking jobs stuck as `Pending` after a payload reaches a terminal state (`Accepted`/`Rejected`), even though the actual Prow job has completed
- This caused the payload analysis skill to skip those jobs entirely — they appeared still running
- When a payload is terminal, `fetch_payloads.py` now cross-checks any `Pending` jobs by fetching their `prowjob.json` from GCS to get the real state
- Example: `gcp-ovn-rt-upgrade-4.20-minor` in [4.20.0-0.nightly-2026-05-18-050422](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.20.0-0.nightly/release/4.20.0-0.nightly-2026-05-18-050422) was reported as Pending by the release controller but had actually failed in Prow

## Test plan
- [x] Verified against the problematic payload — script now correctly resolves `gcp-ovn-rt-upgrade-4.20-minor` from `Pending` to `Failed`
- [x] Non-terminal payloads are unaffected (cross-check only runs for `Accepted`/`Rejected` payloads)
- [x] If GCS artifact is unavailable, the job state is left unchanged (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate job-state reporting by resolving pending jobs against Prow artifacts; improved handling/logging when states differ.
  * More robust artifact fetching with tolerant JSON fetches for transient failures.

* **Refactor**
  * Consolidated job phase computation and streamlined payload construction for clearer processing.

* **Chores**
  * Plugin and marketplace metadata version bumped to 0.0.41; docs metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->