### PR TITLE
USHIFT-7104: Ensure Python pcp module matches the system Python version

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -21,11 +21,13 @@ RUN dnf install -y 'dnf-command(config-manager)' \
     && dnf install -y gh \
     && dnf clean all
 
-# Install PCP tools
+# Install PCP tools with Python bindings
 RUN dnf install -y \
     pcp \
+    pcp-devel \
     pcp-export-pcp2json \
-    && dnf clean all
+    && dnf clean all \
+    && python3 -m pip install --no-cache-dir --use-pep517 pcp
 
 # Create claude user with root group for OpenShift compatibility
 RUN useradd -m -u 1000 -g 0 -s /bin/bash claude


### PR DESCRIPTION
## What this PR does / why we need it:
After the Python version upgrade to 3.11, Python PCP module from the `pcp-export-pcp2json > python3-pcp` package would still use the system default Python binding. We need to explicitly install the `pcp` binding so that it corresponds to the system Python version.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/USHIFT-7104

## Special notes for your reviewer:
Fixes a regression introduced by 2361050fb02c8500b30443d6641459cadab5ea49

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image to include PCP Python bindings and additional development packages for enhanced monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->