### PR TITLE
Upgrade to Python 3.11 in claude-ai-helpers image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,14 +1,16 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 
-# Install Python 3 and development tools
+# Install Python 3.11 (required for agent-eval-harness and modern type syntax)
 RUN dnf install -y \
-    python3 \
-    python3-pip \
-    python3-devel \
-    && dnf clean all
+    python3.11 \
+    python3.11-pip \
+    python3.11-devel \
+    && dnf clean all \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && alternatives --set python3 /usr/bin/python3.11
 
 # Install common Python tools
-RUN pip3 install --no-cache-dir \
+RUN python3 -m pip install --no-cache-dir \
     pytest \
     requests \
     pyyaml


### PR DESCRIPTION
## Summary
- Upgrades Python from 3.9 to 3.11 in the claude-ai-helpers container image
- Required for agent-eval-harness which uses Python 3.10+ type syntax and mlflow[genai]>=3.5

## Changes
- Install `python3.11`, `python3.11-pip`, `python3.11-devel` instead of `python3` packages
- Set Python 3.11 as default via `alternatives`
- Use `python3 -m pip` instead of `pip3` for consistency

## Test plan
- [ ] Verify image builds successfully in CI
- [ ] Verify `python3 --version` shows 3.11.x in the container
- [ ] Verify agent-eval-harness plugin installs and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container toolchain to explicitly use Python 3.11 and streamlined Python package installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->