### PR TITLE
HPNEX-16: feat: add bundles with openshift-developer meta-package

### DIFF
--- a/bundles/README.md
+++ b/bundles/README.md
@@ -1,0 +1,90 @@
+# Bundles
+
+Bundles are curated sets of APM packages for common workflows. Each bundle is a
+subdirectory with an `apm.yml` that lists dependencies — install one bundle and
+get everything you need for that workflow.
+
+## Available Bundles
+
+| Bundle | Description |
+|--------|-------------|
+| [openshift-developer](openshift-developer/) | Skills and tools for any OpenShift engineer |
+
+## Prerequisites
+
+Some plugins in these bundles depend on plugins from the
+`anthropics/claude-plugins-official` marketplace. Register it before
+installing:
+
+```sh
+apm marketplace add anthropics/claude-plugins-official
+```
+
+## Usage
+
+### Global install (recommended for personal dev environments)
+
+Create `~/.apm/apm.yml` if it doesn't exist, then add the bundle as a
+dependency:
+
+```yaml
+# ~/.apm/apm.yml
+name: my-global-config
+version: 1.0.0
+
+dependencies:
+  apm:
+    - openshift-eng/ai-helpers/bundles/openshift-developer
+```
+
+Then install globally:
+
+```sh
+apm install --global
+```
+
+This installs all the skills, plugins, and MCP servers from the bundle into your
+user-level configuration, available in every project.
+
+### Project-scoped install
+
+Add the bundle to your project's `apm.yml`:
+
+```yaml
+# apm.yml
+name: my-project
+version: 1.0.0
+
+dependencies:
+  apm:
+    - openshift-eng/ai-helpers/bundles/openshift-developer
+```
+
+Then:
+
+```sh
+apm install
+```
+
+## Creating a new bundle
+
+1. Create a subdirectory under `bundles/` with your bundle name
+2. Add an `apm.yml` with `name`, `version`, `description`, and `dependencies`
+3. Reference packages from this repo using virtual paths
+   (e.g., `openshift-eng/ai-helpers/plugins/jira`) or any other APM package
+
+Example:
+
+```yaml
+name: my-bundle
+version: 1.0.0
+description: A curated set of tools for my workflow.
+
+dependencies:
+  apm:
+    - openshift-eng/ai-helpers/plugins/jira
+    - openshift-eng/ai-helpers/plugins/ci
+  mcp:
+    - name: some-mcp-server
+      transport: stdio
+```

--- a/bundles/openshift-developer/apm.yml
+++ b/bundles/openshift-developer/apm.yml
@@ -1,0 +1,14 @@
+name: openshift-developer
+version: 1.0.0
+description: Skills and tools useful to any OpenShift Engineer. 
+
+dependencies:
+  apm:
+    - openshift-eng/ai-helpers/plugins/jira
+    - openshift-eng/ai-helpers/plugins/ci
+    - openshift-eng/ai-helpers/plugins/golang
+  mcp:
+    - name: atlassian
+      registry: false
+      transport: http
+      url: https://mcp.atlassian.com/v1/mcp


### PR DESCRIPTION

## What this PR does / why we need it:

Adds a bundles/ directory with curated sets of APM packages. Includes the openshift-developer bundle and documents marketplace registration for plugins that depend on anthropics/claude-plugins-official.

Requires https://github.com/microsoft/apm/pull/1422 first


## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [X] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for APM bundles covering available options, registration prerequisites, and installation instructions for both global and project-scoped deployments, plus guidance for creating custom bundles.

* **New Features**
  * Introduced the openshift-developer bundle with pre-configured dependencies and integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->