### PR TITLE
Consolidate Dockerfile dnf installs and disable foreign-arch repos

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,32 +1,31 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 
-# Install Python 3.11 (required for agent-eval-harness and modern type syntax)
+# Install all system packages in a single dnf transaction to avoid repeated
+# metadata fetches (~800MB each). Disable foreign-arch repos to prevent
+# cross-architecture dependency resolution failures in CI.
 RUN dnf install -y \
+    --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='*-aarch64' \
+    'dnf-command(config-manager)' \
+    && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
+    --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='*-aarch64' \
+    && dnf install -y \
+    --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='*-aarch64' \
     python3.11 \
     python3.11-pip \
     python3.11-devel \
-    && dnf clean all \
-    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
-    && alternatives --set python3 /usr/bin/python3.11
-
-# Install common Python tools
-RUN python3 -m pip install --no-cache-dir \
-    pytest \
-    requests \
-    pyyaml
-
-# Install GitHub CLI
-RUN dnf install -y 'dnf-command(config-manager)' \
-    && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo \
-    && dnf install -y gh \
-    && dnf clean all
-
-# Install PCP tools with Python bindings
-RUN dnf install -y \
+    gh \
     pcp \
     pcp-devel \
     pcp-export-pcp2json \
     && dnf clean all \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && alternatives --set python3 /usr/bin/python3.11
+
+# Install Python tools and PCP bindings
+RUN python3 -m pip install --no-cache-dir \
+    pytest \
+    requests \
+    pyyaml \
     && python3 -m pip install --no-cache-dir --use-pep517 pcp
 
 # Create claude user with root group for OpenShift compatibility


### PR DESCRIPTION
## Summary

Image builds 30 minutes --> 10 minutes

- Consolidate three separate `dnf install` RUN steps into a single RUN instruction to avoid repeated repo metadata downloads (~800MB per invocation, previously happening 7 times)
- Disable ppc64le, s390x, and aarch64 repos via `--disablerepo` flags to skip useless metadata fetches and prevent cross-architecture dependency resolution failures in CI
- Merge the two pip install steps into one RUN layer

## Test plan
- [x] CI image build succeeds
- [x] `python3 --version` returns 3.11 in the built image
- [x] `gh --version` works in the built image
- [x] `python3 -c "import pcp"` works in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized container image build process for improved efficiency and faster builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->