### PR TITLE
feat: Add detect-permafail skill and command (CORENET-7149)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.70",
+      "version": "0.0.71",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -518,7 +518,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.70",
+      "version": "0.0.71",
       "has_readme": true,
       "commands": [
         {
@@ -584,6 +584,14 @@ footer a { color: var(--primary); }
           "description_html": "Download and continue a Claude session from a Prow CI job&#x27;s artifacts",
           "synopsis": "/ci:continue-session \u003cprowjob-url\u003e",
           "body_html": "\u003cp\u003eDownloads Claude session artifacts from a Prow CI job and allows you to continue one of those sessions locally. This is useful when Claude ran as part of a CI job and you want to pick up where it left off.\u003c/p\u003e\u003cp\u003eThe command accepts:\u003cbr\u003e- \u003cstrong\u003eprowjob-url\u003c/strong\u003e (required): URL to a Prow job run\u003c/p\u003e"
+        },
+        {
+          "name": "detect-permafail",
+          "full_name": "ci:detect-permafail",
+          "description": "Detect permafail patterns in consecutive job failures",
+          "description_html": "Detect permafail patterns in consecutive job failures",
+          "synopsis": "/ci:detect-permafail --job-urls=\"[url1,url2,...]\" --job-name=\"job-name\" --pr=\"owner/repo#123\"",
+          "body_html": "\u003cp\u003eAnalyzes 2-10 consecutive failures of the same job to determine if they represent a systematic/permanent failure (permafail) versus a flaky failure. This is critical for CI/CD pipeline analysis to distinguish between:\u003c/p\u003e\u003cp\u003e- \u003cstrong\u003ePermafail\u003c/strong\u003e: A systematic failure affecting the same test(s) or infrastructure issue, detected by analyzing comparable runs (same failure type):\u003cbr\u003e  - Separates test failures from infrastructure failures\u003cbr\u003e  - Applies thresholds based on comparable run count (not total URLs)\u003cbr\u003e  - 2-3 comparable runs: All must match (100% required)\u003cbr\u003e  - 4-5 comparable runs: At least 4 must match (80% required)\u003cbr\u003e  - 6-10 comparable runs: At least ceil(count×0.7) must match (70% required)\u003cbr\u003e  - Example: 7 URLs where 5 are test failures and 4 of those 5 have same test → 4/5 = 80% → PERMAFAIL\u003cbr\u003e- \u003cstrong\u003eFlaky\u003c/strong\u003e: Non-deterministic failures with varying root causes, or failures that don&#x27;t meet the permafail thresholds\u003c/p\u003e\u003cp\u003e### How It Works\u003c/p\u003e\u003cp\u003eThe command uses a deterministic Python classifier script for artifact-based failure classification, compares failure signatures across runs, and returns a JSON result with the permafail verdict, confidence score, failure type, and detailed signatures for each run.\u003c/p\u003e"
         },
         {
           "name": "extract-kubeconfig",
@@ -701,6 +709,12 @@ footer a { color: var(--primary); }
           "name": "analyze-disruption",
           "description": "Analyze and compare disruption across one or more Prow CI job runs by examining interval data, audit logs, pod logs, and CPU metrics",
           "description_html": "Analyze and compare disruption across one or more Prow CI job runs by examining interval data, audit logs, pod logs, and CPU metrics",
+          "meta": ""
+        },
+        {
+          "name": "detect-permafail",
+          "description": "Analyze consecutive job failures to determine if they represent a permafail pattern versus flaky failures",
+          "description_html": "Analyze consecutive job failures to determine if they represent a permafail pattern versus flaky failures",
           "meta": ""
         },
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/README.md
+++ b/plugins/ci/README.md
@@ -162,6 +162,27 @@ Analyze Kubernetes resource lifecycle in Prow job artifacts. Generates interacti
 /ci:analyze-prow-job-resource <prowjob-url> [namespace:][kind/][resource-name]
 ```
 
+### detect-permafail
+
+Detect permafail patterns in consecutive job failures to distinguish systematic failures from flaky failures.
+
+**Usage:**
+```bash
+/ci:detect-permafail --job-urls="[url1,url2,...]" --job-name="job-name" --pr="owner/repo#123"
+```
+
+**Arguments:**
+- `--job-urls`: JSON array of 2-10 consecutive Prow job URLs (newest first)
+- `--job-name`: Name of the job being analyzed
+- `--pr`: PR identifier (format: "owner/repo#number")
+
+**What it does:**
+- Analyzes 2-10 consecutive failures to determine if they represent a permafail
+- Uses artifact-based classification (test vs infrastructure failures)
+- Applies thresholds based on comparable run count (same failure type)
+- Example: 7 runs where 4 are test failures and all 4 have same test → detects permafail (4/4 = 100% ≥ 80% threshold)
+- Returns JSON with permafail verdict, confidence score, and failure signatures
+
 ### extract-kubeconfig
 
 Extract kubeconfig from a running rehearsal/CI job in a GitHub PR. Checks step status to verify the cluster is ready, then connects to the build cluster to extract the kubeconfig from the running pod. Supports both standard and HyperShift (nested kubeconfig) clusters, and both public (`prow.ci.openshift.org`) and private (`qe-private-deck`) jobs.

--- a/plugins/ci/commands/detect-permafail.md
+++ b/plugins/ci/commands/detect-permafail.md
@@ -1,0 +1,46 @@
+---
+description: Detect permafail patterns in consecutive job failures
+argument-hint: --job-urls="<urls>" --job-name="<name>" --pr="<owner/repo#123>"
+---
+
+## Name
+ci:detect-permafail
+
+## Synopsis
+```text
+/ci:detect-permafail --job-urls="[url1,url2,...]" --job-name="job-name" --pr="owner/repo#123"
+```
+
+## Description
+Analyzes 2-10 consecutive failures of the same job to determine if they represent a systematic/permanent failure (permafail) versus a flaky failure. This is critical for CI/CD pipeline analysis to distinguish between:
+
+- **Permafail**: A systematic failure affecting the same test(s) or infrastructure issue, detected by analyzing comparable runs (same failure type):
+  - Separates test failures from infrastructure failures
+  - Applies thresholds based on comparable run count (not total URLs)
+  - 2-3 comparable runs: All must match (100% required)
+  - 4-5 comparable runs: At least 4 must match (80% required)
+  - 6-10 comparable runs: At least ceil(count×0.7) must match (70% required)
+  - Example: 7 URLs where 5 are test failures and 4 of those 5 have same test → 4/5 = 80% → PERMAFAIL
+- **Flaky**: Non-deterministic failures with varying root causes, or failures that don't meet the permafail thresholds
+
+### How It Works
+
+The command uses a deterministic Python classifier script for artifact-based failure classification, compares failure signatures across runs, and returns a JSON result with the permafail verdict, confidence score, failure type, and detailed signatures for each run.
+
+## Implementation
+- Load the "detect-permafail" skill
+- Pass the job URLs, job name, and PR info to the skill
+- The skill handles all analysis including:
+  - Artifact fetching and classification via `plugins/ci/scripts/classify-job-failures.py`
+  - Signature comparison and pattern detection
+  - Threshold-based permafail determination
+
+## Arguments
+- `--job-urls`: JSON array of 2-10 consecutive Prow job URLs (required, newest first)
+- `--job-name`: Name of the job being analyzed (required, e.g., "e2e-aws-ovn")
+- `--pr`: PR identifier (required, format: "owner/repo#number")
+
+## Prerequisites
+- Access to Prow CI job artifacts via gcsweb URLs
+- Access to Bash for running the classifier script
+- Python with the `requests` package available

--- a/plugins/ci/evals/cases/detect-permafail/case-001-test-below-threshold/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-001-test-below-threshold/annotations.yaml
@@ -1,0 +1,9 @@
+expected_permafail: false
+expected_failure_type: test_failure
+expected_confidence_min: 0.65
+expected_pattern: TestNetworkPolicy
+expected_ratio: "2/10"
+notes: >
+  Ten comparable test failures where only two include TestNetworkPolicy.
+  The 6-10 run threshold requires at least seven matching runs, so this is
+  below threshold and should not be classified as a permafail.

--- a/plugins/ci/evals/cases/detect-permafail/case-001-test-below-threshold/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-001-test-below-threshold/input.yaml
@@ -1,0 +1,17 @@
+input_json: |
+  {
+    "job_name": "pull-ci-openshift-origin-master-e2e-aws-ovn",
+    "pr_info": {"pr_number": 3186, "repository": "openshift/ovn-kubernetes"},
+    "signatures": [
+      {"type": "test_failure", "url": "url1", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url2", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url3", "tests": ["TestStorageClass"], "test_count": 1},
+      {"type": "test_failure", "url": "url4", "tests": ["TestPodEviction"], "test_count": 1},
+      {"type": "test_failure", "url": "url5", "tests": ["TestServiceMesh"], "test_count": 1},
+      {"type": "test_failure", "url": "url6", "tests": ["TestLoadBalancer"], "test_count": 1},
+      {"type": "test_failure", "url": "url7", "tests": ["TestDNSResolution"], "test_count": 1},
+      {"type": "test_failure", "url": "url8", "tests": ["TestIngress"], "test_count": 1},
+      {"type": "test_failure", "url": "url9", "tests": ["TestNodeScale"], "test_count": 1},
+      {"type": "test_failure", "url": "url10", "tests": ["TestClusterUpgrade"], "test_count": 1}
+    ]
+  }

--- a/plugins/ci/evals/cases/detect-permafail/case-002-test-permafail/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-002-test-permafail/annotations.yaml
@@ -1,0 +1,8 @@
+expected_permafail: true
+expected_failure_type: test_failure
+expected_confidence_min: 0.85
+expected_pattern: TestNetworkPolicy
+expected_ratio: "7/10"
+notes: >
+  Ten comparable test failures where seven include TestNetworkPolicy. This
+  exactly meets the 70% threshold for 6-10 comparable runs.

--- a/plugins/ci/evals/cases/detect-permafail/case-002-test-permafail/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-002-test-permafail/input.yaml
@@ -1,0 +1,17 @@
+input_json: |
+  {
+    "job_name": "pull-ci-openshift-origin-master-e2e-aws-ovn",
+    "pr_info": {"pr_number": 3186, "repository": "openshift/ovn-kubernetes"},
+    "signatures": [
+      {"type": "test_failure", "url": "url1", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url2", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url3", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url4", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url5", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url6", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url7", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url8", "tests": ["TestStorageClass"], "test_count": 1},
+      {"type": "test_failure", "url": "url9", "tests": ["TestPodEviction"], "test_count": 1},
+      {"type": "test_failure", "url": "url10", "tests": ["TestServiceMesh"], "test_count": 1}
+    ]
+  }

--- a/plugins/ci/evals/cases/detect-permafail/case-003-mixed-test-permafail/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-003-mixed-test-permafail/annotations.yaml
@@ -1,0 +1,9 @@
+expected_permafail: true
+expected_failure_type: test_failure
+expected_confidence_min: 0.90
+expected_pattern: TestNetworkPolicy
+expected_ratio: "4/4"
+notes: >
+  Mixed failure set where all four runs that reached tests failed on the same
+  test. The three diverse infra failures should not dilute the test-failure
+  denominator.

--- a/plugins/ci/evals/cases/detect-permafail/case-003-mixed-test-permafail/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-003-mixed-test-permafail/input.yaml
@@ -1,0 +1,14 @@
+input_json: |
+  {
+    "job_name": "pull-ci-openshift-origin-master-e2e-aws-ovn",
+    "pr_info": {"pr_number": 3186, "repository": "openshift/ovn-kubernetes"},
+    "signatures": [
+      {"type": "test_failure", "url": "url1", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url2", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url3", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "test_failure", "url": "url4", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "infra_failure", "url": "url5", "error": "cluster creation timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url6", "error": "AWS quota exceeded", "error_hash": "def456"},
+      {"type": "infra_failure", "url": "url7", "error": "network unreachable", "error_hash": "ghi789"}
+    ]
+  }

--- a/plugins/ci/evals/cases/detect-permafail/case-004-mixed-diverse-infra/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-004-mixed-diverse-infra/annotations.yaml
@@ -1,0 +1,9 @@
+expected_permafail: false
+expected_failure_type: mixed
+expected_confidence_min: 0.65
+expected_pattern: null
+expected_ratio: "1/6"
+notes: >
+  Only one test failure is present, which is insufficient to establish a test
+  pattern. The six infra failures are all different, so no infra pattern meets
+  the 70% threshold.

--- a/plugins/ci/evals/cases/detect-permafail/case-004-mixed-diverse-infra/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-004-mixed-diverse-infra/input.yaml
@@ -1,0 +1,14 @@
+input_json: |
+  {
+    "job_name": "pull-ci-openshift-origin-master-e2e-aws-ovn",
+    "pr_info": {"pr_number": 3186, "repository": "openshift/ovn-kubernetes"},
+    "signatures": [
+      {"type": "test_failure", "url": "url1", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "infra_failure", "url": "url2", "error": "cluster creation timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url3", "error": "AWS quota exceeded", "error_hash": "def456"},
+      {"type": "infra_failure", "url": "url4", "error": "network unreachable", "error_hash": "ghi789"},
+      {"type": "infra_failure", "url": "url5", "error": "pod eviction", "error_hash": "jkl012"},
+      {"type": "infra_failure", "url": "url6", "error": "storage failure", "error_hash": "mno345"},
+      {"type": "infra_failure", "url": "url7", "error": "DNS timeout", "error_hash": "pqr678"}
+    ]
+  }

--- a/plugins/ci/evals/cases/detect-permafail/case-005-mixed-infra-permafail/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-005-mixed-infra-permafail/annotations.yaml
@@ -1,0 +1,9 @@
+expected_permafail: true
+expected_failure_type: infra_failure
+expected_confidence_min: 0.85
+expected_pattern: operator authentication timeout
+expected_ratio: "5/6"
+notes: >
+  Mixed failure set where the single test failure is insufficient by itself,
+  but five of six comparable infra failures share the same normalized error
+  and meet the 70% threshold.

--- a/plugins/ci/evals/cases/detect-permafail/case-005-mixed-infra-permafail/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-005-mixed-infra-permafail/input.yaml
@@ -1,0 +1,14 @@
+input_json: |
+  {
+    "job_name": "pull-ci-openshift-origin-master-e2e-aws-ovn",
+    "pr_info": {"pr_number": 3186, "repository": "openshift/ovn-kubernetes"},
+    "signatures": [
+      {"type": "test_failure", "url": "url1", "tests": ["TestNetworkPolicy"], "test_count": 1},
+      {"type": "infra_failure", "url": "url2", "error": "operator authentication timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url3", "error": "operator authentication timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url4", "error": "operator authentication timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url5", "error": "operator authentication timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url6", "error": "operator authentication timeout", "error_hash": "abc123"},
+      {"type": "infra_failure", "url": "url7", "error": "DNS timeout", "error_hash": "def456"}
+    ]
+  }

--- a/plugins/ci/evals/cases/detect-permafail/case-006-informing-tests-ignored/annotations.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-006-informing-tests-ignored/annotations.yaml
@@ -1,0 +1,12 @@
+expected_permafail: false
+expected_failure_type: test_failure
+expected_confidence_min: 0.70
+expected_pattern: null
+expected_ratio: "0/3"
+notes: >
+  Three test failures with different blocking tests across runs (sig-storage,
+  Monitor, sig-network). The actual scenario that triggered this test case
+  also had 10 informing NetworkSegmentation tests that failed in all 3 runs,
+  but those should be filtered out by the lifecycle="informing" attribute in
+  the junit XML and not appear in the signatures. Since the blocking tests
+  are all different, this should be NOT permafail (0/3 match).

--- a/plugins/ci/evals/cases/detect-permafail/case-006-informing-tests-ignored/input.yaml
+++ b/plugins/ci/evals/cases/detect-permafail/case-006-informing-tests-ignored/input.yaml
@@ -1,0 +1,38 @@
+input_json: |
+  {
+    "job_name": "5.0-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade",
+    "pr_info": {"pr_number": 3034, "repository": "openshift/cluster-network-operator"},
+    "signatures": [
+      {
+        "type": "test_failure",
+        "url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-network-operator/3034/pull-ci-openshift-cluster-network-operator-master-5.0-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade/2070546160866562048",
+        "tests": [
+          "[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (block volmode)] volumes should store data",
+          "[sig-storage] In-tree Volumes [Driver: azure-disk] [Testpattern: Dynamic PV (ext4)] volumes should store data",
+          "[sig-storage] In-tree Volumes [Driver: emptydir] [Testpattern: Inline-volume (ext4)] volumes should store data",
+          "[sig-storage] In-tree Volumes [Driver: hostPathSymlink] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand Verify if offline PVC expansion works",
+          "[sig-storage] In-tree Volumes [Driver: hostPath] [Testpattern: Pre-provisioned PV (ntfs)] [Feature:Windows] volumes should store data",
+          "[sig-storage] In-tree Volumes [Driver: local] [LocalVolumeType: blockfs] [Testpattern: Pre-provisioned PV (default fs)] subPath should support readOnly file specified in the volumeMount [LinuxOnly]",
+          "[sig-storage] In-tree Volumes [Driver: local] [LocalVolumeType: dir-bindmounted] [Testpattern: Dynamic PV (default fs)] volumes should allow exec of files on the volume",
+          "[sig-storage] PersistentVolumes-local [Volume type: dir-link-bindmounted] Two pods mounting a local volume one after the other should be able to write from pod1 and read from pod2"
+        ],
+        "test_count": 8
+      },
+      {
+        "type": "test_failure",
+        "url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-network-operator/3034/pull-ci-openshift-cluster-network-operator-master-5.0-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade/2070008378477776896",
+        "tests": [
+          "[Monitor:legacy-cvo-invariants][bz-Cloud Compute] clusteroperator/cloud-controller-manager should stay Progressing=False while MCO is Progressing=True"
+        ],
+        "test_count": 1
+      },
+      {
+        "type": "test_failure",
+        "url": "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-network-operator/3034/pull-ci-openshift-cluster-network-operator-master-5.0-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade/2068434768055242752",
+        "tests": [
+          "[sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created [Suite:openshift/conformance/parallel]"
+        ],
+        "test_count": 1
+      }
+    ]
+  }

--- a/plugins/ci/evals/eval-detect-permafail.yaml
+++ b/plugins/ci/evals/eval-detect-permafail.yaml
@@ -1,0 +1,230 @@
+name: detect-permafail-eval
+description: Evaluate ci:detect-permafail threshold reasoning using pre-normalized failure signatures
+skill: ci:detect-permafail
+
+execution:
+  mode: case
+  arguments: "{input_json}"
+  timeout: 180
+  max_budget_usd: 0.75
+
+runner:
+  type: claude-code
+  plugin_dirs:
+    - plugins/ci
+  system_prompt: |
+    Use the ci:detect-permafail skill to analyze the JSON input.
+
+    The eval cases provide pre-normalized failure signatures. Do NOT fetch live
+    Prow artifacts or make network calls when signatures are present. Apply the
+    skill's threshold logic and write ONLY the final JSON result to
+    detect-permafail-result.json in the current working directory. The file must
+    contain valid JSON with fields: permafail, confidence, reason, failure_type,
+    signatures, and any matching pattern fields such as common_tests.
+
+    Output requirements for eval scoring:
+    - confidence must be a JSON number, never a string.
+    - failure_type must be one of: test_failure, infra_failure, mixed.
+    - If permafail is true in a mixed input, failure_type must be the type that
+      triggered the permafail: test_failure or infra_failure, not mixed.
+    - If permafail is false and both test and infra signatures are present,
+      failure_type must be mixed.
+    - reason and/or match_ratio must include slash-format ratios such as 7/10,
+      4/4, 5/6, or 2/10. Do not write only "7 of 10".
+    - match_ratio, matching_runs, comparable_runs, and threshold_required must
+      be top-level fields, not nested under an analysis object.
+    - mixed non-permafail cases with fewer than 2 comparable test failures must
+      use failure_type "mixed" and explain the insufficient comparable runs.
+
+    Required top-level JSON shape:
+    {
+      "permafail": true,
+      "confidence": 0.95,
+      "reason": "7/10 test_failure runs failed TestNetworkPolicy...",
+      "failure_type": "test_failure",
+      "match_ratio": "7/10",
+      "matching_runs": 7,
+      "comparable_runs": 10,
+      "threshold_required": 7,
+      "signatures": []
+    }
+
+models:
+  judge: claude-opus-4-6
+
+permissions:
+  allow:
+    - "Skill"
+    - "Bash"
+    - "Agent"
+    - "Write"
+    - "Read"
+  deny: []
+
+mlflow:
+  experiment: detect-permafail-eval
+
+dataset:
+  path: cases/detect-permafail
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with field:
+      - 'input_json' — JSON string passed to ci:detect-permafail. For mocked
+        evals this includes pre-normalized 'signatures' so artifact fetching is
+        skipped.
+    - annotations.yaml: Expected outcomes and metadata:
+      - 'expected_permafail': boolean verdict
+      - 'expected_failure_type': test_failure|infra_failure|mixed
+      - 'expected_confidence_min': minimum acceptable confidence score
+      - 'expected_pattern': string expected in the result reason or matching fields
+      - 'expected_ratio': match ratio text expected in the result, such as 7/10
+      - 'notes': free text explaining the case
+
+outputs:
+  - path: "detect-permafail-result.json"
+    schema: |
+      JSON object with fields:
+      - permafail: boolean
+      - confidence: number between 0.0 and 1.0
+      - reason: string explaining the verdict
+      - failure_type: test_failure|infra_failure|mixed
+      - signatures: array of normalized failure signatures
+      - match_ratio: string containing the dominant ratio in slash format
+      - matching_runs: integer numerator for the dominant pattern
+      - comparable_runs: integer denominator for the dominant pattern
+      - threshold_required: integer count required for permafail
+      - common_tests: optional array for test permafails
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: valid_output_json
+    description: Verify output is valid JSON with required detect-permafail fields
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      result_files = {k: v for k, v in all_f.items() if k.endswith("detect-permafail-result.json")}
+      if not result_files:
+          return (False, "No detect-permafail-result.json found")
+      content = list(result_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Invalid JSON: {e}")
+      required = [
+          "permafail",
+          "confidence",
+          "reason",
+          "failure_type",
+          "signatures",
+          "match_ratio",
+          "matching_runs",
+          "comparable_runs",
+          "threshold_required",
+      ]
+      missing = [f for f in required if f not in data]
+      if missing:
+          return (False, f"Missing fields: {', '.join(missing)}")
+      if not isinstance(data["permafail"], bool):
+          return (False, "permafail must be boolean")
+      if not isinstance(data["confidence"], (int, float)):
+          return (False, "confidence must be a number")
+      if not (0.0 <= float(data["confidence"]) <= 1.0):
+          return (False, "confidence must be between 0.0 and 1.0")
+      if data["failure_type"] not in ["test_failure", "infra_failure", "mixed"]:
+          return (False, f"invalid failure_type: {data['failure_type']}")
+      if not isinstance(data["match_ratio"], str) or "/" not in data["match_ratio"]:
+          return (False, "match_ratio must be a slash-format string")
+      for field in ["matching_runs", "comparable_runs", "threshold_required"]:
+          if not isinstance(data[field], int):
+              return (False, f"{field} must be an integer")
+      if not isinstance(data["signatures"], list):
+          return (False, "signatures must be an array")
+      return (True, "Valid JSON with required fields")
+
+  - name: verdict_correct
+    description: Verify permafail verdict matches annotations
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      result_files = {k: v for k, v in all_f.items() if k.endswith("detect-permafail-result.json")}
+      if not result_files:
+          return (False, "No detect-permafail-result.json found")
+      data = json.loads(list(result_files.values())[0])
+      predicted = data.get("permafail")
+      expected = ann.get("expected_permafail")
+      if predicted == expected:
+          return (True, f"permafail={predicted}")
+      return (False, f"predicted permafail={predicted}, expected={expected}")
+
+  - name: failure_type_correct
+    description: Verify failure_type matches annotations
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      result_files = {k: v for k, v in all_f.items() if k.endswith("detect-permafail-result.json")}
+      if not result_files:
+          return (False, "No detect-permafail-result.json found")
+      data = json.loads(list(result_files.values())[0])
+      predicted = data.get("failure_type")
+      expected = ann.get("expected_failure_type")
+      if predicted == expected:
+          return (True, f"failure_type={predicted}")
+      return (False, f"predicted failure_type={predicted}, expected={expected}")
+
+  - name: confidence_calibration
+    description: Verify confidence meets the minimum threshold for this case
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      result_files = {k: v for k, v in all_f.items() if k.endswith("detect-permafail-result.json")}
+      if not result_files:
+          return (False, "No detect-permafail-result.json found")
+      data = json.loads(list(result_files.values())[0])
+      confidence = data.get("confidence")
+      min_conf = ann.get("expected_confidence_min", 0.0)
+      if not isinstance(confidence, (int, float)):
+          return (False, f"confidence is {type(confidence).__name__}, expected number")
+      if confidence >= min_conf:
+          return (True, f"confidence={confidence:.2f} >= min={min_conf:.2f}")
+      return (False, f"confidence={confidence:.2f} < min={min_conf:.2f}")
+
+  - name: expected_pattern_present
+    description: Verify expected pattern and ratio are present in result text
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      result_files = {k: v for k, v in all_f.items() if k.endswith("detect-permafail-result.json")}
+      if not result_files:
+          return (False, "No detect-permafail-result.json found")
+      content = list(result_files.values())[0]
+      data = json.loads(content)
+      haystack = json.dumps(data, sort_keys=True).lower()
+      missing = []
+      pattern = str(ann.get("expected_pattern") or "").lower()
+      ratio = str(ann.get("expected_ratio") or "").lower()
+      if pattern and pattern not in haystack:
+          missing.append(f"pattern '{pattern}'")
+      if ratio and ratio not in haystack:
+          missing.append(f"ratio '{ratio}'")
+      if missing:
+          return (False, f"Missing {', '.join(missing)}")
+      return (True, "Expected pattern and ratio present")

--- a/plugins/ci/scripts/classify-job-failures.py
+++ b/plugins/ci/scripts/classify-job-failures.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Classify Prow job failures into normalized permafail signatures.
+
+Reads JSON input with failure_urls, job_name, and pr_info fields, fetches Prow
+job artifacts from gcsweb, and writes a JSON array of normalized signatures.
+"""
+
+import argparse
+import hashlib
+import html.parser
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import unquote, urljoin, urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests is required. Install with: pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+
+GCSWEB_BASE = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/"
+TEST_PATH_PATTERNS = (
+    "e2e-",
+    "openshift-e2e-test",
+    "openshift-tests-",
+    "monitor-test-",
+)
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+INFRA_ONLY_PREFIXES = (
+    "ipi-install",
+    "gather-",
+    "pull-ci-",
+)
+
+
+class ArtifactError(RuntimeError):
+    """Raised when a job cannot be fetched or classified."""
+
+
+class LinkParser(html.parser.HTMLParser):
+    """Small href extractor for gcsweb directory listings."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "a":
+            return
+        for key, value in attrs:
+            if key == "href" and value:
+                self.links.append(value)
+
+
+@dataclass
+class ArtifactEntry:
+    path: str
+    url: str
+    is_dir: bool
+
+
+def fetch_text(session: requests.Session, url: str, timeout: int) -> str:
+    try:
+        response = session.get(url, timeout=timeout)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise ArtifactError(f"failed to fetch {url}: {e}") from e
+    return response.text
+
+
+def parse_gcs_path(prow_url: str) -> str:
+    parsed = urlparse(prow_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ArtifactError(f"invalid Prow URL scheme: {prow_url}")
+    marker = "/view/gs/"
+    if marker not in parsed.path:
+        raise ArtifactError(f"invalid Prow URL, missing /view/gs/: {prow_url}")
+    gcs_path = unquote(parsed.path.split(marker, 1)[1]).strip("/")
+    parts = gcs_path.split("/")
+    if any(part in {".", ".."} for part in parts):
+        raise ArtifactError(f"invalid traversal segment in Prow GCS path: {prow_url}")
+    if not gcs_path or len(parts) < 3:
+        raise ArtifactError(f"invalid Prow GCS path in URL: {prow_url}")
+    return gcs_path
+
+
+def gcsweb_url(gcs_path: str, suffix: str = "") -> str:
+    base = urljoin(GCSWEB_BASE, gcs_path.strip("/") + "/")
+    return urljoin(base, suffix)
+
+
+def list_artifacts(
+    session: requests.Session,
+    artifacts_url: str,
+    timeout: int,
+    max_depth: int = 4,
+    max_entries: int = 500,
+) -> list[ArtifactEntry]:
+    entries: list[ArtifactEntry] = []
+    seen_dirs: set[str] = set()
+
+    def walk(url: str, prefix: str, depth: int) -> None:
+        if depth > max_depth or len(entries) >= max_entries or url in seen_dirs:
+            return
+        seen_dirs.add(url)
+        try:
+            html = fetch_text(session, url, timeout)
+        except ArtifactError:
+            if depth == 0:
+                raise
+            return
+        parser = LinkParser()
+        parser.feed(html)
+        for href in parser.links:
+            if len(entries) >= max_entries:
+                return
+            if href in ("../", "./") or href.startswith("?"):
+                continue
+            absolute = urljoin(url, href)
+            parsed = urlparse(absolute)
+            base = urlparse(artifacts_url)
+            if (parsed.scheme, parsed.netloc) != (base.scheme, base.netloc):
+                continue
+            if not parsed.path.startswith(base.path):
+                continue
+            name = unquote(parsed.path.rstrip("/").rsplit("/", 1)[-1])
+            if not name:
+                continue
+            rel_path = f"{prefix}{name}"
+            is_dir = href.endswith("/") or parsed.path.endswith("/")
+            if is_dir:
+                rel_path = rel_path.rstrip("/") + "/"
+            entries.append(ArtifactEntry(rel_path, absolute, is_dir))
+            if is_dir and should_descend_artifact_dir(rel_path):
+                walk(absolute, rel_path, depth + 1)
+
+    walk(artifacts_url, "", 0)
+    return entries
+
+
+def should_descend_artifact_dir(path: str) -> bool:
+    lower = path.lower()
+    if is_gather_artifact(lower):
+        return False
+    if "/pods/" in lower or "/nodes/" in lower:
+        return False
+    return True
+
+
+def has_test_artifacts(entries: list[ArtifactEntry], prow_description: str) -> bool:
+    for entry in entries:
+        path = entry.path.lower()
+        if is_gather_artifact(path):
+            continue
+        if any(pattern in path for pattern in TEST_PATH_PATTERNS):
+            return True
+        if is_test_junit(path):
+            return True
+    return "monitortest" in prow_description.lower()
+
+
+def is_gather_artifact(path: str) -> bool:
+    return any(part.startswith("gather-") for part in path.split("/"))
+
+
+def is_test_junit(path: str) -> bool:
+    if "junit" not in path:
+        return False
+    if not is_test_runner_path(path):
+        return False
+    if path.endswith("/"):
+        return "/junit/" in path
+    if not path.endswith(".xml"):
+        return False
+    if path.endswith("junit_symptoms.xml") or path.endswith("junit_operator.xml"):
+        return False
+    return True
+
+
+def is_test_runner_path(path: str) -> bool:
+    return any(pattern in path for pattern in TEST_PATH_PATTERNS)
+
+
+def extract_tests_from_junit(xml_text: str) -> list[str]:
+    """Legacy function - kept for compatibility but not used.
+
+    The main logic is now in extract_test_names which aggregates
+    across all junit files to properly detect flakes.
+    """
+    return []
+
+
+def extract_tests_from_log(log_text: str) -> list[str]:
+    tests: list[str] = []
+    for line in log_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[sig-") or stripped.startswith("FAIL:"):
+            tests.append(re.sub(r"^FAIL:\s*", "", stripped))
+    return tests
+
+
+def dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = " ".join(value.split())
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def extract_test_names(
+    session: requests.Session,
+    entries: list[ArtifactEntry],
+    timeout: int,
+) -> list[str]:
+    """Extract test names that failed and never passed across all junit files.
+
+    Aggregates results from all junit files to detect flakes (tests that
+    failed in one file but passed in another).
+    """
+    junit_entries = [
+        entry for entry in entries
+        if not entry.is_dir
+        and not is_gather_artifact(entry.path.lower())
+        and is_test_junit(entry.path.lower())
+    ]
+
+    # Collect all junit XML content
+    junit_xmls: list[str] = []
+    for entry in junit_entries[:20]:
+        try:
+            junit_xmls.append(fetch_text(session, entry.url, timeout))
+        except ArtifactError:
+            continue
+
+    if not junit_xmls:
+        # Fallback to log-based extraction
+        log_entries = [
+            entry for entry in entries
+            if not entry.is_dir
+            and entry.path.endswith("build-log.txt")
+            and has_test_artifacts([entry], "")
+        ]
+        tests: list[str] = []
+        for entry in log_entries[:10]:
+            try:
+                tests.extend(extract_tests_from_log(fetch_text(session, entry.url, timeout)))
+            except ArtifactError:
+                continue
+        return dedupe(tests)
+
+    # Aggregate failures and passes across all junit files
+    def get_test_name(testcase: ET.Element) -> str:
+        classname = testcase.attrib.get("classname", "").strip()
+        name = testcase.attrib.get("name", "").strip()
+        if classname and name:
+            return f"{classname} {name}"
+        elif name:
+            return name
+        elif classname:
+            return classname
+        return ""
+
+    all_failures: set[str] = set()
+    all_passes: set[str] = set()
+
+    for xml_text in junit_xmls:
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError:
+            continue
+
+        for testcase in root.iter("testcase"):
+            test_name = get_test_name(testcase)
+            if not test_name:
+                continue
+
+            # Skip informing tests - they don't determine job pass/fail status
+            lifecycle = testcase.attrib.get("lifecycle", "")
+            if lifecycle == "informing":
+                continue
+
+            failed = testcase.find("failure") is not None or testcase.find("error") is not None
+            skipped = testcase.find("skipped") is not None
+            if failed:
+                all_failures.add(test_name)
+            elif not skipped:
+                all_passes.add(test_name)
+
+    # Only return tests that failed and never passed (real failures, not flakes)
+    real_failures = all_failures - all_passes
+    return dedupe(sorted(real_failures))
+
+
+def normalize_error(message: str) -> str:
+    normalized = ANSI_ESCAPE_RE.sub("", message)
+    normalized = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?", "", normalized)
+    normalized = re.sub(
+        r"\b\d+\.\d+\.\d+-\d+\.ci-\d{4}-\d{2}-\d{2}-\d{6}-[A-Za-z0-9-]+\b",
+        "release-*",
+        normalized,
+    )
+    normalized = re.sub(
+        r"\b\d+\.\d+\.\d+-\d+\.nightly-\d{4}-\d{2}-\d{2}-\d{6}\b",
+        "release-*",
+        normalized,
+    )
+    normalized = re.sub(r"\bci-op-[A-Za-z0-9-]+\b", "ci-op-*", normalized)
+    normalized = re.sub(r"\btest-ci-op-[A-Za-z0-9-]+\b", "test-ci-op-*", normalized)
+    normalized = re.sub(r"\bbuild[-_][A-Za-z0-9_.-]+\b", "build-*", normalized)
+    normalized = re.sub(r"\bpod[-_][A-Za-z0-9_.-]+\b", "pod-*", normalized)
+    normalized = re.sub(r"\b[0-9a-f]{8,}\b", "*", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\b\d+(?:\.\d+)?\s*(?:m|Mi|Gi|Ki|G|M|cpu|cores?)\b", "*", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip(" :-")
+
+
+def error_hash(error: str) -> str:
+    return hashlib.md5(error.encode("utf-8")).hexdigest()
+
+
+def extract_infra_error(
+    session: requests.Session,
+    entries: list[ArtifactEntry],
+    prow_description: str,
+    timeout: int,
+) -> str:
+    candidates: list[str] = []
+    if prow_description and not is_generic_error(prow_description):
+        candidates.append(prow_description)
+    build_logs = [
+        entry for entry in entries
+        if not entry.is_dir and entry.path.endswith("build-log.txt")
+    ]
+    build_logs.sort(key=lambda entry: infra_log_priority(entry.path))
+    for entry in build_logs[:8]:
+        try:
+            text = fetch_text(session, entry.url, timeout)
+        except ArtifactError:
+            continue
+        extracted = extract_error_line(text)
+        if extracted:
+            candidates.append(extracted)
+            break
+    for candidate in candidates:
+        normalized = normalize_error(candidate[:400])
+        if normalized:
+            return normalized[:200]
+    return "unknown infrastructure failure"
+
+
+def is_generic_error(message: str) -> bool:
+    normalized = message.strip().lower().rstrip(".")
+    return normalized in {
+        "job failed",
+        "the test step failed",
+        "build failed",
+        "failed",
+        "failure",
+    }
+
+
+def infra_log_priority(path: str) -> tuple[int, str]:
+    lower = path.lower()
+    if any(prefix in lower for prefix in INFRA_ONLY_PREFIXES):
+        return (0, path)
+    if "install" in lower or "setup" in lower:
+        return (1, path)
+    if "gather" in lower:
+        return (3, path)
+    return (2, path)
+
+
+def extract_error_line(log_text: str) -> str:
+    patterns = (
+        re.compile(r"\b(error|failed|failure|timeout|timed out|exceeded|denied)\b", re.IGNORECASE),
+    )
+    candidates: list[str] = []
+    for line in reversed(log_text.splitlines()[-300:]):
+        stripped = ANSI_ESCAPE_RE.sub("", line).strip()
+        if not stripped:
+            continue
+        if "Reporting job state" in stripped:
+            continue
+        if any(pattern.search(stripped) for pattern in patterns):
+            candidates.append(stripped)
+    if not candidates:
+        return ""
+
+    priority_patterns = (
+        re.compile(r"failed to initialize the cluster", re.IGNORECASE),
+        re.compile(r"unable to import .*release image", re.IGNORECASE),
+        re.compile(r"cluster operator .*degraded", re.IGNORECASE),
+        re.compile(r"\* could not run steps", re.IGNORECASE),
+        re.compile(r"suite run returned error", re.IGNORECASE),
+        re.compile(r"error running a test suite", re.IGNORECASE),
+    )
+    for priority in priority_patterns:
+        for candidate in candidates:
+            if priority.search(candidate):
+                return candidate
+    return candidates[0]
+
+
+def validate_input(data: dict[str, Any]) -> None:
+    urls = data.get("failure_urls")
+    if not isinstance(urls, list) or not 2 <= len(urls) <= 10:
+        raise ArtifactError("failure_urls must be an array with 2-10 URLs")
+    if not all(isinstance(url, str) for url in urls):
+        raise ArtifactError("failure_urls must contain only strings")
+    if not isinstance(data.get("job_name"), str) or not data["job_name"].strip():
+        raise ArtifactError("job_name must be a non-empty string")
+    if not isinstance(data.get("pr_info"), dict):
+        raise ArtifactError("pr_info must be an object")
+
+
+def classify_job(
+    session: requests.Session,
+    prow_url: str,
+    expected_job_name: str,
+    timeout: int,
+) -> dict[str, Any]:
+    gcs_path = parse_gcs_path(prow_url)
+    prowjob = json.loads(fetch_text(session, gcsweb_url(gcs_path, "prowjob.json"), timeout))
+    spec = prowjob.get("spec") or {}
+    metadata = prowjob.get("metadata") or {}
+    actual_job_name = spec.get("job") or metadata.get("name", "")
+    if actual_job_name and actual_job_name != expected_job_name and expected_job_name not in gcs_path:
+        raise ArtifactError(
+            f"job name mismatch for {prow_url}: expected {expected_job_name}, found {actual_job_name}"
+        )
+
+    status = prowjob.get("status") or {}
+    description = status.get("description", "") or ""
+    artifacts_url = gcsweb_url(gcs_path, "artifacts/")
+    entries = list_artifacts(session, artifacts_url, timeout)
+    if has_test_artifacts(entries, description):
+        tests = extract_test_names(session, entries, timeout)
+        if tests:
+            return {
+                "type": "test_failure",
+                "url": prow_url,
+                "tests": tests,
+                "test_count": len(tests),
+            }
+
+    root_entries = [
+        ArtifactEntry("build-log.txt", gcsweb_url(gcs_path, "build-log.txt"), False),
+        ArtifactEntry("finished.json", gcsweb_url(gcs_path, "finished.json"), False),
+    ]
+    error = extract_infra_error(session, root_entries + entries, description, timeout)
+    return {
+        "type": "infra_failure",
+        "url": prow_url,
+        "error": error,
+        "error_hash": error_hash(error),
+    }
+
+
+def load_input(json_input: str | None) -> dict[str, Any]:
+    raw = json_input if json_input is not None else sys.stdin.read()
+    if not raw.strip():
+        raise ArtifactError("no JSON input provided")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ArtifactError(f"invalid JSON input: {e}") from e
+    if not isinstance(data, dict):
+        raise ArtifactError("input must be a JSON object")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify consecutive Prow job failures into permafail signatures."
+    )
+    parser.add_argument(
+        "--json-input",
+        help="JSON object containing failure_urls, job_name, and pr_info. Reads stdin if omitted.",
+    )
+    parser.add_argument("--timeout", type=int, default=30, help="HTTP timeout in seconds.")
+    args = parser.parse_args()
+
+    try:
+        data = load_input(args.json_input)
+        validate_input(data)
+        session = requests.Session()
+        signatures = [
+            classify_job(session, url, data["job_name"], args.timeout)
+            for url in data["failure_urls"]
+        ]
+    except (ArtifactError, requests.RequestException, json.JSONDecodeError) as e:
+        print(json.dumps({"success": False, "error": str(e)}, indent=2), file=sys.stderr)
+        return 1
+
+    print(json.dumps(signatures, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ci/skills/detect-permafail/SKILL.md
+++ b/plugins/ci/skills/detect-permafail/SKILL.md
@@ -1,0 +1,884 @@
+---
+name: detect-permafail
+description: Analyze consecutive job failures to determine if they represent a permafail pattern versus flaky failures
+---
+
+# Detect Permafail
+
+## When to Use This Skill
+
+Use this skill when you have 2-10 consecutive failures of the same job and need to determine if the failures represent a systematic/permanent failure (permafail) versus a flaky failure. This is critical for CI/CD pipeline analysis to distinguish between:
+
+- **Permafail**: A systematic failure affecting the same test(s) or infrastructure issue, detected by analyzing comparable runs (same failure type):
+  - 2-3 comparable runs: All must have the same failure (100% match)
+  - 4-5 comparable runs: At least 4 must have the same failure (80% match)
+  - 6-10 comparable runs: At least ceil(count × 0.7) must have the same failure (70% match)
+- **Flaky**: Non-deterministic failures with varying root causes, or failures that don't meet the permafail thresholds
+
+## Prerequisites
+
+- Access to OpenShift CI Prow job artifacts via gcsweb URLs
+- Access to the `Bash` tool for running `plugins/ci/scripts/classify-job-failures.py`
+- Python with the `requests` package available for artifact fetching
+- Knowledge of Prow artifact structure (from `fetch-prowjob-json` and `prow-job-artifact-search` skills)
+- 2-10 URLs pointing to consecutive job failures (from Prow/OpenShift CI, ordered newest to oldest)
+- Job name context to verify consistency across all failures
+- PR information to provide context for analysis
+
+## Implementation Steps
+
+### Step 1: Validate Inputs
+
+**Standard Mode (URL-based):**
+
+Verify that all required inputs are present with expected types and constraints:
+- `failure_urls`: Array of 2-10 strings matching Prow job URL pattern `https://prow.ci.openshift.org/view/gs/<bucket>/<path>/<job-name>/<build-id>` where path may be `logs/`, `pr-logs/pull/`, or other GCS paths (must be consecutive runs, ordered newest to oldest)
+- `job_name`: Non-empty string identifier of the job being analyzed
+- `pr_info`: Object containing PR number (integer) and repository context (string)
+- Each URL must match the Prow job URL pattern above
+
+Reject requests if:
+- URLs count is less than 2 or more than 10
+- Job names don't match across all URLs (validate via prowjob.json metadata, not path position)
+- PR context is missing
+
+Notes:
+- URL ordering (newest first) is assumed but not validated - the frontend provides them in this order
+- Job name validation should check prowjob.json metadata or verify the name appears in the extracted GCS path, not assume a fixed path position (presubmit URLs include org/repo/pr segments)
+
+**Offline/Eval Mode (Pre-normalized Signatures):**
+
+For testing or offline analysis, the skill can accept pre-normalized failure signatures directly instead of fetching from URLs. This mode skips Steps 2-4 (artifact fetching and classification) and proceeds directly to Step 5 (threshold analysis).
+
+Input format:
+- `signatures`: Array of 2-10 pre-normalized signature objects (see Step 4 output format)
+- Each signature must be either test_failure format `{type: "test_failure", url: "...", tests: [...], test_count: N}` or infra_failure format `{type: "infra_failure", url: "...", error: "...", error_hash: "..."}`
+
+When signatures are provided, skip to Step 5 and apply threshold logic directly. Use this mode only for evals or when signatures have been extracted by another tool.
+
+### Step 2: Classify Job Failures with Script
+
+For standard URL-based analysis, call the deterministic classifier script to fetch artifacts and produce normalized signatures:
+
+```bash
+"$SKILL_DIR/../../scripts/classify-job-failures.py" --json-input '{
+  "failure_urls": ["https://prow.ci.openshift.org/view/gs/..."],
+  "job_name": "pull-ci-openshift-origin-master-e2e-aws",
+  "pr_info": {"pr_number": 12345, "repository": "openshift/origin"}
+}'
+```
+
+The script performs the artifact-based work that does not require AI judgment:
+
+1. Parses the full GCS path from each Prow URL.
+2. Fetches `prowjob.json` from gcsweb.
+3. Browses the artifacts directory.
+4. Classifies each run as `test_failure` or `infra_failure` based on artifacts, not error text alone.
+5. Extracts failing test names from junit/build logs or normalized infrastructure errors.
+6. Returns the Step 4 normalized signature array.
+
+If the script exits non-zero, report its JSON error and do not continue to threshold analysis unless at least two valid signatures are available from another trusted source.
+
+### Step 3: Artifact Classification Rules
+
+The classifier follows these rules:
+
+- **TEST_FAILURE** when artifacts contain `openshift-e2e-test/`, `e2e-*`, `junit/`, junit XML files, `openshift-tests-*`, or `monitor-test-*`.
+- **INFRA_FAILURE** only when artifacts show setup/build/gather output without test artifacts, or artifacts are empty/unavailable after a valid job fetch.
+- MonitorTest failures count as test failures because MonitorTests run during e2e execution.
+- Classification must be artifact-based. Do not classify from Prow descriptions or error messages alone.
+
+### Step 4: Use Normalized Failure Signatures
+
+Use the script output directly as the normalized signature array.
+
+**For test failures:**
+```json
+{
+  "type": "test_failure",
+  "url": "job_url",
+  "tests": ["failing_test_name1", "failing_test_name2"],
+  "test_count": 2
+}
+```
+
+**For infrastructure failures:**
+```json
+{
+  "type": "infra_failure",
+  "url": "job_url",
+  "error": "normalized_error_message",
+  "error_hash": "md5_of_error_message"
+}
+```
+
+### Step 5: Compare Signatures for Permafail Pattern
+
+Apply permafail detection logic using **failure-type-based thresholds** - the denominator is the count of comparable runs (same failure type), not the matching group size:
+
+**Detection Thresholds (based on comparable run count):**
+- 2-3 comparable runs: All must match (100% match required)
+- 4-5 comparable runs: At least 4 must match (80% match required)
+- 6-10 comparable runs: At least ceil(count × 0.7) must match (70% threshold)
+
+**For Test Failures:**
+1. Count total test_failure signatures (this is the **denominator**)
+2. Extract all unique test names from test_failure signatures
+3. For each unique test name, count how many test_failure signatures contain it (this is the **numerator**)
+4. Apply threshold based on the **denominator** (total test_failure count):
+   - If denominator is 2-3: numerator must equal denominator (100%)
+   - If denominator is 4-5: numerator must be ≥4 (80%)
+   - If denominator is 6-10: numerator must be ≥ceil(denominator × 0.7) (70%)
+5. If ANY test name meets its threshold: **PERMAFAIL = TRUE**
+   - Report which test(s) met the threshold and their occurrence count
+6. If no test meets the threshold: **PERMAFAIL = FALSE**
+
+Example: 8 test_failure signatures, "TestNetworkPolicy" appears in 6 → 6/8 = 75% → needs ceil(8×0.7)=6 → 6≥6 ✓ PERMAFAIL
+
+**For Infrastructure Failures:**
+1. Count total infra_failure signatures (this is the **denominator**)
+2. Extract error messages and group similar errors (exact match or >70% character similarity using normalized Levenshtein: `similarity = 1 - (levenshtein_distance(a, b) / max(len(a), len(b)))`. Treat two normalized errors as similar when `similarity > 0.70`. If both strings are empty, do not group them as similar; require a non-empty normalized error.)
+3. For each error group, count how many infra_failure signatures contain it (this is the **numerator**)
+4. Apply threshold based on the **denominator** (total infra_failure count):
+   - If denominator is 2-3: numerator must equal denominator (100%)
+   - If denominator is 4-5: numerator must be ≥4 (80%)
+   - If denominator is 6-10: numerator must be ≥ceil(denominator × 0.7) (70%)
+5. If ANY error group meets its threshold: **PERMAFAIL = TRUE**
+   - Report the error message and occurrence count
+6. If no error group meets the threshold: **PERMAFAIL = FALSE**
+
+Example: 5 infra_failure signatures - 3 have "operator X timeout", 2 have random errors → 3/5 = 60% → needs 4/5 (80%) → 3<4 → NOT PERMAFAIL
+
+**For Mixed Failure Types:**
+1. Separate signatures by type (test_failure vs infra_failure)
+2. For each type, count total signatures (the **denominator** for that type)
+3. Apply threshold logic to each type independently:
+   - **Test failures**: If ≥2 test_failure signatures exist, check if any test appears frequently enough to meet the threshold based on test_failure count
+   - **Infra failures**: If ≥2 infra_failure signatures exist, check if any error appears frequently enough to meet the threshold based on infra_failure count
+4. **Minimum runs requirement**: Need at least 2 runs of the same type to establish a permafail pattern. A single failure of either type is insufficient.
+5. If either type meets the threshold AND has ≥2 runs: **PERMAFAIL = TRUE**
+   - Report the dominant pattern (the one that triggered permafail)
+   - Explain which runs contributed and which were ignored (e.g., "All 4 runs that reached e2e tests failed on TestNetworkPolicy. 3 other runs failed during cluster setup and are not relevant to this test failure pattern.")
+6. If neither type meets criteria: **PERMAFAIL = FALSE**
+
+**Example Scenario 1: PERMAFAIL (4 test, 3 infra):**
+- 7 total runs provided
+- 3 runs: infra_failure (cluster creation failed)
+- 4 runs: test_failure (all failing on TestNetworkPolicy)
+
+**Analysis:**
+- Test failures: 4 runs → use 4/5 threshold (80%) → need 4 matching → have 4/4 (100%) ✓ PERMAFAIL
+- Infra failures: 3 runs → use 3/3 threshold (100%) → different errors → NOT permafail
+- Verdict: **PERMAFAIL = TRUE** (test failure group met criteria)
+- Reason: "All 4 runs that reached e2e tests failed on TestNetworkPolicy (100% match). 3 additional runs failed during infrastructure setup and are not relevant to this test failure pattern."
+
+**Example Scenario 2: NOT PERMAFAIL (1 test, 6 diverse infra):**
+- 7 total runs provided
+- 6 runs: infra_failure (each with different errors: cluster creation timeout, AWS quota, network issue, pod eviction, storage failure, DNS timeout)
+- 1 run: test_failure (failed on TestNetworkPolicy)
+
+**Analysis:**
+- Test failures: 1 run → INSUFFICIENT (need minimum 2 runs to establish pattern)
+- Infra failures: 6 runs with all different errors → no single error appears ≥5 times → NOT permafail
+- Verdict: **PERMAFAIL = FALSE**
+- Reason: "Only 1 out of 7 runs reached e2e tests and failed on '[sig-arch] daemonset cni-sysctl-allowlist-ds maxUnavailable requirement'. The other 6 runs failed during infrastructure setup, each with different unrelated issues (no consistent infra pattern). A single test failure is insufficient to establish a permafail pattern - we need multiple runs with consistent failures to confirm systematic breakage."
+
+### Step 6: Generate Verdict and Return JSON
+
+Construct the final response object with:
+- Boolean verdict: `permafail` (true/false)
+- Reason string explaining the determination. Always include explicit slash-format ratios for the dominant pattern and strongest non-matching pattern, such as `7/10`, `4/4`, `5/6`, or `2/10`. Do not write only `7 of 10`; include `7/10`.
+- Complete failure signatures array
+- Common tests array (if applicable and permafail=true)
+- Confidence score as a JSON number from 0.0 to 1.0, representing confidence in the final verdict, not the raw match ratio. Never use strings such as `"high"`, `"medium"`, or `"0.95"`. For example, a clearly non-permafail `2/10` pattern can still have confidence around 0.70 because the verdict is well supported.
+- Stable `failure_type` value:
+  - `test_failure` when the final verdict is driven by test-failure analysis, or only test failures are present
+  - `infra_failure` when the final verdict is driven by infrastructure-failure analysis, or only infrastructure failures are present
+  - `mixed` when both test and infrastructure failures are present and no single type meets the permafail threshold
+- `match_ratio`: Slash-format string for the dominant pattern, such as `"7/10"`, `"4/4"`, `"5/6"`, or `"2/10"`.
+- `threshold_required`: Integer count required for the comparable-run group to qualify as permafail.
+- `matching_runs`: Integer numerator for the dominant or strongest pattern.
+- `comparable_runs`: Integer denominator for the comparable-run group.
+
+The final JSON must be machine-checkable. The ratio-bearing fields must be top-level fields, not nested under an analysis object. Use this exact style:
+
+```json
+{
+  "permafail": true,
+  "confidence": 0.95,
+  "reason": "7/10 test_failure runs failed TestNetworkPolicy, meeting the required 7/10 threshold.",
+  "failure_type": "test_failure",
+  "match_ratio": "7/10",
+  "matching_runs": 7,
+  "comparable_runs": 10,
+  "threshold_required": 7,
+  "signatures": []
+}
+```
+
+For a mixed non-permafail, use `failure_type: "mixed"` and include the word `insufficient` in the reason when one failure type has fewer than 2 comparable runs.
+
+Do not set `confidence` equal to the match percentage. Confidence means confidence in the verdict:
+
+- Clear non-permafail with complete data and a strongest pattern below threshold, such as `2/10`, should use `confidence: 0.70` or higher.
+- Exact threshold permafail, such as `7/10` test failures or `5/6` infra failures, should use `confidence: 0.85` or higher.
+- All comparable runs matching, such as `4/4`, should use `confidence: 0.99`.
+- Ambiguous or incomplete data should use lower confidence.
+
+## Output Format
+
+The skill returns a JSON object with this schema:
+
+```json
+{
+  "permafail": true,
+  "confidence": 0.95,
+  "reason": "3/3 test_failure runs show the same failing test 'test_node_scale' - consistent permanent failure",
+  "failure_type": "test_failure",
+  "match_ratio": "3/3",
+  "matching_runs": 3,
+  "comparable_runs": 3,
+  "threshold_required": 3,
+  "signatures": [
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "tests": ["test_node_scale"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "tests": ["test_node_scale"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "tests": ["test_node_scale"],
+      "test_count": 1
+    }
+  ],
+  "common_tests": ["test_node_scale"]
+}
+```
+
+### For Infrastructure Failure (permafail=true)
+
+```json
+{
+  "permafail": true,
+  "confidence": 0.92,
+  "reason": "All 3 runs fail at cluster creation with identical error: 'Insufficient quota for machine type n1-standard-4'",
+  "failure_type": "infra_failure",
+  "signatures": [
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "error": "Insufficient quota for machine type n1-standard-4",
+      "error_hash": "a1b2c3d4e5f6g7h8"
+    },
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "error": "Insufficient quota for machine type n1-standard-4",
+      "error_hash": "a1b2c3d4e5f6g7h8"
+    },
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/bucket/logs/...",
+      "error": "Insufficient quota for machine type n1-standard-4",
+      "error_hash": "a1b2c3d4e5f6g7h8"
+    }
+  ]
+}
+```
+
+### For Non-Permafail (mixed or varying failures)
+
+```json
+{
+  "permafail": false,
+  "confidence": 0.88,
+  "reason": "Mixed failure types detected: 2/3 runs are test_failure, 1/3 is infra_failure. Inconsistent pattern indicates flaky behavior, not a systematic permafail. Test failures: 2/3 (threshold: 2/3). Infra failures: 1/3 (threshold: 1/3).",
+  "failure_type": "mixed",
+  "match_ratio": "2/3",
+  "matching_runs": 2,
+  "comparable_runs": 3,
+  "threshold_required": 2,
+  "signatures": [
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["test_networking"],
+      "test_count": 1
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "Pod evicted due to memory pressure",
+      "error_hash": "x1y2z3a4b5c6d7e8"
+    },
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["test_storage", "test_deployment"],
+      "test_count": 2
+    }
+  ]
+}
+```
+
+## Failure Signature Format
+
+### Test Failure Signature
+
+```json
+{
+  "type": "test_failure",
+  "url": "string (job URL)",
+  "tests": ["array", "of", "failing_test_names"],
+  "test_count": "integer (length of tests array)"
+}
+```
+
+**Fields:**
+- `type`: Always "test_failure"
+- `url`: The Prow job URL for this run
+- `tests`: Array of test names extracted from failure logs (deduplicated)
+- `test_count`: Count of unique failing tests
+
+### Infrastructure Failure Signature
+
+```json
+{
+  "type": "infra_failure",
+  "url": "string (job URL)",
+  "error": "string (normalized error message)",
+  "error_hash": "string (MD5 hash of normalized error)"
+}
+```
+
+**Fields:**
+- `type`: Always "infra_failure"
+- `url`: The Prow job URL for this run
+- `error`: Normalized error message with timestamps and build IDs removed
+- `error_hash`: MD5 hash for fast similarity comparison
+
+## Permafail Detection Logic
+
+### Test Failure Logic
+
+Apply the threshold rules from Step 5 based on the number of test_failure signatures (the comparable run count):
+
+1. Count total test_failure signatures (this is N, the **denominator**)
+2. Collect all unique test names from test_failure signatures
+3. For each unique test name, count how many test_failure signatures contain it (the **numerator**)
+4. Check if any test meets the threshold:
+   - **N=2-3**: Test must appear in ALL N runs (100% match required)
+   - **N=4-5**: Test must appear in ≥4 runs (80% match required)
+   - **N=6-10**: Test must appear in ≥ceil(N × 0.7) runs (70% match required)
+5. **Permafail = TRUE** if ANY test meets the threshold
+6. Set confidence based on match strength:
+   - 0.99 if all test_failure runs have identical test set
+   - 0.85 or higher if threshold is met exactly (e.g., 3/3, 4/5, 7/10)
+   - 0.92 if threshold is exceeded (e.g., 5/5, 8/10)
+   - 0.70 or higher if no test meets threshold but the non-permafail verdict is clear
+7. In the `reason`, include the strongest test ratio in slash form, for example `7/10 test_failure runs failed TestNetworkPolicy` or `2/10 test_failure runs failed TestNetworkPolicy`.
+8. Include top-level `match_ratio`, `matching_runs`, `comparable_runs`, and `threshold_required` fields for the strongest test pattern.
+
+### Infrastructure Failure Logic
+
+Apply the threshold rules from Step 5 based on the number of infra_failure signatures (the comparable run count):
+
+1. Count total infra_failure signatures (this is N, the **denominator**)
+2. Extract error messages and group similar errors (exact hash match or >70% string similarity)
+3. For each error group, count how many infra_failure signatures contain it (the **numerator**)
+4. Apply threshold based on **N** (total infra_failure count, not the error group size):
+   - **N=2-3**: Error must appear in ALL N runs (100% required)
+   - **N=4-5**: Error must appear in ≥4 runs (80% required)
+   - **N=6-10**: Error must appear in ≥ceil(N × 0.7) runs (70% required)
+5. **Permafail = TRUE** if ANY error group meets its threshold
+   - Example: 5 total infra_failure signatures, 3 with "operator X timeout", 2 with random errors
+   - Denominator N=5 → needs 4/5 (80%) → 3/5 = 60% < 80% → NOT PERMAFAIL
+6. Set confidence based on match strength:
+   - 0.99 if all infra_failure runs have identical error hash
+   - 0.85 or higher if the threshold is met exactly
+   - 0.92 if threshold is met with >80% string similarity
+   - 0.88 if threshold is met with >70% string similarity
+   - 0.70 or higher if no error group meets threshold but the non-permafail verdict is clear
+7. In the `reason`, include the strongest infra ratio in slash form, for example `5/6 infra_failure runs share operator authentication timeout` or `1/6 infra_failure runs share the strongest error`.
+8. Include top-level `match_ratio`, `matching_runs`, `comparable_runs`, and `threshold_required` fields for the strongest infra pattern.
+
+### Mixed Type Logic
+
+When both test_failure and infra_failure types are present:
+1. **Analyze each group independently** using their respective thresholds
+2. **Test failures**: Check if test_failure signatures have common failing tests
+3. **Infra failures**: Check if infra_failure signatures have common errors
+4. If **either group meets the permafail criteria**: **PERMAFAIL = TRUE**
+   - Report the pattern that triggered permafail (tests or infra)
+   - Explain the breakdown (e.g., "4 of 4 test runs failed on the same test; 3 other runs failed during setup")
+   - Set `failure_type` to the type that triggered the permafail: `test_failure` or `infra_failure`
+   - Use the triggering type's top-level ratio fields. For example, if 4/4 test failures match and infra failures are noise, set `failure_type: "test_failure"`, `match_ratio: "4/4"`, `matching_runs: 4`, `comparable_runs: 4`, and the test threshold.
+5. If **neither group meets criteria**: **PERMAFAIL = FALSE**
+   - Reason: "No consistent pattern found in test failures or infrastructure failures"
+   - If both test_failure and infra_failure signatures are present, set `failure_type` to `mixed`, not `flaky`
+6. In mixed cases, include slash-format ratios for the evaluated groups in the `reason`, such as `1/1 test_failure runs` and `1/6 infra_failure runs`.
+
+**Key Principle**: Infrastructure failures (cluster setup, resource quota, network issues) are **orthogonal** to test failures. A PR can have a systematic test failure (permafail) even if some runs fail during infrastructure setup. Analyze each type separately and detect permafails in either category.
+
+## Error Handling
+
+### Scenario 1: Artifact Fetch Failure
+
+If artifact fetching fails for a job URL:
+- Return status: "error"
+- Return error message with specific failure reason (network error, 404, timeout, etc.)
+- Continue with remaining jobs when at least 2 jobs have not yet been attempted
+- Do NOT return a permafail verdict when fewer than 2 jobs completed successfully
+
+**Response:**
+```json
+{
+  "status": "error",
+  "error": "Failed to fetch artifacts for job: 404 Not Found at gcsweb URL",
+  "action": "verify_job_url_validity"
+}
+```
+
+### Scenario 2: Timeout on Job Analysis
+
+If the classifier script times out or returns an incomplete result:
+- Report the script error.
+- Continue only if at least 2 valid signatures are available from another trusted source.
+- If only 1 or 0 signatures are available: Return error.
+
+**Response:**
+```json
+{
+  "status": "error",
+  "error": "Analysis timeout: Only 2 of 3 jobs analyzed successfully. Insufficient data for permafail determination.",
+  "completed_jobs": 2,
+  "action": "retry_with_single_job"
+}
+```
+
+### Scenario 3: Invalid Job URLs
+
+If URL validation fails:
+- Return status: "error"
+- Return specific validation error message
+- Do NOT attempt analysis
+
+**Response:**
+```json
+{
+  "status": "error",
+  "error": "Invalid job URL format: 'url3' is not a valid Prow job URL",
+  "invalid_url": "url3",
+  "action": "provide_valid_urls"
+}
+```
+
+### Scenario 4: Job Names Don't Match
+
+If the job_name parameter doesn't match the actual job names extracted from URLs:
+- Return status: "error"
+- Return the expected vs actual job names
+
+**Response:**
+```json
+{
+  "status": "error",
+  "error": "Job name mismatch. Expected 'pull-ci-job-xyz' but found 'pull-ci-job-abc' in run 2",
+  "expected_job": "pull-ci-job-xyz",
+  "actual_job": "pull-ci-job-abc",
+  "action": "provide_matching_job_urls"
+}
+```
+
+### Scenario 5: Insufficient Comparable Runs (Different Types)
+
+If analysis completes but there are insufficient comparable runs for permafail determination (e.g., 1 test_failure + 1 infra_failure):
+- Return permafail: false
+- Explain that neither failure type has ≥2 comparable runs
+- This is NOT an error - the analysis succeeded but found no same-type pattern
+
+**Response:**
+```json
+{
+  "permafail": false,
+  "confidence": 0.70,
+  "reason": "Insufficient comparable runs: 1/2 test failures, 1/2 infra failures. Cannot establish a permafail pattern with only one run of each type. Need at least 2 runs of the same failure type to determine if failures are systematic. Test: 1/2 (threshold: 2/2). Infra: 1/2 (threshold: 2/2).",
+  "failure_type": "mixed",
+  "match_ratio": "1/2",
+  "matching_runs": 1,
+  "comparable_runs": 2,
+  "threshold_required": 2,
+  "signatures": [
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["[sig-network] test"]
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "cluster creation failed"
+    }
+  ]
+}
+```
+
+### Scenario 6: Failure to Extract Failure Details
+
+If the classifier output doesn't contain expected failure information:
+- Mark this run as "incomplete"
+- Continue with other runs
+- If ≥2 runs have valid failure data, proceed with analysis
+- Otherwise, return error
+
+**Response:**
+```json
+{
+  "status": "incomplete",
+  "warning": "Run 1 analysis incomplete: could not extract failure details",
+  "completed_jobs": 2,
+  "incomplete_jobs": 1,
+  "permafail": "unknown",
+  "recommendation": "Review job logs manually or retry analysis"
+}
+```
+
+## Examples
+
+### Example 1: Permafail - Identical Failing Test
+
+**Input:**
+```json
+{
+  "failure_urls": [
+    "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234567",
+    "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234568",
+    "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234569"
+  ],
+  "job_name": "pull-ci-openshift-origin-master-e2e-aws",
+  "pr_info": {
+    "pr_number": 12345,
+    "repository": "openshift/origin"
+  }
+}
+```
+
+**Subagent analysis results for all 3 runs:**
+- Run 1: Failed tests = ["[sig-api] API discovery should provide capability information"]
+- Run 2: Failed tests = ["[sig-api] API discovery should provide capability information"]
+- Run 3: Failed tests = ["[sig-api] API discovery should provide capability information"]
+
+**Output:**
+```json
+{
+  "permafail": true,
+  "confidence": 0.99,
+  "reason": "3/3 consecutive runs fail with identical test: '[sig-api] API discovery should provide capability information'. This is a systematic permanent failure.",
+  "failure_type": "test_failure",
+  "match_ratio": "3/3",
+  "matching_runs": 3,
+  "comparable_runs": 3,
+  "threshold_required": 3,
+  "signatures": [
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234567",
+      "tests": ["[sig-api] API discovery should provide capability information"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234568",
+      "tests": ["[sig-api] API discovery should provide capability information"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/pull-ci-openshift-origin-master-e2e-aws/1234569",
+      "tests": ["[sig-api] API discovery should provide capability information"],
+      "test_count": 1
+    }
+  ],
+  "common_tests": ["[sig-api] API discovery should provide capability information"]
+}
+```
+
+### Example 2: Permafail Despite Mixed Failure Types
+
+**Input:**
+```json
+{
+  "failure_urls": [
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1111",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1112",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1113",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1114",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1115",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1116",
+    "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1117"
+  ],
+  "job_name": "periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node",
+  "pr_info": {
+    "pr_number": 3186,
+    "repository": "openshift/ovn-kubernetes"
+  }
+}
+```
+
+**Subagent analysis results:**
+- Run 1: Infrastructure failure = "Cluster creation timeout" (infra_failure)
+- Run 2: Failed tests = ["[sig-network] Networking should provide connectivity"] (test_failure)
+- Run 3: Infrastructure failure = "AWS quota exceeded" (infra_failure)
+- Run 4: Failed tests = ["[sig-network] Networking should provide connectivity"] (test_failure)
+- Run 5: Failed tests = ["[sig-network] Networking should provide connectivity"] (test_failure)
+- Run 6: Infrastructure failure = "Cluster creation timeout" (infra_failure)
+- Run 7: Failed tests = ["[sig-network] Networking should provide connectivity"] (test_failure)
+
+**Analysis:**
+- 7 total runs: 3 infra_failures, 4 test_failures
+- Test failures: 4/4 (100%) have identical failing test
+- Infra failures: 3 runs, but different errors (not a permafail pattern in infra)
+- Verdict: **PERMAFAIL = TRUE** based on test failure group
+
+**Output:**
+```json
+{
+  "permafail": true,
+  "confidence": 0.99,
+  "reason": "All 4 runs that reached e2e tests failed on '[sig-network] Networking should provide connectivity' (100% match). 3 additional runs failed during infrastructure setup (cluster creation, AWS quota) and are not relevant to this test failure pattern. This is a systematic test failure caused by the PR changes.",
+  "failure_type": "test_failure",
+  "signatures": [
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1111",
+      "error": "Cluster creation timeout",
+      "error_hash": "a1b2c3d4"
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1112",
+      "tests": ["[sig-network] Networking should provide connectivity"],
+      "test_count": 1
+    },
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1113",
+      "error": "AWS quota exceeded",
+      "error_hash": "e5f6g7h8"
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1114",
+      "tests": ["[sig-network] Networking should provide connectivity"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1115",
+      "tests": ["[sig-network] Networking should provide connectivity"],
+      "test_count": 1
+    },
+    {
+      "type": "infra_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1116",
+      "error": "Cluster creation timeout",
+      "error_hash": "a1b2c3d4"
+    },
+    {
+      "type": "test_failure",
+      "url": "https://prow.ci.openshift.org/view/gs/..../logs/periodic-ci-openshift-release-main-ci-4.19-e2e-aws-upgrade-ovn-single-node/1117",
+      "tests": ["[sig-network] Networking should provide connectivity"],
+      "test_count": 1
+    }
+  ],
+  "common_tests": ["[sig-network] Networking should provide connectivity"]
+}
+```
+
+### Example 3: NOT Permafail - Insufficient Matching Infra Errors
+
+**Input:** 5 runs where 3 have identical operator installation failure, 2 have random infra issues
+
+**Subagent analysis results:**
+- Run 1: Infrastructure failure = "operator authentication timeout waiting for operator to reach Available=True" (infra_failure)
+- Run 2: Infrastructure failure = "AWS quota exceeded for instance type m5.xlarge" (infra_failure)
+- Run 3: Infrastructure failure = "operator authentication timeout waiting for operator to reach Available=True" (infra_failure)
+- Run 4: Infrastructure failure = "operator authentication timeout waiting for operator to reach Available=True" (infra_failure)
+- Run 5: Infrastructure failure = "Pod evicted due to memory pressure on node ip-10-0-1-2" (infra_failure)
+
+**Analysis:**
+- 5 total infra_failure signatures (denominator = 5)
+- "operator authentication timeout" appears in 3 runs (numerator = 3)
+- Threshold for N=5 (4-5 runs): need at least 4 matching (80% required)
+- 3/5 = 60% < 80% → NOT PERMAFAIL
+
+**Output:**
+```json
+{
+  "permafail": false,
+  "confidence": 0.70,
+  "reason": "Infrastructure failures are not consistent enough. 3/5 runs failed with 'operator authentication timeout waiting for operator to reach Available=True' (60% match), but with 5 infra failures at least 4/5 must match (80% required). The presence of 2 different random errors indicates flaky infrastructure rather than systematic failure.",
+  "failure_type": "infra_failure",
+  "match_ratio": "3/5",
+  "matching_runs": 3,
+  "comparable_runs": 5,
+  "threshold_required": 4,
+  "signatures": [
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "operator authentication timeout waiting for operator to reach Available=True",
+      "error_hash": "a1b2c3d4"
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "AWS quota exceeded for instance type m5.xlarge",
+      "error_hash": "e5f6g7h8"
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "operator authentication timeout waiting for operator to reach Available=True",
+      "error_hash": "a1b2c3d4"
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "operator authentication timeout waiting for operator to reach Available=True",
+      "error_hash": "a1b2c3d4"
+    },
+    {
+      "type": "infra_failure",
+      "url": "...",
+      "error": "Pod evicted due to memory pressure on node ip-10-0-1-2",
+      "error_hash": "i9j0k1l2"
+    }
+  ]
+}
+```
+
+### Example 4: Non-Permafail - No Consistent Pattern
+
+**Input:** 3 runs with different test failures
+
+**Subagent analysis results:**
+- Run 1: Failed tests = ["[sig-network] networking should support networking"] (test_failure)
+- Run 2: Failed tests = ["[sig-storage] storage should support volumes"] (test_failure)
+- Run 3: Failed tests = ["[sig-api] API discovery should work"] (test_failure)
+
+**Output:**
+```json
+{
+  "permafail": false,
+  "confidence": 0.70,
+  "reason": "No consistent failure pattern detected. 0/3 runs show matching tests - each of the 3 runs failed with different tests: networking, storage, API discovery. This indicates flaky/non-deterministic behavior rather than a systematic permafail.",
+  "failure_type": "test_failure",
+  "match_ratio": "0/3",
+  "matching_runs": 0,
+  "comparable_runs": 3,
+  "threshold_required": 3,
+  "signatures": [
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["[sig-network] networking should support networking"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["[sig-storage] storage should support volumes"],
+      "test_count": 1
+    },
+    {
+      "type": "test_failure",
+      "url": "...",
+      "tests": ["[sig-api] API discovery should work"],
+      "test_count": 1
+    }
+  ]
+}
+```
+
+### Threshold Logic Validation Examples
+
+**Table-driven test cases demonstrating correct threshold behavior:**
+
+| Total URLs | Test Failures | Infra Failures | Matching Test Count | Verdict | Reason |
+|------------|---------------|----------------|---------------------|---------|---------|
+| 10 | 10 | 0 | 2 same test | NOT permafail | 2/10 = 20% < 70% threshold (need ≥7) |
+| 10 | 10 | 0 | 7 same test | PERMAFAIL | 7/10 = 70% ≥ 70% threshold ✓ |
+| 7 | 4 | 3 | 4 same test (in test bucket) | PERMAFAIL | 4/4 = 100% ≥ 80% threshold (4-5 runs need ≥4) ✓ |
+| 7 | 1 | 6 | 1 test, all 6 infra diverse | NOT permafail | Only 1 test_failure (need ≥2), and infra errors are all different |
+| 7 | 1 | 6 | 1 test, 5 same infra error | PERMAFAIL | 5/6 = 83% ≥ ceil(6×0.7)=5 (70% threshold) → infra bucket meets threshold ✓ |
+
+## Technical Details
+
+### Artifact Analysis Approach
+
+This skill analyzes Prow job artifacts directly using techniques from existing CI skills:
+
+1. **URL parsing** - Extract job name and build ID from Prow URLs
+2. **Artifact fetching** - Use `plugins/ci/scripts/classify-job-failures.py` to fetch prowjob.json and browse artifacts
+3. **Classification** - Use artifact-based detection (junit files, test directories) to classify failures
+4. **Failure extraction** - Parse junit XML or build logs to extract test names or error messages
+
+This approach follows patterns from `fetch-prowjob-json`, `prow-job-artifact-search`, and `prow-job-analyze-test-failure` skills.
+
+### Script Execution Strategy
+
+The classifier script performs deterministic artifact analysis before AI threshold reasoning:
+
+```text
+failure_urls ━━━ classify-job-failures.py ━━━ normalized signatures ━━━ Step 5 threshold analysis
+```
+
+**Benefits:**
+- Keeps artifact fetching and parsing deterministic.
+- Avoids spending agent reasoning on mechanical classification.
+- Produces the same normalized signature schema used by offline eval cases.
+
+**Synchronization:**
+- Run the script once with all failure URLs.
+- Require at least 2 valid normalized signatures to proceed.
+- Stop and report the script's JSON error if URL validation or artifact fetching fails.
+
+### Error Message Normalization
+
+Normalize infrastructure error messages for comparison:
+
+1. Remove timestamps: `2025-05-12T14:32:10Z` → ""
+2. Remove build IDs: `build-12345-xyz` → ""
+3. Remove resource names with IDs: `pod-abc123xyz` → "pod-*"
+4. Remove request/limit values: Numbers in memory/CPU specs → ""
+5. Keep: Error classification, core message, error type
+
+**Example normalization:**
+```text
+Input:  "Pod evicted at 2025-05-12T14:32:10Z (build-12345): insufficient memory (512M < 1Gi required)"
+Output: "Pod evicted: insufficient memory (* < *Gi required)"
+```
+
+### Confidence Scoring
+
+Confidence reflects how certain the permafail verdict is:
+
+- **0.99**: All 3 runs have identical failure signature (test names or error hashes)
+- **0.95**: All 3 runs have ≥1 common failing test in test_failure
+- **0.92**: All 3 runs have >80% similar error messages in infra_failure
+- **0.85**: 2 of 3 runs share common failure or mixed types detected
+- **0.70**: Insufficient data or ambiguous failure patterns
+
+Use confidence to determine remediation priority:
+- Confidence ≥ 0.95: High priority permafail, block PR merge
+- Confidence 0.85-0.94: Medium priority, warn but allow manual override
+- Confidence < 0.85: Low confidence verdict, require manual review


### PR DESCRIPTION
## Summary

Adds `ci:detect-permafail` skill and command for analyzing consecutive CI job failures with failure-type-aware thresholds, plus an agent eval harness test suite for validating the classification logic.

## Changes

### Commit 1: Feature Implementation (3b14864)
- Add `ci:detect-permafail` skill for artifact-based failure classification
- Add `/ci:detect-permafail` command wrapper
- Add `classify-job-failures.py` script for deterministic artifact analysis
- Implement failure-type-based thresholds (test_failure vs infra_failure)
- Analyze multiple runs through the deterministic classifier script
- Bump plugin version to 0.0.55

**Key algorithm:** Denominator = count of same failure type, not total runs
- Thresholds: 2-3 runs need 100%, 4-5 need 80%, 6-10 need 70%
- Example: 7 runs with 4 test failures → threshold is 4/4 (100%), not 4/7

**Classifier script features:**
- Fetches artifacts from gcsweb with recursive directory walking
- Classifies failures as TEST_FAILURE or INFRA_FAILURE based on artifact patterns
- Extracts test names from JUnit XML and build logs
- Normalizes error messages (removes timestamps, version strings, ANSI codes)
- Aggregates across all JUnit files to detect flakes (tests that failed then passed)
- Validates GCS paths against traversal attacks
- Returns structured JSON signatures for skill consumption

### Commit 2: Eval Suite (bf1988e)
- Add agent eval harness configuration for detect-permafail skill
- Add 5 test cases covering threshold edge cases and mixed failure types
- Cases validate: below-threshold detection, exact-threshold permafails, mixed scenarios
- Each case includes input data and expected output annotations

## What this PR does / why we need it

Automates permafail detection for CI job failures by:
1. Fetching artifacts from 2-10 consecutive runs via Python script
2. Classifying failures by type (test_failure, infra_failure, etc.)
3. Normalizing failure messages into signatures (MD5 + Levenshtein)
4. Applying failure-type-specific thresholds
5. Returning structured JSON with confidence scores

The agent eval harness suite ensures threshold logic correctness and proper confidence calibration.

## Which issue(s) this PR fixes

Fixes [CORENET-7149](https://redhat.atlassian.net/browse/CORENET-7149)

## Checklist
- [x] Subject and description added to both commit and PR
- [x] Relevant issues have been referenced
- [x] This change includes docs
- [x] Agent eval harness test suite added
- [x] All validations passing (make lint, CodeRabbit)

