### PR TITLE
Remove unused JIRA_USERNAME from node-cve plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,7 +375,7 @@
       "name": "node-cve",
       "source": "./plugins/node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.1"
+      "version": "0.0.2"
     },
     {
       "name": "bigquery",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1963,7 +1963,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/node-cve/.claude-plugin/plugin.json
+++ b/plugins/node-cve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-cve",
   "description": "CVE triage for OpenShift Node team components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -47,7 +47,6 @@ Triage all open CVEs for Node team components with automated reachability analys
 
 **Environment variables:**
 - `JIRA_API_TOKEN` - Jira API token (required)
-- `JIRA_USERNAME` - Jira username/email (required)
 - `SLACK_API_TOKEN` - Slack bot token (preferred for `--notify-slack`, enables threaded messages)
 - `SLACK_CHANNEL` - Slack channel ID (required with `SLACK_API_TOKEN`). Default: `GK6BJJ1J5` (`#team-node`)
 - `SLACK_WEBHOOK` - Slack incoming webhook URL (alternative for `--notify-slack`, no threading)
@@ -61,7 +60,6 @@ podman run -it \
   -e CLAUDE_CODE_USE_VERTEX=1 \
   -e ANTHROPIC_VERTEX_PROJECT_ID=your-project \
   -e JIRA_API_TOKEN=... \
-  -e JIRA_USERNAME=... \
   -e SLACK_API_TOKEN=xoxb-... \
   -e SLACK_CHANNEL=GK6BJJ1J5 \
   -v ~/.config/gcloud:/home/claude/.config/gcloud:ro \

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -20,7 +20,7 @@ Designed for both interactive use and headless execution via `claude --print`.
 ## Prerequisites
 
 - `jira` CLI ([ankitpokhrel/jira-cli](https://github.com/ankitpokhrel/jira-cli)) configured with Jira credentials
-- Environment variables: `JIRA_API_TOKEN`, `JIRA_USERNAME`
+- Environment variables: `JIRA_API_TOKEN`
 - `git` (for cloning repos)
 - Optional: `curl` and either `SLACK_API_TOKEN` + `SLACK_CHANNEL` or `SLACK_WEBHOOK` (for `--notify-slack`)
 
@@ -309,7 +309,7 @@ The headline format depends on whether cached results were used. On first run (a
 ## Arguments
 
 - `--component <name>`: Filter to a specific OCPBUGS component. Must match a Node team component name exactly (e.g., "Node / CRI-O"). Optional.
-- `--notify-jira`: Post analysis as a comment on each Jira tracker issue. Requires `JIRA_API_TOKEN` and `JIRA_USERNAME`. Also enables cross-run caching via Jira comments.
+- `--notify-jira`: Post analysis as a comment on each Jira tracker issue. Requires `JIRA_API_TOKEN`. Also enables cross-run caching via Jira comments.
 - `--notify-slack`: Send a summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (no threading).
 - `--days N`: Only include CVEs created or updated in the last N days. Default: all open CVEs.
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when Phase 1 of the `node-cve:triage` command needs to fetch all 
 ## Prerequisites
 
 - `jira` CLI configured with valid credentials
-- Environment variables: `JIRA_API_TOKEN`, `JIRA_USERNAME`
+- Environment variables: `JIRA_API_TOKEN`
 - Network access to Jira instance
 
 ## Implementation Steps

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when Phase 3 of the `node-cve:triage` command needs to generate t
 
 - `jira` CLI (for `--notify-jira`)
 - `curl` (for `--notify-slack`)
-- Environment variables: `JIRA_API_TOKEN`, `JIRA_USERNAME` (for Jira)
+- Environment variables: `JIRA_API_TOKEN` (for Jira)
 - For Slack: either `SLACK_API_TOKEN` + `SLACK_CHANNEL` (preferred, enables threading) or `SLACK_WEBHOOK` (simpler, no threading)
 
 ## Implementation Steps


### PR DESCRIPTION
The `jira` CLI handles authentication through its own config. `JIRA_USERNAME` was listed as required but never used in any command. Removes it from all prerequisite docs and the headless execution example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 0.0.2.

* **Documentation**
  * Simplified Jira integration prerequisites by removing the JIRA_USERNAME requirement. Users now only need to configure JIRA_API_TOKEN for Jira-based features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->