### PR TITLE
Fix plugindocs lint rule error messages to say 'make update'

### DIFF
--- a/.skillsaw/plugindocs_rule.py
+++ b/.skillsaw/plugindocs_rule.py
@@ -58,7 +58,7 @@ class PluginsDocUpToDateRule(Rule):
             if result.returncode != 0:
                 violations.append(
                     self.violation(
-                        f"'skillsaw docs' failed: {result.stderr}",
+                        f"'make update' failed: {result.stderr}",
                         file_path=index_path
                     )
                 )
@@ -68,7 +68,7 @@ class PluginsDocUpToDateRule(Rule):
             if original_content != generated_content:
                 violations.append(
                     self.violation(
-                        "docs/ is out of sync with plugin metadata. Run 'skillsaw docs -o docs/' to update.",
+                        "docs/ is out of sync with plugin metadata. Run 'make update' to update.",
                         file_path=index_path
                     )
                 )
@@ -76,7 +76,7 @@ class PluginsDocUpToDateRule(Rule):
         except subprocess.TimeoutExpired:
             violations.append(
                 self.violation(
-                    "'skillsaw docs' timed out",
+                    "'make update' timed out",
                     file_path=index_path
                 )
             )


### PR DESCRIPTION
## Summary
- Linter error messages in the plugindocs custom rule referenced `skillsaw docs -o docs/` directly, which is an implementation detail users shouldn't need to know
- Changed all three error messages to say `make update` instead, matching the Makefile target users should actually run

## Test plan
- [ ] Run `make lint` with docs out of sync and verify the error message says `make update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error messages across documentation generation scenarios to consistently guide users to use `make update` instead of `skillsaw docs` when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->