### PR TITLE
DRA OCP Validator Plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -513,6 +513,21 @@
         "bundle",
         "meta-plugin"
       ]
+    },
+    {
+      "name": "dra-ocp-validator",
+      "source": "./plugins/dra-ocp-validator",
+      "description": "Comprehensive DRA feature validation for OpenShift clusters with GPU hardware",
+      "version": "1.0.0",
+      "category": "testing",
+      "keywords": [
+        "dra",
+        "gpu",
+        "validation",
+        "nvidia",
+        "testing",
+        "openshift"
+      ]
     }
   ]
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1114,6 +1114,79 @@ footer a { color: var(--primary); }
       }
     },
     {
+      "name": "dra-ocp-validator",
+      "description": "Comprehensive DRA feature validation for OpenShift clusters",
+      "version": "1.0.0",
+      "has_readme": true,
+      "commands": [
+        {
+          "name": "analyze",
+          "full_name": "dra-ocp-validator:analyze",
+          "description": "Analyze DRA test failure and provide debugging guidance",
+          "description_html": "Analyze DRA test failure and provide debugging guidance",
+          "synopsis": "/dra-ocp-validator:analyze \u003ctest-output-directory\u003e",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003edra-ocp-validator:analyze\u003c/code\u003e command analyzes a failed DRA test and provides:\u003cbr\u003e- Failure root cause analysis from logs and events\u003cbr\u003e- Common issue detection (scheduling failures, allocation errors, permissions)\u003cbr\u003e- Test-specific debugging guidance\u003cbr\u003e- Recommended next steps\u003c/p\u003e\u003cp\u003eThis is useful when:\u003cbr\u003e- A test fails and you need to understand why\u003cbr\u003e- You want automated analysis of collected debug artifacts\u003cbr\u003e- You need specific debugging commands for the failure type\u003c/p\u003e\u003cp\u003eThe command analyzes:\u003cbr\u003e1. Test summary and validation status\u003cbr\u003e2. Kubernetes events (scheduling/allocation failures)\u003cbr\u003e3. ResourceClaim status and conditions\u003cbr\u003e4. Pod status and scheduling decisions\u003cbr\u003e5. DRA driver logs for errors\u003cbr\u003e6. Test-specific patterns\u003c/p\u003e"
+        },
+        {
+          "name": "cleanup",
+          "full_name": "dra-ocp-validator:cleanup",
+          "description": "Clean up DRA test resources and optionally uninstall drivers",
+          "description_html": "Clean up DRA test resources and optionally uninstall drivers",
+          "synopsis": "/dra-ocp-validator:cleanup \u003ckubeconfig-path\u003e [options]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003edra-ocp-validator:cleanup\u003c/code\u003e command performs complete cleanup of DRA resources from an OpenShift cluster, auto-detecting and removing the installed driver type (NVIDIA or example).\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDefault behavior\u003c/strong\u003e (no flags):\u003cbr\u003e- Deletes all test namespaces (\u003ccode\u003edra-*-test\u003c/code\u003e)\u003cbr\u003e- Auto-detects driver type (NVIDIA or example)\u003cbr\u003e- Removes DRA driver (Helm release + namespace)\u003cbr\u003e- Removes GPU operator (if present)\u003cbr\u003e- Preserves NFD (foundational cluster infrastructure)\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eSelective preservation flags\u003c/strong\u003e:\u003cbr\u003e- \u003ccode\u003e--keep-driver\u003c/code\u003e: Preserve DRA driver installation\u003cbr\u003e- \u003ccode\u003e--keep-operator\u003c/code\u003e: Preserve GPU operator installation\u003cbr\u003e- Both can be combined to clean only test namespaces\u003c/p\u003e\u003cp\u003eThis is useful for:\u003cbr\u003e- Complete teardown after DRA testing/validation\u003cbr\u003e- Freeing cluster resources\u003cbr\u003e- Resetting cluster to clean state\u003cbr\u003e- Partial cleanup when preserving infrastructure components\u003c/p\u003e"
+        },
+        {
+          "name": "list-features",
+          "full_name": "dra-ocp-validator:list-features",
+          "description": "List all DRA features with metadata, graduation status, and requirements",
+          "description_html": "List all DRA features with metadata, graduation status, and requirements",
+          "synopsis": "/dra-ocp-validator:list-features \u003ckubeconfig-path\u003e [--detailed]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003elist-features\u003c/code\u003e command displays comprehensive information about all Dynamic Resource Allocation (DRA) features supported by the plugin, including:\u003c/p\u003e\u003cp\u003e- Feature graduation levels (Alpha/Beta/GA) for the current cluster\u003cbr\u003e- Kubernetes version requirements\u003cbr\u003e- Feature gate requirements and status\u003cbr\u003e- Setup prerequisites and enablement commands\u003cbr\u003e- Test coverage information\u003c/p\u003e\u003cp\u003eThis command helps answer:\u003cbr\u003e- What DRA features are available on my cluster?\u003cbr\u003e- Which features require feature gates to be enabled?\u003cbr\u003e- What is the graduation status of each feature?\u003cbr\u003e- Which features are testable on my K8s version?\u003c/p\u003e"
+        },
+        {
+          "name": "setup",
+          "full_name": "dra-ocp-validator:setup",
+          "description": "Install DRA stack (auto-detects hardware and installs appropriate driver)",
+          "description_html": "Install DRA stack (auto-detects hardware and installs appropriate driver)",
+          "synopsis": "/dra-ocp-validator:setup \u003ckubeconfig-path\u003e [options]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003edra-ocp-validator:setup\u003c/code\u003e command installs and configures the appropriate DRA driver on an OpenShift cluster based on detected hardware, without running validation tests. This is useful when you want to:\u003c/p\u003e\u003cp\u003e- Prepare a cluster for manual DRA testing\u003cbr\u003e- Install prerequisites before running tests at a later time\u003cbr\u003e- Verify installation works before committing to full validation\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eThe command performs:\u003c/strong\u003e\u003cbr\u003e1. Cluster access verification\u003cbr\u003e2. NFD installation (always - required for hardware detection)\u003cbr\u003e3. Hardware discovery via NFD labels\u003cbr\u003e4. \u003cstrong\u003eAuto-select driver\u003c/strong\u003e based on detected hardware:\u003cbr\u003e   - \u003cstrong\u003eNVIDIA GPUs detected\u003c/strong\u003e → Install GPU operator + NVIDIA DRA driver\u003cbr\u003e   - \u003cstrong\u003eAMD GPUs detected\u003c/strong\u003e → Install GPU operator + AMD DRA driver  \u003cbr\u003e   - \u003cstrong\u003eNo GPUs detected\u003c/strong\u003e → Install dra-example-driver (software-only)\u003cbr\u003e5. Driver installation (conditional based on step 4)\u003cbr\u003e6. Installation verification (DeviceClasses, ResourceSlices)\u003c/p\u003e\u003cp\u003eAfter setup completes, you can run \u003ccode\u003e/dra-ocp-validator:test\u003c/code\u003e to execute validation tests.\u003c/p\u003e"
+        },
+        {
+          "name": "test",
+          "full_name": "dra-ocp-validator:test",
+          "description": "Run DRA feature tests on a cluster with prerequisites already installed",
+          "description_html": "Run DRA feature tests on a cluster with prerequisites already installed",
+          "synopsis": "/dra-ocp-validator:test \u003ckubeconfig-path\u003e [options]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003edra-ocp-validator:test\u003c/code\u003e command runs DRA feature validation tests on a cluster where the DRA driver and GPU operator have already been installed (via \u003ccode\u003e/dra-ocp-validator:setup\u003c/code\u003e or manually).\u003c/p\u003e\u003cp\u003eThis is useful when you want to:\u003cbr\u003e- Re-run tests after fixing issues\u003cbr\u003e- Test a subset of features\u003cbr\u003e- Run tests on a pre-configured cluster\u003cbr\u003e- Validate after cluster or driver configuration changes\u003c/p\u003e\u003cp\u003eThe command performs:\u003cbr\u003e1. Cluster access verification\u003cbr\u003e2. DRA driver readiness check (DeviceClass, ResourceSlice)\u003cbr\u003e3. K8s version detection and feature availability mapping\u003cbr\u003e4. CDMM detection (Grace-Blackwell) for MIG test skipping\u003cbr\u003e5. Feature gate validation (Alpha features only)\u003cbr\u003e6. Test execution for selected features\u003cbr\u003e7. Artifact collection and report generation\u003c/p\u003e"
+        },
+        {
+          "name": "validate",
+          "full_name": "dra-ocp-validator:validate",
+          "description": "Complete DRA validation (setup + test + report) on OpenShift clusters",
+          "description_html": "Complete DRA validation (setup + test + report) on OpenShift clusters",
+          "synopsis": "/dra-ocp-validator:validate \u003ckubeconfig-path\u003e [options]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003edra-ocp-validator:validate\u003c/code\u003e command performs comprehensive end-to-end validation of Dynamic Resource Allocation (DRA) features on an OpenShift cluster. It combines cluster setup, feature testing, and report generation into a single workflow.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eComplete workflow:\u003c/strong\u003e\u003cbr\u003e1. Verify cluster access and detect hardware\u003cbr\u003e2. Install prerequisites (NFD, GPU operator, DRA driver)\u003cbr\u003e3. Determine available DRA features based on K8s version\u003cbr\u003e4. Check CDMM status and feature gates\u003cbr\u003e5. Run feature validation tests\u003cbr\u003e6. Collect artifacts and generate validation report\u003cbr\u003e7. Package results in tarball for JIRA attachment\u003c/p\u003e\u003cp\u003eThis is the recommended command for full DRA validation.\u003c/p\u003e"
+        }
+      ],
+      "skills": [],
+      "agents": [],
+      "hooks": [],
+      "mcp_servers": [],
+      "rules": [],
+      "category": "testing",
+      "keywords": [
+        "dra",
+        "gpu",
+        "validation",
+        "nvidia",
+        "testing",
+        "openshift"
+      ],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
+    },
+    {
       "name": "etcd",
       "description": "Etcd cluster health monitoring and performance analysis utilities",
       "version": "0.0.2",

--- a/plugins/dra-ocp-validator/.claude-plugin/plugin.json
+++ b/plugins/dra-ocp-validator/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "dra-ocp-validator",
+  "description": "Comprehensive DRA feature validation for OpenShift clusters",
+  "version": "1.0.0",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/dra-ocp-validator/DEVELOPMENT-STATUS.md
+++ b/plugins/dra-ocp-validator/DEVELOPMENT-STATUS.md
@@ -1,0 +1,289 @@
+# DRA OCP Validator Plugin - Development Status
+
+**Repository**: https://github.com/sairameshv/ai-helpers  
+**Branch**: `dra-ocp-validator-plugin`  
+**Status**: ✅ Core Implementation Complete  
+**Total Files**: 18  
+**Total Lines**: ~3,700
+
+---
+
+## Implementation Summary
+
+### ✅ Completed Components
+
+#### Commands (4 files)
+- `validate.md` - Main validation command (setup + test + report)
+- `setup.md` - Install prerequisites only
+- `test.md` - Run tests on pre-configured cluster  
+- `cleanup.md` - Remove test resources and drivers
+
+#### Tools (4 scripts)
+- `cluster-info.sh` - Cluster verification, hardware discovery, CDMM detection
+- `install-nvidia-stack.sh` - NVIDIA GPU Operator + DRA Driver installation
+- `install-dra-example.sh` - dra-example-driver for no-GPU testing
+- `collect-artifacts.sh` - Artifact collection and report generation
+
+#### Tests (6 validated scripts)
+- `test-dra-partitionable.sh` - Partitionable Devices (KEP-4815)
+- `test-dra-admin-access.sh` - Admin Access
+- `test-dra-prioritized-list.sh` - Prioritized List (KEP-4816)
+- `test-dra-podresources-api.sh` - PodResources API
+- `test-dra-device-taints.sh` - Device Taints (KEP-5055)
+- `test-dra-extended-resources.sh` - Extended Resources (KEP-5004)
+
+#### References (1 file)
+- `features.md` - DRA feature maturity matrix by K8s version
+
+#### Templates (1 file)
+- `nvidia-dra-driver-values.yaml` - Helm values for NVIDIA DRA driver
+
+#### Documentation (2 files)
+- `README.md` - Plugin overview and usage
+- `OWNERS` - Maintainers file
+
+---
+
+## Key Features Implemented
+
+### 1. ✅ Multi-Driver Support
+- NVIDIA GPUs (primary)
+- dra-example-driver (no-GPU testing)
+- AMD/Intel (planned for future)
+
+### 2. ✅ Auto-Detection
+- GPU vendor (via NFD PCI vendor IDs)
+- K8s version → DRA feature maturity mapping
+- CDMM status → MIG test auto-skipping
+- Feature gate validation
+
+### 3. ✅ Smart Test Execution
+- Beta features tested by default
+- Alpha features require explicit flag + feature gate check
+- Version-gated features auto-skip on unsupported K8s
+- CDMM detection skips MIG tests when needed
+
+### 4. ✅ Comprehensive Reporting
+- Individual test logs (timestamped directories)
+- Consolidated validation report
+- Tarball packaging for JIRA attachment
+- Full artifact collection (logs, configs, events)
+
+---
+
+## Testing Status
+
+### ✅ Validated on Real Hardware
+All test scripts validated on:
+- **Cluster**: OCP 4.21.16 (Kubernetes 1.34.7)
+- **Hardware**: 4x NVIDIA GB300 GPUs (Blackwell)
+- **Results**: 4/4 Beta features PASS
+
+Test scripts are production-ready.
+
+### ⏳ Plugin Integration Testing
+**Status**: Not yet tested end-to-end via Claude plugin system
+
+**Next Steps**:
+1. Test `/dra-ocp-validator:validate` command
+2. Verify tool script execution
+3. Test artifact collection
+4. Validate report generation
+
+---
+
+## Pending Work
+
+### Minor Components
+
+#### 1. Evaluation Tests (`evals/validate.yaml`)
+**Status**: Not implemented  
+**Purpose**: Test cases for plugin validation  
+**Priority**: Medium
+
+**Example structure**:
+```yaml
+prompts:
+  - /dra-ocp-validator:validate ~/test-kubeconfig --driver example
+
+expected_tools:
+  - Bash
+  - Read
+  - Write
+
+expected_outputs:
+  - "Cluster accessible"
+  - "DRA-VALIDATION-REPORT.md"
+```
+
+#### 2. Additional References
+**Status**: Partial  
+**Missing**:
+- `drivers.md` - Driver installation details
+- `hardware.md` - GPU vendor support matrix
+
+**Priority**: Low (information available in README and features.md)
+
+---
+
+## Known Limitations
+
+### 1. CDMM + MIG Incompatibility
+- **Scope**: NVIDIA Grace-Blackwell (GB200/GB300)
+- **Impact**: MIG tests auto-skip when CDMM enabled
+- **Status**: Documented and handled automatically
+
+### 2. Feature Gate Requirements
+- **Scope**: Alpha features (Device Taints in K8s 1.34-1.35)
+- **Impact**: Tests skip if gate not enabled
+- **Status**: Documented with enable commands
+
+### 3. Driver Version Support
+- **Current**: NVIDIA driver 580.126.20 (hardcoded default)
+- **Improvement**: Could support dynamic version detection
+- **Priority**: Low (version override available via flag)
+
+---
+
+## Usage Examples
+
+### Full Validation
+```bash
+/dra-ocp-validator:validate ~/kubeconfig \
+  --driver nvidia \
+  --enable-dynamic-mig
+```
+
+### Setup Only
+```bash
+/dra-ocp-validator:setup ~/kubeconfig \
+  --driver nvidia \
+  --enable-dynamic-mig
+```
+
+### Test Specific Features
+```bash
+/dra-ocp-validator:test ~/kubeconfig \
+  --features partitionable,admin-access
+```
+
+### Cleanup
+```bash
+/dra-ocp-validator:cleanup ~/kubeconfig
+/dra-ocp-validator:cleanup ~/kubeconfig --remove-driver --remove-operator
+```
+
+---
+
+## Next Steps
+
+### Immediate
+1. ✅ Create evaluation tests (`evals/validate.yaml`)
+2. Test plugin end-to-end on real cluster
+3. Fix any issues discovered during testing
+4. Update documentation based on testing feedback
+
+### Before PR
+1. Add missing reference docs (drivers.md, hardware.md)
+2. Create CONTRIBUTING guide specific to this plugin
+3. Add troubleshooting section to README
+4. Verify all scripts are executable (`chmod +x`)
+
+### Future Enhancements
+1. AMD GPU support (`install-amd-stack.sh`)
+2. Intel GPU support (`install-intel-stack.sh`)
+3. openshift-tests integration (replace bash scripts)
+4. CI/CD integration for periodic validation
+5. Multi-cluster validation support
+6. Comparative analysis (different vendors, K8s versions)
+
+---
+
+## File Tree
+
+```
+plugins/dra-ocp-validator/
+├── README.md                                   # Plugin documentation
+├── OWNERS                                      # Maintainers
+├── DEVELOPMENT-STATUS.md                       # This file
+├── commands/
+│   ├── validate.md                             # Main command
+│   ├── setup.md                                # Setup-only
+│   ├── test.md                                 # Test-only
+│   └── cleanup.md                              # Cleanup
+├── tools/
+│   ├── cluster-info.sh                         # Discovery tool
+│   ├── install-nvidia-stack.sh                 # NVIDIA installation
+│   ├── install-dra-example.sh                  # Example driver
+│   └── collect-artifacts.sh                    # Artifact collection
+├── tests/
+│   ├── test-dra-partitionable.sh              # KEP-4815
+│   ├── test-dra-admin-access.sh               # Admin Access
+│   ├── test-dra-prioritized-list.sh           # KEP-4816
+│   ├── test-dra-podresources-api.sh           # PodResources API
+│   ├── test-dra-device-taints.sh              # KEP-5055
+│   └── test-dra-extended-resources.sh         # KEP-5004
+├── references/
+│   └── features.md                             # Feature matrix
+├── templates/
+│   └── nvidia-dra-driver-values.yaml          # Helm values
+└── evals/
+    └── (pending)
+```
+
+---
+
+## Contribution Guidelines
+
+### Adding a New Driver
+
+1. Create `tools/install-<vendor>-stack.sh`
+2. Update `cluster-info.sh` PCI vendor detection
+3. Add vendor section to `references/features.md`
+4. Update README with vendor support status
+
+### Adding a New Test
+
+1. Create test script in `tests/test-dra-<feature>.sh`
+2. Follow existing script structure (phases, logging, validation)
+3. Add feature to `references/features.md` matrix
+4. Update command descriptions to include new feature
+
+### Updating for New K8s Version
+
+1. Update `cluster-info.sh` version case statement
+2. Update `references/features.md` matrix
+3. Test new features on target K8s version
+4. Update README with new OCP/K8s mapping
+
+---
+
+## Maintainer Notes
+
+### Testing Checklist
+- [ ] `/dra-ocp-validator:validate` works end-to-end
+- [ ] NVIDIA stack installation completes
+- [ ] dra-example-driver installation works
+- [ ] Test scripts execute correctly
+- [ ] Artifact collection generates report
+- [ ] Tarball creation succeeds
+- [ ] Cleanup removes all test resources
+- [ ] CDMM detection works on Grace-Blackwell
+- [ ] Feature gate checks work for Alpha features
+- [ ] Version gating skips unsupported features
+
+### PR Checklist
+- [ ] All test scripts validated on real hardware
+- [ ] Plugin tested end-to-end
+- [ ] Documentation complete
+- [ ] Evaluation tests added
+- [ ] No hardcoded paths or credentials
+- [ ] All scripts executable
+- [ ] OWNERS file correct
+- [ ] README matches implementation
+
+---
+
+**Last Updated**: 2026-06-03  
+**Plugin Version**: v1.0.0-dev  
+**Maintainer**: @sairameshv

--- a/plugins/dra-ocp-validator/OWNERS
+++ b/plugins/dra-ocp-validator/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- sairameshv
+
+reviewers:
+- sairameshv

--- a/plugins/dra-ocp-validator/README.md
+++ b/plugins/dra-ocp-validator/README.md
@@ -1,0 +1,160 @@
+# DRA OCP Validator Plugin
+
+Comprehensive Dynamic Resource Allocation (DRA) feature validation for OpenShift clusters.
+
+## Overview
+
+The `dra-ocp-validator` plugin automates end-to-end validation of DRA features on OpenShift clusters with GPU hardware (NVIDIA, AMD, Intel) or using the dra-example-driver for testing without physical GPUs.
+
+**Key Features:**
+- ✅ Automated cluster access verification and hardware discovery
+- ✅ Prerequisites installation (NFD, GPU operators, DRA drivers)
+- ✅ Feature gate management with cluster patching
+- ✅ Comprehensive DRA feature testing (Alpha/Beta/GA based on K8s version)
+- ✅ Artifact collection and validation reporting
+- ✅ CDMM detection and automatic MIG test skipping (Grace-Blackwell)
+
+## Installation
+
+```bash
+/plugin install dra-ocp-validator@ai-helpers
+```
+
+## Commands
+
+### `/dra-ocp-validator:validate`
+
+Complete end-to-end DRA validation: setup, test, and report.
+
+```bash
+/dra-ocp-validator:validate <kubeconfig-path> [options]
+```
+
+**Options:**
+- `--driver <nvidia|amd|example>` - Driver to use (default: auto-detect)
+- `--features <list>` - Comma-separated features to test (default: all Beta)
+- `--skip-install` - Skip driver/operator installation
+- `--enable-dynamic-mig` - Enable DynamicMIG feature gate (required for Partitionable Devices)
+- `--driver-version <version>` - Specific driver version (default: latest)
+- `--output-dir <path>` - Output directory (default: ./dra-validation-<timestamp>)
+
+**Examples:**
+```bash
+# Full validation on NVIDIA cluster with MIG support
+/dra-ocp-validator:validate ~/kubeconfig --driver nvidia --enable-dynamic-mig
+
+# Test specific features on existing setup
+/dra-ocp-validator:validate ~/kubeconfig --skip-install --features partitionable,admin-access
+
+# Test without physical GPUs using dra-example-driver
+/dra-ocp-validator:validate ~/kubeconfig --driver example
+```
+
+### `/dra-ocp-validator:setup`
+
+Install prerequisites only (no testing).
+
+```bash
+/dra-ocp-validator:setup <kubeconfig-path> [options]
+```
+
+**Use Case:** Prepare cluster for manual testing or deferred test execution.
+
+### `/dra-ocp-validator:test`
+
+Run tests only (assumes setup already done).
+
+```bash
+/dra-ocp-validator:test <kubeconfig-path> [options]
+```
+
+**Use Case:** Re-run tests on already configured cluster, or test subset of features.
+
+### `/dra-ocp-validator:cleanup`
+
+Clean up test resources and optionally uninstall drivers.
+
+```bash
+/dra-ocp-validator:cleanup <kubeconfig-path> [options]
+```
+
+**Options:**
+- `--remove-driver` - Uninstall DRA driver
+- `--remove-operator` - Uninstall GPU operator
+- `--keep-namespaces` - Don't delete test namespaces
+
+## Supported Features
+
+| Feature | K8s 1.34 | K8s 1.35 | K8s 1.36 | KEP |
+|---------|----------|----------|----------|-----|
+| Partitionable Devices | Beta | Beta | Beta | [KEP-4815](https://github.com/kubernetes/enhancements/issues/4815) |
+| Admin Access | Beta | Beta | Beta | - |
+| Prioritized List | Beta | Beta | Beta | [KEP-4816](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4816-dra-prioritized-list/README.md) |
+| PodResources API | Beta | Beta | Beta | - |
+| Extended Resources | - | Alpha | Beta | [KEP-5004](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5004-dra-extended-resource/README.md) |
+| Device Taints | Alpha | Alpha | Beta | [KEP-5055](https://github.com/kubernetes/enhancements/issues/5055) |
+
+## GPU Vendor Support
+
+### NVIDIA (Production Ready)
+- ✅ Blackwell (GB300, GB200)
+- ✅ Hopper (H100, H200)
+- ✅ MIG support with DYNAMIC_MIG feature gate
+- ✅ CDMM detection and MIG test auto-skipping
+
+**Installation:** NVIDIA GPU Operator + NVIDIA DRA Driver via Helm
+
+### dra-example-driver (Testing Only)
+- ✅ No physical GPU required
+- ✅ Software-emulated DRA resources
+- ✅ Full DRA feature testing
+
+### AMD / Intel (Future)
+- ⏳ Planned support
+
+## Known Limitations
+
+### CDMM + MIG Incompatibility (NVIDIA Grace-Blackwell)
+
+On GB200/GB300 systems with CDMM (Coherent Driver Memory Management) enabled:
+- **CDMM enabled** (default on Grace) → MIG tests will be **auto-skipped** (NVIDIA driver limitation)
+- **CDMM disabled** → MIG tests run normally
+
+The plugin automatically detects CDMM status via NUMA node count and skips MIG-dependent tests when needed.
+
+**Reference:** [NVIDIA GPU Operator Known Issues](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/release-notes.html)
+
+## Output
+
+The validator generates:
+- **Validation Report** (`DRA-VALIDATION-REPORT-<cluster>-<date>.md`) - Comprehensive results
+- **Tarball** (`dra-validation-<cluster>-<date>.tar.gz`) - All test logs and artifacts
+- **Individual Test Logs** - Timestamped directories per feature
+
+## Prerequisites
+
+**Cluster Requirements:**
+- OpenShift 4.21+ (Kubernetes 1.34+)
+- Cluster admin access
+- Internet connectivity for pulling images
+
+**Local Tools:**
+- `oc` CLI (OpenShift client)
+- `helm` CLI (for driver installation)
+- `jq` (JSON processing)
+- `kubectl` (Kubernetes CLI)
+
+## References
+
+- [Kubernetes DRA Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+- [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver)
+- [dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver)
+- [Installation Guide (NVIDIA)](https://gist.github.com/sairameshv/34a154649ec1339ca06664cb887187d6)
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for plugin development guidelines.
+
+## Maintainers
+
+See [OWNERS](./OWNERS) file.

--- a/plugins/dra-ocp-validator/commands/analyze.md
+++ b/plugins/dra-ocp-validator/commands/analyze.md
@@ -1,0 +1,319 @@
+---
+description: Analyze DRA test failure and provide debugging guidance
+argument-hint: "<test-output-directory>"
+---
+
+## Name
+dra-ocp-validator:analyze
+
+## Synopsis
+```
+/dra-ocp-validator:analyze <test-output-directory>
+```
+
+## Description
+The `dra-ocp-validator:analyze` command analyzes a failed DRA test and provides:
+- Failure root cause analysis from logs and events
+- Common issue detection (scheduling failures, allocation errors, permissions)
+- Test-specific debugging guidance
+- Recommended next steps
+
+This is useful when:
+- A test fails and you need to understand why
+- You want automated analysis of collected debug artifacts
+- You need specific debugging commands for the failure type
+
+The command analyzes:
+1. Test summary and validation status
+2. Kubernetes events (scheduling/allocation failures)
+3. ResourceClaim status and conditions
+4. Pod status and scheduling decisions
+5. DRA driver logs for errors
+6. Test-specific patterns
+
+## Implementation
+
+This command performs automated analysis of DRA test failures by examining collected logs, events, and resource states. It identifies common failure patterns and provides targeted debugging guidance.
+
+### Steps
+
+1. **Validate Arguments**:
+   - Extract test output directory path from first argument (required)
+   - Verify directory exists and contains test artifacts
+   - Check for required files (test-summary.txt, resource manifests, logs)
+
+2. **Execute Failure Analysis Script**:
+   
+   Use the Bash tool to run the plugin's analysis script:
+   
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/analyze-failure.sh"
+   
+   # Pass test output directory to analyzer
+   ${SCRIPT} "$1"
+   ```
+   
+   The analysis script performs structured examination:
+   
+   a. **Test Context**:
+      - Identify test type from directory name
+      - Read test summary file for overall status
+      - Extract test start/end timestamps
+   
+   b. **Event Analysis**:
+      - Parse Kubernetes events from captured logs
+      - Identify scheduling failures (FailedScheduling events)
+      - Find allocation errors (ResourceClaim conditions)
+      - Detect permission/RBAC issues (Forbidden errors)
+      - Extract DRA-specific error messages
+   
+   c. **ResourceClaim Analysis**:
+      - Check ResourceClaim status (allocated vs pending)
+      - Examine allocation conditions and error messages
+      - Verify device assignments in allocation results
+      - Identify unallocated claims and reasons
+   
+   d. **Pod Analysis**:
+      - Check pod scheduling status (Pending, Running, Failed)
+      - Examine pod conditions for scheduling blocks
+      - Review container logs for application-level failures
+      - Verify resource claim references in pod specs
+   
+   e. **Driver Log Analysis**:
+      - Search DRA driver logs for ERROR/WARN messages
+      - Correlate driver errors with claim failures
+      - Identify driver-specific issues (device unavailable, config errors)
+   
+   f. **Pattern Matching**:
+      - Match failure symptoms to known issue patterns:
+        - Feature gate not enabled
+        - CDMM + MIG incompatibility
+        - Device already allocated
+        - Namespace admin access missing
+        - Scheduler configuration issues
+      - Provide test-specific debugging guidance
+
+3. **Present Analysis Results**:
+   
+   The script outputs structured analysis with sections:
+   - Test summary and overall status
+   - Identified failures with error messages
+   - Root cause analysis (if pattern matches)
+   - Debugging commands to run
+   - Recommended next steps
+   
+   Present this output to the user, highlighting:
+   - Key failure messages
+   - Recommended actions
+   - Where to look for more details
+
+4. **Provide Debugging Guidance**:
+   
+   Based on the failure type, the script suggests:
+   - Specific kubectl/oc commands to investigate further
+   - Configuration changes to try
+   - Related tests to check
+   - JIRA search queries for known issues
+   
+   Present these suggestions as actionable next steps.
+
+## Arguments
+
+### Required
+- `test-output-directory` - Path to test output directory (e.g., `./dra-admin-access-20260604-202015`)
+
+## Return Value
+- **Success**: Analysis completed, findings displayed
+- **Failure**: Directory not found or missing required files
+
+## Examples
+
+### Example 1: Analyze admin-access test failure
+```
+/dra-ocp-validator:analyze ./dra-admin-access-20260604-202015
+```
+
+**Output:**
+```
+=========================================
+DRA Test Failure Analysis
+=========================================
+Analyzing: ./dra-admin-access-20260604-202015
+
+Test Type: admin-access
+
+=== Test Summary ===
+
+==========================================
+VALIDATION SUMMARY
+==========================================
+
+Test Results:
+  Unauthorized namespace: FAIL (accepted)
+  Authorized namespace:   PASS (accepted)
+
+⚠ VALIDATION INCOMPLETE
+
+=== Failure Analysis ===
+
+📋 Checking Events for Failures:
+
+  ❌ Found Forbidden/Permission errors:
+     The ResourceClaim "claim-admin-test" is invalid: spec.devices.requests[0].adminAccess: Forbidden: admin access to devices requires the `resource.kubernetes.io/admin-access: true` label
+
+📋 Checking ResourceClaim Status:
+
+  ⚠ Unallocated ResourceClaims found:
+     claim-admin-test
+
+📋 Checking Pod Status:
+
+  ✓ No pending or failed pods
+
+📋 Checking Driver Logs:
+
+  ✓ No errors in driver logs
+
+=== Debugging Guidance ===
+
+Admin Access Test Debugging:
+
+1. Check namespace labels:
+   oc get namespace dra-no-admin dra-with-admin -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels}{"\n"}{end}'
+
+2. Check ResourceClaim rejection reason:
+   cat ./dra-admin-access-20260604-202015/test1-result.txt
+
+3. Verify API server enforces adminAccess:
+   - Look for 'Forbidden' in ./dra-admin-access-20260604-202015/debug/events.txt
+
+=== Summary ===
+
+⚠ Found 2 potential issue(s)
+  Review detailed logs in ./dra-admin-access-20260604-202015/debug/
+
+Key Files:
+  - ./dra-admin-access-20260604-202015/test-output.log
+  - ./dra-admin-access-20260604-202015/debug/events.txt
+  - ./dra-admin-access-20260604-202015/debug/resourceclaims-status.json
+
+Next Steps:
+  1. Review the specific errors shown above
+  2. Check the recommended debug commands for this test type
+  3. Look at ./dra-admin-access-20260604-202015/debug/README.txt
+```
+
+### Example 2: Analyze partitionable devices test
+```
+/dra-ocp-validator:analyze ./dra-validation-20260604-153143
+```
+
+**Output:**
+```
+=========================================
+DRA Test Failure Analysis
+=========================================
+Analyzing: ./dra-validation-20260604-153143
+
+Test Type: partitionable
+
+=== Failure Analysis ===
+
+📋 Checking Events for Failures:
+
+  ❌ Found FailedScheduling events:
+     0/6 nodes are available: 3 Insufficient gpu.example.com
+     Pod "pod-4g" failed to schedule: no devices match selector
+
+📋 Checking ResourceClaim Status:
+
+  ⚠ Unallocated ResourceClaims found:
+     claim-4g
+
+=== Debugging Guidance ===
+
+Partitionable Devices Test Debugging:
+
+1. Check if SharedCounters exist in ResourceSlices:
+   oc get resourceslice -o jsonpath='{.items[0].spec.devices[0].basic.sharedCounters}'
+
+2. Check driver supports MIG/partitioning:
+   cat ./dra-validation-20260604-153143/debug/*-driver-logs.txt | grep -i 'mig|partition'
+
+3. Verify CEL selectors in DeviceClass:
+   oc get deviceclass -o yaml | grep -A5 selectors
+
+=== Summary ===
+
+⚠ Found 2 potential issue(s)
+
+Next Steps:
+  1. Review the specific errors shown above
+  2. Check the recommended debug commands for this test type
+  3. Look at ./dra-validation-20260604-153143/debug/README.txt
+```
+
+### Example 3: Analyze with no debug directory
+```
+/dra-ocp-validator:analyze ./dra-old-test-20260601-120000
+```
+
+**Output:**
+```
+=========================================
+DRA Test Failure Analysis
+=========================================
+Analyzing: ./dra-old-test-20260601-120000
+
+Test Type: admin-access
+
+=== Test Summary ===
+
+(Test summary shown)
+
+=== Failure Analysis ===
+
+⚠ No debug/ directory found
+  This test may not have collected debug info on failure
+  Try re-running the test to collect full diagnostics
+```
+
+## Notes
+- The analyzer reads debug artifacts collected during test execution
+- Tests automatically collect debug info on failure (since latest update)
+- Older test runs may not have debug/ directories
+- The analyzer provides test-specific debugging commands
+- Analysis is read-only - no cluster state is modified
+
+## Common Issues Detected
+
+### Scheduling Failures
+- **Symptom**: "FailedScheduling" in events
+- **Cause**: No nodes with available devices, node selector mismatch
+- **Fix**: Check ResourceSlice capacity, node labels
+
+### Allocation Failures
+- **Symptom**: "FailedAllocation" or "no devices available"
+- **Cause**: All devices in use, selector doesn't match any device
+- **Fix**: Check ResourceSlice device attributes, verify CEL selectors
+
+### Permission Errors
+- **Symptom**: "Forbidden" errors
+- **Cause**: Missing namespace labels, RBAC issues
+- **Fix**: Check namespace `resource.kubernetes.io/admin-access` label
+
+### Unallocated Claims
+- **Symptom**: ResourceClaim has no `.status.allocation`
+- **Cause**: Driver not running, claim request invalid
+- **Fix**: Check driver pods, verify claim spec
+
+### Pending Pods
+- **Symptom**: Pod stuck in Pending
+- **Cause**: ResourceClaim not allocated, node constraints
+- **Fix**: Check `oc describe pod` Events section
+
+## See Also
+- `/dra-ocp-validator:test` - Run tests (auto-collects debug info on failure)
+- `/dra-ocp-validator:validate` - Full validation workflow
+- `/dra-ocp-validator:cleanup` - Clean up test resources

--- a/plugins/dra-ocp-validator/commands/cleanup.md
+++ b/plugins/dra-ocp-validator/commands/cleanup.md
@@ -1,0 +1,324 @@
+---
+description: Clean up DRA test resources and optionally uninstall drivers
+argument-hint: "<kubeconfig-path> [options]"
+---
+
+## Name
+dra-ocp-validator:cleanup
+
+## Synopsis
+```
+/dra-ocp-validator:cleanup <kubeconfig-path> [options]
+```
+
+## Description
+The `dra-ocp-validator:cleanup` command performs complete cleanup of DRA resources from an OpenShift cluster, auto-detecting and removing the installed driver type (NVIDIA or example).
+
+**Default behavior** (no flags):
+- Deletes all test namespaces (`dra-*-test`)
+- Auto-detects driver type (NVIDIA or example)
+- Removes DRA driver (Helm release + namespace)
+- Removes GPU operator (if present)
+- Preserves NFD (foundational cluster infrastructure)
+
+**Selective preservation flags**:
+- `--keep-driver`: Preserve DRA driver installation
+- `--keep-operator`: Preserve GPU operator installation
+- Both can be combined to clean only test namespaces
+
+This is useful for:
+- Complete teardown after DRA testing/validation
+- Freeing cluster resources
+- Resetting cluster to clean state
+- Partial cleanup when preserving infrastructure components
+
+## Implementation
+
+This command performs comprehensive cleanup of DRA resources and drivers from an OpenShift cluster. It auto-detects the installed driver type and removes components based on flags.
+
+### Steps
+
+1. **Parse and Validate Arguments**:
+   - Extract kubeconfig path from first positional argument (required)
+   - Parse optional flags: `--keep-driver`, `--keep-operator`, `--force`
+   - Expand tilde (`~`) to `$HOME` in kubeconfig path
+   - Verify kubeconfig file exists
+
+2. **Execute Cleanup Script**:
+   
+   Use the Bash tool to run the plugin's cleanup script:
+   
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/cleanup-dra.sh"
+   
+   # Pass all arguments to cleanup script
+   ${SCRIPT} "$@"
+   ```
+   
+   The cleanup script performs ordered resource removal:
+   
+   a. **Driver Type Detection**:
+      - Check for NVIDIA DRA driver Helm release
+      - Check for dra-example-driver Helm release
+      - Determine which driver is installed (if any)
+   
+   b. **Test Namespace Cleanup**:
+      - List all namespaces matching `dra-*-test` pattern
+      - Delete each test namespace:
+        - Remove ResourceClaims first (to trigger cleanup handlers)
+        - Delete Pods using claims
+        - Delete namespace (waits for finalizers)
+      - Display progress for each namespace
+   
+   c. **DRA Driver Removal** (unless `--keep-driver`):
+      - Confirm destructive operation (unless `--force`)
+      - For NVIDIA driver:
+        - Delete Helm release: `helm uninstall nvidia-dra-driver -n nvidia-dra-driver`
+        - Delete namespace: `nvidia-dra-driver`
+        - Wait for resources to be removed
+      - For example driver:
+        - Delete Helm release: `helm uninstall dra-example-driver -n dra-example-driver`
+        - Delete namespace: `dra-example-driver`
+      - Verify DeviceClass and ResourceSlice resources are removed
+   
+   d. **GPU Operator Removal** (unless `--keep-operator`):
+      - Confirm destructive operation (unless `--force`)
+      - Delete GPU operator Helm release
+      - Delete GPU operator namespace
+      - Wait for node-level resources to be cleaned up
+      - Note: This step only runs for NVIDIA driver cleanup
+   
+   e. **NFD Preservation**:
+      - NFD is intentionally preserved (foundational infrastructure)
+      - Script displays message: "Preserving NFD (foundational infrastructure)"
+   
+   f. **Verification**:
+      - Check that DeviceClass resources are gone
+      - Check that ResourceSlice resources are gone
+      - Check that test namespaces are removed
+      - Display final cleanup status
+
+3. **Handle User Confirmations**:
+   
+   The cleanup script prompts for confirmation before destructive operations (unless `--force`):
+   - "This will uninstall <driver-name> driver. Continue? (y/N)"
+   - "This will uninstall GPU operator. Continue? (y/N)"
+   
+   When running via Claude Code:
+   - If `--force` is NOT specified, the script will wait for user input
+   - Claude should inform the user that confirmation is needed
+   - User must respond in terminal or command should be re-run with `--force`
+   
+   **Recommendation**: Always suggest adding `--force` flag when calling cleanup via automation.
+
+4. **Monitor Progress**:
+   
+   The script outputs progress messages during cleanup:
+   - Which resources are being deleted
+   - Helm release deletion status
+   - Namespace deletion progress (may take 30-60s for finalizers)
+   - Verification results
+   
+   Present these updates to the user.
+
+5. **Handle Errors**:
+   
+   Cleanup can fail at various stages:
+   - Namespace stuck in Terminating (finalizer issues)
+   - Helm release deletion timeout
+   - ResourceClaim finalizers blocking deletion
+   
+   If errors occur:
+   - Display error message from script
+   - Show which resources failed to delete
+   - Suggest manual cleanup commands
+   - Note: Script continues with remaining cleanup even if some steps fail
+
+6. **Report Completion**:
+   
+   When cleanup completes, the script outputs:
+   - Summary of what was removed
+   - What was preserved (NFD, optionally driver/operator)
+   - Verification of resource removal
+   - Cluster is ready for fresh DRA installation
+   
+   Present this summary to the user.
+
+## Arguments
+
+### Required
+- `kubeconfig-path` - Path to cluster kubeconfig file
+
+### Optional
+- `--keep-driver` - Preserve DRA driver installation (default: remove)
+- `--keep-operator` - Preserve GPU operator installation (default: remove)
+- `--force` - Skip confirmation prompts for destructive operations
+
+## Return Value
+- **Success**: Resources cleaned up successfully
+- **Failure**: Cleanup error with diagnostic information
+
+## Examples
+
+### Example 1: Full cleanup (default)
+```
+/dra-ocp-validator:cleanup ~/kubeconfig
+```
+
+**Output:**
+```
+⚠ WARNING: This will uninstall nvidia driver. Continue? (y/N): y
+
+Deleting test namespaces...
+  ✓ dra-podresources-test deleted
+  ✓ dra-prioritized-test deleted
+
+Detected: NVIDIA DRA driver
+Uninstalling NVIDIA DRA driver...
+  Cleaning up SCC permissions...
+  ✓ Helm release removed
+  ✓ Namespace deletion initiated
+
+Detected: NVIDIA GPU Operator
+Uninstalling NVIDIA GPU Operator...
+  ✓ ClusterPolicy deleted
+  ✓ Subscription deleted
+  ✓ CSV deleted
+  ✓ Namespace deletion initiated
+
+Cleanup complete!
+```
+
+### Example 2: Clean test namespaces only
+```
+/dra-ocp-validator:cleanup ~/kubeconfig --keep-driver --keep-operator
+```
+
+**Output:**
+```
+Deleting test namespaces...
+  ✓ dra-podresources-test deleted
+  ✓ dra-prioritized-test deleted
+
+Driver installation preserved.
+GPU operator preserved.
+
+Cleanup complete!
+```
+
+### Example 3: Non-interactive full cleanup
+```
+/dra-ocp-validator:cleanup ~/kubeconfig --force
+```
+
+**Output:**
+```
+Deleting test namespaces... ✓
+Uninstalling NVIDIA DRA driver... ✓
+Uninstalling NVIDIA GPU Operator... ✓
+
+Cleanup complete!
+```
+
+### Example 4: Keep driver, remove operator
+```
+/dra-ocp-validator:cleanup ~/kubeconfig --keep-driver
+```
+
+**Output:**
+```
+Deleting test namespaces... ✓
+Driver preserved.
+Uninstalling GPU operator... ✓
+
+Cleanup complete!
+```
+
+## Safety Features
+
+### Confirmation Prompts
+Destructive operations require confirmation unless `--force` is specified:
+- Driver removal: Confirms before uninstalling DRA driver
+- Operator removal: Confirms before uninstalling GPU operator
+
+### What's Preserved
+- **NFD** - Foundational cluster infrastructure (may be used by other components)
+- **FeatureGate settings** - Cluster configuration unchanged
+- **Node labels** - GPU/hardware labels remain (until node reboot)
+
+### What's Removed
+**Default (no flags) - Full cleanup:**
+- Test namespaces: `dra-*-test`
+- Test pods, ResourceClaims, ResourceClaimTemplates
+- DRA driver (auto-detected: NVIDIA or example)
+- GPU operator (if present)
+- DeviceClasses and ResourceSlices
+- SCC permissions for driver
+
+**With `--keep-driver`:**
+- Test namespaces removed
+- Driver and operator preserved
+
+**With `--keep-operator`:**
+- Test namespaces and driver removed
+- GPU operator preserved
+
+## Impact Analysis
+
+### Full Cleanup (default)
+- **Downtime**: All GPU and DRA functionality unavailable
+- **Remaining resources**: NFD only (foundational cluster infrastructure)
+- **Can re-test**: After running `/dra-ocp-validator:setup`
+- **Cluster state**: DRA/GPU stack removed, NFD preserved
+
+### Partial Cleanup (with --keep-driver/--keep-operator)
+- **Downtime**: Test workloads only
+- **Remaining resources**: As specified by keep flags (plus NFD always)
+- **Can re-test**: Immediately (if driver kept) or after setup
+- **Cluster state**: Infrastructure intact
+
+## Notes
+- Cleanup requires cluster-admin privileges
+- Test namespaces are detected by `dra-*-test` pattern
+- Helm releases are uninstalled cleanly (no orphaned resources)
+- Namespace deletion waits for finalizers (may take 1-2 minutes)
+- If cleanup fails partway, it's safe to re-run
+- GPU workloads using DRA will fail if driver is removed
+- Removing GPU operator affects all GPU functionality (not just DRA)
+- **NFD is never removed** - it's foundational cluster infrastructure that may be used by other operators
+
+## Troubleshooting
+
+### Namespace stuck in Terminating
+```
+ERROR: Namespace dra-partitionable-test stuck in Terminating
+```
+**Solution:** Check for finalizers:
+```bash
+oc get namespace dra-partitionable-test -o json | jq '.spec.finalizers'
+oc patch namespace dra-partitionable-test -p '{"spec":{"finalizers":[]}}' --type=merge
+```
+
+### Helm release not found
+```
+WARNING: Release 'nvidia-dra-driver' not found
+```
+**Solution:** Normal if driver was installed manually (not via Helm). Delete namespace directly:
+```bash
+oc delete namespace nvidia-dra-driver
+```
+
+### Resources still in use
+```
+ERROR: Cannot delete namespace - pods still running
+```
+**Solution:** Force delete pods first:
+```bash
+oc delete pods --all -n dra-partitionable-test --grace-period=0 --force
+```
+
+## See Also
+- `/dra-ocp-validator:validate` - Full validation (creates test resources)
+- `/dra-ocp-validator:setup` - Install DRA stack
+- `/dra-ocp-validator:test` - Run tests (creates test namespaces)

--- a/plugins/dra-ocp-validator/commands/list-features.md
+++ b/plugins/dra-ocp-validator/commands/list-features.md
@@ -1,0 +1,178 @@
+---
+description: List all DRA features with metadata, graduation status, and requirements
+argument-hint: "<kubeconfig-path> [--detailed]"
+---
+
+## Name
+dra-ocp-validator:list-features
+
+## Synopsis
+```
+/dra-ocp-validator:list-features <kubeconfig-path> [--detailed]
+```
+
+## Description
+
+The `list-features` command displays comprehensive information about all Dynamic Resource Allocation (DRA) features supported by the plugin, including:
+
+- Feature graduation levels (Alpha/Beta/GA) for the current cluster
+- Kubernetes version requirements
+- Feature gate requirements and status
+- Setup prerequisites and enablement commands
+- Test coverage information
+
+This command helps answer:
+- What DRA features are available on my cluster?
+- Which features require feature gates to be enabled?
+- What is the graduation status of each feature?
+- Which features are testable on my K8s version?
+
+## Arguments
+
+- `<kubeconfig-path>` (required): Path to kubeconfig file for the target cluster
+  - Supports tilde expansion (e.g., `~/.kube/config`)
+  - Can be relative or absolute path
+
+- `[--detailed]` (optional): Display detailed information for each feature including:
+  - Full descriptions
+  - Feature gate names and enablement commands
+  - Setup flags required
+  - Associated test scripts
+
+## Implementation
+
+This command executes a bash script from the plugin's `tools/` directory to analyze and display DRA feature information for the target cluster.
+
+### Steps
+
+1. **Parse Arguments**:
+   - Extract kubeconfig path from `$1` (required)
+   - Check for `--detailed` flag in `$2` (optional)
+   - Expand tilde (`~`) to `$HOME` if present in the path
+
+2. **Validate Kubeconfig**:
+   - Verify kubeconfig path is provided (error if missing)
+   - Verify kubeconfig file exists at the path (error if not found)
+
+3. **Execute Feature List Script**:
+   
+   Use the Bash tool to run the plugin's list-features script:
+   
+   ```bash
+   # Build the command with the plugin root path
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/list-features.sh"
+   
+   # Pass through arguments
+   ${SCRIPT} "$1" "${2:-}"
+   ```
+   
+   The script will:
+   - Connect to the cluster using the provided kubeconfig
+   - Detect cluster version (K8s 1.32-1.36)
+   - Check if DRA driver is installed
+   - List all features with their graduation status for this K8s version
+   - Show feature gate status (enabled/disabled/not applicable)
+   - Display detailed information if `--detailed` flag provided
+
+4. **Present Output**:
+   
+   The script outputs formatted tables showing:
+   - Cluster information (OCP version, K8s version, DRA driver status)
+   - Feature table (name, graduation level, min K8s version, gate status, description)
+   - Summary (count of Alpha/Beta/GA features available)
+   - Next step commands
+   
+   Present this output directly to the user. If the script fails, show the error message.
+
+## Return Value
+
+- **Success**: Formatted tables showing all DRA features with their status
+- **Error**: 
+  - Missing or invalid kubeconfig path
+  - Cluster connectivity issues (falls back to offline mode)
+  - Missing required tools (`oc`, `jq`)
+
+## Examples
+
+### Basic List (Summary View)
+
+```
+/dra-ocp-validator:list-features ~/.kube/cluster-bot-config
+```
+
+**Output:**
+```
+==========================================
+DRA Features - Cluster Analysis
+==========================================
+
+Cluster: OCP 4.21.18, Kubernetes v1.34.8
+
+DRA Driver: ✓ Installed (gpu.example.com)
+
+==========================================
+Available DRA Features
+==========================================
+
+FEATURE              GRADUATION   MIN K8S    GATE STATUS     DESCRIPTION
+-------              ----------   -------    -----------     -----------
+partitionable        Alpha        1.34       ✗ Not enabled   Support for GPU partition...
+admin-access         Beta         1.34       N/A             Namespace-based admin ac...
+prioritized-list     Beta         1.34       N/A             Scheduler preference ord...
+```
+
+### Detailed View
+
+```
+/dra-ocp-validator:list-features ~/.kube/cluster-bot-config --detailed
+```
+
+**Output:**
+```
+==========================================
+Detailed Feature Information
+==========================================
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Feature: partitionable
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Name:        Partitionable Devices
+Description: Support for GPU partitioning via SharedCounters (e.g., NVIDIA MIG)
+Min K8s:     1.34
+Graduation:  alpha (on K8s 1.34)
+Feature Gate: DRAPartitionableDevices
+Gate Status:  ✗ Not enabled (Alpha - requires enablement)
+
+To enable:
+  oc patch featuregate cluster --type=merge \
+    -p '{"spec":{"customNoUpgrade":{"enabled":["DRAPartitionableDevices"]}}}'
+
+Setup Flags:  --enable-dynamic-mig
+Test Script:  test-dra-partitionable.sh
+```
+
+## Prerequisites
+
+**Required Tools:**
+- `oc` CLI (OpenShift client)
+- `jq` (JSON processor)
+- `kubectl` (Kubernetes CLI)
+
+**Cluster Requirements:**
+- Kubeconfig with valid cluster credentials
+- Network connectivity to cluster (optional - falls back to offline mode if unavailable)
+
+## Notes
+
+- **Offline Mode**: If cluster is unreachable, the command displays feature metadata for K8s 1.36 without cluster-specific information
+- **Graduation Levels**: Automatically determined based on the cluster's Kubernetes version
+- **Feature Gates**: Command checks actual cluster configuration to determine if gates are enabled
+- **Beta Features**: Some beta features don't require explicit feature gate enablement
+- **Alpha Features**: Always require feature gate enablement via `customNoUpgrade`
+
+## See Also
+
+- `/dra-ocp-validator:setup` - Install DRA driver with required features
+- `/dra-ocp-validator:test` - Run DRA feature tests
+- `/dra-ocp-validator:validate` - Full validation workflow

--- a/plugins/dra-ocp-validator/commands/setup.md
+++ b/plugins/dra-ocp-validator/commands/setup.md
@@ -1,0 +1,198 @@
+---
+description: Install DRA stack (auto-detects hardware and installs appropriate driver)
+argument-hint: "<kubeconfig-path> [options]"
+---
+
+## Name
+dra-ocp-validator:setup
+
+## Synopsis
+```
+/dra-ocp-validator:setup <kubeconfig-path> [options]
+```
+
+## Description
+The `dra-ocp-validator:setup` command installs and configures the appropriate DRA driver on an OpenShift cluster based on detected hardware, without running validation tests. This is useful when you want to:
+
+- Prepare a cluster for manual DRA testing
+- Install prerequisites before running tests at a later time
+- Verify installation works before committing to full validation
+
+**The command performs:**
+1. Cluster access verification
+2. NFD installation (always - required for hardware detection)
+3. Hardware discovery via NFD labels
+4. **Auto-select driver** based on detected hardware:
+   - **NVIDIA GPUs detected** → Install GPU operator + NVIDIA DRA driver
+   - **AMD GPUs detected** → Install GPU operator + AMD DRA driver  
+   - **No GPUs detected** → Install dra-example-driver (software-only)
+5. Driver installation (conditional based on step 4)
+6. Installation verification (DeviceClasses, ResourceSlices)
+
+After setup completes, you can run `/dra-ocp-validator:test` to execute validation tests.
+
+## Implementation
+
+This command executes a comprehensive setup script that installs the DRA stack on an OpenShift cluster. The setup is a long-running operation (5-10 minutes) that installs operators and waits for them to be ready.
+
+### Steps
+
+1. **Parse and Validate Arguments**:
+   - Extract kubeconfig path from first positional argument (required)
+   - Parse optional flags: `--driver`, `--enable-dynamic-mig`, `--driver-version`
+   - Expand tilde (`~`) to `$HOME` in kubeconfig path
+   - Verify kubeconfig file exists
+
+2. **Execute Setup Script**:
+   
+   Use the Bash tool to run the plugin's setup script, passing all arguments:
+   
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/setup-dra.sh"
+   
+   # Pass all arguments to setup script
+   ${SCRIPT} "$@"
+   ```
+   
+   The setup script performs these steps automatically:
+   
+   a. **Cluster Validation**:
+      - Verify cluster connectivity
+      - Check cluster is OpenShift 4.21+ (K8s 1.34+)
+      - Verify cluster-admin access
+   
+   b. **NFD Installation** (always required):
+      - Install Node Feature Discovery operator if not present
+      - Wait for NFD DaemonSet to be ready on all nodes
+      - Verify nodes are labeled with hardware information
+   
+   c. **Hardware Detection**:
+      - Query NFD labels to detect GPU vendor (NVIDIA, AMD, Intel)
+      - Auto-select driver based on detection (unless `--driver` flag provided)
+      - If no GPUs found: default to `dra-example-driver`
+   
+   d. **Driver Installation**:
+      - **NVIDIA**: Install GPU Operator + NVIDIA DRA Driver via Helm
+        - Configure `DYNAMIC_MIG=true` if `--enable-dynamic-mig` flag set
+        - Use specified version or latest stable
+      - **Example**: Install dra-example-driver via Helm
+        - Configure `gpuPartitions=4` if `--enable-dynamic-mig` flag set
+   
+   e. **Feature Gate Enablement** (if `--enable-dynamic-mig`):
+      - Patch OpenShift FeatureGate to enable `DRAPartitionableDevices`
+      - Uses `customNoUpgrade` field for alpha feature gates
+      - Wait for feature gate to be applied
+   
+   f. **Installation Verification**:
+      - Wait for all driver pods to be Running
+      - Verify DeviceClass resources are created
+      - Verify ResourceSlice resources are created
+      - Display summary of installed resources
+
+3. **Monitor Progress**:
+   
+   The script outputs progress messages during installation. Present these to the user in real-time to show:
+   - Which step is currently executing
+   - When operators/pods are being waited on
+   - When installation completes successfully
+
+4. **Handle Errors**:
+   
+   If setup fails, the script will:
+   - Display specific error message (e.g., "NFD pods not ready", "Helm install failed")
+   - Show relevant diagnostic information (pod logs, resource status)
+   - Exit with non-zero status
+   
+   Present error details to the user and suggest next steps (e.g., check cluster logs, verify prerequisites)
+
+5. **Report Completion**:
+   
+   When setup completes successfully, the script outputs:
+   - Summary of what was installed
+   - Verification of DRA resources (DeviceClasses, ResourceSlices)
+   - Suggested next command: `/dra-ocp-validator:test`
+   
+   Present this summary to the user.
+
+## Arguments
+
+### Required
+- `kubeconfig-path` - Path to cluster kubeconfig file
+
+### Optional
+- `--driver <nvidia|amd|example>` - Driver to install (default: auto-detect based on hardware)
+
+- `--enable-dynamic-mig` - **Enable DRAPartitionableDevices testing** (does TWO things):
+  1. **OCP cluster**: Enables DRAPartitionableDevices feature gate via CustomNoUpgrade
+  2. **Driver**: Configures driver with partition support
+     - NVIDIA: Sets DYNAMIC_MIG=true
+     - Example: Sets gpuPartitions=4
+  
+  **IMPORTANT**: Only use this flag if you plan to test partitionable devices. Without it:
+  - OCP feature gate remains disabled
+  - Driver installed without partition support  
+  - Partitionable device tests will be skipped
+  
+- `--driver-version <version>` - Specific driver version (default: latest/recommended)
+
+## Return Value
+- **Success**: Installation completed, DRA driver ready
+- **Failure**: Installation error with diagnostic information
+
+## Examples
+
+### Example 1: Setup NVIDIA stack with MIG support
+```
+/dra-ocp-validator:setup ~/clusters/gb300/kubeconfig --driver nvidia --enable-dynamic-mig
+```
+
+**Output:**
+```
+✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
+✓ Hardware detected: 4x NVIDIA GB300
+✓ Installing NFD...
+✓ Installing NVIDIA GPU Operator...
+✓ Installing NVIDIA DRA Driver (DYNAMIC_MIG=true)...
+✓ DeviceClass created: mig.nvidia.com
+✓ ResourceSlices created: 4
+✓ MIG devices found: 16
+
+Setup complete! Ready for testing.
+Run: /dra-ocp-validator:test ~/clusters/gb300/kubeconfig
+```
+
+### Example 2: Setup without physical GPUs
+```
+/dra-ocp-validator:setup ~/clusters/test/kubeconfig --driver example
+```
+
+**Output:**
+```
+✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
+⚠ No GPUs detected - using dra-example-driver
+✓ Installing dra-example-driver...
+✓ DeviceClass created: example.com
+✓ ResourceSlices created: 2
+
+Setup complete! Ready for testing.
+```
+
+### Example 3: Setup with specific driver version
+```
+/dra-ocp-validator:setup ~/kubeconfig --driver nvidia --driver-version 580.126.20 --enable-dynamic-mig
+```
+
+## Notes
+- Setup requires cluster-admin privileges
+- Installation can take 5-10 minutes depending on cluster size and image pull times
+- NFD is always installed (or verified if already present) - it's required for hardware detection
+- NFD installation does NOT require cluster restart - it uses DaemonSets that roll out automatically
+- GPU operator and DRA driver installations wait for all pods to be Ready before completing
+- If installation fails, diagnostic logs are displayed
+- Use `/dra-ocp-validator:cleanup` to uninstall (removes driver + operator by default, preserves NFD)
+
+## See Also
+- `/dra-ocp-validator:validate` - Full validation (setup + test + report)
+- `/dra-ocp-validator:test` - Run tests only (assumes setup done)
+- `/dra-ocp-validator:cleanup` - Clean up test resources and drivers

--- a/plugins/dra-ocp-validator/commands/test.md
+++ b/plugins/dra-ocp-validator/commands/test.md
@@ -1,0 +1,296 @@
+---
+description: Run DRA feature tests on a cluster with prerequisites already installed
+argument-hint: "<kubeconfig-path> [options]"
+---
+
+## Name
+dra-ocp-validator:test
+
+## Synopsis
+```
+/dra-ocp-validator:test <kubeconfig-path> [options]
+```
+
+## Description
+The `dra-ocp-validator:test` command runs DRA feature validation tests on a cluster where the DRA driver and GPU operator have already been installed (via `/dra-ocp-validator:setup` or manually).
+
+This is useful when you want to:
+- Re-run tests after fixing issues
+- Test a subset of features
+- Run tests on a pre-configured cluster
+- Validate after cluster or driver configuration changes
+
+The command performs:
+1. Cluster access verification
+2. DRA driver readiness check (DeviceClass, ResourceSlice)
+3. K8s version detection and feature availability mapping
+4. CDMM detection (Grace-Blackwell) for MIG test skipping
+5. Feature gate validation (Alpha features only)
+6. Test execution for selected features
+7. Artifact collection and report generation
+
+## Implementation
+
+This command executes comprehensive DRA feature tests on a cluster where the DRA driver has already been installed. Tests are selected based on K8s version and feature gates.
+
+### Steps
+
+1. **Parse and Validate Arguments**:
+   - Extract kubeconfig path from first positional argument (required)
+   - Parse optional flags: `--features`, `--output-dir`
+   - Expand tilde (`~`) to `$HOME` in paths
+   - Verify kubeconfig file exists
+
+2. **Execute Test Runner Script**:
+   
+   Use the Bash tool to run the plugin's test runner script:
+   
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/run-tests.sh"
+   
+   # Pass all arguments to test script
+   ${SCRIPT} "$@"
+   ```
+   
+   The test script performs these steps automatically:
+   
+   a. **Cluster Validation**:
+      - Verify cluster connectivity
+      - Check DRA driver is installed (DeviceClass and ResourceSlice resources exist)
+      - Detect cluster K8s version (1.32-1.36)
+      - Verify cluster-admin access for test operations
+   
+   b. **Feature Selection**:
+      - Parse `--features` flag or use defaults (all Beta features)
+      - Map features to their graduation level for this K8s version
+      - Filter out features unavailable on this K8s version
+      - Check CDMM status for MIG test skipping (Grace-Blackwell systems)
+   
+   c. **Feature Gate Validation** (Alpha features only):
+      - Query cluster FeatureGate status
+      - Skip Alpha features if their feature gate is not enabled
+      - Provide enablement command in skip message
+   
+   d. **Test Execution**:
+      - For each feature in the selected list:
+        - Create timestamped test directory in output-dir
+        - Execute corresponding test script from `tests/` directory
+        - Capture test output and pod logs
+        - Mark result as PASS, FAIL, or SKIP
+      - Test scripts are self-contained and validate specific DRA functionality
+   
+   e. **Artifact Collection**:
+      - Run `tools/collect-artifacts.sh` to gather:
+        - All test logs
+        - Pod manifests and logs
+        - DeviceClass and ResourceSlice definitions
+        - Cluster diagnostics
+      - Package artifacts into tarball
+   
+   f. **Report Generation**:
+      - Generate markdown validation report with:
+        - Cluster details (version, nodes, GPU info)
+        - Test results summary (PASS/FAIL/SKIP counts)
+        - Per-feature test details
+        - Recommendations for failed tests
+      - Write report to output directory
+
+3. **Monitor Progress**:
+   
+   The script outputs progress messages during test execution. Present these to the user to show:
+   - Which tests are being run
+   - Test execution status (running, passed, failed, skipped)
+   - Reasons for skipped tests
+   - Where artifacts are being collected
+
+4. **Handle Test Failures**:
+   
+   If tests fail, the script will:
+   - Display which tests failed
+   - Show relevant error messages from test logs
+   - Continue running remaining tests (fail-fast is not used)
+   - Exit with non-zero status if any test failed
+   
+   Present failure details to the user and suggest:
+   - Running `/dra-ocp-validator:analyze` to diagnose failures
+   - Checking the generated report for detailed failure information
+   - Reviewing test logs in the output directory
+
+5. **Report Completion**:
+   
+   When all tests complete, the script outputs:
+   - Test results summary (X/Y PASS, Z SKIP, W FAIL)
+   - Path to generated report
+   - Path to artifact tarball
+   - Suggested next steps
+   
+   Present this summary to the user.
+
+## Arguments
+
+### Required
+- `kubeconfig-path` - Path to cluster kubeconfig file
+
+### Optional
+- `--features <list>` - Comma-separated features to test (default: all Beta features)
+  - `partitionable` - DRA Partitionable Devices (KEP-4815)
+  - `admin-access` - DRA Admin Access
+  - `prioritized-list` - DRA Prioritized List (KEP-4816)
+  - `podresources-api` - PodResources API for DRA
+  - `device-taints` - Device Taints (Alpha in K8s 1.34-1.35, Beta in 1.36+)
+  - `extended-resources` - Extended Resources (requires K8s 1.35+)
+  - `all` - All Beta features available for this K8s version
+- `--output-dir <path>` - Output directory for artifacts (default: ./dra-validation-<timestamp>)
+
+## Return Value
+- **Success**: All tests passed or skipped with valid reasons
+- **Failure**: One or more tests failed
+
+Test results summary:
+- ✅ PASS - Feature validated successfully
+- ⚠️ SKIP - Feature skipped (reason provided)
+- ❌ FAIL - Feature validation failed
+
+## Examples
+
+### Example 1: Run all Beta tests
+```
+/dra-ocp-validator:test ~/kubeconfig
+```
+
+**Output:**
+```
+✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
+✓ DRA driver ready (DeviceClass: mig.nvidia.com, ResourceSlices: 4)
+✓ Available features: partitionable, admin-access, prioritized-list, podresources-api
+✓ CDMM disabled - MIG tests can run
+
+Running tests:
+  ✅ Partitionable Devices: PASS (4 pods scheduled, SharedCounters verified)
+  ✅ Admin Access: PASS (namespace enforcement validated)
+  ✅ Prioritized List: PASS (scheduler preference confirmed)
+  ✅ PodResources API: PASS (claim status populated)
+
+✓ Artifacts collected: ./dra-validation-20260603/
+✓ Report generated: ./dra-validation-20260603/DRA-VALIDATION-REPORT.md
+
+Results: 4/4 PASS
+```
+
+### Example 2: Test specific features
+```
+/dra-ocp-validator:test ~/kubeconfig --features partitionable,prioritized-list
+```
+
+**Output:**
+```
+Running tests:
+  ✅ Partitionable Devices: PASS
+  ✅ Prioritized List: PASS
+
+Results: 2/2 PASS
+```
+
+### Example 3: Alpha feature (requires feature gate)
+```
+/dra-ocp-validator:test ~/kubeconfig --features device-taints
+```
+
+**Output:**
+```
+Running tests:
+  ⚠️ Device Taints: SKIP (DRADeviceTaints feature gate not enabled)
+
+To enable:
+  oc patch featuregate cluster --type=merge \
+    -p '{"spec":{"customNoUpgrade":{"enabled":["DRADeviceTaints"]}}}'
+
+Results: 0/1 PASS, 1 SKIP
+```
+
+### Example 4: MIG test with CDMM enabled (auto-skip)
+```
+/dra-ocp-validator:test ~/kubeconfig --features partitionable
+```
+
+**Output:**
+```
+✓ CDMM enabled (2 NUMA nodes detected)
+⚠️ CDMM + MIG incompatible (NVIDIA driver limitation)
+
+Running tests:
+  ⚠️ Partitionable Devices: SKIP (CDMM enabled, MIG unavailable)
+
+Reference: NVIDIA GPU Operator Known Issues
+Results: 0/1 PASS, 1 SKIP
+```
+
+### Example 5: Version-gated feature
+```
+/dra-ocp-validator:test ~/kubeconfig --features extended-resources
+```
+
+**K8s 1.34 Output:**
+```
+Running tests:
+  ⚠️ Extended Resources: SKIP (requires Kubernetes 1.35+, cluster has 1.34.7)
+
+Results: 0/1 PASS, 1 SKIP
+```
+
+## Prerequisites
+- DRA driver must be installed and running
+- DeviceClass and ResourceSlice resources must exist
+- For Alpha features: Required feature gates must be enabled
+- For MIG tests: CDMM must be disabled (auto-detected)
+
+## Test Output Structure
+
+Each test creates a timestamped directory:
+```
+dra-<feature>-<timestamp>/
+├── test-output.log              # Complete test transcript
+├── 00-cluster-version.txt       # Cluster information
+├── 01-nodes.txt                 # Node details
+├── 02-deviceclass-*.yaml        # DeviceClass config
+├── 03-resourceslice-*.json      # ResourceSlice state
+├── test1-manifest.yaml          # Test 1 manifests
+├── test1-allocation.json        # Test 1 device allocation
+├── test2-*                      # Test 2 artifacts
+└── 99-*-final.txt               # Final state captures
+```
+
+## Notes
+- Tests create temporary namespaces (e.g., `dra-partitionable-test`)
+- Each test is independent and can run in parallel
+- Test scripts have comprehensive logging and state capture
+- Failed tests leave resources for debugging
+- Use `/dra-ocp-validator:cleanup` to remove test namespaces
+- Tests require ~5-10 minutes per feature
+- Network policies or security constraints may affect pod scheduling
+
+## Troubleshooting
+
+### DRA driver not found
+```
+ERROR: No DeviceClass found - DRA driver not installed
+```
+**Solution:** Run `/dra-ocp-validator:setup` first
+
+### Feature gate not enabled
+```
+SKIP: Feature requires DRADeviceTaints=true
+```
+**Solution:** Patch FeatureGate (command shown in output)
+
+### CDMM blocks MIG tests
+```
+SKIP: CDMM enabled, MIG unavailable (NVIDIA limitation)
+```
+**Solution:** Accept skip (known limitation) or disable CDMM (not recommended for production)
+
+## See Also
+- `/dra-ocp-validator:validate` - Full validation (setup + test + report)
+- `/dra-ocp-validator:setup` - Install prerequisites only
+- `/dra-ocp-validator:cleanup` - Clean up test resources

--- a/plugins/dra-ocp-validator/commands/test.md
+++ b/plugins/dra-ocp-validator/commands/test.md
@@ -62,15 +62,22 @@ This command executes comprehensive DRA feature tests on a cluster where the DRA
       - Verify cluster-admin access for test operations
    
    b. **Feature Selection**:
-      - Parse `--features` flag or use defaults (all Beta features)
+      - Parse `--features` flag or use defaults (Beta + GA features only)
       - Map features to their graduation level for this K8s version
       - Filter out features unavailable on this K8s version
-      - Check CDMM status for MIG test skipping (Grace-Blackwell systems)
+      - **IMPORTANT**: Default behavior excludes Alpha features
+      - If Alpha features are explicitly requested via `--features`, the test runner will ERROR and require manual feature gate enablement
    
-   c. **Feature Gate Validation** (Alpha features only):
-      - Query cluster FeatureGate status
-      - Skip Alpha features if their feature gate is not enabled
-      - Provide enablement command in skip message
+   c. **Alpha Feature Handling**:
+      - If user requests Alpha features explicitly (e.g., `--features partitionable,device-taints`), the test runner will:
+        - Detect that Alpha features require feature gates
+        - ERROR with detailed message explaining:
+          - Which feature gates are required
+          - OpenShift featureset conflict (TechPreviewNoUpgrade vs CustomNoUpgrade)
+          - Manual steps to enable feature gates
+        - Exit without running tests
+      - User must manually enable feature gates and re-run tests
+      - This prevents automatic featureset conflicts
    
    d. **Test Execution**:
       - For each feature in the selected list:
@@ -133,14 +140,28 @@ This command executes comprehensive DRA feature tests on a cluster where the DRA
 - `kubeconfig-path` - Path to cluster kubeconfig file
 
 ### Optional
-- `--features <list>` - Comma-separated features to test (default: all Beta features)
-  - `partitionable` - DRA Partitionable Devices (KEP-4815)
-  - `admin-access` - DRA Admin Access
-  - `prioritized-list` - DRA Prioritized List (KEP-4816)
-  - `podresources-api` - PodResources API for DRA
-  - `device-taints` - Device Taints (Alpha in K8s 1.34-1.35, Beta in 1.36+)
-  - `extended-resources` - Extended Resources (requires K8s 1.35+)
-  - `all` - All Beta features available for this K8s version
+- `--features <list>` - Comma-separated features to test (default: `all` = Beta + GA only)
+  
+  **Beta/GA Features** (safe to test without manual feature gate setup):
+  - `structured-parameters` - DRA Structured Parameters (GA in K8s 1.34+)
+  - `admin-access` - Namespace Admin Access Control (Beta in K8s 1.34-1.35)
+  - `prioritized-list` - Scheduler Preference Ordering (Beta in K8s 1.34-1.35)
+  - `resource-claim-status` - Enhanced Claim Status (Beta in K8s 1.32+)
+  - `podresources-api` - Kubelet PodResources API (Beta in K8s 1.34+)
+  
+  **Alpha Features** (require manual feature gate enablement - will ERROR if requested):
+  - `partitionable` - GPU Partitioning/MIG Support (Alpha, requires DRAPartitionableDevices gate)
+  - `device-taints` - Automatic Node Tainting (Alpha, requires DRADeviceTaints gate)
+  - `consumable-capacity` - Consumable Resources (Alpha, requires DRAConsumableCapacity gate)
+  - `extended-resources` - Extended Resource Requests (Alpha, requires DRAExtendedResources gate)
+  - `resource-health-status` - Device Health Info (Alpha, requires DRAResourceHealthStatus gate)
+  - `device-binding-conditions` - Enhanced Binding Conditions (Alpha, requires DRADeviceBindingConditions gate)
+  
+  **Special values**:
+  - `all` - All Beta + GA features (excludes Alpha)
+  
+  **⚠️ Important**: Requesting Alpha features will ERROR with instructions to manually enable feature gates
+  
 - `--output-dir <path>` - Output directory for artifacts (default: ./dra-validation-<timestamp>)
 
 ## Return Value
@@ -154,7 +175,7 @@ Test results summary:
 
 ## Examples
 
-### Example 1: Run all Beta tests
+### Example 1: Run all Beta + GA tests (default)
 ```
 /dra-ocp-validator:test ~/kubeconfig
 ```
@@ -162,51 +183,72 @@ Test results summary:
 **Output:**
 ```
 ✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
-✓ DRA driver ready (DeviceClass: mig.nvidia.com, ResourceSlices: 4)
-✓ Available features: partitionable, admin-access, prioritized-list, podresources-api
-✓ CDMM disabled - MIG tests can run
+✓ DRA driver ready (DeviceClass: gpu.example.com, ResourceSlices: 3)
+Default mode: Testing Beta and GA features only
 
 Running tests:
-  ✅ Partitionable Devices: PASS (4 pods scheduled, SharedCounters verified)
+  ✅ Structured Parameters: PASS
   ✅ Admin Access: PASS (namespace enforcement validated)
   ✅ Prioritized List: PASS (scheduler preference confirmed)
+  ✅ Resource Claim Status: PASS
   ✅ PodResources API: PASS (claim status populated)
 
 ✓ Artifacts collected: ./dra-validation-20260603/
 ✓ Report generated: ./dra-validation-20260603/DRA-VALIDATION-REPORT.md
 
-Results: 4/4 PASS
+Results: 5/5 PASS
 ```
 
-### Example 2: Test specific features
+### Example 2: Test specific Beta features
 ```
-/dra-ocp-validator:test ~/kubeconfig --features partitionable,prioritized-list
+/dra-ocp-validator:test ~/kubeconfig --features admin-access,prioritized-list
 ```
 
 **Output:**
 ```
 Running tests:
-  ✅ Partitionable Devices: PASS
+  ✅ Admin Access: PASS
   ✅ Prioritized List: PASS
 
 Results: 2/2 PASS
 ```
 
-### Example 3: Alpha feature (requires feature gate)
+### Example 3: Request Alpha feature (ERROR with instructions)
 ```
-/dra-ocp-validator:test ~/kubeconfig --features device-taints
+/dra-ocp-validator:test ~/kubeconfig --features device-taints,consumable-capacity
 ```
 
 **Output:**
 ```
-Running tests:
-  ⚠️ Device Taints: SKIP (DRADeviceTaints feature gate not enabled)
+❌ ERROR: Alpha features requested but not enabled
 
-To enable:
-  oc patch featuregate cluster --type=merge \
-    -p '{"spec":{"customNoUpgrade":{"enabled":["DRADeviceTaints"]}}}'
+The following Alpha features require feature gate enablement:
+  - device-taints → requires 'DRADeviceTaints' feature gate
+  - consumable-capacity → requires 'DRAConsumableCapacity' feature gate
 
-Results: 0/1 PASS, 1 SKIP
+⚠️  IMPORTANT: OpenShift only allows ONE featureset at a time:
+  - TechPreviewNoUpgrade (for officially supported tech preview features)
+  - CustomNoUpgrade (for upstream Alpha features not in downstream)
+
+You cannot enable features from different featuresets simultaneously.
+
+To enable Alpha features, you must:
+  1. Determine which featureset each feature requires
+  2. Choose features from the SAME featureset
+  3. Enable the feature gate(s) manually via:
+
+     For TechPreviewNoUpgrade (e.g., DRAPartitionableDevices):
+       oc patch featuregate cluster --type=merge \
+         -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}'
+
+     For CustomNoUpgrade (e.g., DRADeviceTaints, DRAConsumableCapacity):
+       oc patch featuregate cluster --type=merge \
+         -p '{"spec":{"customNoUpgrade":{"enabled":["DRADeviceTaints","DRAConsumableCapacity"]}}}'
+
+  4. Re-run setup if driver configuration is needed:
+       /dra-ocp-validator:setup ~/kubeconfig [--enable-dynamic-mig]
+
+  5. Re-run tests with the same --features flag
 ```
 
 ### Example 4: MIG test with CDMM enabled (auto-skip)

--- a/plugins/dra-ocp-validator/commands/validate.md
+++ b/plugins/dra-ocp-validator/commands/validate.md
@@ -1,0 +1,258 @@
+---
+description: Complete DRA validation (setup + test + report) on OpenShift clusters
+argument-hint: "<kubeconfig-path> [options]"
+---
+
+## Name
+dra-ocp-validator:validate
+
+## Synopsis
+```
+/dra-ocp-validator:validate <kubeconfig-path> [options]
+```
+
+## Description
+The `dra-ocp-validator:validate` command performs comprehensive end-to-end validation of Dynamic Resource Allocation (DRA) features on an OpenShift cluster. It combines cluster setup, feature testing, and report generation into a single workflow.
+
+**Complete workflow:**
+1. Verify cluster access and detect hardware
+2. Install prerequisites (NFD, GPU operator, DRA driver)
+3. Determine available DRA features based on K8s version
+4. Check CDMM status and feature gates
+5. Run feature validation tests
+6. Collect artifacts and generate validation report
+7. Package results in tarball for JIRA attachment
+
+This is the recommended command for full DRA validation.
+
+## Implementation
+
+This command executes the complete end-to-end DRA validation workflow, combining setup, testing, and reporting into a single operation. This is a long-running command (10-20 minutes) that performs cluster modifications.
+
+### Steps
+
+1. **Parse and Validate Arguments**:
+   - Extract kubeconfig path from first positional argument (required)
+   - Parse optional flags: `--driver`, `--features`, `--skip-install`, `--enable-dynamic-mig`, `--driver-version`, `--output-dir`
+   - Expand tilde (`~`) to `$HOME` in paths
+   - Verify kubeconfig file exists
+
+2. **Execute Validation Workflow Script**:
+   
+   Use the Bash tool to run the plugin's comprehensive validation script:
+   
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+   SCRIPT="${PLUGIN_ROOT}/tools/validate-dra.sh"
+   
+   # Pass all arguments to validation script
+   ${SCRIPT} "$@"
+   ```
+   
+   The validation script orchestrates the complete workflow:
+   
+   a. **Setup Phase** (unless `--skip-install`):
+      - Verify cluster connectivity and admin access
+      - Detect GPU vendor from NFD labels (or use `--driver` flag)
+      - Install NFD if not present
+      - Install appropriate DRA driver stack:
+        - NVIDIA: GPU Operator + NVIDIA DRA Driver
+        - Example: dra-example-driver (software-only)
+      - Enable feature gates if `--enable-dynamic-mig` specified
+      - Verify driver installation (DeviceClass, ResourceSlice)
+   
+   b. **Pre-Test Checks**:
+      - Detect cluster K8s version (1.32-1.36)
+      - Determine available DRA features for this version
+      - Check CDMM status (Grace-Blackwell MIG compatibility)
+      - Validate feature gates for Alpha features
+      - Parse `--features` flag or select all Beta features
+   
+   c. **Test Execution**:
+      - For each selected feature:
+        - Create timestamped test directory
+        - Run corresponding test from `tests/` directory
+        - Capture test output and resource logs
+        - Mark as PASS, FAIL, or SKIP with reason
+      - All tests run to completion (no fail-fast)
+   
+   d. **Artifact Collection & Reporting**:
+      - Collect all test logs and manifests
+      - Gather cluster diagnostics (nodes, GPU info, DRA resources)
+      - Generate comprehensive validation report (markdown)
+      - Package everything into tarball for JIRA attachment
+      - Create summary with next-step recommendations
+
+3. **Monitor Progress**:
+   
+   The script outputs detailed progress throughout the workflow. Present these updates to the user:
+   - Setup phase progress (NFD install, GPU operator install, driver install)
+   - Test execution status (which test is running, results)
+   - Artifact collection progress
+   - Report generation
+   
+   The workflow is long-running (10-20 minutes), so keeping the user informed is important.
+
+4. **Handle Failures**:
+   
+   The script handles failures at each phase:
+   
+   - **Setup failures**: Driver installation errors, operator deployment issues
+     - Displays error diagnostics
+     - Suggests troubleshooting steps
+     - Exits without running tests
+   
+   - **Test failures**: Feature validation failures
+     - Continues running remaining tests
+     - Collects failure logs and diagnostics
+     - Includes failure analysis in report
+     - Exits with non-zero status
+   
+   Present failure details to the user and suggest running `/dra-ocp-validator:analyze` for detailed failure diagnosis.
+
+5. **Report Completion**:
+   
+   When validation completes, the script outputs:
+   - Test results summary (X/Y PASS, Z SKIP, W FAIL)
+   - Path to validation report (markdown)
+   - Path to artifact tarball (for JIRA attachment)
+   - Cleanup command (if needed)
+   - Next steps based on results
+   
+   Present this summary to the user.
+
+## Arguments
+
+### Required
+- `kubeconfig-path` - Path to cluster kubeconfig file
+
+### Optional
+- `--driver <nvidia|amd|example>` - Driver to install (default: auto-detect)
+  - `nvidia` - NVIDIA GPU Operator + DRA driver
+  - `amd` - AMD GPU driver (planned)
+  - `example` - dra-example-driver (no GPU required)
+- `--features <list>` - Comma-separated features to test (default: all Beta)
+  - `partitionable` - DRA Partitionable Devices (KEP-4815)
+  - `admin-access` - DRA Admin Access
+  - `prioritized-list` - DRA Prioritized List (KEP-4816)
+  - `podresources-api` - PodResources API
+  - `device-taints` - Device Taints (Alpha/Beta)
+  - `extended-resources` - Extended Resources (K8s 1.35+)
+  - `all` - All Beta features for this K8s version
+- `--skip-install` - Skip driver/operator installation (assumes already installed)
+- `--enable-dynamic-mig` - Enable DynamicMIG feature gate (required for Partitionable Devices)
+- `--driver-version <version>` - Specific driver version (default: 580.126.20)
+- `--output-dir <path>` - Output directory (default: ./dra-validation-<timestamp>)
+
+## Return Value
+- **Success**: All requested features validated or skipped with valid reasons
+- **Failure**: One or more features failed validation
+
+## Examples
+
+### Example 1: Full validation on NVIDIA cluster with MIG
+```
+/dra-ocp-validator:validate ~/clusters/a100/kubeconfig \
+  --driver nvidia \
+  --enable-dynamic-mig
+```
+
+**Output:**
+```
+✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
+✓ Hardware detected: 2x NVIDIA A100-SXM4-40GB
+✓ Installing NFD...
+✓ Installing NVIDIA GPU Operator...
+✓ Installing NVIDIA DRA Driver (DYNAMIC_MIG=true)...
+✓ MIG devices found: 14
+✓ CDMM disabled - MIG tests can run
+
+Running tests:
+  ✅ Partitionable Devices: PASS
+  ✅ Admin Access: PASS
+  ✅ Prioritized List: PASS
+  ✅ PodResources API: PASS
+
+✓ Artifacts collected: ./dra-validation-20260603/
+✓ Report generated: ./dra-validation-20260603/DRA-VALIDATION-REPORT.md
+✓ Tarball created: ./dra-validation-20260603.tar.gz (2.3M)
+
+Results: 4/4 Beta features VALIDATED
+```
+
+### Example 2: Validation without physical GPUs
+```
+/dra-ocp-validator:validate ~/kubeconfig \
+  --driver example \
+  --features admin-access,prioritized-list
+```
+
+**Output:**
+```
+✓ Cluster accessible (OCP 4.21.16, K8s 1.34.7)
+⚠ No GPUs detected - using dra-example-driver
+✓ Installing dra-example-driver...
+✓ ResourceSlices created: 2
+
+Running tests:
+  ✅ Admin Access: PASS
+  ✅ Prioritized List: PASS
+
+Results: 2/2 VALIDATED
+```
+
+### Example 3: Test specific features on pre-configured cluster
+```
+/dra-ocp-validator:validate ~/kubeconfig \
+  --skip-install \
+  --features partitionable,admin-access
+```
+
+### Example 4: Custom output directory
+```
+/dra-ocp-validator:validate ~/kubeconfig \
+  --driver nvidia \
+  --enable-dynamic-mig \
+  --output-dir ./validation-results-$(date +%Y%m%d)
+```
+
+## Prerequisites
+- Cluster admin access
+- Internet connectivity for pulling images
+- Local tools: `oc`, `kubectl`, `helm`, `jq`
+
+## Notes
+- Full validation can take 20-30 minutes depending on cluster size
+- Test namespaces are created: `dra-*-test`
+- Alpha features require feature gates to be enabled
+- CDMM detection auto-skips MIG tests on Grace-Blackwell
+- Use `/dra-ocp-validator:cleanup` to remove test resources after validation
+
+## Troubleshooting
+
+### Driver installation fails
+```
+ERROR: Helm release failed
+```
+**Solution:** Check cluster permissions and network connectivity
+```bash
+oc auth can-i create namespace
+helm repo list
+```
+
+### Feature gate not enabled
+```
+SKIP: DRADeviceTaints requires feature gate
+```
+**Solution:** Enable feature gate (shown in output) or skip Alpha features
+
+### CDMM blocks MIG tests
+```
+SKIP: Partitionable Devices (CDMM enabled)
+```
+**Solution:** This is expected on Grace-Blackwell with CDMM. Test non-MIG features instead.
+
+## See Also
+- `/dra-ocp-validator:setup` - Install prerequisites only
+- `/dra-ocp-validator:test` - Run tests on pre-configured cluster
+- `/dra-ocp-validator:cleanup` - Clean up test resources

--- a/plugins/dra-ocp-validator/dra-features.yaml
+++ b/plugins/dra-ocp-validator/dra-features.yaml
@@ -1,0 +1,755 @@
+# DRA Features Metadata
+# Single source of truth for DRA feature requirements, versions, and configuration
+#
+# This file defines:
+# - K8s/OCP version requirements for each DRA feature
+# - Feature gate names and default status per version
+# - Driver prerequisites and configuration
+# - Setup flags and test file locations
+#
+# Source: https://docs.google.com/presentation/d/1COH8dG8qZ9jEMXzQVdco74XmroZQTMYcUgwAES8FYWU/
+
+version: "1.1"
+last_updated: "2026-06-05"
+
+features:
+
+  # ============================================
+  # KEP-4831: Structured Parameters
+  # ============================================
+  structured-parameters:
+    name: "Structured Parameters"
+    description: "DRA: Structured Parameters for device allocation requests"
+    kep: "KEP-4831"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4831-dra-structured-parameters"
+
+    kubernetes:
+      introduced: "1.32"
+      alpha: []
+      beta: ["1.32", "1.33"]
+      ga: "1.34"
+
+    openshift:
+      min_version: "4.19"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: null  # GA in 1.34+, always enabled
+
+    prerequisites: []
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-structured-parameters.sh"
+      namespaces_created: ["dra-structured-params-test"]
+      cleanup_pattern: "dra-structured-params-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5018: Namespace Controlled Admin Access
+  # ============================================
+  admin-access:
+    name: "Namespace Controlled Admin Access"
+    description: "Namespace-based admin access control for device allocation"
+    kep: "KEP-5018"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5018-dra-admin-access"
+
+    kubernetes:
+      introduced: "1.33"
+      alpha: ["1.33"]
+      beta: ["1.34", "1.35"]
+      ga: "1.36"
+
+    openshift:
+      min_version: "4.20"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: null  # Beta by default in 1.34+
+
+    prerequisites: []
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-admin-access.sh"
+      namespaces_created: ["dra-no-admin", "dra-with-admin"]
+      cleanup_pattern: "dra-(no|with)-admin"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-4816: Prioritized Alternatives in Device Requests
+  # ============================================
+  prioritized-list:
+    name: "Prioritized Alternatives in Device Requests"
+    description: "Scheduler preference ordering for device allocation (KEP-4816)"
+    kep: "KEP-4816"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4816-dra-prioritized-list"
+
+    kubernetes:
+      introduced: "1.33"
+      alpha: ["1.33"]
+      beta: ["1.34", "1.35"]
+      ga: "1.36"
+
+    openshift:
+      min_version: "4.20"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: null  # Beta by default in 1.34+
+
+    prerequisites: []
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-prioritized-list.sh"
+      namespaces_created: ["dra-prioritized-test"]
+      cleanup_pattern: "dra-prioritized-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-4817: Resource Claim Status
+  # ============================================
+  resource-claim-status:
+    name: "Resource Claim Status"
+    description: "Enhanced status reporting for ResourceClaim objects"
+    kep: "KEP-4817"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4817-dra-claim-status"
+
+    kubernetes:
+      introduced: "1.32"
+      alpha: ["1.32"]
+      beta: ["1.33", "1.34", "1.35", "1.36"]
+      ga: null  # Still in beta as of 1.36
+
+    openshift:
+      min_version: "4.19"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: null  # Beta by default in 1.33+
+
+    prerequisites: []
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-claim-status.sh"
+      namespaces_created: ["dra-claim-status-test"]
+      cleanup_pattern: "dra-claim-status-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5004: Extended Resource Requests via DRA
+  # ============================================
+  extended-resources:
+    name: "Extended Resource Requests via DRA"
+    description: "Additional resource attributes beyond basic device allocation"
+    kep: "KEP-5004"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5004-dra-extended-resources"
+
+    kubernetes:
+      introduced: "1.34"
+      alpha: ["1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.21"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAExtendedResources"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAExtendedResources"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.34"
+        error_message: "Extended Resources requires Kubernetes 1.34+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRAExtendedResources"
+        check_method: "featuregate_enabled"
+        error_message: "DRAExtendedResources feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-extended-resources.sh"
+      namespaces_created: ["dra-extended-test"]
+      cleanup_pattern: "dra-extended-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5055: Device Taints and Tolerations
+  # ============================================
+  device-taints:
+    name: "Device Taints and Tolerations"
+    description: "Automatic node tainting based on device health"
+    kep: "KEP-5055"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5055-dra-device-taints"
+
+    kubernetes:
+      introduced: "1.33"
+      alpha: ["1.33", "1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.20"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: "DRADeviceTaints"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRADeviceTaints"]}}}'
+
+    prerequisites:
+      - type: "feature_gate"
+        name: "DRADeviceTaints"
+        check_method: "featuregate_enabled"
+        error_message: "DRADeviceTaints feature gate not enabled (Alpha feature)"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-device-taints.sh"
+      namespaces_created: ["dra-taints-test"]
+      cleanup_pattern: "dra-taints-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5075: Consumable Capacity
+  # ============================================
+  consumable-capacity:
+    name: "Consumable Capacity"
+    description: "Support for consumable resources that can be shared across pods"
+    kep: "KEP-5075"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5075-dra-consumable-capacity"
+
+    kubernetes:
+      introduced: "1.34"
+      alpha: ["1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.21"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAConsumableCapacity"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAConsumableCapacity"]}}}'
+
+    prerequisites:
+      - type: "feature_gate"
+        name: "DRAConsumableCapacity"
+        check_method: "featuregate_enabled"
+        error_message: "DRAConsumableCapacity feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-consumable-capacity.sh"
+      namespaces_created: ["dra-consumable-test"]
+      cleanup_pattern: "dra-consumable-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-4815: Partitionable Devices
+  # ============================================
+  partitionable:
+    name: "Partitionable Devices"
+    description: "Support for GPU partitioning via SharedCounters (e.g., NVIDIA MIG)"
+    kep: "KEP-4815"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4815-dra-partitionable"
+
+    kubernetes:
+      introduced: "1.33"
+      alpha: ["1.33", "1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.20"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: "DRAPartitionableDevices"
+      enablement:
+        command: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAPartitionableDevices"]}}}'
+
+    prerequisites:
+      - type: "feature_gate"
+        name: "DRAPartitionableDevices"
+        check_method: "featuregate_enabled"
+        error_message: "DRAPartitionableDevices feature gate not enabled (use --enable-dynamic-mig during setup)"
+
+      - type: "driver_capability"
+        capability: "partitioning_support"
+        check_method: "resourceslice_has_sharedcounters"
+        description: "Driver must have partition support (SharedCounters in ResourceSlices)"
+        error_message: "Driver does not have partition support (reinstall with --enable-dynamic-mig)"
+
+    setup:
+      flags: ["--enable-dynamic-mig"]
+
+      driver_config:
+        nvidia:
+          type: "helm_values"
+          values:
+            env:
+              DYNAMIC_MIG: "true"
+          description: "Enables NVIDIA MIG (Multi-Instance GPU) dynamic partitioning"
+
+        example:
+          type: "helm_values"
+          values:
+            kubeletPlugin:
+              gpuPartitions: 4
+          description: "Configures example driver with 4 simulated GPU partitions"
+
+    test:
+      script: "tests/test-dra-partitionable.sh"
+      namespaces_created: ["dra-e2e-test"]
+      cleanup_pattern: "dra-e2e-test"
+      estimated_duration: "5-10 minutes"
+
+
+  # ============================================
+  # KEP-4680: Resource Health Status in Pod Status
+  # ============================================
+  resource-health-status:
+    name: "Resource Health Status in Pod Status"
+    description: "Device health information exposed in Pod status"
+    kep: "KEP-4680"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4680-dra-health-status"
+
+    kubernetes:
+      introduced: "1.32"
+      alpha: ["1.32", "1.33", "1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.19"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAResourceHealthStatus"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAResourceHealthStatus"]}}}'
+
+    prerequisites:
+      - type: "feature_gate"
+        name: "DRAResourceHealthStatus"
+        check_method: "featuregate_enabled"
+        error_message: "DRAResourceHealthStatus feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-health-status.sh"
+      namespaces_created: ["dra-health-test"]
+      cleanup_pattern: "dra-health-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5007: Device Binding Conditions
+  # ============================================
+  device-binding-conditions:
+    name: "Device Binding Conditions"
+    description: "Enhanced conditions for device binding status"
+    kep: "KEP-5007"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5007-dra-binding-conditions"
+
+    kubernetes:
+      introduced: "1.34"
+      alpha: ["1.34", "1.35"]
+      beta: ["1.36"]
+      ga: null
+
+    openshift:
+      min_version: "4.21"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRADeviceBindingConditions"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRADeviceBindingConditions"]}}}'
+
+    prerequisites:
+      - type: "feature_gate"
+        name: "DRADeviceBindingConditions"
+        check_method: "featuregate_enabled"
+        error_message: "DRADeviceBindingConditions feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-binding-conditions.sh"
+      namespaces_created: ["dra-binding-test"]
+      cleanup_pattern: "dra-binding-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5304: Attributes Downward API
+  # ============================================
+  attributes-downward-api:
+    name: "Attributes Downward API"
+    description: "Expose device attributes via Downward API to containers"
+    kep: "KEP-5304"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5304-dra-attributes-downward-api"
+
+    kubernetes:
+      introduced: "1.36"
+      alpha: ["1.36"]
+      beta: []
+      ga: null
+
+    openshift:
+      min_version: "4.23"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAAttributesDownwardAPI"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAAttributesDownwardAPI"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.36"
+        error_message: "Attributes Downward API requires Kubernetes 1.36+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRAAttributesDownwardAPI"
+        check_method: "featuregate_enabled"
+        error_message: "DRAAttributesDownwardAPI feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-attributes-downward-api.sh"
+      namespaces_created: ["dra-downward-api-test"]
+      cleanup_pattern: "dra-downward-api-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5729: ResourceClaim Support for Workloads
+  # ============================================
+  resourceclaim-workloads:
+    name: "ResourceClaim Support for Workloads"
+    description: "Direct ResourceClaim support in workload controllers (Jobs, StatefulSets, etc.)"
+    kep: "KEP-5729"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5729-dra-resourceclaim-workloads"
+
+    kubernetes:
+      introduced: "1.36"
+      alpha: ["1.36"]
+      beta: []
+      ga: null
+
+    openshift:
+      min_version: "4.23"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAResourceClaimWorkloads"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAResourceClaimWorkloads"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.36"
+        error_message: "ResourceClaim Workloads requires Kubernetes 1.36+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRAResourceClaimWorkloads"
+        check_method: "featuregate_enabled"
+        error_message: "DRAResourceClaimWorkloads feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-resourceclaim-workloads.sh"
+      namespaces_created: ["dra-workloads-test"]
+      cleanup_pattern: "dra-workloads-test"
+      estimated_duration: "5-7 minutes"
+
+
+  # ============================================
+  # KEP-5517: Native Resource Requests
+  # ============================================
+  native-resource-requests:
+    name: "Native Resource Requests"
+    description: "Native Kubernetes resource request syntax for DRA devices"
+    kep: "KEP-5517"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5517-dra-native-requests"
+
+    kubernetes:
+      introduced: "1.36"
+      alpha: ["1.36"]
+      beta: []
+      ga: null
+
+    openshift:
+      min_version: "4.23"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRANativeResourceRequests"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRANativeResourceRequests"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.36"
+        error_message: "Native Resource Requests requires Kubernetes 1.36+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRANativeResourceRequests"
+        check_method: "featuregate_enabled"
+        error_message: "DRANativeResourceRequests feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-native-requests.sh"
+      namespaces_created: ["dra-native-test"]
+      cleanup_pattern: "dra-native-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5677: Resource Availability Visibility
+  # ============================================
+  resource-availability:
+    name: "Resource Availability Visibility"
+    description: "Enhanced visibility into device resource availability across the cluster"
+    kep: "KEP-5677"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5677-dra-resource-availability"
+
+    kubernetes:
+      introduced: "1.36"
+      alpha: ["1.36"]
+      beta: []
+      ga: null
+
+    openshift:
+      min_version: "4.23"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAResourceAvailability"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAResourceAvailability"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.36"
+        error_message: "Resource Availability requires Kubernetes 1.36+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRAResourceAvailability"
+        check_method: "featuregate_enabled"
+        error_message: "DRAResourceAvailability feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-resource-availability.sh"
+      namespaces_created: ["dra-availability-test"]
+      cleanup_pattern: "dra-availability-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # KEP-5491: List Types for Attributes
+  # ============================================
+  list-types-attributes:
+    name: "List Types for Attributes"
+    description: "Support for list-type attributes in device specifications"
+    kep: "KEP-5491"
+    status_tracker: "https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5491-dra-list-attributes"
+
+    kubernetes:
+      introduced: "1.36"
+      alpha: ["1.36"]
+      beta: []
+      ga: null
+
+    openshift:
+      min_version: "4.23"
+      max_version: null
+      tested_versions: []
+
+    feature_gate:
+      name: "DRAListTypeAttributes"
+      enablement:
+        openshift: |
+          oc patch featuregate cluster --type=merge \
+            -p '{"spec":{"customNoUpgrade":{"enabled":["DRAListTypeAttributes"]}}}'
+
+    prerequisites:
+      - type: "k8s_version"
+        min_version: "1.36"
+        error_message: "List Types for Attributes requires Kubernetes 1.36+ (cluster has {version})"
+      - type: "feature_gate"
+        name: "DRAListTypeAttributes"
+        check_method: "featuregate_enabled"
+        error_message: "DRAListTypeAttributes feature gate not enabled"
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-list-attributes.sh"
+      namespaces_created: ["dra-list-attrs-test"]
+      cleanup_pattern: "dra-list-attrs-test"
+      estimated_duration: "3-5 minutes"
+
+
+  # ============================================
+  # PodResources API (Enhancement to existing API)
+  # ============================================
+  podresources-api:
+    name: "PodResources API"
+    description: "Kubelet PodResources API support for DRA devices"
+    kep: "Enhancement to existing PodResources API"
+    status_tracker: "https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/"
+
+    kubernetes:
+      introduced: "1.34"
+      alpha: []
+      beta: ["1.34", "1.35", "1.36"]
+      ga: "1.37"
+
+    openshift:
+      min_version: "4.21"
+      max_version: null
+      tested_versions: ["4.21"]
+
+    feature_gate:
+      name: null  # Beta by default
+
+    prerequisites: []
+
+    setup:
+      flags: []
+
+    test:
+      script: "tests/test-dra-podresources-api.sh"
+      namespaces_created: ["dra-podresources-test"]
+      cleanup_pattern: "dra-podresources-test"
+      estimated_duration: "3-5 minutes"
+
+
+# ============================================
+# Check Methods Registry
+# ============================================
+# Defines how to check each prerequisite type
+check_methods:
+
+  featuregate_enabled:
+    description: "Check if a feature gate is enabled in the cluster"
+    implementation: |
+      # Check CustomNoUpgrade first
+      ENABLED=$(oc get featuregate cluster -o json | \
+        jq -r --arg fg "${FEATURE_GATE_NAME}" \
+        '.spec.customNoUpgrade.enabled[]? | select(. == $fg)' || true)
+
+      # Check default FeatureSet
+      if [ -z "${ENABLED}" ]; then
+        ENABLED=$(oc get featuregate cluster -o json | \
+          jq -r --arg fg "${FEATURE_GATE_NAME}" \
+          '.status.featureGates[].enabled[]? | select(.name == $fg).name' || true)
+      fi
+
+      [ -n "${ENABLED}" ]
+
+  resourceslice_has_sharedcounters:
+    description: "Check if ResourceSlices have SharedCounters (partition support)"
+    implementation: |
+      COUNT=$(oc get resourceslice -o json | \
+        jq -r '.items[] | select(.spec.sharedCounters != null) | .metadata.name' | \
+        wc -l || echo "0")
+      [ "${COUNT}" -gt 0 ]
+
+  k8s_version:
+    description: "Check if K8s version meets minimum requirement"
+    implementation: |
+      CURRENT_MINOR=$(echo "${K8S_VERSION}" | sed -E 's/v1\.([0-9]+)\..*/\1/')
+      [ "${CURRENT_MINOR}" -ge "${MIN_VERSION_MINOR}" ]
+
+
+# ============================================
+# Cleanup Patterns
+# ============================================
+# Used by cleanup-dra.sh to identify test namespaces
+cleanup:
+  test_namespace_patterns:
+    - "dra-*-test"
+    - "dra-*-admin"
+
+  driver_namespaces:
+    - "dra-example-driver"
+    - "nvidia-dra-driver"
+    - "dra-nvidia-driver"
+    - "nvidia-gpu-operator"

--- a/plugins/dra-ocp-validator/references/features.md
+++ b/plugins/dra-ocp-validator/references/features.md
@@ -1,0 +1,278 @@
+# DRA Features by Kubernetes Version
+
+Reference for DRA feature maturity levels across Kubernetes/OpenShift versions.
+
+---
+
+## Feature Maturity Matrix
+
+| Feature | K8s 1.33 | K8s 1.34 | K8s 1.35 | K8s 1.36 | KEP | Plugin Flag |
+|---------|----------|----------|----------|----------|-----|-------------|
+| **Partitionable Devices** | Beta | Beta | Beta | Beta | [KEP-4815](https://github.com/kubernetes/enhancements/issues/4815) | `partitionable` |
+| **Admin Access** | Beta | Beta | Beta | Beta | - | `admin-access` |
+| **Prioritized List** | Beta | Beta | Beta | Beta | [KEP-4816](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4816-dra-prioritized-list/README.md) | `prioritized-list` |
+| **PodResources API** | Beta | Beta | Beta | Beta | - | `podresources-api` |
+| **Extended Resources** | - | - | Alpha | Beta | [KEP-5004](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5004-dra-extended-resource/README.md) | `extended-resources` |
+| **Device Taints** | Alpha | Alpha | Alpha | Beta | [KEP-5055](https://github.com/kubernetes/enhancements/issues/5055) | `device-taints` |
+
+---
+
+## OpenShift to Kubernetes Version Mapping
+
+| OCP Version | K8s Version | Default Tested Features |
+|-------------|-------------|-------------------------|
+| OCP 4.20 | 1.33.x | partitionable, admin-access, prioritized-list, podresources-api |
+| OCP 4.21 | 1.34.x | partitionable, admin-access, prioritized-list, podresources-api |
+| OCP 4.22 | 1.35.x | partitionable, admin-access, prioritized-list, podresources-api, extended-resources |
+| OCP 4.23 | 1.36.x | All Beta features |
+
+---
+
+## Feature Descriptions
+
+### 1. Partitionable Devices (KEP-4815)
+
+**Status**: Beta in K8s 1.34+  
+**Feature Gate**: `DRAPartitionableDevices` (enabled by default)  
+**Driver Requirement**: DYNAMIC_MIG=true (NVIDIA)
+
+**What it does:**
+- Allows devices to be partitioned into smaller units
+- Tracks resource consumption via SharedCounters
+- Enables MIG (Multi-Instance GPU) support on NVIDIA
+
+**Example:**
+```yaml
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 1
+```
+
+**Validation:**
+- MIG devices exposed in ResourceSlice
+- SharedCounters track memory slice consumption
+- Pods scheduled with partitioned devices
+
+---
+
+### 2. Admin Access
+
+**Status**: Beta in K8s 1.34+  
+**Feature Gate**: N/A (core Beta feature)
+
+**What it does:**
+- Namespace-level device access control
+- Requires label `resource.kubernetes.io/admin-access=true`
+- Prevents unauthorized admin access to devices
+
+**Example:**
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: mig.nvidia.com
+        adminAccess: true
+        count: 1
+```
+
+**Validation:**
+- Unauthorized namespace: ResourceClaim rejected
+- Authorized namespace (with label): ResourceClaim accepted
+
+---
+
+### 3. Prioritized List (KEP-4816)
+
+**Status**: Beta in K8s 1.34+  
+**Feature Gate**: `DRAPrioritizedList` (enabled by default)
+
+**What it does:**
+- Request multiple device alternatives with preference order
+- Scheduler selects first available option
+- Fallback to secondary options if preferred unavailable
+
+**Example:**
+```yaml
+spec:
+  devices:
+    requests:
+    - name: preferred-large
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+    - name: fallback-small
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 2
+```
+
+**Validation:**
+- Scheduler selects preferred when available
+- Scheduler falls back when preferred exhausted
+- Allocation shows which request was satisfied
+
+---
+
+### 4. PodResources API
+
+**Status**: Beta in K8s 1.34+  
+**Feature Gate**: `DRAPodResourcesAPI` (enabled by default)
+
+**What it does:**
+- Kubelet API for querying DRA resource allocations
+- Socket at `/var/lib/kubelet/pod-resources/kubelet.sock`
+- Provides gRPC API for device monitoring tools
+
+**Example Query:**
+```bash
+# Requires gRPC client
+grpcurl -unix /var/lib/kubelet/pod-resources/kubelet.sock \
+  v1.PodResources/List
+```
+
+**Validation:**
+- Pod.status.resourceClaimStatuses populated
+- Socket accessible on nodes
+- Device allocations queryable
+
+---
+
+### 5. Extended Resources (KEP-5004)
+
+**Status**: Alpha in K8s 1.35, Beta in K8s 1.36  
+**Feature Gate**: `DRAExtendedResources` (Alpha: disabled by default, Beta: enabled)  
+**Availability**: K8s 1.35+ only
+
+**What it does:**
+- Map DRA devices to traditional resource names
+- Backwards compatibility with existing tooling
+- Expose DRA devices via `resources.limits`
+
+**Example:**
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: mig.nvidia.com
+spec:
+  extendedResourceName: nvidia.com/mig-1g.35gb
+```
+
+**Validation:**
+- DeviceClass with extendedResourceName accepted
+- Pods can request via traditional resource name
+- Allocations tracked correctly
+
+---
+
+### 6. Device Taints (KEP-5055)
+
+**Status**: Alpha in K8s 1.33-1.35, Beta in K8s 1.36  
+**Feature Gate**: `DRADeviceTaints` (Alpha: disabled by default, Beta: enabled)
+
+**What it does:**
+- Device-level taints prevent pod scheduling
+- Similar to node taints
+- Pods need tolerations to use tainted devices
+
+**Example:**
+```yaml
+# ResourceSlice with device taint
+spec:
+  devices:
+  - name: gpu-0
+    taints:
+    - key: "special-workload"
+      effect: "NoSchedule"
+      value: "true"
+---
+# Pod with toleration
+spec:
+  tolerations:
+  - key: "special-workload"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+```
+
+**Validation:**
+- Devices can have taints in ResourceSlice
+- Pods without tolerations rejected
+- Pods with tolerations scheduled
+
+---
+
+## Feature Dependencies
+
+### NVIDIA Driver Requirements
+
+| Feature | NVIDIA Driver Requirement |
+|---------|---------------------------|
+| Partitionable Devices | DYNAMIC_MIG=true in driver env |
+| Admin Access | No special requirement |
+| Prioritized List | No special requirement |
+| PodResources API | No special requirement |
+| Extended Resources | K8s 1.35+ API support |
+| Device Taints | Driver must apply taints to ResourceSlice |
+
+### Known Limitations
+
+**CDMM + MIG Incompatibility (NVIDIA Grace-Blackwell):**
+- CDMM enabled → MIG unavailable (driver limitation)
+- Affects: Partitionable Devices feature
+- Detection: NUMA node count check
+- Workaround: Plugin auto-skips MIG tests when CDMM detected
+
+---
+
+## Testing Strategy
+
+### Beta Features (Default Testing)
+Plugin tests all Beta features by default:
+```bash
+/dra-ocp-validator:validate ~/kubeconfig
+# Tests: partitionable, admin-access, prioritized-list, podresources-api
+```
+
+### Alpha Features (Opt-in Testing)
+Must explicitly request Alpha features:
+```bash
+/dra-ocp-validator:validate ~/kubeconfig --features device-taints
+# Checks if DRADeviceTaints feature gate enabled first
+```
+
+### Version-Gated Features
+Automatically skipped on unsupported K8s versions:
+```bash
+# On K8s 1.34:
+/dra-ocp-validator:validate ~/kubeconfig --features extended-resources
+# → SKIP: requires Kubernetes 1.35+
+```
+
+---
+
+## References
+
+- [Kubernetes DRA Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+- [KEP-4815: Partitionable Devices](https://github.com/kubernetes/enhancements/issues/4815)
+- [KEP-4816: Prioritized List](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4816-dra-prioritized-list/README.md)
+- [KEP-5004: Extended Resources](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/5004-dra-extended-resource/README.md)
+- [KEP-5055: Device Taints](https://github.com/kubernetes/enhancements/issues/5055)
+- [Kubernetes v1.36 Release Notes](https://kubernetes.io/blog/2026/03/30/kubernetes-v1-36-sneak-peek/)

--- a/plugins/dra-ocp-validator/templates/nvidia-dra-driver-values.yaml
+++ b/plugins/dra-ocp-validator/templates/nvidia-dra-driver-values.yaml
@@ -1,0 +1,46 @@
+# Helm values for NVIDIA DRA Driver
+# Used by tools/install-nvidia-stack.sh
+
+nfd:
+  enabled: true
+
+devicePlugin:
+  enabled: false
+
+dra:
+  driver:
+    image:
+      repository: nvcr.io/nvidia/cloud-native/k8s-dra-driver
+      tag: v0.6.0
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi
+
+    # Feature gates
+    extraEnv:
+    - name: DYNAMIC_MIG
+      value: "false"  # Set to "true" to enable Partitionable Devices (MIG support)
+    - name: LOG_VERBOSITY
+      value: "4"      # Log level (0-5, higher = more verbose)
+    - name: MASK_NVIDIA_DRIVER_PARAMS
+      value: ""
+    - name: NVIDIA_DRIVER_ROOT
+      value: "/run/nvidia/driver"
+    - name: CDI_ROOT
+      value: "/var/run/cdi"
+
+    # Node selector (optional)
+    # nodeSelector:
+    #   feature.node.kubernetes.io/pci-10de.present: "true"
+
+    # Tolerations (optional)
+    # tolerations:
+    # - key: nvidia.com/gpu
+    #   operator: Exists
+    #   effect: NoSchedule

--- a/plugins/dra-ocp-validator/tests/test-dra-admin-access.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-admin-access.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# DRA Admin Access Validation Test (Fixed)
+# Tests namespace-level device access control
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-admin-access-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Admin Access Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: DRA Admin Access (Beta)"
+echo ""
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ===" 
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+echo ""
+
+#==============================================
+# Phase 1: Unauthorized Namespace
+#==============================================
+echo "=== PHASE 1: Unauthorized Namespace ==="
+NAMESPACE_UNAUTH="dra-no-admin"
+
+oc create namespace ${NAMESPACE_UNAUTH}
+echo "Created namespace without admin-access label"
+echo ""
+
+echo "--- Attempting ResourceClaim with adminAccess=true ---"
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f - 2>&1 | tee ${LOG_DIR}/test1-result.txt || true
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-admin-test
+  namespace: ${NAMESPACE_UNAUTH}
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: mig.nvidia.com
+        adminAccess: true
+        count: 1
+EOF
+
+APPLY1_CODE=${PIPESTATUS[2]}
+echo ""
+
+if [ ${APPLY1_CODE} -ne 0 ]; then
+    echo "✅ PASS: Unauthorized namespace rejected adminAccess claim"
+    cat ${LOG_DIR}/test1-result.txt
+else
+    echo "⚠ Claim accepted (unexpected)"
+fi
+echo ""
+
+echo "--- Testing Regular Claim (no adminAccess) ---"
+cat <<EOF | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-regular
+  namespace: ${NAMESPACE_UNAUTH}
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: mig.nvidia.com
+        count: 1
+EOF
+
+sleep 2
+oc get resourceclaim claim-regular -n ${NAMESPACE_UNAUTH} -o yaml > ${LOG_DIR}/test1-regular-claim.yaml
+echo "✅ Regular claim created successfully"
+echo ""
+
+#==============================================
+# Phase 2: Authorized Namespace
+#==============================================
+echo "=== PHASE 2: Authorized Namespace ==="
+NAMESPACE_AUTH="dra-with-admin"
+
+oc create namespace ${NAMESPACE_AUTH}
+oc label namespace ${NAMESPACE_AUTH} "resource.kubernetes.io/admin-access=true"
+echo "Created namespace WITH admin-access label"
+echo ""
+
+oc get namespace ${NAMESPACE_AUTH} -o yaml | tee ${LOG_DIR}/test2-namespace.yaml | grep -A 10 "labels:"
+echo ""
+
+echo "--- Creating ResourceClaim with adminAccess=true ---"
+cat <<EOF | tee ${LOG_DIR}/test2-claim.yaml | oc apply -f - 2>&1 | tee ${LOG_DIR}/test2-result.txt
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-with-admin
+  namespace: ${NAMESPACE_AUTH}
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: mig.nvidia.com
+        adminAccess: true
+        count: 1
+EOF
+
+APPLY2_CODE=${PIPESTATUS[2]}
+echo ""
+
+if [ ${APPLY2_CODE} -eq 0 ]; then
+    echo "✅ PASS: Authorized namespace accepted adminAccess claim"
+    sleep 2
+    
+    ADMIN_VAL=$(oc get resourceclaim claim-with-admin -n ${NAMESPACE_AUTH} -o jsonpath='{.spec.devices.requests[0].exactly.adminAccess}')
+    echo "adminAccess field value: ${ADMIN_VAL}"
+    
+    if [ "${ADMIN_VAL}" == "true" ]; then
+        echo "✅ adminAccess=true preserved in ResourceClaim"
+    fi
+    
+    oc get resourceclaim claim-with-admin -n ${NAMESPACE_AUTH} -o yaml > ${LOG_DIR}/test2-claim-created.yaml
+else
+    echo "❌ FAIL: Claim rejected even with label"
+    cat ${LOG_DIR}/test2-result.txt
+fi
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+echo "Test Results:"
+echo "  Unauthorized namespace: $([ ${APPLY1_CODE} -ne 0 ] && echo 'PASS (rejected)' || echo 'FAIL (accepted)')"
+echo "  Authorized namespace:   $([ ${APPLY2_CODE} -eq 0 ] && echo 'PASS (accepted)' || echo 'FAIL (rejected)')"
+echo ""
+
+if [ ${APPLY1_CODE} -ne 0 ] && [ ${APPLY2_CODE} -eq 0 ]; then
+    echo "🎉 DRA ADMIN ACCESS: VALIDATED"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE_UNAUTH}"
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE_AUTH}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete namespace ${NAMESPACE_UNAUTH} ${NAMESPACE_AUTH}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tests/test-dra-binding-conditions.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-binding-conditions.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+# DRA Device Binding Conditions Validation Test
+# Tests enhanced conditions for device binding state
+# Alpha in K8s 1.34+
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-binding-conditions-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Device Binding Conditions Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: Device Binding Conditions (Alpha)"
+echo ""
+
+NAMESPACE="dra-binding-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+DEVICECLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+echo "DeviceClass: ${DEVICECLASS}"
+echo ""
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: ResourceClaim Status Conditions
+#==============================================
+echo "=== PHASE 1: ResourceClaim Status Conditions ==="
+
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-binding-test
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+EOF
+
+echo ""
+sleep 5
+
+# Check for conditions in claim status
+oc get resourceclaim claim-binding-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-claim-unbound.yaml
+
+CONDITIONS=$(oc get resourceclaim claim-binding-test -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+if [ -n "${CONDITIONS}" ] && [ "${CONDITIONS}" != "null" ] && [ "${CONDITIONS}" != "[]" ]; then
+    echo "✅ ResourceClaim has status.conditions field"
+    echo "${CONDITIONS}" | jq '.' > ${LOG_DIR}/test1-conditions-initial.json
+
+    # List condition types
+    echo "Condition types present:"
+    echo "${CONDITIONS}" | jq -r '.[].type' | sed 's/^/  - /'
+else
+    echo "ℹ No conditions in unbound claim (may appear after binding)"
+fi
+echo ""
+
+#==============================================
+# Phase 2: Conditions After Pod Binding
+#==============================================
+echo "=== PHASE 2: Conditions After Device Binding ==="
+
+cat <<EOF | tee ${LOG_DIR}/test2-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-binding-test
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Device bound to pod'; sleep 60"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-binding-test
+EOF
+
+echo ""
+sleep 10
+
+POD_STATUS=$(oc get pod pod-binding-test -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD_STATUS}"
+
+if [ "${POD_STATUS}" == "Running" ] || [ "${POD_STATUS}" == "Succeeded" ]; then
+    echo "✅ Pod scheduled and device bound"
+
+    # Check conditions after binding
+    sleep 5
+    oc get resourceclaim claim-binding-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-claim-bound.yaml
+
+    CONDITIONS_BOUND=$(oc get resourceclaim claim-binding-test -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+
+    if [ -n "${CONDITIONS_BOUND}" ] && [ "${CONDITIONS_BOUND}" != "null" ] && [ "${CONDITIONS_BOUND}" != "[]" ]; then
+        echo "✅ PASS: Conditions present after binding"
+        echo "${CONDITIONS_BOUND}" | jq '.' > ${LOG_DIR}/test2-conditions-bound.json
+
+        echo "Binding conditions:"
+        echo "${CONDITIONS_BOUND}" | jq -r '.[] | "  - \(.type): \(.status) (\(.reason))"'
+
+        # Check for common condition types
+        READY_CONDITION=$(echo "${CONDITIONS_BOUND}" | jq -r '.[] | select(.type == "Ready") | .status')
+        ALLOCATED_CONDITION=$(echo "${CONDITIONS_BOUND}" | jq -r '.[] | select(.type == "Allocated") | .status')
+
+        if [ -n "${READY_CONDITION}" ]; then
+            echo "  Ready condition: ${READY_CONDITION}"
+        fi
+        if [ -n "${ALLOCATED_CONDITION}" ]; then
+            echo "  Allocated condition: ${ALLOCATED_CONDITION}"
+        fi
+    else
+        echo "ℹ No conditions after binding (may not be implemented by driver)"
+    fi
+else
+    echo "❌ FAIL: Pod not running: ${POD_STATUS}"
+    oc describe pod pod-binding-test -n ${NAMESPACE} > ${LOG_DIR}/test2-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 3: Pod Scheduling Conditions
+#==============================================
+echo "=== PHASE 3: Pod Scheduling Conditions ==="
+
+if [ "${POD_STATUS}" == "Running" ] || [ "${POD_STATUS}" == "Succeeded" ]; then
+    # Check pod conditions related to resource claims
+    POD_CONDITIONS=$(oc get pod pod-binding-test -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+
+    echo "Pod conditions:"
+    echo "${POD_CONDITIONS}" | jq '.' > ${LOG_DIR}/test3-pod-conditions.json
+    echo "${POD_CONDITIONS}" | jq -r '.[] | "  - \(.type): \(.status)"'
+
+    # Check for PodScheduled condition
+    SCHEDULED_CONDITION=$(echo "${POD_CONDITIONS}" | jq -r '.[] | select(.type == "PodScheduled")')
+    if [ -n "${SCHEDULED_CONDITION}" ]; then
+        echo ""
+        echo "PodScheduled condition details:"
+        echo "${SCHEDULED_CONDITION}" | jq '.'
+
+        SCHED_REASON=$(echo "${SCHEDULED_CONDITION}" | jq -r '.reason')
+        SCHED_MESSAGE=$(echo "${SCHEDULED_CONDITION}" | jq -r '.message')
+
+        echo "  Reason: ${SCHED_REASON}"
+        if [ -n "${SCHED_MESSAGE}" ] && [ "${SCHED_MESSAGE}" != "null" ]; then
+            echo "  Message: ${SCHED_MESSAGE}"
+        fi
+    fi
+fi
+echo ""
+
+#==============================================
+# Phase 4: Failure Scenario - Invalid Selector
+#==============================================
+echo "=== PHASE 4: Conditions on Allocation Failure ==="
+
+cat <<EOF | tee ${LOG_DIR}/test4-claim-invalid.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-invalid-selector
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        selectors:
+        - cel:
+            expression: "device.name == 'nonexistent-device-12345'"
+        count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test4-pod-failing.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-binding-fail
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "sleep 60"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-invalid-selector
+EOF
+
+echo ""
+sleep 15
+
+# Check pod and claim conditions for failure case
+FAIL_POD_STATUS=$(oc get pod pod-binding-fail -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Failing Pod Status: ${FAIL_POD_STATUS}"
+
+if [ "${FAIL_POD_STATUS}" == "Pending" ]; then
+    echo "✅ Pod pending as expected (device not available)"
+
+    # Check pod conditions for scheduling failure
+    FAIL_POD_CONDITIONS=$(oc get pod pod-binding-fail -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+    echo "${FAIL_POD_CONDITIONS}" | jq '.' > ${LOG_DIR}/test4-fail-pod-conditions.json
+
+    SCHED_FAIL=$(echo "${FAIL_POD_CONDITIONS}" | jq -r '.[] | select(.type == "PodScheduled" and .status == "False")')
+    if [ -n "${SCHED_FAIL}" ]; then
+        echo "✅ PodScheduled=False condition present"
+
+        FAIL_REASON=$(echo "${SCHED_FAIL}" | jq -r '.reason')
+        FAIL_MESSAGE=$(echo "${SCHED_FAIL}" | jq -r '.message')
+
+        echo "  Reason: ${FAIL_REASON}"
+        echo "  Message: ${FAIL_MESSAGE}"
+    fi
+
+    # Check claim conditions
+    FAIL_CLAIM_CONDITIONS=$(oc get resourceclaim claim-invalid-selector -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+    if [ -n "${FAIL_CLAIM_CONDITIONS}" ] && [ "${FAIL_CLAIM_CONDITIONS}" != "null" ] && [ "${FAIL_CLAIM_CONDITIONS}" != "[]" ]; then
+        echo ""
+        echo "ResourceClaim conditions on failure:"
+        echo "${FAIL_CLAIM_CONDITIONS}" | jq '.' > ${LOG_DIR}/test4-fail-claim-conditions.json
+        echo "${FAIL_CLAIM_CONDITIONS}" | jq -r '.[] | "  - \(.type): \(.status) - \(.message)"'
+    fi
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+oc get pods -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-pods-full.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+HAS_CLAIM_CONDITIONS=$([ -n "${CONDITIONS_BOUND}" ] && [ "${CONDITIONS_BOUND}" != "null" ] && [ "${CONDITIONS_BOUND}" != "[]" ] && echo "YES" || echo "NO")
+HAS_FAIL_CONDITIONS=$([ -n "${FAIL_CLAIM_CONDITIONS}" ] && [ "${FAIL_CLAIM_CONDITIONS}" != "null" ] && [ "${FAIL_CLAIM_CONDITIONS}" != "[]" ] && echo "YES" || echo "NO")
+
+echo "Test Results:"
+echo "  Pod Status (success):       ${POD_STATUS}"
+echo "  Claim conditions (bound):   ${HAS_CLAIM_CONDITIONS}"
+echo "  Pod Status (failure):       ${FAIL_POD_STATUS}"
+echo "  Claim conditions (failed):  ${HAS_FAIL_CONDITIONS}"
+echo ""
+
+if [ "${POD_STATUS}" == "Running" ]; then
+    echo "🎉 DRA DEVICE BINDING CONDITIONS: VALIDATED"
+    echo ""
+    echo "Note: Binding conditions provide enhanced state tracking:"
+    echo "  - ResourceClaim.status.conditions tracks allocation state"
+    echo "  - Pod.status.conditions tracks scheduling with DRA"
+    echo "  - Failure conditions help diagnose allocation issues"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tests/test-dra-claim-status.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-claim-status.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+# DRA ResourceClaim Status Validation Test
+# Tests enhanced status reporting for ResourceClaim objects (KEP-4817)
+# Beta in K8s 1.33+
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-claim-status-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA ResourceClaim Status Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: ResourceClaim Status (Beta - KEP-4817)"
+echo ""
+
+NAMESPACE="dra-claim-status-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+DEVICECLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+echo "DeviceClass: ${DEVICECLASS}"
+echo ""
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Basic ResourceClaim Status Fields
+#==============================================
+echo "=== PHASE 1: ResourceClaim Status Fields ==="
+
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-status-test
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+EOF
+
+echo ""
+sleep 5
+
+# Check initial status
+oc get resourceclaim claim-status-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-claim-initial.yaml
+
+# Verify status structure
+STATUS=$(oc get resourceclaim claim-status-test -n ${NAMESPACE} -o jsonpath='{.status}')
+if [ -n "${STATUS}" ]; then
+    echo "✅ ResourceClaim has status field"
+    echo "${STATUS}" | jq '.' > ${LOG_DIR}/test1-status-initial.json
+else
+    echo "⚠ ResourceClaim status empty (claim not allocated yet)"
+fi
+echo ""
+
+#==============================================
+# Phase 2: Status with Pod Allocation
+#==============================================
+echo "=== PHASE 2: Status After Pod Allocation ==="
+
+cat <<EOF | tee ${LOG_DIR}/test2-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-claim-status
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Testing claim status'; sleep 60"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-status-test
+EOF
+
+echo ""
+sleep 10
+
+# Wait for pod to be scheduled
+POD_STATUS=$(oc get pod pod-claim-status -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD_STATUS}"
+
+if [ "${POD_STATUS}" == "Running" ] || [ "${POD_STATUS}" == "Succeeded" ]; then
+    echo "✅ Pod scheduled successfully"
+
+    # Check allocation status
+    sleep 5
+    ALLOCATION=$(oc get resourceclaim claim-status-test -n ${NAMESPACE} -o jsonpath='{.status.allocation}')
+
+    if [ -n "${ALLOCATION}" ]; then
+        echo "✅ PASS: status.allocation populated"
+        echo "${ALLOCATION}" | jq '.' > ${LOG_DIR}/test2-allocation.json
+
+        # Check allocation.devices.results
+        RESULTS=$(oc get resourceclaim claim-status-test -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results}')
+        if [ -n "${RESULTS}" ] && [ "${RESULTS}" != "null" ]; then
+            echo "✅ PASS: status.allocation.devices.results present"
+            echo "${RESULTS}" | jq '.' > ${LOG_DIR}/test2-results.json
+
+            # Extract allocated device info
+            REQUEST_NAME=$(echo "${RESULTS}" | jq -r '.[0].request')
+            DRIVER=$(echo "${RESULTS}" | jq -r '.[0].driver')
+            POOL=$(echo "${RESULTS}" | jq -r '.[0].pool')
+            DEVICE=$(echo "${RESULTS}" | jq -r '.[0].device')
+
+            echo "  Request: ${REQUEST_NAME}"
+            echo "  Driver: ${DRIVER}"
+            echo "  Pool: ${POOL}"
+            echo "  Device: ${DEVICE}"
+        else
+            echo "❌ FAIL: status.allocation.devices.results missing"
+        fi
+    else
+        echo "❌ FAIL: status.allocation missing"
+    fi
+
+    # Check reserved status
+    RESERVED=$(oc get resourceclaim claim-status-test -n ${NAMESPACE} -o jsonpath='{.status.reserved}')
+    if [ "${RESERVED}" == "true" ]; then
+        echo "✅ PASS: status.reserved=true (claim is in use)"
+    else
+        echo "⚠ WARNING: status.reserved not true"
+    fi
+else
+    echo "❌ FAIL: Pod not running: ${POD_STATUS}"
+    oc describe pod pod-claim-status -n ${NAMESPACE} > ${LOG_DIR}/test2-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 3: Status RBAC Testing
+#==============================================
+echo "=== PHASE 3: Status Subresource RBAC ==="
+
+# Create ServiceAccount for status updates
+SA_NAME="claim-status-updater-sa"
+ROLE_NAME="claim-status-updater-role"
+BINDING_NAME="claim-status-updater-binding"
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${SA_NAME}
+  namespace: ${NAMESPACE}
+EOF
+
+# Create Role with status subresource permissions
+cat <<EOF | tee ${LOG_DIR}/test3-role.yaml | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${ROLE_NAME}
+rules:
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["get", "update", "patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get", "list"]
+EOF
+
+cat <<EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${BINDING_NAME}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${ROLE_NAME}
+subjects:
+- kind: ServiceAccount
+  name: ${SA_NAME}
+  namespace: ${NAMESPACE}
+EOF
+
+echo "✓ RBAC configured for status updates"
+
+# Test that status subresource exists
+TOKEN=$(oc create token ${SA_NAME} -n ${NAMESPACE} --duration=10m)
+API_SERVER=$(oc whoami --show-server)
+
+# Try to get status subresource
+RESPONSE=$(curl -k -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${API_SERVER}/apis/resource.k8s.io/v1/namespaces/${NAMESPACE}/resourceclaims/claim-status-test/status")
+
+echo "Status subresource GET response: ${RESPONSE}"
+
+if [ "${RESPONSE}" == "200" ]; then
+    echo "✅ PASS: resourceclaims/status subresource accessible"
+else
+    echo "⚠ WARNING: Status subresource returned ${RESPONSE}"
+fi
+echo ""
+
+#==============================================
+# Phase 4: Status Conditions
+#==============================================
+echo "=== PHASE 4: Status Conditions ==="
+
+oc get resourceclaim claim-status-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test4-claim-full.yaml
+
+# Check for conditions in status
+CONDITIONS=$(oc get resourceclaim claim-status-test -n ${NAMESPACE} -o jsonpath='{.status.conditions}')
+if [ -n "${CONDITIONS}" ] && [ "${CONDITIONS}" != "null" ]; then
+    echo "✅ status.conditions field present"
+    echo "${CONDITIONS}" | jq '.' > ${LOG_DIR}/test4-conditions.json
+
+    # List condition types
+    CONDITION_TYPES=$(echo "${CONDITIONS}" | jq -r '.[].type')
+    echo "Condition types:"
+    echo "${CONDITION_TYPES}" | sed 's/^/  - /'
+else
+    echo "ℹ No conditions in status (may be normal for simple allocation)"
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim claim-status-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claim-final.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+HAS_ALLOCATION=$([ -n "${ALLOCATION}" ] && echo "YES" || echo "NO")
+HAS_RESULTS=$([ -n "${RESULTS}" ] && [ "${RESULTS}" != "null" ] && echo "YES" || echo "NO")
+RBAC_OK=$([ "${RESPONSE}" == "200" ] && echo "YES" || echo "NO")
+
+echo "Test Results:"
+echo "  Pod Status:              ${POD_STATUS}"
+echo "  status.allocation:       ${HAS_ALLOCATION}"
+echo "  status.allocation.devices.results: ${HAS_RESULTS}"
+echo "  status.reserved:         ${RESERVED:-unknown}"
+echo "  Status subresource:      ${RBAC_OK}"
+echo ""
+
+if [ "${POD_STATUS}" == "Running" ] && [ "${HAS_ALLOCATION}" == "YES" ] && [ "${HAS_RESULTS}" == "YES" ]; then
+    echo "🎉 DRA RESOURCECLAIM STATUS: VALIDATED"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete clusterrolebinding ${BINDING_NAME}"
+echo "  oc delete clusterrole ${ROLE_NAME}"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tests/test-dra-consumable-capacity.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-consumable-capacity.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# DRA Consumable Capacity Validation Test
+# Tests support for consumable resource capacity (memory, bandwidth, etc.)
+# Alpha in K8s 1.34+
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-consumable-capacity-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Consumable Capacity Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: Consumable Capacity (Alpha)"
+echo ""
+
+NAMESPACE="dra-consumable-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+DEVICECLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+echo "DeviceClass: ${DEVICECLASS}"
+echo ""
+
+# Check for feature gate
+echo "Checking for DRAConsumableCapacity feature gate..."
+FEATURE_GATES=$(oc get featuregate cluster -o jsonpath='{.spec.customNoUpgrade.enabled}' 2>/dev/null || echo "[]")
+if echo "${FEATURE_GATES}" | grep -q "DRAConsumableCapacity"; then
+    echo "✓ DRAConsumableCapacity feature gate enabled"
+else
+    echo "⚠ WARNING: DRAConsumableCapacity feature gate may not be enabled"
+    echo "  This is an Alpha feature requiring explicit enablement"
+    echo ""
+    echo "To enable:"
+    echo "  oc patch featuregate cluster --type=merge \\"
+    echo "    -p '{\"spec\":{\"customNoUpgrade\":{\"enabled\":[\"DRAConsumableCapacity\"]}}}'"
+    echo ""
+fi
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Check Device Capacity
+#==============================================
+echo "=== PHASE 1: Device Capacity Information ==="
+
+# Check if any devices have capacity defined
+RESOURCE_SLICES=$(oc get resourceslice -o json)
+echo "${RESOURCE_SLICES}" > ${LOG_DIR}/test1-resourceslices.json
+
+# Look for capacity in device definitions
+CAPACITY_COUNT=$(echo "${RESOURCE_SLICES}" | jq '[.items[].spec.devices[] | select(.capacity != null)] | length')
+echo "Devices with capacity: ${CAPACITY_COUNT}"
+
+if [ "${CAPACITY_COUNT}" -gt 0 ]; then
+    echo "✅ Found devices with capacity definitions"
+
+    # Show first device with capacity
+    DEVICE_WITH_CAPACITY=$(echo "${RESOURCE_SLICES}" | jq -r '.items[].spec.devices[] | select(.capacity != null) | .name' | head -1)
+    echo "Example device: ${DEVICE_WITH_CAPACITY}"
+
+    CAPACITY_INFO=$(echo "${RESOURCE_SLICES}" | jq '.items[].spec.devices[] | select(.name == "'${DEVICE_WITH_CAPACITY}'") | .capacity')
+    echo "Capacity info:"
+    echo "${CAPACITY_INFO}" | jq '.' > ${LOG_DIR}/test1-capacity-example.json
+    echo "${CAPACITY_INFO}" | jq '.'
+else
+    echo "ℹ No devices with capacity found"
+    echo "  Consumable capacity requires driver support"
+    echo "  Example drivers (test-driver, NVIDIA with MIG) may provide capacity"
+fi
+echo ""
+
+#==============================================
+# Phase 2: Capacity Request in ResourceClaim
+#==============================================
+echo "=== PHASE 2: ResourceClaim with Capacity Request ==="
+
+cat <<EOF | tee ${LOG_DIR}/test2-claim-with-capacity.yaml | oc apply -f - 2>&1 | tee ${LOG_DIR}/test2-apply-result.txt || true
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-capacity-request
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device-with-capacity
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+        capacity:
+          requests:
+            memory: "2Gi"
+EOF
+
+CLAIM_CREATED=$?
+echo ""
+
+if [ ${CLAIM_CREATED} -eq 0 ]; then
+    echo "✅ ResourceClaim with capacity request created"
+
+    sleep 5
+    oc get resourceclaim claim-capacity-request -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-claim-full.yaml
+
+    # Verify capacity field preserved
+    CAPACITY_REQ=$(oc get resourceclaim claim-capacity-request -n ${NAMESPACE} -o jsonpath='{.spec.devices.requests[0].exactly.capacity.requests.memory}')
+
+    if [ -n "${CAPACITY_REQ}" ]; then
+        echo "✅ PASS: Capacity request preserved in claim: ${CAPACITY_REQ}"
+    else
+        echo "⚠ Capacity request missing in created claim"
+    fi
+else
+    echo "⚠ ResourceClaim with capacity rejected (expected if feature not enabled)"
+    cat ${LOG_DIR}/test2-apply-result.txt
+fi
+echo ""
+
+#==============================================
+# Phase 3: Multiple Allocations Test
+#==============================================
+echo "=== PHASE 3: Multiple Allocations Consuming Capacity ==="
+
+if [ ${CLAIM_CREATED} -eq 0 ]; then
+    echo "Testing multiple allocations from same device..."
+
+    # Create first pod requesting 2Gi
+    cat <<EOF | tee ${LOG_DIR}/test3-pod1.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-capacity-1
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Using 2Gi capacity'; sleep 60"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-capacity-request
+EOF
+
+    sleep 10
+    POD1_STATUS=$(oc get pod pod-capacity-1 -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+    echo "Pod 1 Status: ${POD1_STATUS}"
+
+    if [ "${POD1_STATUS}" == "Running" ]; then
+        echo "✅ First pod allocated successfully"
+
+        # Create second claim requesting more capacity
+        cat <<EOF | tee ${LOG_DIR}/test3-claim2.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-capacity-2
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device-with-capacity
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+        capacity:
+          requests:
+            memory: "4Gi"
+EOF
+
+        cat <<EOF | tee ${LOG_DIR}/test3-pod2.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-capacity-2
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Using 4Gi capacity'; sleep 60"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-capacity-2
+EOF
+
+        sleep 15
+        POD2_STATUS=$(oc get pod pod-capacity-2 -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+        echo "Pod 2 Status: ${POD2_STATUS}"
+
+        # Check if scheduling was affected by capacity
+        POD2_EVENTS=$(oc get events -n ${NAMESPACE} --field-selector involvedObject.name=pod-capacity-2 -o json)
+        echo "${POD2_EVENTS}" > ${LOG_DIR}/test3-pod2-events.json
+
+        if [ "${POD2_STATUS}" == "Running" ]; then
+            echo "✅ Second pod also allocated (sufficient capacity available)"
+        elif [ "${POD2_STATUS}" == "Pending" ]; then
+            echo "✅ PASS: Second pod pending (capacity exhausted as expected)"
+
+            # Check for capacity-related events
+            CAPACITY_EVENT=$(echo "${POD2_EVENTS}" | jq -r '.items[] | select(.reason == "FailedScheduling" or .message | contains("capacity")) | .message' | head -1)
+            if [ -n "${CAPACITY_EVENT}" ]; then
+                echo "  Event: ${CAPACITY_EVENT}"
+            fi
+        fi
+    else
+        echo "⚠ First pod not running: ${POD1_STATUS}"
+    fi
+else
+    echo "Skipping multiple allocation test (capacity claim not created)"
+fi
+echo ""
+
+#==============================================
+# Phase 4: Capacity Validation
+#==============================================
+echo "=== PHASE 4: Capacity Request Validation ==="
+
+if [ ${CLAIM_CREATED} -eq 0 ]; then
+    # Check allocation shows consumed capacity
+    ALLOCATION=$(oc get resourceclaim claim-capacity-request -n ${NAMESPACE} -o jsonpath='{.status.allocation}')
+
+    if [ -n "${ALLOCATION}" ]; then
+        echo "Allocation details:"
+        echo "${ALLOCATION}" | jq '.' > ${LOG_DIR}/test4-allocation.json
+        echo "${ALLOCATION}" | jq '.'
+
+        # Look for capacity in allocation
+        ALLOCATED_CAPACITY=$(echo "${ALLOCATION}" | jq '.devices.results[0].capacity // {}')
+        if [ "${ALLOCATED_CAPACITY}" != "{}" ]; then
+            echo "✅ Capacity information in allocation"
+        else
+            echo "ℹ No capacity information in allocation (may not be reported)"
+        fi
+    fi
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+echo "Test Results:"
+echo "  Devices with capacity:      ${CAPACITY_COUNT}"
+echo "  Capacity claim created:     $([ ${CLAIM_CREATED} -eq 0 ] && echo 'YES' || echo 'NO')"
+if [ ${CLAIM_CREATED} -eq 0 ]; then
+    echo "  Capacity request preserved: $([ -n "${CAPACITY_REQ}" ] && echo 'YES' || echo 'NO')"
+    echo "  Pod 1 status:              ${POD1_STATUS:-not-created}"
+    echo "  Pod 2 status:              ${POD2_STATUS:-not-created}"
+fi
+echo ""
+
+if [ "${CAPACITY_COUNT}" -gt 0 ] || [ ${CLAIM_CREATED} -eq 0 ]; then
+    echo "🎉 DRA CONSUMABLE CAPACITY: VALIDATED"
+    echo ""
+    echo "Note: Full consumable capacity requires:"
+    echo "  - Feature gate DRAConsumableCapacity (Alpha)"
+    echo "  - Driver that supports capacity definitions"
+    echo "  - Device with allowMultipleAllocations=true"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    echo ""
+    echo "Consumable capacity not available on this cluster."
+    echo "This is expected if:"
+    echo "  - Feature gate not enabled"
+    echo "  - Driver doesn't support capacity"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tests/test-dra-device-taints.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-device-taints.sh
@@ -1,0 +1,473 @@
+#!/bin/bash
+# DRA Device Taints and Tolerations Validation Test
+# Tests device-level taints similar to node taints (KEP-5055)
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+set -e
+
+LOG_DIR="./dra-device-taints-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Device Taints Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+# Redirect all output
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: DRA Device Taints and Tolerations (Beta - KEP-5055)"
+echo "Description: Device-level taints prevent pods from using specific"
+echo "             devices unless they have matching tolerations"
+echo ""
+echo "Test Objectives:"
+echo "1. Check if DRADeviceTaints feature gate is enabled"
+echo "2. Apply taints to specific devices"
+echo "3. Verify pods without tolerations cannot use tainted devices"
+echo "4. Add tolerations to pod and verify allocation succeeds"
+echo ""
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=========================================="
+echo "PHASE 0: Prerequisites and Feature Gate Check"
+echo "=========================================="
+echo ""
+
+NAMESPACE="dra-taint-test"
+
+echo "--- Cluster Version ---"
+oc version | tee ${LOG_DIR}/00-cluster-version.txt
+echo ""
+
+echo "--- Checking Feature Gates ---"
+oc get featuregate cluster -o json | jq '.status.featureGates[].enabled[] | select(.name | contains("DRA") or .name | contains("Taint"))' | tee ${LOG_DIR}/00-featuregates.json
+echo ""
+
+DRA_TAINTS_ENABLED=$(oc get featuregate cluster -o json | jq -r '.status.featureGates[].enabled[] | select(.name == "DRADeviceTaints") | .name' 2>/dev/null || echo "")
+
+if [ -z "${DRA_TAINTS_ENABLED}" ]; then
+    echo "⚠ WARNING: DRADeviceTaints feature gate is NOT enabled"
+    echo ""
+    echo "This feature requires the DRADeviceTaints feature gate to be enabled in:"
+    echo "  - kube-apiserver"
+    echo "  - kube-controller-manager"
+    echo "  - kube-scheduler"
+    echo ""
+    echo "To enable, patch the FeatureGate:"
+    echo "  oc patch featuregate cluster --type=merge -p '{\"spec\":{\"customNoUpgrade\":{\"enabled\":[\"DRADeviceTaints\"]}}}'"
+    echo ""
+    echo "Continuing with test to document expected behavior..."
+    echo ""
+    FEATURE_AVAILABLE=false
+else
+    echo "✅ DRADeviceTaints feature gate is enabled"
+    FEATURE_AVAILABLE=true
+fi
+echo ""
+
+echo "--- Node Information ---"
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+echo ""
+
+echo "--- DeviceClasses ---"
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass-list.txt
+oc get deviceclass -o yaml > ${LOG_DIR}/02-deviceclass-full.yaml
+echo ""
+
+echo "--- Sample ResourceSlice (checking for taint support) ---"
+oc get resourceslice -o json | jq '.items[0] | {name: .metadata.name, spec: .spec | {devices: .devices[0:2]}}' > ${LOG_DIR}/03-resourceslice-sample.json
+cat ${LOG_DIR}/03-resourceslice-sample.json
+echo ""
+
+echo "--- Creating Test Namespace ---"
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+if [ "${FEATURE_AVAILABLE}" = "false" ]; then
+    echo "=========================================="
+    echo "FEATURE NOT AVAILABLE - DOCUMENTING API"
+    echo "=========================================="
+    echo ""
+    echo "Expected ResourceSlice structure with taints:"
+    cat > ${LOG_DIR}/expected-taint-structure.yaml <<'EOF'
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+metadata:
+  name: example-slice
+spec:
+  devices:
+  - name: gpu-0
+    taints:
+    - key: "special-workload"
+      effect: "NoSchedule"
+      value: "true"
+    - key: "maintenance"
+      effect: "NoSchedule"
+  # ... rest of device spec
+EOF
+    cat ${LOG_DIR}/expected-taint-structure.yaml
+    echo ""
+
+    echo "Expected Pod tolerations:"
+    cat > ${LOG_DIR}/expected-pod-tolerations.yaml <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-pod
+spec:
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: example-claim
+  containers:
+  - name: app
+    resources:
+      claims:
+      - name: gpu
+  # Pod tolerations for device taints
+  tolerations:
+  - key: "special-workload"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+EOF
+    cat ${LOG_DIR}/expected-pod-tolerations.yaml
+    echo ""
+
+    echo "=========================================="
+    echo "TEST CONCLUSION"
+    echo "=========================================="
+    echo ""
+    echo "❌ DRADeviceTaints feature NOT available in current cluster"
+    echo ""
+    echo "Feature requires:"
+    echo "  - Kubernetes 1.34+ (cluster has v1.34.7 ✓)"
+    echo "  - DRADeviceTaints feature gate enabled ✗"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Enable feature gate: DRADeviceTaints=true"
+    echo "  2. Wait for API server restart"
+    echo "  3. Verify ResourceSlice API supports 'taints' field"
+    echo "  4. Re-run this test script"
+    echo ""
+    echo "Cleanup: oc delete namespace ${NAMESPACE}"
+    echo ""
+    exit 0
+fi
+
+#==============================================
+# Phase 1: Check if Devices Have Taints
+#==============================================
+echo "=========================================="
+echo "PHASE 1: Inspect Device Taints"
+echo "=========================================="
+echo ""
+
+echo "--- Checking Existing Device Taints ---"
+DEVICES_WITH_TAINTS=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.taints != null)] | length')
+
+echo "Devices with taints: ${DEVICES_WITH_TAINTS}"
+echo ""
+
+if [ ${DEVICES_WITH_TAINTS} -gt 0 ]; then
+    echo "Found devices with taints:"
+    oc get resourceslice -o json | jq '.items[].spec.devices[] | select(.taints != null) | {name, taints}' | tee ${LOG_DIR}/test1-existing-taints.json
+else
+    echo "No devices currently have taints"
+    echo "Note: Taints are typically applied by the DRA driver, not manually"
+    echo ""
+    echo "To test device taints, the NVIDIA DRA driver would need to:"
+    echo "  1. Support taint configuration"
+    echo "  2. Apply taints to ResourceSlice devices"
+    echo "  3. Update taints based on device state/policy"
+fi
+echo ""
+
+#==============================================
+# Phase 2: Test Pod Without Tolerations
+#==============================================
+echo "=========================================="
+echo "PHASE 2: Pod Without Tolerations (Baseline)"
+echo "=========================================="
+echo ""
+
+echo "--- Creating ResourceClaim (No Specific Taint Requirements) ---"
+cat <<EOF | tee ${LOG_DIR}/test2-claim-manifest.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-no-toleration
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: mig
+      deviceClassName: mig.nvidia.com
+      count: 1
+EOF
+
+echo ""
+sleep 3
+
+echo "--- Creating Pod Without Tolerations ---"
+cat <<EOF | tee ${LOG_DIR}/test2-pod-manifest.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-no-toleration
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-no-toleration
+EOF
+
+echo ""
+oc wait --for=condition=Ready pod/pod-no-toleration -n ${NAMESPACE} --timeout=60s || true
+
+POD1_STATUS=$(oc get pod pod-no-toleration -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD1_STATUS}"
+echo ""
+
+oc get pod pod-no-toleration -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod.yaml
+oc get resourceclaim claim-no-toleration -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-claim.yaml
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "✅ Pod scheduled (no tainted devices, or tolerations not required)"
+    oc logs pod-no-toleration -n ${NAMESPACE} > ${LOG_DIR}/test2-pod-logs.txt
+    cat ${LOG_DIR}/test2-pod-logs.txt
+    echo ""
+
+    echo "--- Allocated Device ---"
+    oc get resourceclaim claim-no-toleration -n ${NAMESPACE} -o json | jq '.status.allocation.devices.results[0].device' | tee ${LOG_DIR}/test2-allocated-device.txt
+else
+    echo "⚠ Pod failed to schedule"
+    oc describe pod pod-no-toleration -n ${NAMESPACE} > ${LOG_DIR}/test2-pod-describe.txt
+    tail -20 ${LOG_DIR}/test2-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 3: Test Pod With Tolerations
+#==============================================
+echo "=========================================="
+echo "PHASE 3: Pod With Device Tolerations"
+echo "=========================================="
+echo ""
+
+echo "--- Creating Pod With Example Tolerations ---"
+cat <<EOF | tee ${LOG_DIR}/test3-claim-manifest.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-with-toleration
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: mig
+      deviceClassName: mig.nvidia.com
+      count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test3-pod-manifest.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-toleration
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: "special-workload"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+  - key: "maintenance"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-with-toleration
+EOF
+
+echo ""
+oc wait --for=condition=Ready pod/pod-with-toleration -n ${NAMESPACE} --timeout=60s || true
+
+POD2_STATUS=$(oc get pod pod-with-toleration -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD2_STATUS}"
+echo ""
+
+oc get pod pod-with-toleration -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test3-pod.yaml
+oc get resourceclaim claim-with-toleration -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test3-claim.yaml
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "✅ Pod with tolerations scheduled"
+    oc logs pod-with-toleration -n ${NAMESPACE} > ${LOG_DIR}/test3-pod-logs.txt
+    cat ${LOG_DIR}/test3-pod-logs.txt
+    echo ""
+
+    echo "--- Allocated Device ---"
+    oc get resourceclaim claim-with-toleration -n ${NAMESPACE} -o json | jq '.status.allocation.devices.results[0].device' | tee ${LOG_DIR}/test3-allocated-device.txt
+else
+    echo "⚠ Pod failed to schedule"
+    oc describe pod pod-with-toleration -n ${NAMESPACE} > ${LOG_DIR}/test3-pod-describe.txt
+    tail -20 ${LOG_DIR}/test3-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 4: Capture Final State
+#==============================================
+echo "=========================================="
+echo "PHASE 4: Final State Capture"
+echo "=========================================="
+echo ""
+
+echo "--- All Pods ---"
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods-final.txt
+echo ""
+
+echo "--- All ResourceClaims ---"
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims-list.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+echo ""
+
+echo "--- ResourceSlice Device Taints (If Any) ---"
+oc get resourceslice -o json | jq '[.items[].spec.devices[] | select(.taints != null)] | unique' > ${LOG_DIR}/99-all-device-taints.json
+cat ${LOG_DIR}/99-all-device-taints.json
+echo ""
+
+echo "--- Events ---"
+oc get events -n ${NAMESPACE} --sort-by='.lastTimestamp' > ${LOG_DIR}/99-events.txt
+tail -30 ${LOG_DIR}/99-events.txt
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+echo "Test Results:"
+echo "  Devices with taints found: ${DEVICES_WITH_TAINTS}"
+echo "  Pod without tolerations:   ${POD1_STATUS}"
+echo "  Pod with tolerations:      ${POD2_STATUS}"
+echo ""
+
+echo "Validation Checklist:"
+if [ "${FEATURE_AVAILABLE}" = "true" ]; then
+    echo "  ✅ DRADeviceTaints feature gate enabled"
+else
+    echo "  ⚠ DRADeviceTaints feature gate NOT enabled"
+fi
+
+if [ ${DEVICES_WITH_TAINTS} -gt 0 ]; then
+    echo "  ✅ Devices with taints found"
+    echo "  ℹ️  Taint enforcement depends on driver implementation"
+else
+    echo "  ℹ️  No tainted devices found (depends on driver)"
+fi
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "  ✅ Baseline pod scheduling works"
+fi
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "  ✅ Pod with tolerations scheduling works"
+fi
+
+echo ""
+
+echo "Key Concepts:"
+echo "  - Device taints are set in ResourceSlice.spec.devices[].taints"
+echo "  - Pod tolerations are in pod.spec.tolerations (same as node taints)"
+echo "  - Taint effects: NoSchedule, PreferNoSchedule, NoExecute"
+echo "  - Taint operators: Equal, Exists"
+echo ""
+
+if [ ${DEVICES_WITH_TAINTS} -eq 0 ]; then
+    echo "Note: No device taints found. This is expected if:"
+    echo "  - NVIDIA DRA driver doesn't implement device tainting"
+    echo "  - No devices are currently in a tainted state"
+    echo "  - Driver configuration doesn't enable taints"
+    echo ""
+    echo "To fully test this feature, the DRA driver must support and"
+    echo "apply taints to devices based on their state or policy."
+fi
+
+echo ""
+echo "=========================================="
+echo "CAPTURED ARTIFACTS"
+echo "=========================================="
+echo "Directory: ${LOG_DIR}"
+echo ""
+ls -lh ${LOG_DIR}/ | awk 'NR>1 {print $9, $5}' | grep -v "^$"
+echo ""
+
+echo "Key Files:"
+echo "  ${LOG_DIR}/test-output.log              - Complete test transcript"
+echo "  ${LOG_DIR}/00-featuregates.json         - Feature gate status"
+echo "  ${LOG_DIR}/test3-pod.yaml               - Pod with tolerations example"
+echo "  ${LOG_DIR}/99-all-device-taints.json    - All device taints found"
+echo ""
+
+echo "Cleanup Commands:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+echo ""
+
+echo "=========================================="
+echo "Validation Complete - $(date)"
+echo "=========================================="
+
+# Collect debug info on failure (always collect for device-taints since it is informational)
+echo ""
+echo "Collecting debug information..."
+collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+echo "Debug: ${LOG_DIR}/debug/"
+
+# Exit with proper code
+# Test passes if feature is available OR if pods scheduled successfully
+if [ "${FEATURE_AVAILABLE}" = "true" ] || [ "${POD1_STATUS}" == "Running" ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/plugins/dra-ocp-validator/tests/test-dra-extended-resources.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-extended-resources.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# DRA Extended Resources Validation Test
+# Uses existing NVIDIA DeviceClasses created by the driver
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+set -e
+
+NAMESPACE="dra-extended-test"
+LOG_DIR="./dra-extended-validation-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Extended Resources Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+# Redirect all output
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: DRAExtendedResources"
+echo "Allows DRA devices to be requested via standard extended resource syntax"
+echo ""
+
+# Prerequisites check
+echo "=== Phase 0: Prerequisites ===" 
+oc get featuregate cluster -o json | jq '.status.featureGates[0].enabled[] | select(.name | contains("DRA"))' | tee ${LOG_DIR}/00-featuregates.json
+echo ""
+
+DRA_EXTENDED=$(oc get featuregate cluster -o json | jq -r '.status.featureGates[0].enabled[] | select(.name == "DRAExtendedResources") | .name' || echo "")
+if [ -z "${DRA_EXTENDED}" ]; then
+    echo "❌ DRAExtendedResources NOT enabled"
+    exit 1
+fi
+echo "✅ DRAExtendedResources enabled"
+echo ""
+
+# Capture cluster state
+oc version | tee ${LOG_DIR}/01-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/02-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/03-deviceclass-list.txt
+oc get deviceclass -o yaml > ${LOG_DIR}/03-deviceclass-full.yaml
+
+# Create namespace
+oc create namespace ${NAMESPACE} 2>/dev/null || true
+echo ""
+
+# Define implicit resource names
+IMPLICIT_MIG="deviceclass.resource.kubernetes.io/mig.nvidia.com"
+IMPLICIT_GPU="deviceclass.resource.kubernetes.io/gpu.nvidia.com"
+
+echo "Implicit extended resource names:"
+echo "  MIG: ${IMPLICIT_MIG}"
+echo "  GPU: ${IMPLICIT_GPU}"
+echo ""
+
+# Test 1: MIG implicit
+echo "=== Test 1: MIG Implicit Extended Resource ==="
+cat <<EOF | tee ${LOG_DIR}/test1-manifest.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-mig
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+    resources:
+      requests:
+        ${IMPLICIT_MIG}: "1"
+      limits:
+        ${IMPLICIT_MIG}: "1"
+EOF
+
+sleep 10
+oc wait --for=condition=Ready pod/pod-mig -n ${NAMESPACE} --timeout=90s || true
+sleep 5
+
+POD1=$(oc get pod pod-mig -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod status: ${POD1}"
+
+oc get pod pod-mig -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-pod.yaml
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/test1-claims.txt
+
+if [ "${POD1}" == "Running" ]; then
+    echo "✅ MIG pod running"
+    oc logs pod-mig -n ${NAMESPACE} > ${LOG_DIR}/test1-logs.txt
+    oc get pod pod-mig -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus' | tee ${LOG_DIR}/test1-claim-status.json
+    CLAIM=$(oc get pod pod-mig -n ${NAMESPACE} -o jsonpath='{.status.extendedResourceClaimStatus.resourceClaimName}')
+    if [ -n "${CLAIM}" ]; then
+        oc get resourceclaim ${CLAIM} -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-resourceclaim.yaml
+    fi
+else
+    echo "❌ MIG pod failed"
+    oc describe pod pod-mig -n ${NAMESPACE} > ${LOG_DIR}/test1-describe.txt
+fi
+echo ""
+
+# Test 2: GPU implicit
+echo "=== Test 2: GPU Implicit Extended Resource ==="
+cat <<EOF | tee ${LOG_DIR}/test2-manifest.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-gpu
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+    resources:
+      requests:
+        ${IMPLICIT_GPU}: "1"
+      limits:
+        ${IMPLICIT_GPU}: "1"
+EOF
+
+sleep 10
+oc wait --for=condition=Ready pod/pod-gpu -n ${NAMESPACE} --timeout=90s || true
+sleep 5
+
+POD2=$(oc get pod pod-gpu -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod status: ${POD2}"
+
+oc get pod pod-gpu -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod.yaml
+
+if [ "${POD2}" == "Running" ]; then
+    echo "✅ GPU pod running"
+    oc logs pod-gpu -n ${NAMESPACE} > ${LOG_DIR}/test2-logs.txt
+    oc get pod pod-gpu -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus' > ${LOG_DIR}/test2-claim-status.json
+fi
+echo ""
+
+# Test 3: Multi-container
+echo "=== Test 3: Multi-Container ==="
+cat <<EOF | tee ${LOG_DIR}/test3-manifest.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-multi
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: c1
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+    resources:
+      requests:
+        ${IMPLICIT_MIG}: "1"
+      limits:
+        ${IMPLICIT_MIG}: "1"
+  - name: c2
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+    resources:
+      requests:
+        ${IMPLICIT_MIG}: "1"
+      limits:
+        ${IMPLICIT_MIG}: "1"
+EOF
+
+sleep 10
+oc wait --for=condition=Ready pod/pod-multi -n ${NAMESPACE} --timeout=90s || true
+sleep 5
+
+POD3=$(oc get pod pod-multi -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod status: ${POD3}"
+
+oc get pod pod-multi -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test3-pod.yaml
+
+if [ "${POD3}" == "Running" ]; then
+    echo "✅ Multi-container pod running"
+    oc get pod pod-multi -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus.requestMappings' > ${LOG_DIR}/test3-mappings.json
+fi
+echo ""
+
+# Final state
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+oc get events -n ${NAMESPACE} --sort-by='.lastTimestamp' > ${LOG_DIR}/99-events.txt
+
+# Summary
+echo "=========================================="
+echo "SUMMARY"
+echo "=========================================="
+echo "Test 1 (MIG): ${POD1}"
+echo "Test 2 (GPU): ${POD2}"
+echo "Test 3 (Multi): ${POD3}"
+echo ""
+
+SUCCESS=0
+[ "${POD1}" == "Running" ] && SUCCESS=$((SUCCESS + 1))
+[ "${POD2}" == "Running" ] && SUCCESS=$((SUCCESS + 1))
+[ "${POD3}" == "Running" ] && SUCCESS=$((SUCCESS + 1))
+
+if [ ${SUCCESS} -ge 2 ]; then
+    echo "🎉 DRA EXTENDED RESOURCES: VALIDATED"
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+fi
+echo ""
+echo "Logs: ${LOG_DIR}"
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+# Collect debug info on failure
+if [ ${SUCCESS} -lt 2 ]; then
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+
+# Exit with proper code
+if [ ${SUCCESS} -ge 2 ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/plugins/dra-ocp-validator/tests/test-dra-extended-resources.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-extended-resources.sh
@@ -61,93 +61,109 @@ oc get deviceclass -o yaml > ${LOG_DIR}/03-deviceclass-full.yaml
 oc create namespace ${NAMESPACE} 2>/dev/null || true
 echo ""
 
-# Define implicit resource names
-IMPLICIT_MIG="deviceclass.resource.kubernetes.io/mig.nvidia.com"
-IMPLICIT_GPU="deviceclass.resource.kubernetes.io/gpu.nvidia.com"
+# Detect available DeviceClass dynamically
+DEVICE_CLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+if [ -z "${DEVICE_CLASS}" ]; then
+    echo "❌ ERROR: No DeviceClass found - DRA driver not installed"
+    exit 1
+fi
 
-echo "Implicit extended resource names:"
-echo "  MIG: ${IMPLICIT_MIG}"
-echo "  GPU: ${IMPLICIT_GPU}"
+# Build implicit extended resource name
+IMPLICIT_RESOURCE="deviceclass.resource.kubernetes.io/${DEVICE_CLASS}"
+
+echo "Detected DeviceClass: ${DEVICE_CLASS}"
+echo "Implicit extended resource name: ${IMPLICIT_RESOURCE}"
 echo ""
 
-# Test 1: MIG implicit
-echo "=== Test 1: MIG Implicit Extended Resource ==="
+# Detect driver type for appropriate container image
+if [[ "${DEVICE_CLASS}" == *"nvidia"* ]]; then
+    CONTAINER_IMAGE="nvidia/cuda:12.2.0-base-ubi8"
+    CONTAINER_CMD='["sh", "-c", "nvidia-smi -L && sleep 300"]'
+else
+    CONTAINER_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    CONTAINER_CMD='["sh", "-c", "echo DRA device allocated && env | grep -i device && sleep 300"]'
+fi
+echo ""
+
+# Test 1: Extended resource request
+echo "=== Test 1: Implicit Extended Resource (${DEVICE_CLASS}) ==="
 cat <<EOF | tee ${LOG_DIR}/test1-manifest.yaml | oc apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-mig
+  name: pod-extended-resource
   namespace: ${NAMESPACE}
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       requests:
-        ${IMPLICIT_MIG}: "1"
+        ${IMPLICIT_RESOURCE}: "1"
       limits:
-        ${IMPLICIT_MIG}: "1"
+        ${IMPLICIT_RESOURCE}: "1"
 EOF
 
 sleep 10
-oc wait --for=condition=Ready pod/pod-mig -n ${NAMESPACE} --timeout=90s || true
+oc wait --for=condition=Ready pod/pod-extended-resource -n ${NAMESPACE} --timeout=90s || true
 sleep 5
 
-POD1=$(oc get pod pod-mig -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD1=$(oc get pod pod-extended-resource -n ${NAMESPACE} -o jsonpath='{.status.phase}')
 echo "Pod status: ${POD1}"
 
-oc get pod pod-mig -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-pod.yaml
+oc get pod pod-extended-resource -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-pod.yaml
 oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/test1-claims.txt
 
 if [ "${POD1}" == "Running" ]; then
-    echo "✅ MIG pod running"
-    oc logs pod-mig -n ${NAMESPACE} > ${LOG_DIR}/test1-logs.txt
-    oc get pod pod-mig -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus' | tee ${LOG_DIR}/test1-claim-status.json
-    CLAIM=$(oc get pod pod-mig -n ${NAMESPACE} -o jsonpath='{.status.extendedResourceClaimStatus.resourceClaimName}')
+    echo "✅ Pod running with extended resource"
+    oc logs pod-extended-resource -n ${NAMESPACE} > ${LOG_DIR}/test1-logs.txt
+    oc get pod pod-extended-resource -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus' | tee ${LOG_DIR}/test1-claim-status.json
+    CLAIM=$(oc get pod pod-extended-resource -n ${NAMESPACE} -o jsonpath='{.status.extendedResourceClaimStatus.resourceClaimName}')
     if [ -n "${CLAIM}" ]; then
         oc get resourceclaim ${CLAIM} -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-resourceclaim.yaml
+        echo "✅ Automatic ResourceClaim created: ${CLAIM}"
     fi
 else
-    echo "❌ MIG pod failed"
-    oc describe pod pod-mig -n ${NAMESPACE} > ${LOG_DIR}/test1-describe.txt
+    echo "❌ Pod failed"
+    oc describe pod pod-extended-resource -n ${NAMESPACE} > ${LOG_DIR}/test1-describe.txt
 fi
 echo ""
 
-# Test 2: GPU implicit
-echo "=== Test 2: GPU Implicit Extended Resource ==="
+# Test 2: Multiple resource requests
+echo "=== Test 2: Multiple Extended Resource Requests ==="
 cat <<EOF | tee ${LOG_DIR}/test2-manifest.yaml | oc apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-gpu
+  name: pod-multi-resource
   namespace: ${NAMESPACE}
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 300"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       requests:
-        ${IMPLICIT_GPU}: "1"
+        ${IMPLICIT_RESOURCE}: "2"
       limits:
-        ${IMPLICIT_GPU}: "1"
+        ${IMPLICIT_RESOURCE}: "2"
 EOF
 
 sleep 10
-oc wait --for=condition=Ready pod/pod-gpu -n ${NAMESPACE} --timeout=90s || true
+oc wait --for=condition=Ready pod/pod-multi-resource -n ${NAMESPACE} --timeout=90s || true
 sleep 5
 
-POD2=$(oc get pod pod-gpu -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD2=$(oc get pod pod-multi-resource -n ${NAMESPACE} -o jsonpath='{.status.phase}')
 echo "Pod status: ${POD2}"
 
-oc get pod pod-gpu -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod.yaml
+oc get pod pod-multi-resource -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod.yaml
 
 if [ "${POD2}" == "Running" ]; then
-    echo "✅ GPU pod running"
-    oc logs pod-gpu -n ${NAMESPACE} > ${LOG_DIR}/test2-logs.txt
+    echo "✅ Pod running with 2 extended resources"
+    oc logs pod-multi-resource -n ${NAMESPACE} > ${LOG_DIR}/test2-logs.txt
     oc get pod pod-gpu -n ${NAMESPACE} -o json | jq '.status.extendedResourceClaimStatus' > ${LOG_DIR}/test2-claim-status.json
 fi
 echo ""

--- a/plugins/dra-ocp-validator/tests/test-dra-health-status.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-health-status.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# DRA Device Health Status Validation Test
+# Tests device health information exposure through pod status
+# Alpha in K8s 1.32+
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-health-status-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Device Health Status Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: Device Health Status (Alpha)"
+echo ""
+
+NAMESPACE="dra-health-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+DEVICECLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+echo "DeviceClass: ${DEVICECLASS}"
+echo ""
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Create Pod with Device Claim
+#==============================================
+echo "=== PHASE 1: Pod with Device Allocation ==="
+
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-health-test
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test1-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-health-test
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Monitoring device health'; sleep 120"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-health-test
+EOF
+
+echo ""
+sleep 15
+
+POD_STATUS=$(oc get pod pod-health-test -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD_STATUS}"
+
+if [ "${POD_STATUS}" != "Running" ] && [ "${POD_STATUS}" != "Succeeded" ]; then
+    echo "❌ FAIL: Pod not running: ${POD_STATUS}"
+    oc describe pod pod-health-test -n ${NAMESPACE} > ${LOG_DIR}/test1-pod-describe.txt
+    exit 1
+fi
+
+echo "✅ Pod running with allocated device"
+echo ""
+
+#==============================================
+# Phase 2: Check AllocatedResourcesStatus
+#==============================================
+echo "=== PHASE 2: AllocatedResourcesStatus in Pod Status ==="
+
+sleep 5
+oc get pod pod-health-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod-full.yaml
+
+# Check for allocatedResourcesStatus in container status
+ARS_EXISTS=$(oc get pod pod-health-test -n ${NAMESPACE} -o jsonpath='{.status.containerStatuses[0].allocatedResourcesStatus}')
+
+if [ -n "${ARS_EXISTS}" ] && [ "${ARS_EXISTS}" != "null" ]; then
+    echo "✅ PASS: allocatedResourcesStatus field present in container status"
+    echo "${ARS_EXISTS}" | jq '.' > ${LOG_DIR}/test2-allocated-resources-status.json
+
+    # Extract resource health info
+    CLAIM_NAME=$(oc get pod pod-health-test -n ${NAMESPACE} -o jsonpath='{.spec.resourceClaims[0].name}')
+    RESOURCE_NAME="claim:${CLAIM_NAME}"
+
+    echo "Looking for resource: ${RESOURCE_NAME}"
+
+    # Check for resources array
+    RESOURCES=$(oc get pod pod-health-test -n ${NAMESPACE} -o jsonpath="{.status.containerStatuses[0].allocatedResourcesStatus[?(@.name=='${RESOURCE_NAME}')].resources}")
+
+    if [ -n "${RESOURCES}" ] && [ "${RESOURCES}" != "null" ] && [ "${RESOURCES}" != "[]" ]; then
+        echo "✅ PASS: Resource health information available"
+        echo "${RESOURCES}" | jq '.' > ${LOG_DIR}/test2-resources-health.json
+
+        # Extract health fields
+        HEALTH_STATUS=$(echo "${RESOURCES}" | jq -r '.[0].health // "not-set"')
+        HEALTH_MESSAGE=$(echo "${RESOURCES}" | jq -r '.[0].message // ""')
+
+        echo "  Health Status: ${HEALTH_STATUS}"
+        if [ -n "${HEALTH_MESSAGE}" ]; then
+            echo "  Health Message: ${HEALTH_MESSAGE}"
+        fi
+
+        # Validate health status values
+        if [ "${HEALTH_STATUS}" == "Healthy" ] || [ "${HEALTH_STATUS}" == "Unhealthy" ] || [ "${HEALTH_STATUS}" == "Unknown" ]; then
+            echo "✅ PASS: Health status uses valid value: ${HEALTH_STATUS}"
+        elif [ "${HEALTH_STATUS}" == "not-set" ]; then
+            echo "ℹ Health status not set (driver may not report health)"
+        else
+            echo "⚠ WARNING: Unexpected health status: ${HEALTH_STATUS}"
+        fi
+    else
+        echo "ℹ No health resources in allocatedResourcesStatus"
+        echo "  (Driver may not implement health reporting)"
+    fi
+else
+    echo "ℹ allocatedResourcesStatus not present"
+    echo "  (Feature may require specific feature gate or driver support)"
+fi
+echo ""
+
+#==============================================
+# Phase 3: Monitor Health Status Changes
+#==============================================
+echo "=== PHASE 3: Health Status Monitoring ==="
+
+# Note: Real health status changes require driver support
+# This test documents the expected behavior
+
+echo "Health status is reported by the DRA driver through the kubelet."
+echo "Expected fields in status.containerStatuses[].allocatedResourcesStatus[]:"
+echo "  - name: Resource name (e.g., 'claim:device')"
+echo "  - resources[].health: 'Healthy', 'Unhealthy', or 'Unknown'"
+echo "  - resources[].message: Optional health message"
+echo ""
+
+# Check if driver supports health reporting
+DRIVER=$(oc get resourceclaim claim-health-test -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].driver}')
+echo "Driver: ${DRIVER}"
+
+if [ "${DRIVER}" == "gpu.example.com" ]; then
+    echo "ℹ Using dra-example-driver (health reporting may not be implemented)"
+elif echo "${DRIVER}" | grep -q "nvidia"; then
+    echo "✓ Using NVIDIA driver (may support health reporting)"
+fi
+echo ""
+
+#==============================================
+# Phase 4: Health Status API Validation
+#==============================================
+echo "=== PHASE 4: Health Status API Structure ==="
+
+# Verify the API structure matches the spec
+cat > ${LOG_DIR}/test4-expected-structure.yaml <<'EOFSTRUCT'
+# Expected structure in Pod status:
+status:
+  containerStatuses:
+  - name: consumer
+    allocatedResourcesStatus:
+    - name: "claim:device"
+      resources:
+      - resourceID: "pool-123:device-456"
+        health: "Healthy"  # or "Unhealthy", "Unknown"
+        message: "Device operating normally, temperature: 45°C"
+EOFSTRUCT
+
+cat ${LOG_DIR}/test4-expected-structure.yaml
+echo ""
+
+# Extract actual structure
+ACTUAL_STRUCTURE=$(oc get pod pod-health-test -n ${NAMESPACE} -o jsonpath='{.status.containerStatuses[0]}' | jq '{name: .name, allocatedResourcesStatus: .allocatedResourcesStatus}')
+
+echo "Actual container status structure:"
+echo "${ACTUAL_STRUCTURE}" | jq '.' > ${LOG_DIR}/test4-actual-structure.json
+echo "${ACTUAL_STRUCTURE}" | jq '.'
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims.yaml
+oc get pod pod-health-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-pod-full.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+HAS_ARS=$([ -n "${ARS_EXISTS}" ] && [ "${ARS_EXISTS}" != "null" ] && echo "YES" || echo "NO")
+HAS_HEALTH_DATA=$([ -n "${RESOURCES}" ] && [ "${RESOURCES}" != "null" ] && [ "${RESOURCES}" != "[]" ] && echo "YES" || echo "NO")
+
+echo "Test Results:"
+echo "  Pod Status:                     ${POD_STATUS}"
+echo "  allocatedResourcesStatus:       ${HAS_ARS}"
+echo "  Health Resources Data:          ${HAS_HEALTH_DATA}"
+if [ "${HAS_HEALTH_DATA}" == "YES" ]; then
+    echo "  Health Status Value:            ${HEALTH_STATUS}"
+fi
+echo ""
+
+if [ "${POD_STATUS}" == "Running" ] && [ "${HAS_ARS}" == "YES" ]; then
+    echo "🎉 DRA DEVICE HEALTH STATUS: VALIDATED"
+    echo ""
+    echo "Note: Full health status reporting requires:"
+    echo "  - Driver that implements health status updates"
+    echo "  - Feature gate DRAResourceHealth (Alpha)"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tests/test-dra-partitionable.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-partitionable.sh
@@ -1,0 +1,625 @@
+#!/bin/bash
+# DRA Partitionable Devices Validation Test
+# Comprehensive test with explicit data capture for documentation/future reference
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+set -e
+
+NAMESPACE="dra-e2e-test"
+LOG_DIR="./dra-validation-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Partitionable Devices Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+# Redirect all output to both console and master log file
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Validation Objectives:"
+echo "1. Verify SharedCounters exist in ResourceSlices"
+echo "2. Validate CEL selectors filter devices by MIG profile"
+echo "3. Confirm multiple pods can allocate different MIG partitions"
+echo "4. Document DRAPartitionableDevices feature on OCP 4.21.16"
+echo ""
+
+#==============================================
+# Phase 1: Capture Pre-Test Cluster State
+#==============================================
+echo "=========================================="
+echo "PHASE 1: Pre-Test Cluster State"
+echo "=========================================="
+echo ""
+
+echo "--- Capturing OpenShift and Kubernetes Versions ---"
+oc version | tee ${LOG_DIR}/01-cluster-version.txt
+echo ""
+
+echo "--- Capturing Node Information ---"
+oc get nodes -o wide | tee ${LOG_DIR}/02-nodes.txt
+echo ""
+oc get nodes -o yaml > ${LOG_DIR}/02-nodes-full.yaml
+echo "✓ Saved to: ${LOG_DIR}/02-nodes-full.yaml"
+echo ""
+
+echo "--- Capturing DeviceClass Definitions ---"
+oc get deviceclass | tee ${LOG_DIR}/03-deviceclass-list.txt
+echo ""
+oc get deviceclass -o yaml > ${LOG_DIR}/03-deviceclass-full.yaml
+echo "✓ Saved to: ${LOG_DIR}/03-deviceclass-full.yaml"
+echo ""
+
+echo "--- Capturing ResourceSlice Information ---"
+oc get resourceslice -o wide | tee ${LOG_DIR}/04-resourceslice-list.txt
+echo ""
+oc get resourceslice -o yaml > ${LOG_DIR}/04-resourceslice-full.yaml
+echo "✓ Saved to: ${LOG_DIR}/04-resourceslice-full.yaml"
+echo ""
+
+echo "--- Verifying Partitionable Devices Prerequisites ---"
+# Note: Test runner (run-tests.sh) already checked prerequisites at Step 3.5
+# This test should only run if prerequisites are met
+echo ""
+
+echo "--- Extracting SharedCounter Structure ---"
+SLICES_WITH_COUNTERS=$(oc get resourceslice -o json | jq -r '.items[] | select(.spec.sharedCounters != null) | .metadata.name' | wc -l)
+echo "ResourceSlices with sharedCounters: ${SLICES_WITH_COUNTERS}"
+
+if [ "${SLICES_WITH_COUNTERS}" -gt 0 ]; then
+    echo ""
+    echo "Sample SharedCounter:"
+    oc get resourceslice -o json | jq '.items[0].spec.sharedCounters[0]' | tee ${LOG_DIR}/05-sharedcounter-sample.json
+    echo ""
+    echo "✓ Saved to: ${LOG_DIR}/05-sharedcounter-sample.json"
+
+    echo ""
+    echo "All SharedCounters:"
+    oc get resourceslice -o json | jq '[.items[].spec.sharedCounters]' > ${LOG_DIR}/05-sharedcounters-all.json
+    echo "✓ Saved to: ${LOG_DIR}/05-sharedcounters-all.json"
+else
+    echo "❌ ERROR: No SharedCounters found - DRAPartitionableDevices not enabled"
+    exit 1
+fi
+echo ""
+
+echo "--- Extracting Device Structure ---"
+oc get resourceslice -o json | jq '.items[0].spec.devices[1] | {
+  name,
+  type: .attributes.type.string,
+  profile: .attributes.profile.string,
+  capacity,
+  consumesCounters
+}' | tee ${LOG_DIR}/06-device-sample.json
+echo ""
+echo "✓ Saved to: ${LOG_DIR}/06-device-sample.json"
+echo ""
+
+echo "--- Counting Available MIG Profiles ---"
+AVAILABLE_1G35=$(oc get resourceslice -o json | jq -r '.items[].spec.devices[] | select(.attributes.profile.string == "1g.35gb") | .name' | wc -l)
+AVAILABLE_1G70=$(oc get resourceslice -o json | jq -r '.items[].spec.devices[] | select(.attributes.profile.string == "1g.70gb") | .name' | wc -l)
+
+echo "Available MIG Profiles:" | tee ${LOG_DIR}/07-mig-profile-count.txt
+echo "  - 1g.35gb (small): ${AVAILABLE_1G35} instances" | tee -a ${LOG_DIR}/07-mig-profile-count.txt
+echo "  - 1g.70gb (large): ${AVAILABLE_1G70} instances" | tee -a ${LOG_DIR}/07-mig-profile-count.txt
+echo ""
+
+if [ "${AVAILABLE_1G35}" -lt 2 ] || [ "${AVAILABLE_1G70}" -lt 2 ]; then
+    echo "⚠ WARNING: Insufficient MIG instances for full test"
+fi
+echo ""
+
+echo "--- Listing All Devices with Profiles ---"
+oc get resourceslice -o json | jq -r '.items[].spec.devices[] | select(.attributes.profile.string) |
+  "\(.name) | Profile: \(.attributes.profile.string) | Memory: \(.capacity.memory.value)"' > ${LOG_DIR}/08-all-devices.txt
+echo "✓ Saved to: ${LOG_DIR}/08-all-devices.txt"
+head -10 ${LOG_DIR}/08-all-devices.txt
+echo "..."
+echo ""
+
+#==============================================
+# Phase 2: Create Test Namespace
+#==============================================
+echo "--- Creating Test Namespace ---"
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace '${NAMESPACE}' created"
+echo ""
+
+#==============================================
+# Phase 3: Test 1 - Small MIG Partition (1g.35gb)
+#==============================================
+echo "=========================================="
+echo "PHASE 3: Test 1 - Small MIG Partition (1g.35gb)"
+echo "=========================================="
+echo ""
+
+echo "--- Creating Manifest: ResourceClaim + Pod ---"
+cat <<'EOF' | tee ${LOG_DIR}/test1-manifest.yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-2g
+  namespace: dra-e2e-test
+spec:
+  devices:
+    requests:
+    - name: memory-2g
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2g
+  namespace: dra-e2e-test
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["bash", "-c", "echo 'Pod 2G allocated' && nvidia-smi -L && sleep 300"]
+    resources:
+      claims:
+      - name: claim-pod-2g
+  resourceClaims:
+  - name: claim-pod-2g
+    resourceClaimName: claim-2g
+EOF
+
+echo ""
+echo "--- Applying Manifest ---"
+oc apply -f ${LOG_DIR}/test1-manifest.yaml
+echo ""
+
+echo "--- Waiting for Pod to Schedule ---"
+sleep 5
+oc wait --for=condition=Ready pod/pod-2g -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD1_STATUS=$(oc get pod pod-2g -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD1_STATUS}"
+echo ""
+
+echo "--- Capturing Pod YAML ---"
+oc get pod pod-2g -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-pod.yaml
+echo "✓ Saved to: ${LOG_DIR}/test1-pod.yaml"
+echo ""
+
+echo "--- Capturing ResourceClaim YAML ---"
+oc get resourceclaim claim-2g -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-resourceclaim.yaml
+echo "✓ Saved to: ${LOG_DIR}/test1-resourceclaim.yaml"
+echo ""
+
+echo "--- Capturing Allocation Details ---"
+oc get resourceclaim claim-2g -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation.json
+echo "✓ Saved to: ${LOG_DIR}/test1-allocation.json"
+cat ${LOG_DIR}/test1-allocation.json
+echo ""
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "✅ Test 1: PASS - Pod scheduled successfully"
+    echo ""
+    echo "--- Capturing Pod Logs ---"
+    oc logs -n ${NAMESPACE} pod-2g > ${LOG_DIR}/test1-pod-logs.txt
+    echo "✓ Saved to: ${LOG_DIR}/test1-pod-logs.txt"
+    cat ${LOG_DIR}/test1-pod-logs.txt
+else
+    echo "❌ Test 1: FAIL - Pod did not schedule"
+    oc describe pod pod-2g -n ${NAMESPACE} > ${LOG_DIR}/test1-pod-describe.txt
+    echo "✓ Saved to: ${LOG_DIR}/test1-pod-describe.txt"
+fi
+echo ""
+
+#==============================================
+# Phase 4: Test 2 - Large MIG Partition (1g.70gb)
+#==============================================
+echo "=========================================="
+echo "PHASE 4: Test 2 - Large MIG Partition (1g.70gb)"
+echo "=========================================="
+echo ""
+
+echo "--- Creating Manifest: ResourceClaim + Pod ---"
+cat <<'EOF' | tee ${LOG_DIR}/test2-manifest.yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-4g
+  namespace: dra-e2e-test
+spec:
+  devices:
+    requests:
+    - name: memory-4g
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-4g
+  namespace: dra-e2e-test
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["bash", "-c", "echo 'Pod 4G allocated' && nvidia-smi -L && sleep 300"]
+    resources:
+      claims:
+      - name: claim-pod-4g
+  resourceClaims:
+  - name: claim-pod-4g
+    resourceClaimName: claim-4g
+EOF
+
+echo ""
+echo "--- Applying Manifest ---"
+oc apply -f ${LOG_DIR}/test2-manifest.yaml
+echo ""
+
+echo "--- Waiting for Pod to Schedule ---"
+sleep 5
+oc wait --for=condition=Ready pod/pod-4g -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD2_STATUS=$(oc get pod pod-4g -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD2_STATUS}"
+echo ""
+
+echo "--- Capturing Pod YAML ---"
+oc get pod pod-4g -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-pod.yaml
+echo "✓ Saved to: ${LOG_DIR}/test2-pod.yaml"
+echo ""
+
+echo "--- Capturing ResourceClaim YAML ---"
+oc get resourceclaim claim-4g -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-resourceclaim.yaml
+echo "✓ Saved to: ${LOG_DIR}/test2-resourceclaim.yaml"
+echo ""
+
+echo "--- Capturing Allocation Details ---"
+oc get resourceclaim claim-4g -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test2-allocation.json
+echo "✓ Saved to: ${LOG_DIR}/test2-allocation.json"
+cat ${LOG_DIR}/test2-allocation.json
+echo ""
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "✅ Test 2: PASS - Pod scheduled successfully"
+    echo ""
+    echo "--- Capturing Pod Logs ---"
+    oc logs -n ${NAMESPACE} pod-4g > ${LOG_DIR}/test2-pod-logs.txt
+    echo "✓ Saved to: ${LOG_DIR}/test2-pod-logs.txt"
+    cat ${LOG_DIR}/test2-pod-logs.txt
+else
+    echo "❌ Test 2: FAIL - Pod did not schedule"
+    oc describe pod pod-4g -n ${NAMESPACE} > ${LOG_DIR}/test2-pod-describe.txt
+    echo "✓ Saved to: ${LOG_DIR}/test2-pod-describe.txt"
+fi
+echo ""
+
+#==============================================
+# Phase 5: Test 3 - SharedCounter Limit Test
+#==============================================
+echo "=========================================="
+echo "PHASE 5: Test 3 - SharedCounter Limit Test"
+echo "=========================================="
+echo "Testing: Can we allocate another large partition?"
+echo "Expected: May succeed (multiple GPUs) or fail (SharedCounter limit)"
+echo ""
+
+echo "--- Creating Manifest: ResourceClaim + Pod ---"
+cat <<'EOF' | tee ${LOG_DIR}/test3-manifest.yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-4g-2
+  namespace: dra-e2e-test
+spec:
+  devices:
+    requests:
+    - name: memory-4g-2
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-4g-limit-test
+  namespace: dra-e2e-test
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["bash", "-c", "nvidia-smi -L && sleep 300"]
+    resources:
+      claims:
+      - name: claim-pod-4g-2
+  resourceClaims:
+  - name: claim-pod-4g-2
+    resourceClaimName: claim-4g-2
+EOF
+
+echo ""
+echo "--- Applying Manifest ---"
+oc apply -f ${LOG_DIR}/test3-manifest.yaml
+echo ""
+
+echo "--- Waiting to Check Pod Status ---"
+sleep 15
+
+POD3_STATUS=$(oc get pod pod-4g-limit-test -n ${NAMESPACE} -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+echo "Pod Status: ${POD3_STATUS}"
+echo ""
+
+echo "--- Capturing Pod YAML ---"
+oc get pod pod-4g-limit-test -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test3-pod.yaml
+echo "✓ Saved to: ${LOG_DIR}/test3-pod.yaml"
+echo ""
+
+echo "--- Capturing ResourceClaim YAML ---"
+oc get resourceclaim claim-4g-2 -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test3-resourceclaim.yaml
+echo "✓ Saved to: ${LOG_DIR}/test3-resourceclaim.yaml"
+echo ""
+
+if [ "${POD3_STATUS}" == "Pending" ]; then
+    echo "✅ Test 3: SharedCounter enforcement working - Pod unschedulable"
+    echo ""
+    echo "--- Capturing Scheduling Events ---"
+    oc describe pod pod-4g-limit-test -n ${NAMESPACE} > ${LOG_DIR}/test3-pod-describe.txt
+    echo "✓ Saved to: ${LOG_DIR}/test3-pod-describe.txt"
+    grep -A 5 "Events:" ${LOG_DIR}/test3-pod-describe.txt
+elif [ "${POD3_STATUS}" == "Running" ]; then
+    echo "ℹ Test 3: Pod scheduled (sufficient GPU resources available)"
+    echo ""
+    echo "--- Capturing Allocation Details ---"
+    oc get resourceclaim claim-4g-2 -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test3-allocation.json
+    echo "✓ Saved to: ${LOG_DIR}/test3-allocation.json"
+    cat ${LOG_DIR}/test3-allocation.json
+    echo ""
+    echo "--- Capturing Pod Logs ---"
+    oc logs -n ${NAMESPACE} pod-4g-limit-test > ${LOG_DIR}/test3-pod-logs.txt
+    echo "✓ Saved to: ${LOG_DIR}/test3-pod-logs.txt"
+    cat ${LOG_DIR}/test3-pod-logs.txt
+else
+    echo "⚠ Test 3: Unexpected status: ${POD3_STATUS}"
+    oc describe pod pod-4g-limit-test -n ${NAMESPACE} > ${LOG_DIR}/test3-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 6: Test 4 - Additional Small Partition
+#==============================================
+echo "=========================================="
+echo "PHASE 6: Test 4 - Additional Small Partition (1g.35gb)"
+echo "=========================================="
+echo ""
+
+echo "--- Creating Manifest: ResourceClaim + Pod ---"
+cat <<'EOF' | tee ${LOG_DIR}/test4-manifest.yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-2g-2
+  namespace: dra-e2e-test
+spec:
+  devices:
+    requests:
+    - name: memory-2g-2
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2g-second
+  namespace: dra-e2e-test
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["bash", "-c", "echo 'Pod 2G-2 allocated' && nvidia-smi -L && sleep 300"]
+    resources:
+      claims:
+      - name: claim-pod-2g-2
+  resourceClaims:
+  - name: claim-pod-2g-2
+    resourceClaimName: claim-2g-2
+EOF
+
+echo ""
+echo "--- Applying Manifest ---"
+oc apply -f ${LOG_DIR}/test4-manifest.yaml
+echo ""
+
+echo "--- Waiting for Pod to Schedule ---"
+sleep 5
+oc wait --for=condition=Ready pod/pod-2g-second -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD4_STATUS=$(oc get pod pod-2g-second -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD4_STATUS}"
+echo ""
+
+echo "--- Capturing Pod YAML ---"
+oc get pod pod-2g-second -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test4-pod.yaml
+echo "✓ Saved to: ${LOG_DIR}/test4-pod.yaml"
+echo ""
+
+echo "--- Capturing ResourceClaim YAML ---"
+oc get resourceclaim claim-2g-2 -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test4-resourceclaim.yaml
+echo "✓ Saved to: ${LOG_DIR}/test4-resourceclaim.yaml"
+echo ""
+
+echo "--- Capturing Allocation Details ---"
+oc get resourceclaim claim-2g-2 -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test4-allocation.json
+echo "✓ Saved to: ${LOG_DIR}/test4-allocation.json"
+cat ${LOG_DIR}/test4-allocation.json
+echo ""
+
+if [ "${POD4_STATUS}" == "Running" ]; then
+    echo "✅ Test 4: PASS - Pod scheduled successfully"
+    echo ""
+    echo "--- Capturing Pod Logs ---"
+    oc logs -n ${NAMESPACE} pod-2g-second > ${LOG_DIR}/test4-pod-logs.txt
+    echo "✓ Saved to: ${LOG_DIR}/test4-pod-logs.txt"
+    cat ${LOG_DIR}/test4-pod-logs.txt
+else
+    echo "❌ Test 4: FAIL - Pod did not schedule"
+    oc describe pod pod-2g-second -n ${NAMESPACE} > ${LOG_DIR}/test4-pod-describe.txt
+    echo "✓ Saved to: ${LOG_DIR}/test4-pod-describe.txt"
+fi
+echo ""
+
+#==============================================
+# Phase 7: Capture Post-Test State
+#==============================================
+echo "=========================================="
+echo "PHASE 7: Post-Test State Capture"
+echo "=========================================="
+echo ""
+
+echo "--- Listing All Pods ---"
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods-final.txt
+echo ""
+
+echo "--- Listing All ResourceClaims ---"
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-resourceclaims-list.txt
+echo ""
+
+echo "--- Capturing All ResourceClaims YAML ---"
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-resourceclaims-full.yaml
+echo "✓ Saved to: ${LOG_DIR}/99-resourceclaims-full.yaml"
+echo ""
+
+echo "--- Capturing ResourceSlices (Post-Test) ---"
+oc get resourceslice -o wide > ${LOG_DIR}/99-resourceslice-post.txt
+echo "✓ Saved to: ${LOG_DIR}/99-resourceslice-post.txt"
+echo ""
+
+echo "--- Capturing Namespace Events ---"
+oc get events -n ${NAMESPACE} --sort-by='.lastTimestamp' > ${LOG_DIR}/99-events.txt
+echo "✓ Saved to: ${LOG_DIR}/99-events.txt"
+tail -20 ${LOG_DIR}/99-events.txt
+echo ""
+
+#==============================================
+# Phase 8: Validation Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+
+echo "Test Results:"
+echo "  Test 1 (1g.35gb):     ${POD1_STATUS}"
+echo "  Test 2 (1g.70gb):     ${POD2_STATUS}"
+echo "  Test 3 (1g.70gb #2):  ${POD3_STATUS}"
+echo "  Test 4 (1g.35gb #2):  ${POD4_STATUS}"
+echo ""
+
+# Count successful allocations
+SUCCESS_COUNT=0
+[ "${POD1_STATUS}" == "Running" ] && SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+[ "${POD2_STATUS}" == "Running" ] && SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+[ "${POD4_STATUS}" == "Running" ] && SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+
+echo "Validation Checklist:"
+echo "  ✅ SharedCounters present in ResourceSlices"
+echo "  ✅ DeviceClass 'mig.nvidia.com' operational"
+if [ ${SUCCESS_COUNT} -ge 3 ]; then
+    echo "  ✅ CEL selectors filter by MIG profile correctly"
+    echo "  ✅ Multiple pods can allocate different MIG partitions"
+    echo "  ✅ ResourceClaims allocated successfully"
+    echo ""
+    echo "🎉 DRA PARTITIONABLE DEVICES: VALIDATED"
+else
+    echo "  ❌ Some tests failed - review logs"
+    echo ""
+    echo "⚠ VALIDATION INCOMPLETE"
+fi
+echo ""
+
+echo "Environment Details:"
+oc version --short 2>/dev/null || oc version | head -3
+echo ""
+
+echo "Hardware Summary:"
+echo "  - MIG 1g.35gb instances: ${AVAILABLE_1G35}"
+echo "  - MIG 1g.70gb instances: ${AVAILABLE_1G70}"
+echo ""
+
+echo "=========================================="
+echo "CAPTURED ARTIFACTS"
+echo "=========================================="
+echo "Directory: ${LOG_DIR}"
+echo ""
+ls -lh ${LOG_DIR}/ | awk '{print $9, $5}' | grep -v "^$"
+echo ""
+
+echo "Key Files for Documentation:"
+echo "  ${LOG_DIR}/test-output.log                    - Complete test transcript"
+echo "  ${LOG_DIR}/03-deviceclass-full.yaml           - DeviceClass definitions"
+echo "  ${LOG_DIR}/04-resourceslice-full.yaml         - ResourceSlice structure"
+echo "  ${LOG_DIR}/05-sharedcounter-sample.json       - SharedCounter example"
+echo "  ${LOG_DIR}/test1-manifest.yaml                - Example ResourceClaim manifest"
+echo "  ${LOG_DIR}/test1-resourceclaim.yaml           - Allocated ResourceClaim"
+echo "  ${LOG_DIR}/test1-allocation.json              - Allocation details"
+echo ""
+
+echo "Cleanup Commands:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+echo ""
+
+echo "=========================================="
+echo "Validation Complete - $(date)"
+echo "=========================================="
+
+# Collect debug info on failure
+if [ ${SUCCESS_COUNT} -lt 3 ]; then
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+
+# Exit with proper code based on SUCCESS_COUNT
+if [ ${SUCCESS_COUNT} -ge 3 ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/plugins/dra-ocp-validator/tests/test-dra-partitionable.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-partitionable.sh
@@ -75,29 +75,38 @@ echo "✓ Saved to: ${LOG_DIR}/04-resourceslice-full.yaml"
 echo ""
 
 echo "--- Verifying Partitionable Devices Prerequisites ---"
-# Note: Test runner (run-tests.sh) already checked prerequisites at Step 3.5
-# This test should only run if prerequisites are met
+# Check if driver supports partitionable devices (sharedCounters)
 echo ""
 
-echo "--- Extracting SharedCounter Structure ---"
+echo "--- Checking for SharedCounter Support ---"
 SLICES_WITH_COUNTERS=$(oc get resourceslice -o json | jq -r '.items[] | select(.spec.sharedCounters != null) | .metadata.name' | wc -l)
 echo "ResourceSlices with sharedCounters: ${SLICES_WITH_COUNTERS}"
 
-if [ "${SLICES_WITH_COUNTERS}" -gt 0 ]; then
+if [ "${SLICES_WITH_COUNTERS}" -eq 0 ]; then
     echo ""
-    echo "Sample SharedCounter:"
-    oc get resourceslice -o json | jq '.items[0].spec.sharedCounters[0]' | tee ${LOG_DIR}/05-sharedcounter-sample.json
+    echo "⚠️  SKIP: Driver does not support partitionable devices"
     echo ""
-    echo "✓ Saved to: ${LOG_DIR}/05-sharedcounter-sample.json"
-
+    echo "Reason: No sharedCounters found in ResourceSlices"
     echo ""
-    echo "All SharedCounters:"
-    oc get resourceslice -o json | jq '[.items[].spec.sharedCounters]' > ${LOG_DIR}/05-sharedcounters-all.json
-    echo "✓ Saved to: ${LOG_DIR}/05-sharedcounters-all.json"
-else
-    echo "❌ ERROR: No SharedCounters found - DRAPartitionableDevices not enabled"
-    exit 1
+    echo "For NVIDIA GPUs:"
+    echo "  Re-run setup with: /dra-ocp-validator:setup <kubeconfig> --driver nvidia --enable-dynamic-mig"
+    echo ""
+    echo "For example driver:"
+    echo "  Re-run setup with: /dra-ocp-validator:setup <kubeconfig> --driver example --enable-dynamic-mig"
+    echo ""
+    exit 0  # Exit 0 = SKIP (not a failure)
 fi
+
+echo ""
+echo "Sample SharedCounter:"
+oc get resourceslice -o json | jq '.items[0].spec.sharedCounters[0]' | tee ${LOG_DIR}/05-sharedcounter-sample.json
+echo ""
+echo "✓ Saved to: ${LOG_DIR}/05-sharedcounter-sample.json"
+
+echo ""
+echo "All SharedCounters:"
+oc get resourceslice -o json | jq '[.items[].spec.sharedCounters]' > ${LOG_DIR}/05-sharedcounters-all.json
+echo "✓ Saved to: ${LOG_DIR}/05-sharedcounters-all.json"
 echo ""
 
 echo "--- Extracting Device Structure ---"

--- a/plugins/dra-ocp-validator/tests/test-dra-podresources-api.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-podresources-api.sh
@@ -43,7 +43,32 @@ NAMESPACE="dra-podresources-test"
 echo "=== PHASE 0: Prerequisites ==="
 oc version | tee ${LOG_DIR}/00-version.txt
 
-NODE_NAME=$(oc get nodes -o jsonpath='{.items[0].metadata.name}')
+# Detect available DeviceClass dynamically
+DEVICE_CLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+if [ -z "${DEVICE_CLASS}" ]; then
+    echo "❌ ERROR: No DeviceClass found - DRA driver not installed"
+    exit 1
+fi
+echo "Using DeviceClass: ${DEVICE_CLASS}" | tee ${LOG_DIR}/00-deviceclass.txt
+
+# Detect driver type and appropriate test attributes
+SAMPLE_DEVICE=$(oc get resourceslice -o json | jq -r '.items[0].spec.devices[0]' 2>/dev/null || echo "{}")
+HAS_NVIDIA_PROFILE=$(echo "${SAMPLE_DEVICE}" | jq -r 'has("attributes") and (.attributes | has("profile"))')
+
+if [ "${HAS_NVIDIA_PROFILE}" == "true" ]; then
+    DRIVER_TYPE="nvidia"
+    SELECTOR_EXPR='device.attributes["profile"].string == "1g.35gb"'
+    CONTAINER_IMAGE="nvidia/cuda:12.2.0-base-ubi8"
+    CONTAINER_CMD='["sh", "-c", "nvidia-smi -L && sleep 180"]'
+else
+    DRIVER_TYPE="example"
+    SELECTOR_EXPR='has(device.attributes.model)'
+    CONTAINER_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    CONTAINER_CMD='["sh", "-c", "echo DRA device allocated && sleep 180"]'
+fi
+echo "Driver type: ${DRIVER_TYPE}" | tee -a ${LOG_DIR}/00-deviceclass.txt
+
+NODE_NAME=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}')
 echo "Target node: ${NODE_NAME}" | tee ${LOG_DIR}/01-node.txt
 oc get nodes -o wide | tee -a ${LOG_DIR}/01-node.txt
 
@@ -56,22 +81,22 @@ echo ""
 #==============================================
 echo "=== PHASE 1: Create Pods with DRA Claims ==="
 
-echo "--- Pod 1: MIG 1g.35gb ---"
+echo "--- Pod 1: DRA Device Request ---"
 cat <<EOF | tee ${LOG_DIR}/test1-claim1.yaml | oc apply -f -
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:
-  name: claim-mig-small
+  name: claim-device-1
   namespace: ${NAMESPACE}
 spec:
   devices:
     requests:
-    - name: mig-small
+    - name: device-request
       exactly:
-        deviceClassName: mig.nvidia.com
+        deviceClassName: ${DEVICE_CLASS}
         selectors:
         - cel:
-            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+            expression: "${SELECTOR_EXPR}"
         count: 1
 EOF
 
@@ -79,58 +104,58 @@ cat <<EOF | tee ${LOG_DIR}/test1-pod1.yaml | oc apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-mig-small
+  name: pod-device-1
   namespace: ${NAMESPACE}
   labels:
     test: podresources-api
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 180"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       claims:
       - name: gpu
   resourceClaims:
   - name: gpu
-    resourceClaimName: claim-mig-small
+    resourceClaimName: claim-device-1
 EOF
 
 echo ""
 sleep 10
-oc wait --for=condition=Ready pod/pod-mig-small -n ${NAMESPACE} --timeout=60s || true
+oc wait --for=condition=Ready pod/pod-device-1 -n ${NAMESPACE} --timeout=60s || true
 sleep 3
 
-POD1_STATUS=$(oc get pod pod-mig-small -n ${NAMESPACE} -o jsonpath='{.status.phase}')
-POD1_UID=$(oc get pod pod-mig-small -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
+POD1_STATUS=$(oc get pod pod-device-1 -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD1_UID=$(oc get pod pod-device-1 -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
 
 echo "Pod 1 Status: ${POD1_STATUS}"
 echo "Pod 1 UID: ${POD1_UID}" | tee ${LOG_DIR}/test1-pod1-uid.txt
 
 if [ "${POD1_STATUS}" == "Running" ]; then
     echo "✅ Pod 1 running"
-    oc logs pod-mig-small -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod1-logs.txt
-    oc get resourceclaim claim-mig-small -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation1.json
+    oc logs pod-device-1 -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod1-logs.txt
+    oc get resourceclaim claim-device-1 -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation1.json
 fi
 echo ""
 
-echo "--- Pod 2: MIG 1g.70gb ---"
+echo "--- Pod 2: Second DRA Device Request ---"
 cat <<EOF | tee ${LOG_DIR}/test1-claim2.yaml | oc apply -f -
 apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:
-  name: claim-mig-large
+  name: claim-device-2
   namespace: ${NAMESPACE}
 spec:
   devices:
     requests:
-    - name: mig-large
+    - name: device-request
       exactly:
-        deviceClassName: mig.nvidia.com
+        deviceClassName: ${DEVICE_CLASS}
         selectors:
         - cel:
-            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+            expression: "${SELECTOR_EXPR}"
         count: 1
 EOF
 
@@ -138,39 +163,39 @@ cat <<EOF | tee ${LOG_DIR}/test1-pod2.yaml | oc apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-mig-large
+  name: pod-device-2
   namespace: ${NAMESPACE}
   labels:
     test: podresources-api
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 180"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       claims:
       - name: gpu
   resourceClaims:
   - name: gpu
-    resourceClaimName: claim-mig-large
+    resourceClaimName: claim-device-2
 EOF
 
 echo ""
 sleep 10
-oc wait --for=condition=Ready pod/pod-mig-large -n ${NAMESPACE} --timeout=60s || true
+oc wait --for=condition=Ready pod/pod-device-2 -n ${NAMESPACE} --timeout=60s || true
 sleep 3
 
-POD2_STATUS=$(oc get pod pod-mig-large -n ${NAMESPACE} -o jsonpath='{.status.phase}')
-POD2_UID=$(oc get pod pod-mig-large -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
+POD2_STATUS=$(oc get pod pod-device-2 -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD2_UID=$(oc get pod pod-device-2 -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
 
 echo "Pod 2 Status: ${POD2_STATUS}"
 echo "Pod 2 UID: ${POD2_UID}" | tee ${LOG_DIR}/test1-pod2-uid.txt
 
 if [ "${POD2_STATUS}" == "Running" ]; then
     echo "✅ Pod 2 running"
-    oc logs pod-mig-large -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod2-logs.txt
-    oc get resourceclaim claim-mig-large -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation2.json
+    oc logs pod-device-2 -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod2-logs.txt
+    oc get resourceclaim claim-device-2 -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation2.json
 fi
 echo ""
 
@@ -181,30 +206,30 @@ echo "=== PHASE 2: Pod ResourceClaim Status ==="
 
 if [ "${POD1_STATUS}" == "Running" ]; then
     echo "--- Pod 1 ResourceClaim Status ---"
-    oc get pod pod-mig-small -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod1-claim-status.json
+    oc get pod pod-device-1 -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod1-claim-status.json
     
     echo "--- Pod 1 Claim Info ---"
-    oc get pod pod-mig-small -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
+    oc get pod pod-device-1 -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
     echo ""
 fi
 
 if [ "${POD2_STATUS}" == "Running" ]; then
     echo "--- Pod 2 ResourceClaim Status ---"
-    oc get pod pod-mig-large -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod2-claim-status.json
+    oc get pod pod-device-2 -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod2-claim-status.json
     
     echo "--- Pod 2 Claim Info ---"
-    oc get pod pod-mig-large -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
+    oc get pod pod-device-2 -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
     echo ""
 fi
 
 echo "--- DRA Allocations Summary ---"
 if [ "${POD1_STATUS}" == "Running" ]; then
-    DEVICE1=$(oc get resourceclaim claim-mig-small -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
+    DEVICE1=$(oc get resourceclaim claim-device-1 -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
     echo "Pod 1: ${DEVICE1}"
 fi
 
 if [ "${POD2_STATUS}" == "Running" ]; then
-    DEVICE2=$(oc get resourceclaim claim-mig-large -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
+    DEVICE2=$(oc get resourceclaim claim-device-2 -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
     echo "Pod 2: ${DEVICE2}"
 fi
 echo ""

--- a/plugins/dra-ocp-validator/tests/test-dra-podresources-api.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-podresources-api.sh
@@ -1,0 +1,347 @@
+#!/bin/bash
+# DRA PodResources API Validation Test (Fixed)
+# Tests kubelet PodResources API for DRA resource tracking
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+set -e
+
+LOG_DIR="./dra-podresources-api-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA PodResources API Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: PodResources API for DRA (Beta)"
+echo ""
+
+NAMESPACE="dra-podresources-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+
+NODE_NAME=$(oc get nodes -o jsonpath='{.items[0].metadata.name}')
+echo "Target node: ${NODE_NAME}" | tee ${LOG_DIR}/01-node.txt
+oc get nodes -o wide | tee -a ${LOG_DIR}/01-node.txt
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Create Pods with DRA Claims
+#==============================================
+echo "=== PHASE 1: Create Pods with DRA Claims ==="
+
+echo "--- Pod 1: MIG 1g.35gb ---"
+cat <<EOF | tee ${LOG_DIR}/test1-claim1.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-mig-small
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: mig-small
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test1-pod1.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-mig-small
+  namespace: ${NAMESPACE}
+  labels:
+    test: podresources-api
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 180"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-mig-small
+EOF
+
+echo ""
+sleep 10
+oc wait --for=condition=Ready pod/pod-mig-small -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD1_STATUS=$(oc get pod pod-mig-small -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD1_UID=$(oc get pod pod-mig-small -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
+
+echo "Pod 1 Status: ${POD1_STATUS}"
+echo "Pod 1 UID: ${POD1_UID}" | tee ${LOG_DIR}/test1-pod1-uid.txt
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "✅ Pod 1 running"
+    oc logs pod-mig-small -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod1-logs.txt
+    oc get resourceclaim claim-mig-small -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation1.json
+fi
+echo ""
+
+echo "--- Pod 2: MIG 1g.70gb ---"
+cat <<EOF | tee ${LOG_DIR}/test1-claim2.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-mig-large
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: mig-large
+      exactly:
+        deviceClassName: mig.nvidia.com
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test1-pod2.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-mig-large
+  namespace: ${NAMESPACE}
+  labels:
+    test: podresources-api
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 180"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-mig-large
+EOF
+
+echo ""
+sleep 10
+oc wait --for=condition=Ready pod/pod-mig-large -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD2_STATUS=$(oc get pod pod-mig-large -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+POD2_UID=$(oc get pod pod-mig-large -n ${NAMESPACE} -o jsonpath='{.metadata.uid}')
+
+echo "Pod 2 Status: ${POD2_STATUS}"
+echo "Pod 2 UID: ${POD2_UID}" | tee ${LOG_DIR}/test1-pod2-uid.txt
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "✅ Pod 2 running"
+    oc logs pod-mig-large -n ${NAMESPACE} | tee ${LOG_DIR}/test1-pod2-logs.txt
+    oc get resourceclaim claim-mig-large -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation2.json
+fi
+echo ""
+
+#==============================================
+# Phase 2: Verify Pod ResourceClaim Status
+#==============================================
+echo "=== PHASE 2: Pod ResourceClaim Status ==="
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "--- Pod 1 ResourceClaim Status ---"
+    oc get pod pod-mig-small -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod1-claim-status.json
+    
+    echo "--- Pod 1 Claim Info ---"
+    oc get pod pod-mig-small -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
+    echo ""
+fi
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "--- Pod 2 ResourceClaim Status ---"
+    oc get pod pod-mig-large -n ${NAMESPACE} -o json | jq '.status.resourceClaimStatuses' | tee ${LOG_DIR}/test2-pod2-claim-status.json
+    
+    echo "--- Pod 2 Claim Info ---"
+    oc get pod pod-mig-large -n ${NAMESPACE} -o json | jq -r '.spec.resourceClaims[] | "Claim: \(.name) -> \(.resourceClaimName)"'
+    echo ""
+fi
+
+echo "--- DRA Allocations Summary ---"
+if [ "${POD1_STATUS}" == "Running" ]; then
+    DEVICE1=$(oc get resourceclaim claim-mig-small -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
+    echo "Pod 1: ${DEVICE1}"
+fi
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    DEVICE2=$(oc get resourceclaim claim-mig-large -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
+    echo "Pod 2: ${DEVICE2}"
+fi
+echo ""
+
+#==============================================
+# Phase 3: PodResources Socket Check
+#==============================================
+echo "=== PHASE 3: PodResources Socket Check ==="
+
+echo "Creating debug pod with host access..."
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podresources-debug
+  namespace: ${NAMESPACE}
+spec:
+  hostNetwork: true
+  hostPID: true
+  nodeName: ${NODE_NAME}
+  containers:
+  - name: debug
+    image: registry.access.redhat.com/ubi8/ubi-minimal
+    command: ["sleep", "180"]
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: kubelet-podresources
+      mountPath: /var/lib/kubelet/pod-resources
+      readOnly: true
+  volumes:
+  - name: kubelet-podresources
+    hostPath:
+      path: /var/lib/kubelet/pod-resources
+      type: Directory
+EOF
+
+echo ""
+sleep 10
+oc wait --for=condition=Ready pod/podresources-debug -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+DEBUG_STATUS=$(oc get pod podresources-debug -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+
+if [ "${DEBUG_STATUS}" == "Running" ]; then
+    echo "✅ Debug pod running"
+    echo ""
+    
+    echo "--- PodResources Directory ---"
+    oc exec -n ${NAMESPACE} podresources-debug -- ls -la /var/lib/kubelet/pod-resources/ | tee ${LOG_DIR}/test3-socket-ls.txt
+    
+    SOCKET_EXISTS=$(oc exec -n ${NAMESPACE} podresources-debug -- test -S /var/lib/kubelet/pod-resources/kubelet.sock && echo "yes" || echo "no")
+    echo ""
+    echo "Socket exists: ${SOCKET_EXISTS}" | tee ${LOG_DIR}/test3-socket-status.txt
+    
+    if [ "${SOCKET_EXISTS}" == "yes" ]; then
+        echo "✅ PodResources API socket available"
+        echo ""
+        echo "Note: PodResources API uses gRPC protocol"
+        echo "      Querying requires gRPC client (not curl/oc)"
+    fi
+else
+    echo "⚠ Debug pod failed"
+    oc describe pod podresources-debug -n ${NAMESPACE} > ${LOG_DIR}/test3-debug-describe.txt
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+
+echo "" | tee ${LOG_DIR}/99-summary.txt
+echo "--- Pod-Claim Summary ---" | tee -a ${LOG_DIR}/99-summary.txt
+oc get pods -n ${NAMESPACE} -l test=podresources-api -o json | jq -r '.items[] | {
+  pod: .metadata.name,
+  uid: .metadata.uid,
+  phase: .status.phase,
+  claims: [.spec.resourceClaims[]? | {name: .name, resourceClaimName: .resourceClaimName}]
+}' | tee -a ${LOG_DIR}/99-summary.txt
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+echo "Test Results:"
+echo "  Pod 1 (small MIG):  ${POD1_STATUS}"
+echo "  Pod 2 (large MIG):  ${POD2_STATUS}"
+echo "  Debug pod:          ${DEBUG_STATUS}"
+echo "  PodResources socket: ${SOCKET_EXISTS:-unknown}"
+echo ""
+
+SUCCESS=0
+[ "${POD1_STATUS}" == "Running" ] && SUCCESS=$((SUCCESS + 1))
+[ "${POD2_STATUS}" == "Running" ] && SUCCESS=$((SUCCESS + 1))
+[ "${SOCKET_EXISTS}" == "yes" ] && SUCCESS=$((SUCCESS + 1))
+
+if [ ${SUCCESS} -ge 2 ]; then
+    echo "🎉 DRA PODRESOURCES API: INFRASTRUCTURE VALIDATED"
+    echo ""
+    echo "✅ DRA pods scheduled successfully"
+    echo "✅ Pod.status.resourceClaimStatuses populated"
+    if [ "${SOCKET_EXISTS}" == "yes" ]; then
+        echo "✅ PodResources API socket accessible"
+    fi
+    echo ""
+    echo "Note: Full API validation requires gRPC client tool"
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+# Collect debug info on failure
+if [ "${POD1_STATUS}" != "Running" ] || [ "${POD2_STATUS}" != "Running" ]; then
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}" "pod-with-claim"
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+
+# Exit with proper code
+if [ "${POD1_STATUS}" == "Running" ] && [ "${POD2_STATUS}" == "Running" ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/plugins/dra-ocp-validator/tests/test-dra-prioritized-list.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-prioritized-list.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# DRA Prioritized List Validation Test (Fixed)
+# Tests device alternatives and fallback (KEP-4816)
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+set -e
+
+LOG_DIR="./dra-prioritized-list-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Prioritized List Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: DRA Prioritized List (Beta - KEP-4816)"
+echo ""
+
+NAMESPACE="dra-prioritized-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+# Detect available DeviceClass dynamically
+DEVICE_CLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+if [ -z "${DEVICE_CLASS}" ]; then
+    echo "❌ ERROR: No DeviceClass found - DRA driver not installed"
+    exit 1
+fi
+echo "Using DeviceClass: ${DEVICE_CLASS}" | tee ${LOG_DIR}/03-deviceclass-detected.txt
+echo ""
+
+AVAILABLE_1G70=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.70gb")] | length')
+AVAILABLE_1G35=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.35gb")] | length')
+
+echo "" | tee ${LOG_DIR}/03-devices.txt
+echo "Available MIG Profiles:" | tee -a ${LOG_DIR}/03-devices.txt
+echo "  - 1g.70gb (large): ${AVAILABLE_1G70} instances" | tee -a ${LOG_DIR}/03-devices.txt
+echo "  - 1g.35gb (small): ${AVAILABLE_1G35} instances" | tee -a ${LOG_DIR}/03-devices.txt
+echo ""
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Single Preferred Request
+#==============================================
+echo "=== PHASE 1: Single Preferred Request (1g.70gb) ==="
+
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-preferred-only
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: large-mig
+      exactly:
+        deviceClassName: ${DEVICE_CLASS}
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test1-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-preferred-only
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-preferred-only
+EOF
+
+echo ""
+sleep 10
+oc wait --for=condition=Ready pod/pod-preferred-only -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD1_STATUS=$(oc get pod pod-preferred-only -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD1_STATUS}"
+
+if [ "${POD1_STATUS}" == "Running" ]; then
+    echo "✅ Preferred device allocated"
+    oc logs pod-preferred-only -n ${NAMESPACE} | tee ${LOG_DIR}/test1-logs.txt
+    oc get resourceclaim claim-preferred-only -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test1-allocation.json
+    
+    DEVICE1=$(oc get resourceclaim claim-preferred-only -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results[0].device}')
+    echo "Allocated: ${DEVICE1}"
+else
+    echo "⚠ Pod failed"
+    oc describe pod pod-preferred-only -n ${NAMESPACE} > ${LOG_DIR}/test1-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 2: Prioritized List (Preferred + Fallback)
+#==============================================
+echo "=== PHASE 2: Prioritized List (1g.70gb OR 2x 1g.35gb) ==="
+
+cat <<EOF | tee ${LOG_DIR}/test2-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-with-fallback
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: preferred-large
+      exactly:
+        deviceClassName: ${DEVICE_CLASS}
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
+        count: 1
+    - name: fallback-small
+      exactly:
+        deviceClassName: ${DEVICE_CLASS}
+        selectors:
+        - cel:
+            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
+        count: 2
+EOF
+
+cat <<EOF | tee ${LOG_DIR}/test2-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-fallback
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cuda
+    image: nvidia/cuda:12.2.0-base-ubi8
+    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimName: claim-with-fallback
+EOF
+
+echo ""
+sleep 10
+oc wait --for=condition=Ready pod/pod-with-fallback -n ${NAMESPACE} --timeout=60s || true
+sleep 3
+
+POD2_STATUS=$(oc get pod pod-with-fallback -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD2_STATUS}"
+
+if [ "${POD2_STATUS}" == "Running" ]; then
+    echo "✅ Pod scheduled with prioritized list"
+    oc logs pod-with-fallback -n ${NAMESPACE} | tee ${LOG_DIR}/test2-logs.txt
+    oc get resourceclaim claim-with-fallback -n ${NAMESPACE} -o json | jq '.status.allocation' > ${LOG_DIR}/test2-allocation.json
+    
+    echo ""
+    echo "--- Analyzing Selection ---"
+    oc get resourceclaim claim-with-fallback -n ${NAMESPACE} -o json | jq -r '.status.allocation.devices.results[] | "Request: \(.request) -> Device: \(.device)"' | tee ${LOG_DIR}/test2-selected.txt
+    
+    SELECTED=$(oc get resourceclaim claim-with-fallback -n ${NAMESPACE} -o json | jq -r '.status.allocation.devices.results[0].request')
+    
+    if echo "${SELECTED}" | grep -q "preferred"; then
+        echo "✅ Scheduler selected PREFERRED (1g.70gb)"
+    elif echo "${SELECTED}" | grep -q "fallback"; then
+        echo "✅ Scheduler selected FALLBACK (2x 1g.35gb)"
+    fi
+else
+    echo "⚠ Pod failed"
+    oc describe pod pod-with-fallback -n ${NAMESPACE} > ${LOG_DIR}/test2-describe.txt
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+echo "Test Results:"
+echo "  Phase 1 (Preferred only):   ${POD1_STATUS}"
+echo "  Phase 2 (With fallback):    ${POD2_STATUS}"
+echo ""
+
+if [ "${POD1_STATUS}" == "Running" ] && [ "${POD2_STATUS}" == "Running" ]; then
+    echo "🎉 DRA PRIORITIZED LIST: VALIDATED"
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+# Collect debug info on failure
+if [ "${POD1_STATUS}" != "Running" ] || [ "${POD2_STATUS}" != "Running" ]; then
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+
+# Exit with proper code
+if [ "${POD1_STATUS}" == "Running" ] && [ "${POD2_STATUS}" == "Running" ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/plugins/dra-ocp-validator/tests/test-dra-prioritized-list.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-prioritized-list.sh
@@ -54,13 +54,46 @@ fi
 echo "Using DeviceClass: ${DEVICE_CLASS}" | tee ${LOG_DIR}/03-deviceclass-detected.txt
 echo ""
 
-AVAILABLE_1G70=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.70gb")] | length')
-AVAILABLE_1G35=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.35gb")] | length')
+# Detect available attributes from actual ResourceSlice
+echo "Detecting driver attributes..." | tee ${LOG_DIR}/03-attribute-detection.txt
+SAMPLE_DEVICE=$(oc get resourceslice -o json | jq -r '.items[0].spec.devices[0]' 2>/dev/null || echo "{}")
+echo "${SAMPLE_DEVICE}" | jq '.' > ${LOG_DIR}/03-sample-device.json
 
-echo "" | tee ${LOG_DIR}/03-devices.txt
-echo "Available MIG Profiles:" | tee -a ${LOG_DIR}/03-devices.txt
-echo "  - 1g.70gb (large): ${AVAILABLE_1G70} instances" | tee -a ${LOG_DIR}/03-devices.txt
-echo "  - 1g.35gb (small): ${AVAILABLE_1G35} instances" | tee -a ${LOG_DIR}/03-devices.txt
+# Check if NVIDIA profile attribute exists
+HAS_NVIDIA_PROFILE=$(echo "${SAMPLE_DEVICE}" | jq -r 'has("attributes") and (.attributes | has("profile"))')
+
+if [ "${HAS_NVIDIA_PROFILE}" == "true" ]; then
+    DRIVER_TYPE="nvidia"
+    AVAILABLE_1G70=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.70gb")] | length')
+    AVAILABLE_1G35=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[] | select(.attributes.profile.string == "1g.35gb")] | length')
+
+    echo "" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "Driver Type: NVIDIA GPU (MIG profiles detected)" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "Available MIG Profiles:" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "  - 1g.70gb (large): ${AVAILABLE_1G70} instances" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "  - 1g.35gb (small): ${AVAILABLE_1G35} instances" | tee -a ${LOG_DIR}/03-devices.txt
+
+    # CEL expressions for NVIDIA
+    SELECTOR_PREFERRED='device.attributes["profile"].string == "1g.70gb"'
+    SELECTOR_FALLBACK='device.attributes["profile"].string == "1g.35gb"'
+    COUNT_PREFERRED=1
+    COUNT_FALLBACK=2
+else
+    DRIVER_TYPE="example"
+    AVAILABLE_DEVICES=$(oc get resourceslice -o json | jq -r '[.items[].spec.devices[]] | length')
+
+    echo "" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "Driver Type: Example Driver (software simulation)" | tee -a ${LOG_DIR}/03-devices.txt
+    echo "Available Devices: ${AVAILABLE_DEVICES}" | tee -a ${LOG_DIR}/03-devices.txt
+
+    # CEL expressions for example driver - test prioritization with any available device
+    # Preferred: Request 2 devices (might not be available)
+    # Fallback: Request 1 device (should always succeed)
+    SELECTOR_PREFERRED='has(device.attributes.model)'
+    SELECTOR_FALLBACK='has(device.attributes.model)'
+    COUNT_PREFERRED=2
+    COUNT_FALLBACK=1
+fi
 echo ""
 
 oc create namespace ${NAMESPACE}
@@ -70,7 +103,11 @@ echo ""
 #==============================================
 # Phase 1: Single Preferred Request
 #==============================================
-echo "=== PHASE 1: Single Preferred Request (1g.70gb) ==="
+if [ "${DRIVER_TYPE}" == "nvidia" ]; then
+    echo "=== PHASE 1: Single Preferred Request (1g.70gb) ==="
+else
+    echo "=== PHASE 1: Single Preferred Request (${COUNT_PREFERRED} devices) ==="
+fi
 
 cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
 apiVersion: resource.k8s.io/v1
@@ -81,14 +118,23 @@ metadata:
 spec:
   devices:
     requests:
-    - name: large-mig
+    - name: preferred-request
       exactly:
         deviceClassName: ${DEVICE_CLASS}
         selectors:
         - cel:
-            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
-        count: 1
+            expression: "${SELECTOR_PREFERRED}"
+        count: ${COUNT_PREFERRED}
 EOF
+
+# Choose appropriate container image based on driver type
+if [ "${DRIVER_TYPE}" == "nvidia" ]; then
+    CONTAINER_IMAGE="nvidia/cuda:12.2.0-base-ubi8"
+    CONTAINER_CMD='["sh", "-c", "nvidia-smi -L && sleep 60"]'
+else
+    CONTAINER_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    CONTAINER_CMD='["sh", "-c", "echo DRA device allocated && env | grep -i device && sleep 60"]'
+fi
 
 cat <<EOF | tee ${LOG_DIR}/test1-pod.yaml | oc apply -f -
 apiVersion: v1
@@ -99,9 +145,9 @@ metadata:
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       claims:
       - name: gpu
@@ -134,7 +180,11 @@ echo ""
 #==============================================
 # Phase 2: Prioritized List (Preferred + Fallback)
 #==============================================
-echo "=== PHASE 2: Prioritized List (1g.70gb OR 2x 1g.35gb) ==="
+if [ "${DRIVER_TYPE}" == "nvidia" ]; then
+    echo "=== PHASE 2: Prioritized List (1g.70gb OR 2x 1g.35gb) ==="
+else
+    echo "=== PHASE 2: Prioritized List (${COUNT_PREFERRED} devices OR ${COUNT_FALLBACK} device) ==="
+fi
 
 cat <<EOF | tee ${LOG_DIR}/test2-claim.yaml | oc apply -f -
 apiVersion: resource.k8s.io/v1
@@ -145,20 +195,20 @@ metadata:
 spec:
   devices:
     requests:
-    - name: preferred-large
+    - name: preferred-request
       exactly:
         deviceClassName: ${DEVICE_CLASS}
         selectors:
         - cel:
-            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.70gb'"
-        count: 1
-    - name: fallback-small
+            expression: "${SELECTOR_PREFERRED}"
+        count: ${COUNT_PREFERRED}
+    - name: fallback-request
       exactly:
         deviceClassName: ${DEVICE_CLASS}
         selectors:
         - cel:
-            expression: "device.attributes['gpu.nvidia.com'].profile == '1g.35gb'"
-        count: 2
+            expression: "${SELECTOR_FALLBACK}"
+        count: ${COUNT_FALLBACK}
 EOF
 
 cat <<EOF | tee ${LOG_DIR}/test2-pod.yaml | oc apply -f -
@@ -170,9 +220,9 @@ metadata:
 spec:
   restartPolicy: Never
   containers:
-  - name: cuda
-    image: nvidia/cuda:12.2.0-base-ubi8
-    command: ["sh", "-c", "nvidia-smi -L && sleep 60"]
+  - name: test-container
+    image: ${CONTAINER_IMAGE}
+    command: ${CONTAINER_CMD}
     resources:
       claims:
       - name: gpu

--- a/plugins/dra-ocp-validator/tests/test-dra-structured-parameters.sh
+++ b/plugins/dra-ocp-validator/tests/test-dra-structured-parameters.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# DRA Structured Parameters Validation Test
+# Tests structured parameter support for device allocation (KEP-4831)
+# GA in K8s 1.34+
+
+# Handle KUBECONFIG argument
+if [ -n "${1}" ]; then
+  KUBECONFIG_PATH="${1/#~/$HOME}"
+  if [ -f "${KUBECONFIG_PATH}" ]; then
+    export KUBECONFIG="${KUBECONFIG_PATH}"
+  fi
+fi
+
+set -e
+
+# Source debug collection utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(dirname "${SCRIPT_DIR}")/tools"
+if [ -f "${TOOLS_DIR}/collect-debug-info.sh" ]; then
+    source "${TOOLS_DIR}/collect-debug-info.sh"
+fi
+
+LOG_DIR="./dra-structured-params-$(date +%Y%m%d-%H%M%S)"
+mkdir -p ${LOG_DIR}
+
+echo "=============================================="
+echo "DRA Structured Parameters Validation Test"
+echo "=============================================="
+echo "Test Date: $(date)"
+echo "Logs Directory: ${LOG_DIR}"
+echo ""
+
+exec > >(tee -a ${LOG_DIR}/test-output.log)
+exec 2>&1
+
+echo "Feature: Structured Parameters (GA - KEP-4831)"
+echo ""
+
+NAMESPACE="dra-structured-params-test"
+
+#==============================================
+# Phase 0: Prerequisites
+#==============================================
+echo "=== PHASE 0: Prerequisites ==="
+oc version | tee ${LOG_DIR}/00-version.txt
+oc get nodes -o wide | tee ${LOG_DIR}/01-nodes.txt
+oc get deviceclass | tee ${LOG_DIR}/02-deviceclass.txt
+
+# Get DeviceClass to verify structured parameters support
+DEVICECLASS=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}')
+echo "DeviceClass: ${DEVICECLASS}" | tee -a ${LOG_DIR}/02-deviceclass.txt
+
+# Check if structured parameters API is available (v1)
+API_VERSION=$(oc api-resources --api-group=resource.k8s.io -o name | grep -E '^deviceclasses\.resource\.k8s\.io$' || echo "not found")
+if [ "${API_VERSION}" == "not found" ]; then
+    echo "❌ FAIL: resource.k8s.io/v1 API not available"
+    exit 1
+fi
+echo "✓ resource.k8s.io/v1 API available"
+
+# Verify DeviceClass has structured parameters format
+oc get deviceclass ${DEVICECLASS} -o yaml | tee ${LOG_DIR}/02-deviceclass-full.yaml
+echo ""
+
+oc create namespace ${NAMESPACE}
+echo "✓ Namespace created"
+echo ""
+
+#==============================================
+# Phase 1: Basic Structured Parameters Request
+#==============================================
+echo "=== PHASE 1: Basic Structured Parameters ==="
+
+cat <<EOF | tee ${LOG_DIR}/test1-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-structured-basic
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        count: 1
+EOF
+
+echo ""
+sleep 5
+
+# Check claim was created with structured parameters API
+CLAIM_API=$(oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.apiVersion}')
+echo "ResourceClaim API Version: ${CLAIM_API}"
+
+if echo "${CLAIM_API}" | grep -q "resource.k8s.io/v1"; then
+    echo "✅ PASS: ResourceClaim created with v1 API (structured parameters)"
+else
+    echo "⚠ WARNING: ResourceClaim not using v1 API: ${CLAIM_API}"
+fi
+
+oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test1-claim-created.yaml
+
+# Verify structured format in spec.devices
+HAS_DEVICES=$(oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.spec.devices}' | grep -q "requests" && echo "yes" || echo "no")
+if [ "${HAS_DEVICES}" == "yes" ]; then
+    echo "✅ PASS: Claim uses spec.devices.requests (structured format)"
+    oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.spec.devices}' | jq '.' > ${LOG_DIR}/test1-devices-spec.json
+else
+    echo "❌ FAIL: Claim missing spec.devices.requests"
+fi
+echo ""
+
+#==============================================
+# Phase 2: Structured Parameters with Selectors
+#==============================================
+echo "=== PHASE 2: Structured Parameters with CEL Selectors ==="
+
+cat <<EOF | tee ${LOG_DIR}/test2-claim.yaml | oc apply -f -
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: claim-structured-selector
+  namespace: ${NAMESPACE}
+spec:
+  devices:
+    requests:
+    - name: selected-device
+      exactly:
+        deviceClassName: ${DEVICECLASS}
+        selectors:
+        - cel:
+            expression: "device.driver == '${DEVICECLASS}'"
+        count: 1
+EOF
+
+echo ""
+sleep 5
+
+# Verify selector was accepted
+SELECTOR=$(oc get resourceclaim claim-structured-selector -n ${NAMESPACE} -o jsonpath='{.spec.devices.requests[0].exactly.selectors[0].cel.expression}')
+echo "CEL Selector: ${SELECTOR}"
+
+if [ -n "${SELECTOR}" ]; then
+    echo "✅ PASS: CEL selector preserved in ResourceClaim"
+    oc get resourceclaim claim-structured-selector -n ${NAMESPACE} -o yaml > ${LOG_DIR}/test2-claim-with-selector.yaml
+else
+    echo "❌ FAIL: CEL selector missing or rejected"
+fi
+echo ""
+
+#==============================================
+# Phase 3: Pod with Structured Parameters Claim
+#==============================================
+echo "=== PHASE 3: Pod Using Structured Parameters Claim ==="
+
+cat <<EOF | tee ${LOG_DIR}/test3-pod.yaml | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-structured-claim
+  namespace: ${NAMESPACE}
+spec:
+  restartPolicy: Never
+  containers:
+  - name: consumer
+    image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+    command: ["sh", "-c", "echo 'Using structured parameters device'; sleep 30"]
+    resources:
+      claims:
+      - name: device
+  resourceClaims:
+  - name: device
+    resourceClaimName: claim-structured-basic
+EOF
+
+echo ""
+sleep 10
+
+POD_STATUS=$(oc get pod pod-structured-claim -n ${NAMESPACE} -o jsonpath='{.status.phase}')
+echo "Pod Status: ${POD_STATUS}"
+
+if [ "${POD_STATUS}" == "Running" ] || [ "${POD_STATUS}" == "Succeeded" ]; then
+    echo "✅ PASS: Pod scheduled with structured parameters claim"
+
+    # Check allocation
+    sleep 5
+    ALLOCATION=$(oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.status.allocation}')
+    if [ -n "${ALLOCATION}" ]; then
+        echo "✅ Allocation present in claim status"
+        oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.status.allocation}' | jq '.' > ${LOG_DIR}/test3-allocation.json
+
+        # Verify allocation uses structured format (devices.results)
+        HAS_RESULTS=$(oc get resourceclaim claim-structured-basic -n ${NAMESPACE} -o jsonpath='{.status.allocation.devices.results}' | grep -q "\[" && echo "yes" || echo "no")
+        if [ "${HAS_RESULTS}" == "yes" ]; then
+            echo "✅ PASS: Allocation uses structured format (devices.results)"
+        fi
+    else
+        echo "⚠ WARNING: No allocation in claim status"
+    fi
+
+    oc logs pod-structured-claim -n ${NAMESPACE} | tee ${LOG_DIR}/test3-pod-logs.txt
+else
+    echo "❌ FAIL: Pod not running: ${POD_STATUS}"
+    oc describe pod pod-structured-claim -n ${NAMESPACE} > ${LOG_DIR}/test3-pod-describe.txt
+fi
+echo ""
+
+#==============================================
+# Phase 4: DeviceClass Validation
+#==============================================
+echo "=== PHASE 4: DeviceClass Structured Format ==="
+
+# Verify DeviceClass uses structured selectors
+DEVICECLASS_SELECTORS=$(oc get deviceclass ${DEVICECLASS} -o jsonpath='{.spec.selectors}')
+if [ -n "${DEVICECLASS_SELECTORS}" ]; then
+    echo "✅ DeviceClass has spec.selectors (structured format)"
+    oc get deviceclass ${DEVICECLASS} -o jsonpath='{.spec.selectors}' | jq '.' > ${LOG_DIR}/test4-deviceclass-selectors.json
+
+    # Check for CEL selector
+    HAS_CEL=$(echo "${DEVICECLASS_SELECTORS}" | grep -q "cel" && echo "yes" || echo "no")
+    if [ "${HAS_CEL}" == "yes" ]; then
+        echo "✅ DeviceClass uses CEL selectors"
+    fi
+else
+    echo "⚠ WARNING: DeviceClass missing spec.selectors"
+fi
+echo ""
+
+#==============================================
+# Final State
+#==============================================
+echo "=== Final State ==="
+oc get pods -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-pods.txt
+oc get resourceclaim -n ${NAMESPACE} -o wide | tee ${LOG_DIR}/99-claims.txt
+oc get resourceclaim -n ${NAMESPACE} -o yaml > ${LOG_DIR}/99-claims-full.yaml
+echo ""
+
+#==============================================
+# Summary
+#==============================================
+echo "=========================================="
+echo "VALIDATION SUMMARY"
+echo "=========================================="
+echo ""
+echo "Test Results:"
+echo "  API Version:              ${CLAIM_API}"
+echo "  Structured spec.devices:  ${HAS_DEVICES}"
+echo "  CEL Selector Support:     $([ -n "${SELECTOR}" ] && echo 'YES' || echo 'NO')"
+echo "  Pod Status:               ${POD_STATUS}"
+echo "  Allocation Format:        ${HAS_RESULTS:-unknown}"
+echo ""
+
+if [ "${HAS_DEVICES}" == "yes" ] && [ "${POD_STATUS}" == "Running" ]; then
+    echo "🎉 DRA STRUCTURED PARAMETERS: VALIDATED"
+    EXIT_CODE=0
+else
+    echo "⚠ VALIDATION INCOMPLETE"
+    EXIT_CODE=1
+
+    # Collect debug info on failure
+    echo ""
+    echo "Collecting debug information..."
+    collect_test_debug_info "${LOG_DIR}" "${NAMESPACE}"
+fi
+echo ""
+
+echo "Logs: ${LOG_DIR}"
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Debug: ${LOG_DIR}/debug/"
+fi
+echo ""
+echo "Cleanup:"
+echo "  oc delete pods --all -n ${NAMESPACE}"
+echo "  oc delete resourceclaim --all -n ${NAMESPACE}"
+echo "  oc delete namespace ${NAMESPACE}"
+
+exit ${EXIT_CODE}

--- a/plugins/dra-ocp-validator/tools/analyze-failure.sh
+++ b/plugins/dra-ocp-validator/tools/analyze-failure.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# Analyze DRA test failure and provide debugging guidance
+# Usage: analyze-failure.sh <test-output-directory>
+
+set -euo pipefail
+
+TEST_DIR="${1:-}"
+
+if [ -z "${TEST_DIR}" ]; then
+    echo "ERROR: Missing required argument: test-output-directory"
+    echo "Usage: $0 <test-output-directory>"
+    echo ""
+    echo "Example:"
+    echo "  $0 ./dra-admin-access-20260604-202015"
+    exit 1
+fi
+
+if [ ! -d "${TEST_DIR}" ]; then
+    echo "ERROR: Directory not found: ${TEST_DIR}"
+    exit 1
+fi
+
+echo "========================================="
+echo "DRA Test Failure Analysis"
+echo "========================================="
+echo "Analyzing: ${TEST_DIR}"
+echo ""
+
+# Detect test type from directory name
+TEST_NAME=$(basename "${TEST_DIR}" | sed -E 's/dra-([a-z-]+)-[0-9]{8}-.*/\1/')
+echo "Test Type: ${TEST_NAME}"
+echo ""
+
+#==============================================
+# 1. Extract test summary from output log
+#==============================================
+echo "=== Test Summary ==="
+if [ -f "${TEST_DIR}/test-output.log" ]; then
+    # Show validation summary
+    sed -n '/VALIDATION SUMMARY/,/Logs:/p' "${TEST_DIR}/test-output.log" | head -20
+    echo ""
+else
+    echo "⚠ No test-output.log found"
+    echo ""
+fi
+
+#==============================================
+# 2. Check for common failure patterns
+#==============================================
+echo "=== Failure Analysis ==="
+echo ""
+
+ISSUES_FOUND=0
+
+# Check debug directory exists
+if [ ! -d "${TEST_DIR}/debug" ]; then
+    echo "⚠ No debug/ directory found"
+    echo "  This test may not have collected debug info on failure"
+    echo "  Try re-running the test to collect full diagnostics"
+    echo ""
+    exit 0
+fi
+
+# Analyze events for scheduling failures
+if [ -f "${TEST_DIR}/debug/events.txt" ]; then
+    echo "📋 Checking Events for Failures:"
+    echo ""
+
+    # Common failure patterns
+    FAILED_SCHEDULING=$(grep -i "FailedScheduling\|failed to schedule" "${TEST_DIR}/debug/events.txt" 2>/dev/null || true)
+    FAILED_ALLOCATION=$(grep -i "FailedAllocation\|allocation failed\|no devices available" "${TEST_DIR}/debug/events.txt" 2>/dev/null || true)
+    FORBIDDEN_ERRORS=$(grep -i "Forbidden\|forbidden" "${TEST_DIR}/debug/events.txt" 2>/dev/null || true)
+
+    if [ -n "${FAILED_SCHEDULING}" ]; then
+        echo "  ❌ Found FailedScheduling events:"
+        echo "${FAILED_SCHEDULING}" | head -5 | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+
+    if [ -n "${FAILED_ALLOCATION}" ]; then
+        echo "  ❌ Found FailedAllocation events:"
+        echo "${FAILED_ALLOCATION}" | head -5 | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+
+    if [ -n "${FORBIDDEN_ERRORS}" ]; then
+        echo "  ❌ Found Forbidden/Permission errors:"
+        echo "${FORBIDDEN_ERRORS}" | head -5 | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+fi
+
+# Analyze ResourceClaim status
+if [ -f "${TEST_DIR}/debug/resourceclaims-status.json" ]; then
+    echo "📋 Checking ResourceClaim Status:"
+    echo ""
+
+    UNALLOCATED_CLAIMS=$(jq -r '.[] | select(.allocated == null) | .name' "${TEST_DIR}/debug/resourceclaims-status.json" 2>/dev/null || true)
+
+    if [ -n "${UNALLOCATED_CLAIMS}" ]; then
+        echo "  ⚠ Unallocated ResourceClaims found:"
+        echo "${UNALLOCATED_CLAIMS}" | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+
+    # Check claim conditions
+    CLAIM_ERRORS=$(jq -r '.[] | select(.conditions != null) | .conditions[] | select(.status == "False" or .type == "Failed") | "\(.type): \(.message)"' "${TEST_DIR}/debug/resourceclaims-status.json" 2>/dev/null || true)
+
+    if [ -n "${CLAIM_ERRORS}" ]; then
+        echo "  ❌ ResourceClaim errors:"
+        echo "${CLAIM_ERRORS}" | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+fi
+
+# Analyze pod status
+if [ -f "${TEST_DIR}/debug/pods-status.json" ]; then
+    echo "📋 Checking Pod Status:"
+    echo ""
+
+    PENDING_PODS=$(jq -r '.[] | select(.phase == "Pending") | .name' "${TEST_DIR}/debug/pods-status.json" 2>/dev/null || true)
+    FAILED_PODS=$(jq -r '.[] | select(.phase == "Failed") | .name' "${TEST_DIR}/debug/pods-status.json" 2>/dev/null || true)
+
+    if [ -n "${PENDING_PODS}" ]; then
+        echo "  ⚠ Pending Pods:"
+        echo "${PENDING_PODS}" | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+
+    if [ -n "${FAILED_PODS}" ]; then
+        echo "  ❌ Failed Pods:"
+        echo "${FAILED_PODS}" | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+fi
+
+# Check driver logs for errors
+echo "📋 Checking Driver Logs:"
+echo ""
+
+DRIVER_LOG=$(find "${TEST_DIR}/debug" -name "*-driver-logs.txt" 2>/dev/null | head -1)
+if [ -n "${DRIVER_LOG}" ]; then
+    DRIVER_ERRORS=$(grep -i "error\|fatal\|panic" "${DRIVER_LOG}" 2>/dev/null | tail -5 || true)
+    if [ -n "${DRIVER_ERRORS}" ]; then
+        echo "  ⚠ Driver errors found:"
+        echo "${DRIVER_ERRORS}" | sed 's/^/     /'
+        echo ""
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    else
+        echo "  ✓ No errors in driver logs"
+        echo ""
+    fi
+else
+    echo "  ℹ No driver logs found"
+    echo ""
+fi
+
+#==============================================
+# 3. Provide specific guidance based on test type
+#==============================================
+echo "=== Debugging Guidance ==="
+echo ""
+
+case "${TEST_NAME}" in
+    admin-access)
+        echo "Admin Access Test Debugging:"
+        echo ""
+        echo "1. Check namespace labels:"
+        echo "   oc get namespace dra-no-admin dra-with-admin -o jsonpath='{range .items[*]}{.metadata.name}{\"\\t\"}{.metadata.labels}{\"\\n\"}{end}'"
+        echo ""
+        echo "2. Check ResourceClaim rejection reason:"
+        echo "   cat ${TEST_DIR}/test1-result.txt"
+        echo ""
+        echo "3. Verify API server enforces adminAccess:"
+        echo "   - Look for 'Forbidden' in ${TEST_DIR}/debug/events.txt"
+        echo ""
+        ;;
+
+    partitionable)
+        echo "Partitionable Devices Test Debugging:"
+        echo ""
+        echo "1. Check if SharedCounters exist in ResourceSlices:"
+        echo "   oc get resourceslice -o jsonpath='{.items[0].spec.devices[0].basic.sharedCounters}'"
+        echo ""
+        echo "2. Check driver supports MIG/partitioning:"
+        echo "   cat ${TEST_DIR}/debug/*-driver-logs.txt | grep -i 'mig\|partition'"
+        echo ""
+        echo "3. Verify CEL selectors in DeviceClass:"
+        echo "   oc get deviceclass -o yaml | grep -A5 selectors"
+        echo ""
+        ;;
+
+    podresources-api)
+        echo "PodResources API Test Debugging:"
+        echo ""
+        echo "1. Check pod.status.resourceClaimStatuses field:"
+        echo "   cat ${TEST_DIR}/debug/pods-status.json | jq '.[] | .resourceClaimStatuses'"
+        echo ""
+        echo "2. Verify kubelet API socket exists on nodes:"
+        echo "   oc debug node/<node> -- chroot /host ls -la /var/lib/kubelet/pod-resources/"
+        echo ""
+        ;;
+
+    prioritized-list)
+        echo "Prioritized List Test Debugging:"
+        echo ""
+        echo "1. Check scheduler decision logs:"
+        echo "   cat ${TEST_DIR}/debug/scheduler-logs.txt | grep -i 'prioritized\|preference'"
+        echo ""
+        echo "2. Verify DeviceClass has selector preferences:"
+        echo "   oc get deviceclass -o jsonpath='{.items[0].spec.suitableNodes.preferences}'"
+        echo ""
+        ;;
+
+    *)
+        echo "General DRA Debugging Steps:"
+        echo ""
+        echo "1. Check events for failures:"
+        echo "   cat ${TEST_DIR}/debug/events.txt"
+        echo ""
+        echo "2. Check ResourceClaim allocation:"
+        echo "   cat ${TEST_DIR}/debug/resourceclaims-status.json"
+        echo ""
+        echo "3. Check pod describe for scheduling decisions:"
+        echo "   ls ${TEST_DIR}/debug/describe-*.txt"
+        echo ""
+        ;;
+esac
+
+#==============================================
+# 4. Summary
+#==============================================
+echo ""
+echo "=== Summary ==="
+echo ""
+
+if [ ${ISSUES_FOUND} -eq 0 ]; then
+    echo "✓ No obvious issues found in logs"
+    echo "  Review ${TEST_DIR}/test-output.log for test-specific details"
+else
+    echo "⚠ Found ${ISSUES_FOUND} potential issue(s)"
+    echo "  Review detailed logs in ${TEST_DIR}/debug/"
+fi
+
+echo ""
+echo "Key Files:"
+echo "  - ${TEST_DIR}/test-output.log          - Full test transcript"
+echo "  - ${TEST_DIR}/debug/events.txt         - Events (most useful)"
+echo "  - ${TEST_DIR}/debug/resourceclaims-status.json - Allocation status"
+echo "  - ${TEST_DIR}/debug/pods-status.json   - Pod details"
+echo "  - ${TEST_DIR}/debug/describe-*.txt     - Pod scheduling details"
+echo ""
+echo "Next Steps:"
+if [ ${ISSUES_FOUND} -gt 0 ]; then
+    echo "  1. Review the specific errors shown above"
+    echo "  2. Check the recommended debug commands for this test type"
+    echo "  3. Look at ${TEST_DIR}/debug/README.txt for more guidance"
+else
+    echo "  1. Review ${TEST_DIR}/test-output.log for test logic"
+    echo "  2. Check if test expectations match cluster behavior"
+    echo "  3. Verify feature gates are enabled (if Alpha feature)"
+fi
+echo ""

--- a/plugins/dra-ocp-validator/tools/cleanup-dra-example.sh
+++ b/plugins/dra-ocp-validator/tools/cleanup-dra-example.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Cleanup script for dra-example-driver and test resources
+# Based on: /dra-ocp-validator:cleanup command specification
+
+set -euo pipefail
+
+KUBECONFIG_PATH=$1
+REMOVE_DRIVER="${2:-false}"
+FORCE="${3:-false}"
+
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "========================================="
+echo "DRA OCP Validator - Cleanup"
+echo "========================================="
+echo ""
+
+# Verify required tools
+for cmd in oc kubectl helm; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "ERROR: Required command not found: $cmd"
+        exit 1
+    fi
+done
+
+#=========================================
+# Step 1: Clean up test namespaces
+#=========================================
+echo "=== Step 1: Clean up test namespaces ==="
+
+TEST_NAMESPACES=$(oc get namespaces -o name 2>/dev/null | grep 'namespace/dra-.*-test' | sed 's|namespace/||' || true)
+
+if [ -z "${TEST_NAMESPACES}" ]; then
+    echo "No test namespaces found (pattern: dra-*-test)"
+else
+    echo "Found test namespaces:"
+    echo "${TEST_NAMESPACES}" | sed 's/^/  - /'
+    echo ""
+
+    echo "Deleting test namespaces..."
+    for ns in ${TEST_NAMESPACES}; do
+        oc delete namespace ${ns} --wait=false 2>/dev/null && echo "  ✓ ${ns} deleted" || echo "  ⚠ ${ns} failed to delete"
+    done
+fi
+
+echo ""
+
+#=========================================
+# Step 2: Remove dra-example-driver (if requested)
+#=========================================
+if [ "${REMOVE_DRIVER}" == "true" ] || [ "${REMOVE_DRIVER}" == "--remove-driver" ]; then
+    echo "=== Step 2: Remove dra-example-driver ==="
+    echo ""
+    echo "Uninstalling dra-example-driver..."
+
+    # Check if Helm release exists
+    if helm list -n dra-example-driver 2>/dev/null | grep -q dra-example-driver; then
+        echo "  Removing Helm release..."
+        helm uninstall dra-example-driver -n dra-example-driver || echo "  ⚠ Helm uninstall failed"
+        echo "  ✓ Helm release removed"
+    else
+        echo "  ℹ Helm release not found (may have been installed manually)"
+    fi
+
+    # Delete namespace
+    if oc get namespace dra-example-driver &>/dev/null; then
+        echo "  Deleting namespace dra-example-driver..."
+        oc delete namespace dra-example-driver --wait=false
+        echo "  ✓ Namespace deletion initiated"
+    else
+        echo "  ℹ Namespace dra-example-driver not found"
+    fi
+
+    echo ""
+    echo "Waiting for namespace deletion..."
+    timeout 120 bash -c '
+    while oc get namespace dra-example-driver &>/dev/null; do
+        echo "  Waiting..."
+        sleep 5
+    done
+    ' || echo "  ⚠ Timeout waiting for namespace deletion"
+
+    # Verify cleanup
+    echo ""
+    echo "Verifying cleanup..."
+
+    if oc get namespace dra-example-driver &>/dev/null; then
+        echo "  ⚠ Namespace still exists"
+    else
+        echo "  ✓ Namespace removed"
+    fi
+
+    if oc get deviceclass gpu.example.com &>/dev/null; then
+        echo "  ⚠ DeviceClass still exists"
+    else
+        echo "  ✓ DeviceClass removed"
+    fi
+
+    RESOURCESLICES=$(oc get resourceslice -o json 2>/dev/null | grep -c "example.com" || true)
+    if [ -n "${RESOURCESLICES}" ] && [ "${RESOURCESLICES}" -gt 0 ] 2>/dev/null; then
+        echo "  ⚠ ${RESOURCESLICES} ResourceSlices still exist"
+    else
+        echo "  ✓ ResourceSlices removed"
+    fi
+else
+    echo "=== Step 2: Preserve dra-example-driver ==="
+    echo "Driver installation preserved."
+    echo "To remove driver, run with --remove-driver flag"
+fi
+
+echo ""
+echo "========================================="
+echo "Cleanup Complete!"
+echo "========================================="
+echo ""
+echo "Summary:"
+if [ -n "${TEST_NAMESPACES}" ]; then
+    echo "  ✓ Test namespaces cleaned up"
+else
+    echo "  ℹ No test namespaces found"
+fi
+
+if [ "${REMOVE_DRIVER}" == "true" ] || [ "${REMOVE_DRIVER}" == "--remove-driver" ]; then
+    echo "  ✓ dra-example-driver removed"
+else
+    echo "  ℹ dra-example-driver preserved"
+fi
+echo ""

--- a/plugins/dra-ocp-validator/tools/cleanup-dra.sh
+++ b/plugins/dra-ocp-validator/tools/cleanup-dra.sh
@@ -1,0 +1,429 @@
+#!/bin/bash
+# Cleanup script for DRA drivers (NVIDIA or example) and test resources
+# Auto-detects installed driver type
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common utilities
+if [ -f "${SCRIPT_DIR}/common.sh" ]; then
+    source "${SCRIPT_DIR}/common.sh"
+fi
+
+KUBECONFIG_PATH=$1
+# Default: full cleanup (remove everything)
+REMOVE_DRIVER="true"
+REMOVE_OPERATOR="true"
+FORCE="false"
+
+# Parse flags from all arguments after kubeconfig
+shift  # Remove kubeconfig path
+for arg in "$@"; do
+    case "$arg" in
+        --keep-driver) REMOVE_DRIVER="false" ;;
+        --keep-operator) REMOVE_OPERATOR="false" ;;
+        --force) FORCE="true" ;;
+    esac
+done
+
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "========================================="
+echo "DRA OCP Validator - Cleanup"
+echo "========================================="
+echo ""
+
+# Verify required tools
+for cmd in oc kubectl; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "ERROR: Required command not found: $cmd"
+        exit 1
+    fi
+done
+
+# Verify cluster connectivity
+if ! validate_cluster_connectivity "true"; then
+  exit 1
+fi
+
+#=========================================
+# Step 1: Clean up test namespaces
+#=========================================
+echo "=== Step 1: Clean up test namespaces ==="
+
+TEST_NAMESPACES=$(oc get namespaces -o name 2>/dev/null | \
+    grep 'namespace/dra-' | \
+    grep -v 'namespace/dra-example-driver' | \
+    grep -v 'namespace/dra-nvidia-driver' | \
+    sed 's|namespace/||' || true)
+
+if [ -z "${TEST_NAMESPACES}" ]; then
+    echo "No test namespaces found"
+else
+    echo "Found test namespaces:"
+    echo "${TEST_NAMESPACES}" | sed 's/^/  - /'
+    echo ""
+
+    echo "Deleting test namespaces..."
+    for ns in ${TEST_NAMESPACES}; do
+        oc delete namespace ${ns} --wait=false 2>/dev/null && echo "  ✓ ${ns} deleted" || echo "  ⚠ ${ns} failed to delete"
+    done
+fi
+
+echo ""
+
+#=========================================
+# Step 2: Detect and remove DRA driver (if requested)
+#=========================================
+if [ "${REMOVE_DRIVER}" == "true" ] || [ "${REMOVE_DRIVER}" == "--remove-driver" ]; then
+    echo "=== Step 2: Detect and remove DRA driver ==="
+    echo ""
+
+    # Detect which driver is installed with multi-layer verification
+    DRIVER_TYPE="none"
+    DRIVER_NAMESPACE=""
+    DRIVER_RELEASE=""
+
+    # Cache helm list results if helm is available
+    HELM_AVAILABLE=false
+    HELM_NVIDIA_LIST=""
+    HELM_EXAMPLE_LIST=""
+    if command -v helm &>/dev/null; then
+        HELM_AVAILABLE=true
+        HELM_NVIDIA_LIST=$(helm list -n nvidia-dra-driver 2>/dev/null || true)
+        HELM_EXAMPLE_LIST=$(helm list -n dra-example-driver 2>/dev/null || true)
+    fi
+
+    # Function: Detect NVIDIA DRA driver (namespace + at least one confirming resource)
+    detect_nvidia_driver() {
+        # Layer 1: Check namespace exists
+        if ! oc get namespace nvidia-dra-driver &>/dev/null; then
+            return 1
+        fi
+
+        # Layer 2: Confirm with deeper checks (any one proves it's real)
+        # Check Helm release (using cached result)
+        if [ "${HELM_AVAILABLE}" == "true" ] && echo "${HELM_NVIDIA_LIST}" | grep -q nvidia-dra-driver; then
+            return 0
+        fi
+
+        # Check DeviceClass with NVIDIA pattern
+        if oc get deviceclass 2>/dev/null | grep -q 'nvidia.com/'; then
+            return 0
+        fi
+
+        # Check DaemonSet in namespace
+        if oc get daemonset -n nvidia-dra-driver 2>/dev/null | grep -q nvidia-dra; then
+            return 0
+        fi
+
+        # Check for driver pods
+        if oc get pods -n nvidia-dra-driver --no-headers 2>/dev/null | grep -q nvidia-dra; then
+            return 0
+        fi
+
+        # Namespace exists but no confirming resources
+        echo "  ⚠ Found nvidia-dra-driver namespace but no driver resources - skipping"
+        return 1
+    }
+
+    # Function: Detect example DRA driver (namespace + at least one confirming resource)
+    detect_example_driver() {
+        # Layer 1: Check namespace exists
+        if ! oc get namespace dra-example-driver &>/dev/null; then
+            return 1
+        fi
+
+        # Layer 2: Confirm with deeper checks (any one proves it's real)
+        # Check Helm release (using cached result)
+        if [ "${HELM_AVAILABLE}" == "true" ] && echo "${HELM_EXAMPLE_LIST}" | grep -q dra-example-driver; then
+            return 0
+        fi
+
+        # Check DeviceClass with example pattern
+        if oc get deviceclass 2>/dev/null | grep -qE '(example.com/|dra.example.com/)'; then
+            return 0
+        fi
+
+        # Check Deployment in namespace
+        if oc get deployment -n dra-example-driver 2>/dev/null | grep -q dra-example-driver; then
+            return 0
+        fi
+
+        # Check for controller pods
+        if oc get pods -n dra-example-driver --no-headers 2>/dev/null | grep -q example; then
+            return 0
+        fi
+
+        # Namespace exists but no confirming resources
+        echo "  ⚠ Found dra-example-driver namespace but no driver resources - skipping"
+        return 1
+    }
+
+    # Detect drivers with robust checks
+    if detect_example_driver; then
+        DRIVER_TYPE="example"
+        DRIVER_NAMESPACE="dra-example-driver"
+        DRIVER_RELEASE="dra-example-driver"
+        echo "Detected: dra-example-driver (verified)"
+    fi
+
+    if detect_nvidia_driver; then
+        DRIVER_TYPE="nvidia"
+        DRIVER_NAMESPACE="nvidia-dra-driver"
+        DRIVER_RELEASE="nvidia-dra-driver"
+        echo "Detected: NVIDIA DRA driver (verified)"
+    fi
+
+    # Check for GPU operator (NVIDIA) - multi-layer verification
+    if oc get namespace nvidia-gpu-operator &>/dev/null; then
+        # Verify with ClusterPolicy or Subscription
+        if oc get clusterpolicy 2>/dev/null | grep -q cluster-policy || \
+           oc get subscription -n nvidia-gpu-operator 2>/dev/null | grep -q gpu-operator; then
+            if [ "${DRIVER_TYPE}" == "none" ]; then
+                DRIVER_TYPE="nvidia-operator"
+            fi
+            echo "Detected: NVIDIA GPU Operator (verified)"
+        else
+            echo "  ⚠ Found nvidia-gpu-operator namespace but no operator resources - skipping"
+        fi
+    fi
+
+    if [ "${DRIVER_TYPE}" == "none" ]; then
+        echo "ℹ No DRA driver installation detected"
+        echo ""
+        echo "Checked namespaces:"
+        echo "  - dra-example-driver (not found or no resources)"
+        echo "  - nvidia-dra-driver (not found or no resources)"
+        echo "  - nvidia-gpu-operator (not found or no resources)"
+    else
+        echo ""
+        echo "Driver type: ${DRIVER_TYPE}"
+        echo "Namespace: ${DRIVER_NAMESPACE}"
+        echo ""
+        echo "Uninstalling ${DRIVER_TYPE} driver..."
+        echo ""
+
+        # Helper functions
+        uninstall_helm_if_exists() {
+            local release="$1" namespace="$2" cached_list="$3"
+            if [ "${HELM_AVAILABLE}" == "true" ] && echo "${cached_list}" | grep -q "${release}"; then
+                echo "  Removing Helm release..."
+                helm uninstall "${release}" -n "${namespace}" || echo "  ⚠ Helm uninstall failed"
+                echo "  ✓ Helm release removed"
+            else
+                echo "  ℹ Helm release not found"
+            fi
+        }
+
+        delete_namespace_if_exists() {
+            local ns="$1"
+            if oc get namespace "${ns}" &>/dev/null; then
+                echo "  Deleting namespace ${ns}..."
+                oc delete namespace "${ns}" --wait=false
+                echo "  ✓ Namespace deletion initiated"
+            fi
+        }
+
+        # Remove driver based on type
+        case "${DRIVER_TYPE}" in
+            example)
+                echo "Uninstalling dra-example-driver..."
+                uninstall_helm_if_exists "${DRIVER_RELEASE}" "${DRIVER_NAMESPACE}" "${HELM_EXAMPLE_LIST}"
+                delete_namespace_if_exists "${DRIVER_NAMESPACE}"
+                ;;
+
+            nvidia)
+                echo "Uninstalling NVIDIA DRA driver..."
+
+                # Clean up SCC permissions (ClusterRoleBindings)
+                echo "  Cleaning up SCC permissions..."
+                for crb in \
+                  nvidia-dra-privileged-nvidia-dra-driver-gpu-service-account-controller \
+                  nvidia-dra-privileged-nvidia-dra-driver-gpu-service-account-kubeletplugin \
+                  nvidia-dra-privileged-compute-domain-daemon-service-account; do
+                  oc delete clusterrolebinding "$crb" --ignore-not-found=true 2>/dev/null && \
+                    echo "    Deleted ClusterRoleBinding: $crb" || true
+                done
+
+                uninstall_helm_if_exists "nvidia-dra-driver" "${DRIVER_NAMESPACE}" "${HELM_NVIDIA_LIST}"
+                delete_namespace_if_exists "${DRIVER_NAMESPACE}"
+
+                # Note about GPU operator
+                if [ "${REMOVE_OPERATOR}" != "true" ]; then
+                    if oc get namespace nvidia-gpu-operator &>/dev/null; then
+                        echo ""
+                        echo "  ℹ GPU Operator is still installed"
+                        echo "  To remove GPU operator, run cleanup without --keep-operator flag"
+                    fi
+                fi
+                ;;
+
+            nvidia-operator)
+                echo "Uninstalling NVIDIA GPU Operator (OLM-based)..."
+
+                # Delete ClusterPolicy first
+                if oc get clusterpolicy gpu-cluster-policy &>/dev/null; then
+                    echo "  Deleting ClusterPolicy..."
+                    oc delete clusterpolicy gpu-cluster-policy --ignore-not-found=true
+                    echo "  ✓ ClusterPolicy deleted"
+                fi
+
+                # Delete subscription
+                if oc get subscription gpu-operator-certified -n nvidia-gpu-operator &>/dev/null; then
+                    echo "  Deleting GPU Operator subscription..."
+                    oc delete subscription gpu-operator-certified -n nvidia-gpu-operator
+                    echo "  ✓ Subscription deleted"
+                fi
+
+                # Delete CSV
+                CSV_NAME=$(oc get csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                if [ -n "${CSV_NAME}" ]; then
+                    echo "  Deleting CSV: ${CSV_NAME}..."
+                    oc delete csv "${CSV_NAME}" -n nvidia-gpu-operator
+                    echo "  ✓ CSV deleted"
+                fi
+
+                # Delete namespace
+                if oc get namespace nvidia-gpu-operator &>/dev/null; then
+                    echo "  Deleting namespace nvidia-gpu-operator..."
+                    oc delete namespace nvidia-gpu-operator --wait=false
+                    echo "  ✓ Namespace deletion initiated"
+                fi
+                ;;
+        esac
+
+        echo ""
+        echo "Waiting for namespace deletion..."
+        oc wait --for=delete namespace/${DRIVER_NAMESPACE} --timeout=120s 2>/dev/null || echo "  ⚠ Timeout waiting for namespace deletion"
+
+        # Verify cleanup
+        echo ""
+        echo "Verifying cleanup..."
+
+        if oc get namespace ${DRIVER_NAMESPACE} &>/dev/null 2>&1; then
+            echo "  ⚠ Namespace ${DRIVER_NAMESPACE} still exists"
+        else
+            echo "  ✓ Namespace removed"
+        fi
+
+        # Check for DeviceClass removal
+        DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l)
+        if [ "${DEVICECLASS_COUNT}" -gt 0 ]; then
+            echo "  ⚠ ${DEVICECLASS_COUNT} DeviceClass(es) still exist"
+            oc get deviceclass -o name
+        else
+            echo "  ✓ DeviceClasses removed"
+        fi
+
+        # Check for ResourceSlice removal (filter by driver to avoid false warnings)
+        if [ "${DRIVER_TYPE}" == "example" ]; then
+            DRIVER_RESOURCESLICES=$(oc get resourceslice -o json 2>/dev/null | jq -r '.items[] | select(.spec.driver == "gpu.example.com") | .metadata.name' | wc -l)
+        elif [ "${DRIVER_TYPE}" == "nvidia" ]; then
+            DRIVER_RESOURCESLICES=$(oc get resourceslice -o json 2>/dev/null | jq -r '.items[] | select(.spec.driver == "nvidia.com/gpu" or .spec.driver == "mig.nvidia.com") | .metadata.name' | wc -l)
+        else
+            DRIVER_RESOURCESLICES=0
+        fi
+
+        if [ "${DRIVER_RESOURCESLICES}" -gt 0 ]; then
+            echo "  ℹ ${DRIVER_RESOURCESLICES} ${DRIVER_TYPE} driver ResourceSlice(s) still being garbage collected"
+        else
+            echo "  ✓ Driver ResourceSlices removed"
+        fi
+    fi
+else
+    echo "=== Step 2: Preserve DRA driver ==="
+    echo "Driver installation preserved (--keep-driver specified)."
+fi
+
+echo ""
+
+#=========================================
+# Step 3: Remove GPU Operator (if requested and applicable)
+#=========================================
+if [ "${REMOVE_OPERATOR}" == "true" ]; then
+    echo "=== Step 3: Remove GPU Operator ==="
+    echo ""
+
+    # Check if NVIDIA GPU operator is installed
+    if oc get namespace nvidia-gpu-operator &>/dev/null; then
+        echo "Detected: NVIDIA GPU Operator (namespace: nvidia-gpu-operator)"
+        echo ""
+        echo "Uninstalling NVIDIA GPU Operator (OLM-based)..."
+
+        # Delete ClusterPolicy first
+        if oc get clusterpolicy gpu-cluster-policy &>/dev/null; then
+            echo "  Deleting ClusterPolicy..."
+            oc delete clusterpolicy gpu-cluster-policy --ignore-not-found=true
+            echo "  ✓ ClusterPolicy deleted"
+        fi
+
+        # Delete subscription
+        if oc get subscription gpu-operator-certified -n nvidia-gpu-operator &>/dev/null; then
+            echo "  Deleting GPU Operator subscription..."
+            oc delete subscription gpu-operator-certified -n nvidia-gpu-operator
+            echo "  ✓ Subscription deleted"
+        fi
+
+        # Delete CSV
+        CSV_NAME=$(oc get csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        if [ -n "${CSV_NAME}" ]; then
+            echo "  Deleting CSV: ${CSV_NAME}..."
+            oc delete csv "${CSV_NAME}" -n nvidia-gpu-operator
+            echo "  ✓ CSV deleted"
+        fi
+
+        # Delete namespace
+        if oc get namespace nvidia-gpu-operator &>/dev/null; then
+            echo "  Deleting namespace nvidia-gpu-operator..."
+            oc delete namespace nvidia-gpu-operator --wait=false
+            echo "  ✓ Namespace deletion initiated"
+        fi
+
+        echo ""
+        echo "Waiting for GPU operator namespace deletion..."
+        oc wait --for=delete namespace/nvidia-gpu-operator --timeout=120s 2>/dev/null || echo "  ⚠ Timeout waiting for namespace deletion"
+
+        echo ""
+        echo "  ✓ GPU operator removed"
+    else
+        echo "ℹ No GPU operator installation detected (checked nvidia-gpu-operator namespace)"
+    fi
+else
+    echo "=== Step 3: Preserve GPU Operator ==="
+    echo "GPU operator preserved (--keep-operator specified)."
+fi
+
+echo ""
+echo "========================================="
+echo "Cleanup Complete!"
+echo "========================================="
+echo ""
+echo "Summary:"
+if [ -n "${TEST_NAMESPACES}" ]; then
+    echo "  ✓ Test namespaces cleaned up"
+else
+    echo "  ℹ No test namespaces found"
+fi
+
+if [ "${REMOVE_DRIVER}" == "true" ]; then
+    if [ "${DRIVER_TYPE}" != "none" ]; then
+        echo "  ✓ ${DRIVER_TYPE} driver removed"
+    else
+        echo "  ℹ No driver found to remove"
+    fi
+else
+    echo "  ℹ DRA driver preserved (--keep-driver)"
+fi
+
+if [ "${REMOVE_OPERATOR}" == "true" ]; then
+    if oc get namespace nvidia-gpu-operator &>/dev/null 2>&1; then
+        echo "  ⚠ GPU operator namespace still exists"
+    else
+        echo "  ✓ GPU operator removed"
+    fi
+else
+    echo "  ℹ GPU operator preserved (--keep-operator)"
+fi
+echo ""

--- a/plugins/dra-ocp-validator/tools/cluster-info.sh
+++ b/plugins/dra-ocp-validator/tools/cluster-info.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# Cluster access verification and hardware discovery tool
+
+set -euo pipefail
+
+KUBECONFIG_PATH=$1
+
+# Get script directory and plugin root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+# Verify required tools
+for cmd in oc kubectl jq yq; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "ERROR: Required command not found: $cmd"
+        exit 1
+    fi
+done
+
+# Source the feature metadata helper
+METADATA_HELPER="${SCRIPT_DIR}/feature-metadata.sh"
+if [ ! -f "${METADATA_HELPER}" ]; then
+    echo "ERROR: feature-metadata.sh not found at ${METADATA_HELPER}"
+    exit 1
+fi
+source "${METADATA_HELPER}"
+
+# Export kubeconfig
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "=== Cluster Access Verification ==="
+
+# Test cluster access
+if ! oc cluster-info >/dev/null 2>&1; then
+    echo "ERROR: Cannot access cluster with kubeconfig: ${KUBECONFIG_PATH}"
+    exit 1
+fi
+
+echo "✓ Cluster accessible"
+
+# Get cluster versions
+OCP_VERSION=$(oc version -o json 2>/dev/null | jq -r '.openshiftVersion // "unknown"')
+K8S_VERSION=$(oc version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion // "unknown"')
+K8S_MINOR=$(echo ${K8S_VERSION} | sed -E 's/v1\.([0-9]+)\..*/\1/')
+
+echo "OCP Version: ${OCP_VERSION}"
+echo "Kubernetes Version: ${K8S_VERSION}"
+
+# Get node count
+NODE_COUNT=$(oc get nodes --no-headers 2>/dev/null | wc -l)
+echo "Nodes: ${NODE_COUNT}"
+
+echo ""
+echo "=== Hardware Discovery ==="
+
+# Check if NFD is installed (check for NFD CR, not just namespace)
+NFD_INSTALLED=0
+if oc get namespace openshift-nfd &>/dev/null && oc get nodefeaturediscovery -n openshift-nfd &>/dev/null 2>&1; then
+    NFD_INSTALLED=1
+fi
+
+if [ ${NFD_INSTALLED} -gt 0 ]; then
+    echo "✓ NFD installed"
+
+    # Detect NVIDIA GPUs (PCI vendor 10de)
+    NVIDIA_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-10de.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+    # Detect AMD GPUs (PCI vendor 1002)
+    AMD_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-1002.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+    # Detect Intel GPUs (PCI vendor 8086)
+    INTEL_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-8086.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+    if [ ${NVIDIA_NODES} -gt 0 ]; then
+        GPU_VENDOR="nvidia"
+        GPU_NODES=${NVIDIA_NODES}
+    elif [ ${AMD_NODES} -gt 0 ]; then
+        GPU_VENDOR="amd"
+        GPU_NODES=${AMD_NODES}
+    elif [ ${INTEL_NODES} -gt 0 ]; then
+        GPU_VENDOR="intel"
+        GPU_NODES=${INTEL_NODES}
+    else
+        GPU_VENDOR="none"
+        GPU_NODES=0
+    fi
+else
+    echo "⚠ NFD not installed - cannot auto-detect GPUs"
+    GPU_VENDOR="unknown"
+    GPU_NODES=0
+fi
+
+echo "GPU Vendor: ${GPU_VENDOR}"
+echo "GPU Nodes: ${GPU_NODES}"
+
+# Initialize GPU_MODEL
+GPU_MODEL=""
+
+# Detect GPU model (if NVIDIA)
+if [ "${GPU_VENDOR}" = "nvidia" ] && [ ${GPU_NODES} -gt 0 ]; then
+    # Get first GPU node
+    GPU_NODE=$(oc get nodes -l 'feature.node.kubernetes.io/pci-10de.present=true' -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+    # Try to get GPU model from node labels
+    GPU_MODEL=$(oc get node ${GPU_NODE} -o json 2>/dev/null | \
+        jq -r '.metadata.labels | to_entries[] | select(.key | contains("nvidia.com/gpu.product")) | .value' | head -1)
+
+    if [ -z "${GPU_MODEL}" ]; then
+        GPU_MODEL="Unknown NVIDIA GPU"
+    fi
+
+    echo "GPU Model: ${GPU_MODEL}"
+fi
+
+echo ""
+echo "=== DRA Feature Detection ==="
+
+# Use metadata system to detect features by graduation level
+K8S_VERSION_FULL=$(echo "${K8S_VERSION}" | sed -E 's/v(1\.[0-9]+)\..*/\1/')
+
+ALPHA_FEATURES=()
+BETA_FEATURES=()
+GA_FEATURES=()
+
+for feature in $(list_all_features); do
+    if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
+        GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || echo "unknown")
+        case "${GRADUATION}" in
+            alpha)
+                ALPHA_FEATURES+=("${feature}")
+                ;;
+            beta)
+                BETA_FEATURES+=("${feature}")
+                ;;
+            ga)
+                GA_FEATURES+=("${feature}")
+                ;;
+        esac
+    fi
+done
+
+# Convert arrays to comma-separated strings for backward compatibility
+ALPHA_FEATURES_STR=$(IFS=,; echo "${ALPHA_FEATURES[*]}")
+BETA_FEATURES_STR=$(IFS=,; echo "${BETA_FEATURES[*]}")
+GA_FEATURES_STR=$(IFS=,; echo "${GA_FEATURES[*]}")
+
+echo "GA Features: ${GA_FEATURES_STR:-none}"
+echo "Beta Features: ${BETA_FEATURES_STR:-none}"
+echo "Alpha Features: ${ALPHA_FEATURES_STR:-none}"
+
+# Check DRA driver installation
+echo ""
+echo "=== DRA Driver Status ==="
+
+if oc get deviceclass &>/dev/null; then
+    DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l)
+    echo "DeviceClasses: ${DEVICECLASS_COUNT}"
+
+    if [ ${DEVICECLASS_COUNT} -gt 0 ]; then
+        oc get deviceclass -o name
+    fi
+else
+    echo "⚠ No DeviceClasses found - DRA driver may not be installed"
+fi
+
+if oc get resourceslice &>/dev/null; then
+    RESOURCESLICE_COUNT=$(oc get resourceslice --no-headers 2>/dev/null | wc -l)
+    echo "ResourceSlices: ${RESOURCESLICE_COUNT}"
+else
+    echo "⚠ No ResourceSlices found"
+fi
+
+# CDMM detection (NVIDIA Grace-Blackwell only)
+echo ""
+echo "=== CDMM Detection (NVIDIA Grace-Blackwell) ==="
+
+if [ "${GPU_VENDOR}" = "nvidia" ] && [[ "${GPU_MODEL}" =~ "GB" ]]; then
+    # Get first GPU node
+    GPU_NODE=$(oc get nodes -l 'feature.node.kubernetes.io/pci-10de.present=true' -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+    # Check NUMA node count (requires debug pod)
+    NUMA_COUNT=$(oc debug node/${GPU_NODE} -- chroot /host lscpu 2>/dev/null | \
+        grep "NUMA node(s):" | awk '{print $3}' || echo "0")
+
+    echo "NUMA nodes: ${NUMA_COUNT}"
+
+    if [ "${NUMA_COUNT}" -gt 10 ]; then
+        echo "CDMM Status: Disabled (MIG tests can run)"
+        SKIP_MIG="false"
+    elif [ "${NUMA_COUNT}" -gt 0 ] && [ "${NUMA_COUNT}" -le 10 ]; then
+        echo "CDMM Status: Enabled (MIG tests will be skipped - NVIDIA limitation)"
+        SKIP_MIG="true"
+    else
+        echo "CDMM Status: Unknown (could not determine NUMA count)"
+        SKIP_MIG="false"
+    fi
+else
+    echo "CDMM detection not applicable (not NVIDIA Grace-Blackwell)"
+    SKIP_MIG="false"
+fi
+
+# Output summary as JSON for programmatic consumption
+echo ""
+echo "=== Summary (JSON) ==="
+cat <<EOF
+{
+  "cluster": {
+    "ocp_version": "${OCP_VERSION}",
+    "k8s_version": "${K8S_VERSION}",
+    "k8s_minor": ${K8S_MINOR},
+    "node_count": ${NODE_COUNT}
+  },
+  "hardware": {
+    "gpu_vendor": "${GPU_VENDOR}",
+    "gpu_nodes": ${GPU_NODES},
+    "gpu_model": "${GPU_MODEL:-unknown}",
+    "nfd_installed": $([ ${NFD_INSTALLED} -gt 0 ] && echo "true" || echo "false")
+  },
+  "dra": {
+    "beta_features": "${BETA_FEATURES}",
+    "alpha_features": "${ALPHA_FEATURES}",
+    "deviceclass_count": ${DEVICECLASS_COUNT:-0},
+    "resourceslice_count": ${RESOURCESLICE_COUNT:-0}
+  },
+  "cdmm": {
+    "skip_mig": ${SKIP_MIG}
+  }
+}
+EOF

--- a/plugins/dra-ocp-validator/tools/collect-artifacts.sh
+++ b/plugins/dra-ocp-validator/tools/collect-artifacts.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# Collect all DRA validation artifacts and generate report
+
+set -euo pipefail
+
+KUBECONFIG_PATH=$1
+OUTPUT_DIR=$2
+CLUSTER_NAME=${3:-cluster}
+
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "======================================"
+echo "Artifact Collection"
+echo "======================================"
+echo "Output Directory: ${OUTPUT_DIR}"
+echo ""
+
+mkdir -p "${OUTPUT_DIR}"
+
+#========================================
+# Cluster Information
+#========================================
+echo "=== Collecting Cluster Information ==="
+
+oc version -o json > "${OUTPUT_DIR}/cluster-version.json" 2>/dev/null || true
+oc get nodes -o wide > "${OUTPUT_DIR}/nodes.txt" 2>/dev/null || true
+oc get nodes -o json > "${OUTPUT_DIR}/nodes.json" 2>/dev/null || true
+
+echo "✓ Cluster info collected"
+
+#========================================
+# DRA Resources
+#========================================
+echo "=== Collecting DRA Resources ==="
+
+oc get deviceclass -o yaml > "${OUTPUT_DIR}/deviceclass.yaml" 2>/dev/null || echo "⚠ No DeviceClasses"
+oc get deviceclass -o json > "${OUTPUT_DIR}/deviceclass.json" 2>/dev/null || true
+
+oc get resourceslice -o yaml > "${OUTPUT_DIR}/resourceslice.yaml" 2>/dev/null || echo "⚠ No ResourceSlices"
+oc get resourceslice -o json > "${OUTPUT_DIR}/resourceslice.json" 2>/dev/null || true
+
+oc get resourceclaim --all-namespaces -o yaml > "${OUTPUT_DIR}/resourceclaims-all.yaml" 2>/dev/null || true
+
+echo "✓ DRA resources collected"
+
+#========================================
+# Driver Logs
+#========================================
+echo "=== Collecting Driver Logs ==="
+
+# NVIDIA DRA driver
+if oc get namespace nvidia-dra-driver &>/dev/null 2>&1; then
+    echo "Collecting NVIDIA DRA driver logs..."
+    oc logs -n nvidia-dra-driver daemonset/nvidia-dra-driver --tail=2000 \
+        > "${OUTPUT_DIR}/nvidia-dra-driver-logs.txt" 2>/dev/null || true
+
+    oc get pods -n nvidia-dra-driver -o wide \
+        > "${OUTPUT_DIR}/nvidia-dra-driver-pods.txt" 2>/dev/null || true
+fi
+
+# dra-example-driver
+if oc get namespace dra-example-driver &>/dev/null 2>&1; then
+    echo "Collecting dra-example-driver logs..."
+    oc logs -n dra-example-driver -l app=dra-example-driver --tail=2000 \
+        > "${OUTPUT_DIR}/dra-example-driver-logs.txt" 2>/dev/null || true
+
+    oc get pods -n dra-example-driver -o wide \
+        > "${OUTPUT_DIR}/dra-example-driver-pods.txt" 2>/dev/null || true
+fi
+
+# GPU Operator
+if oc get namespace gpu-operator-resources &>/dev/null 2>&1; then
+    echo "Collecting GPU Operator logs..."
+    oc logs -n gpu-operator-resources deployment/gpu-operator --tail=1000 \
+        > "${OUTPUT_DIR}/gpu-operator-logs.txt" 2>/dev/null || true
+
+    oc get pods -n gpu-operator-resources -o wide \
+        > "${OUTPUT_DIR}/gpu-operator-pods.txt" 2>/dev/null || true
+fi
+
+echo "✓ Driver logs collected"
+
+#========================================
+# Test Logs
+#========================================
+echo "=== Collecting Test Logs ==="
+
+# Copy test log directories
+for dir in dra-*-20*/; do
+    if [ -d "$dir" ]; then
+        cp -r "$dir" "${OUTPUT_DIR}/" 2>/dev/null || true
+        echo "  ✓ Copied: $dir"
+    fi
+done
+
+# Count test logs
+TEST_LOG_COUNT=$(find "${OUTPUT_DIR}" -type d -name "dra-*-20*" | wc -l)
+echo "✓ Collected ${TEST_LOG_COUNT} test log directories"
+
+#========================================
+# Feature Gates
+#========================================
+echo "=== Collecting Feature Gate Status ==="
+
+oc get featuregate cluster -o json > "${OUTPUT_DIR}/featuregate.json" 2>/dev/null || true
+oc get featuregate cluster -o json | \
+    jq -r '.status.featureGates[].enabled[] | select(.name | contains("DRA"))' \
+    > "${OUTPUT_DIR}/featuregate-dra.json" 2>/dev/null || true
+
+echo "✓ Feature gates collected"
+
+#========================================
+# Events
+#========================================
+echo "=== Collecting Events ==="
+
+# Get events from all test namespaces
+for ns in $(oc get namespaces -o name | grep 'dra-.*-test' | sed 's|namespace/||'); do
+    oc get events -n ${ns} --sort-by='.lastTimestamp' \
+        > "${OUTPUT_DIR}/events-${ns}.txt" 2>/dev/null || true
+done
+
+echo "✓ Events collected"
+
+#========================================
+# Generate Validation Report
+#========================================
+echo "=== Generating Validation Report ==="
+
+# Extract cluster info
+OCP_VERSION=$(jq -r '.openshiftVersion // "unknown"' "${OUTPUT_DIR}/cluster-version.json" 2>/dev/null || echo "unknown")
+K8S_VERSION=$(jq -r '.serverVersion.gitVersion // "unknown"' "${OUTPUT_DIR}/cluster-version.json" 2>/dev/null || echo "unknown")
+NODE_COUNT=$(wc -l < "${OUTPUT_DIR}/nodes.txt" 2>/dev/null || echo "0")
+
+# Count DRA resources
+DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l || echo "0")
+RESOURCESLICE_COUNT=$(oc get resourceslice --no-headers 2>/dev/null | wc -l || echo "0")
+
+# Detect GPU info
+GPU_INFO=$(oc get nodes -o json | \
+    jq -r '.items[0].metadata.labels | to_entries[] | select(.key | contains("pci-10de")) | .key' 2>/dev/null | head -1 || echo "")
+
+if [ -n "${GPU_INFO}" ]; then
+    GPU_VENDOR="NVIDIA"
+else
+    GPU_VENDOR="Unknown/Example Driver"
+fi
+
+# Generate report
+cat > "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md" <<EOF
+# DRA Validation Report
+
+**Date**: $(date +%Y-%m-%d)
+**Cluster**: ${CLUSTER_NAME}
+**OCP Version**: ${OCP_VERSION}
+**Kubernetes Version**: ${K8S_VERSION}
+**Nodes**: ${NODE_COUNT}
+**GPU Vendor**: ${GPU_VENDOR}
+
+---
+
+## Cluster Summary
+
+- **DeviceClasses**: ${DEVICECLASS_COUNT}
+- **ResourceSlices**: ${RESOURCESLICE_COUNT}
+- **Test Logs**: ${TEST_LOG_COUNT} feature validations
+
+---
+
+## DRA Resources
+
+### DeviceClasses
+\`\`\`
+$(oc get deviceclass 2>/dev/null || echo "None")
+\`\`\`
+
+### ResourceSlices (sample)
+\`\`\`
+$(oc get resourceslice 2>/dev/null | head -10 || echo "None")
+\`\`\`
+
+---
+
+## Test Results
+
+EOF
+
+# Parse test results from log directories
+for dir in "${OUTPUT_DIR}"/dra-*-20*/; do
+    if [ -d "$dir" ]; then
+        TEST_NAME=$(basename "$dir" | sed 's/dra-\(.*\)-20.*/\1/' | tr '-' ' ' | sed 's/\b\(.\)/\u\1/g')
+        if [ -f "${dir}/test-output.log" ]; then
+            # Check for validation status in log
+            if grep -q "VALIDATED\|PASS" "${dir}/test-output.log"; then
+                echo "### ✅ ${TEST_NAME}" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+                echo "**Status**: PASS" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+            elif grep -q "SKIP" "${dir}/test-output.log"; then
+                echo "### ⚠️ ${TEST_NAME}" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+                echo "**Status**: SKIP" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+            else
+                echo "### ❌ ${TEST_NAME}" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+                echo "**Status**: UNKNOWN" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+            fi
+            echo "**Logs**: $(basename "$dir")" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+            echo "" >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+        fi
+    fi
+done
+
+cat >> "${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md" <<EOF
+
+---
+
+## Artifacts
+
+All validation artifacts are available in this directory:
+
+- \`cluster-version.json\` - Cluster version information
+- \`nodes.txt/json\` - Node details
+- \`deviceclass.yaml/json\` - DeviceClass configurations
+- \`resourceslice.yaml/json\` - ResourceSlice states
+- \`*-driver-logs.txt\` - Driver logs
+- \`dra-*-20*/\` - Individual test logs
+
+---
+
+## References
+
+- [Kubernetes DRA Documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/)
+- [NVIDIA DRA Driver](https://github.com/NVIDIA/k8s-dra-driver)
+- [dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver)
+
+---
+
+**Generated by**: dra-ocp-validator plugin
+**Timestamp**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+EOF
+
+echo "✓ Report generated: ${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+
+#========================================
+# Create Tarball
+#========================================
+echo "=== Creating Tarball ==="
+
+TARBALL="${OUTPUT_DIR}.tar.gz"
+tar -czf "${TARBALL}" -C "$(dirname "${OUTPUT_DIR}")" "$(basename "${OUTPUT_DIR}")"
+
+TARBALL_SIZE=$(du -h "${TARBALL}" | cut -f1)
+echo "✓ Tarball created: ${TARBALL} (${TARBALL_SIZE})"
+
+echo ""
+echo "======================================"
+echo "Artifact Collection Complete!"
+echo "======================================"
+echo ""
+echo "Report: ${OUTPUT_DIR}/DRA-VALIDATION-REPORT.md"
+echo "Tarball: ${TARBALL}"
+echo ""
+echo "Artifacts ready for attachment to JIRA"

--- a/plugins/dra-ocp-validator/tools/collect-debug-info.sh
+++ b/plugins/dra-ocp-validator/tools/collect-debug-info.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Shared debug collection function for DRA tests
+# Usage: source this file and call collect_test_debug_info <log_dir> <namespace> [pod_name]
+
+collect_test_debug_info() {
+    local LOG_DIR="${1}"
+    local NAMESPACE="${2}"
+    local POD_NAME="${3:-}"
+
+    if [ -z "${LOG_DIR}" ] || [ -z "${NAMESPACE}" ]; then
+        echo "⚠ collect_test_debug_info: Missing required arguments"
+        return 1
+    fi
+
+    mkdir -p "${LOG_DIR}/debug"
+
+    echo ""
+    echo "=== Collecting Debug Information ==="
+
+    # 1. Events (most important for debugging scheduling failures)
+    echo "  → Events in namespace ${NAMESPACE}..."
+    oc get events -n "${NAMESPACE}" --sort-by='.lastTimestamp' \
+        > "${LOG_DIR}/debug/events.txt" 2>/dev/null || true
+
+    # Also get cluster-wide events related to DRA
+    oc get events -A --sort-by='.lastTimestamp' | grep -i "dra\|resource.*claim\|device" \
+        > "${LOG_DIR}/debug/events-cluster-dra.txt" 2>/dev/null || true
+
+    # 2. ResourceClaims status
+    echo "  → ResourceClaims in namespace ${NAMESPACE}..."
+    oc get resourceclaim -n "${NAMESPACE}" -o yaml \
+        > "${LOG_DIR}/debug/resourceclaims-full.yaml" 2>/dev/null || true
+
+    oc get resourceclaim -n "${NAMESPACE}" -o json | \
+        jq '.items[] | {name: .metadata.name, allocated: .status.allocation.devices.results, conditions: .status.conditions}' \
+        > "${LOG_DIR}/debug/resourceclaims-status.json" 2>/dev/null || true
+
+    # 3. Pod logs (if pod name provided)
+    if [ -n "${POD_NAME}" ]; then
+        echo "  → Pod logs for ${POD_NAME}..."
+        oc logs -n "${NAMESPACE}" "${POD_NAME}" --all-containers=true \
+            > "${LOG_DIR}/debug/pod-${POD_NAME}-logs.txt" 2>/dev/null || echo "Pod not found or no logs" > "${LOG_DIR}/debug/pod-${POD_NAME}-logs.txt"
+
+        oc logs -n "${NAMESPACE}" "${POD_NAME}" --previous --all-containers=true \
+            > "${LOG_DIR}/debug/pod-${POD_NAME}-logs-previous.txt" 2>/dev/null || true
+    fi
+
+    # 4. All pods in namespace
+    echo "  → All pods in namespace ${NAMESPACE}..."
+    oc get pods -n "${NAMESPACE}" -o wide \
+        > "${LOG_DIR}/debug/pods.txt" 2>/dev/null || true
+
+    oc get pods -n "${NAMESPACE}" -o json | \
+        jq '.items[] | {name: .metadata.name, phase: .status.phase, conditions: .status.conditions, resourceClaimStatuses: .status.resourceClaimStatuses}' \
+        > "${LOG_DIR}/debug/pods-status.json" 2>/dev/null || true
+
+    # 5. Pod descriptions (contains scheduling failures)
+    for pod in $(oc get pods -n "${NAMESPACE}" -o name 2>/dev/null); do
+        POD_SHORT=$(basename "$pod")
+        oc describe -n "${NAMESPACE}" "$pod" \
+            > "${LOG_DIR}/debug/describe-${POD_SHORT}.txt" 2>/dev/null || true
+    done
+
+    # 6. DRA driver logs (from driver namespace)
+    echo "  → DRA driver logs..."
+
+    # NVIDIA driver
+    if oc get namespace nvidia-dra-driver &>/dev/null; then
+        oc logs -n nvidia-dra-driver -l app=nvidia-dra-driver --tail=500 --timestamps \
+            > "${LOG_DIR}/debug/nvidia-dra-driver-logs.txt" 2>/dev/null || true
+    fi
+
+    # Example driver
+    if oc get namespace dra-example-driver &>/dev/null; then
+        oc logs -n dra-example-driver -l app=dra-example-driver --tail=500 --timestamps \
+            > "${LOG_DIR}/debug/dra-example-driver-logs.txt" 2>/dev/null || true
+    fi
+
+    # 7. Current ResourceSlice state
+    echo "  → ResourceSlice state..."
+    oc get resourceslice -o yaml > "${LOG_DIR}/debug/resourceslice-current.yaml" 2>/dev/null || true
+
+    # 8. Scheduler logs (if accessible)
+    echo "  → Scheduler logs..."
+    oc logs -n openshift-kube-scheduler -l app=openshift-kube-scheduler --tail=200 --timestamps \
+        > "${LOG_DIR}/debug/scheduler-logs.txt" 2>/dev/null || true
+
+    # 9. Create a quick summary
+    cat > "${LOG_DIR}/debug/README.txt" <<EOF
+==============================================
+Debug Information Summary
+==============================================
+
+This directory contains debugging artifacts collected at: $(date)
+
+Key Files:
+----------
+1. events.txt                    - Namespace events (check for scheduling/allocation failures)
+2. events-cluster-dra.txt        - Cluster-wide DRA-related events
+3. resourceclaims-full.yaml      - Complete ResourceClaim state
+4. resourceclaims-status.json    - Allocation status and conditions (easier to read)
+5. pods-status.json              - Pod status and resourceClaimStatuses
+6. describe-*.txt                - Pod descriptions (scheduling decisions)
+7. *-driver-logs.txt             - DRA driver logs
+8. scheduler-logs.txt            - Scheduler logs (allocation decisions)
+
+What to Check First:
+-------------------
+1. events.txt - Look for "FailedScheduling", "FailedAllocation", errors
+2. resourceclaims-status.json - Check if claims are allocated
+3. pods-status.json - Check resourceClaimStatuses field
+4. describe-pod-*.txt - Check "Events:" section for scheduling failures
+5. Driver logs - Check for allocation errors
+
+Common Issues:
+-------------
+- "No devices available" → Check ResourceSlice capacity
+- "AdminAccess forbidden" → Check namespace labels
+- "Pending" pods → Check events.txt for scheduling failures
+- Empty resourceClaimStatuses → Claim not allocated to pod
+
+EOF
+
+    echo "✓ Debug info collected in ${LOG_DIR}/debug/"
+    echo ""
+}
+
+# Export the function so tests can use it
+export -f collect_test_debug_info 2>/dev/null || true

--- a/plugins/dra-ocp-validator/tools/common.sh
+++ b/plugins/dra-ocp-validator/tools/common.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -euo pipefail
+
+setup_kubeconfig() {
+  local kubeconfig_path="${1/#~/$HOME}"
+
+  if [ ! -f "${kubeconfig_path}" ]; then
+    echo "ERROR: KUBECONFIG file not found: ${kubeconfig_path}" >&2
+    return 1
+  fi
+
+  export KUBECONFIG="${kubeconfig_path}"
+  return 0
+}
+
+validate_cluster_connectivity() {
+  local required="${1:-true}"
+
+  if [ -z "${KUBECONFIG:-}" ]; then
+    echo "ERROR: KUBECONFIG not set" >&2
+    return 1
+  fi
+
+  if ! command -v oc &>/dev/null; then
+    echo "ERROR: 'oc' command not found. Please install OpenShift CLI" >&2
+    return 1
+  fi
+
+  echo "Validating cluster connectivity..." >&2
+
+  if ! oc version --request-timeout=5s &>/dev/null; then
+    if [ "${required}" == "true" ]; then
+      echo "" >&2
+      echo "ERROR: Cluster unreachable or unavailable" >&2
+      echo "  KUBECONFIG: ${KUBECONFIG}" >&2
+      echo "" >&2
+      echo "Possible causes:" >&2
+      echo "  - Cluster is down or network is unreachable" >&2
+      echo "  - Invalid or expired credentials in kubeconfig" >&2
+      echo "  - Firewall blocking connection to cluster API" >&2
+      echo "" >&2
+      echo "Troubleshooting:" >&2
+      echo "  1. Verify cluster status: oc cluster-info" >&2
+      echo "  2. Check kubeconfig: cat ${KUBECONFIG}" >&2
+      echo "  3. Test connectivity: curl -k \$(oc whoami --show-server)" >&2
+      return 1
+    else
+      echo "  ⚠ Cluster unreachable - running in offline mode" >&2
+      return 2
+    fi
+  fi
+
+  echo "  ✓ Cluster accessible" >&2
+  return 0
+}
+
+locate_tool_script() {
+  local script_name="$1"
+
+  # Prefer installed plugin location
+  local script_path=$(find ~/.claude/plugins -type f -path "*/dra-ocp-validator/tools/${script_name}" 2>/dev/null | sort | head -1)
+
+  if [ -z "${script_path}" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    script_path="${CLAUDE_PLUGIN_ROOT}/tools/${script_name}"
+  fi
+
+  if [ ! -f "${script_path}" ]; then
+    echo "ERROR: ${script_name} not found. Plugin may not be installed correctly." >&2
+    return 1
+  fi
+
+  echo "${script_path}"
+}
+
+setup_test_logging() {
+  local feature_name="$1"
+  local log_dir="./dra-${feature_name}-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "${log_dir}"
+
+  echo "Test Date: $(date)"
+  echo "Logs Directory: ${log_dir}"
+
+  exec > >(tee -a "${log_dir}/test-output.log")
+  exec 2>&1
+
+  echo "${log_dir}"
+}
+
+get_script_dir() {
+  cd "$(dirname "${BASH_SOURCE[1]}")" && pwd
+}
+
+get_tools_dir() {
+  local script_dir="$1"
+  dirname "${script_dir}"
+}

--- a/plugins/dra-ocp-validator/tools/feature-metadata.sh
+++ b/plugins/dra-ocp-validator/tools/feature-metadata.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# Feature Metadata Helper
+# Provides functions to query DRA feature metadata from dra-features.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "${SCRIPT_DIR}")"
+METADATA_FILE="${PLUGIN_ROOT}/dra-features.yaml"
+
+# Check if yq is available (required for YAML parsing)
+if ! command -v yq &> /dev/null; then
+    echo "ERROR: yq is required but not installed" >&2
+    echo "Install with: brew install yq (macOS) or dnf install yq (RHEL/Fedora)" >&2
+    exit 1
+fi
+
+# Get feature name (human-readable)
+get_feature_name() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.name" "${METADATA_FILE}"
+}
+
+# Get minimum K8s version for a feature
+get_min_k8s_version() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.kubernetes.introduced" "${METADATA_FILE}"
+}
+
+# Get feature gate name
+get_feature_gate() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.feature_gate.name" "${METADATA_FILE}"
+}
+
+# Get graduation level of a feature for given K8s version
+get_feature_graduation() {
+    local feature_key="$1"
+    local k8s_version="$2"  # e.g., "1.34"
+
+    # Check if version is in GA range
+    local ga_version
+    ga_version=$(yq eval ".features.${feature_key}.kubernetes.ga" "${METADATA_FILE}" 2>/dev/null || echo "null")
+
+    if [ "${ga_version}" != "null" ]; then
+        local ga_minor
+        ga_minor=$(echo "${ga_version}" | sed -E 's/1\.([0-9]+)/\1/')
+        local current_minor
+        current_minor=$(echo "${k8s_version}" | sed -E 's/1\.([0-9]+)/\1/')
+
+        if [ "${current_minor}" -ge "${ga_minor}" ]; then
+            echo "ga"
+            return 0
+        fi
+    fi
+
+    # Check if version is in Beta list
+    local beta_count
+    beta_count=$(yq eval ".features.${feature_key}.kubernetes.beta[]? | select(. == \"${k8s_version}\")" "${METADATA_FILE}" 2>/dev/null | wc -l)
+
+    if [ "${beta_count}" -gt 0 ]; then
+        echo "beta"
+        return 0
+    fi
+
+    # Check if version is in Alpha list
+    local alpha_count
+    alpha_count=$(yq eval ".features.${feature_key}.kubernetes.alpha[]? | select(. == \"${k8s_version}\")" "${METADATA_FILE}" 2>/dev/null | wc -l)
+
+    if [ "${alpha_count}" -gt 0 ]; then
+        echo "alpha"
+        return 0
+    fi
+
+    # Not available in this version
+    echo "unavailable"
+    return 1
+}
+
+# Check if feature gate is required for given K8s version
+# Logic:
+#   - Alpha: Feature gate REQUIRED (not enabled by default)
+#   - Beta: Feature gate OPTIONAL (enabled by default in K8s, may need explicit enable in OCP)
+#   - GA: Feature gate NOT required (always enabled, can't be disabled)
+is_feature_gate_required() {
+    local feature_key="$1"
+    local k8s_version="$2"  # e.g., "1.34"
+
+    local gate_name
+    gate_name=$(get_feature_gate "${feature_key}")
+
+    # If no feature gate defined, not required
+    if [ "${gate_name}" == "null" ] || [ -z "${gate_name}" ]; then
+        return 1
+    fi
+
+    # Determine graduation level
+    local graduation
+    graduation=$(get_feature_graduation "${feature_key}" "${k8s_version}")
+
+    case "${graduation}" in
+        alpha)
+            # Alpha features ALWAYS require explicit enablement
+            return 0
+            ;;
+        beta)
+            # Beta features are enabled by default in K8s, but OCP may require CustomNoUpgrade
+            # Return true to indicate it needs to be checked/enabled in OCP
+            return 0
+            ;;
+        ga)
+            # GA features are always enabled, gate not required
+            return 1
+            ;;
+        unavailable)
+            # Feature not available, gate not applicable
+            return 1
+            ;;
+    esac
+}
+
+# Get setup flags for a feature
+get_setup_flags() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.setup.flags[]?" "${METADATA_FILE}" 2>/dev/null || echo ""
+}
+
+# Get test script path
+get_test_script() {
+    local feature_key="$1"
+    local script_path
+    script_path=$(yq eval ".features.${feature_key}.test.script" "${METADATA_FILE}")
+    echo "${PLUGIN_ROOT}/${script_path}"
+}
+
+# Get cleanup pattern for a feature
+get_cleanup_pattern() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.test.cleanup_pattern" "${METADATA_FILE}"
+}
+
+# Get all cleanup patterns (for cleanup script)
+get_all_cleanup_patterns() {
+    yq eval ".cleanup.test_namespace_patterns[]" "${METADATA_FILE}"
+}
+
+# Get driver namespaces (should not be cleaned)
+get_driver_namespaces() {
+    yq eval ".cleanup.driver_namespaces[]" "${METADATA_FILE}"
+}
+
+# Get prerequisites for a feature
+get_prerequisites() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.prerequisites[]" "${METADATA_FILE}" -o json 2>/dev/null || echo "[]"
+}
+
+# Check if a feature is available for given K8s version
+is_feature_available() {
+    local feature_key="$1"
+    local k8s_minor="$2"  # e.g., 34
+
+    local min_version
+    min_version=$(get_min_k8s_version "${feature_key}")
+
+    if [ "${min_version}" == "null" ]; then
+        return 1
+    fi
+
+    # Extract minor version from introduced version
+    local min_minor
+    min_minor=$(echo "${min_version}" | sed -E 's/1\.([0-9]+)/\1/')
+
+    if [ "${k8s_minor}" -ge "${min_minor}" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Get driver configuration for a feature
+get_driver_config() {
+    local feature_key="$1"
+    local driver_type="$2"  # nvidia or example
+
+    yq eval ".features.${feature_key}.setup.driver_config.${driver_type}" "${METADATA_FILE}" -o json 2>/dev/null || echo "{}"
+}
+
+# List all features
+list_all_features() {
+    yq eval '.features | keys | .[]' "${METADATA_FILE}"
+}
+
+# Get feature description
+get_feature_description() {
+    local feature_key="$1"
+    yq eval ".features.${feature_key}.description" "${METADATA_FILE}"
+}
+
+# Get check method implementation
+get_check_method() {
+    local method_name="$1"
+    yq eval ".check_methods.${method_name}.implementation" "${METADATA_FILE}"
+}
+
+# Check if feature gate is currently enabled in the cluster
+is_featuregate_currently_enabled() {
+    local gate_name="$1"
+
+    # Check CustomNoUpgrade first (OCP-specific granular control)
+    local enabled
+    enabled=$(oc get featuregate cluster -o json 2>/dev/null | \
+        jq -r --arg fg "${gate_name}" '.spec.customNoUpgrade.enabled[]? | select(. == $fg)' || true)
+
+    if [ -n "${enabled}" ]; then
+        return 0
+    fi
+
+    # Check default FeatureSet
+    enabled=$(oc get featuregate cluster -o json 2>/dev/null | \
+        jq -r --arg fg "${gate_name}" '.status.featureGates[].enabled[]? | select(.name == $fg).name' || true)
+
+    if [ -n "${enabled}" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Get enablement command for a feature
+get_enablement_command() {
+    local feature_key="$1"
+    # Try .command first (newer format)
+    local cmd
+    cmd=$(yq eval ".features.${feature_key}.feature_gate.enablement.command" "${METADATA_FILE}" 2>/dev/null)
+    if [ "${cmd}" != "null" ] && [ -n "${cmd}" ]; then
+        echo "${cmd}"
+        return 0
+    fi
+
+    # Try .openshift (older format)
+    cmd=$(yq eval ".features.${feature_key}.feature_gate.enablement.openshift" "${METADATA_FILE}" 2>/dev/null)
+    if [ "${cmd}" != "null" ] && [ -n "${cmd}" ]; then
+        echo "${cmd}"
+        return 0
+    fi
+
+    echo "null"
+    return 1
+}
+
+# Check and report feature gate status
+check_feature_gate_status() {
+    local feature_key="$1"
+    local k8s_version="$2"  # e.g., "1.34"
+
+    local gate_name
+    gate_name=$(get_feature_gate "${feature_key}")
+
+    if [ "${gate_name}" == "null" ] || [ -z "${gate_name}" ]; then
+        echo "no_gate_required"
+        return 0
+    fi
+
+    # Determine if gate is required based on graduation
+    local graduation
+    graduation=$(get_feature_graduation "${feature_key}" "${k8s_version}")
+
+    case "${graduation}" in
+        ga)
+            echo "ga_always_enabled"
+            return 0
+            ;;
+        alpha|beta)
+            # Check if currently enabled
+            if is_featuregate_currently_enabled "${gate_name}"; then
+                echo "enabled"
+                return 0
+            else
+                echo "not_enabled:${graduation}"
+                return 1
+            fi
+            ;;
+        unavailable)
+            echo "feature_unavailable"
+            return 1
+            ;;
+    esac
+}
+
+# Display feature info (for debugging/documentation)
+show_feature_info() {
+    local feature_key="$1"
+
+    echo "Feature: ${feature_key}"
+    echo "  Name: $(get_feature_name "${feature_key}")"
+    echo "  Description: $(get_feature_description "${feature_key}")"
+    echo "  Min K8s: $(get_min_k8s_version "${feature_key}")"
+
+    local gate
+    gate=$(get_feature_gate "${feature_key}")
+    if [ "${gate}" != "null" ] && [ -n "${gate}" ]; then
+        echo "  Feature Gate: ${gate}"
+    fi
+
+    local flags
+    flags=$(get_setup_flags "${feature_key}")
+    if [ -n "${flags}" ]; then
+        echo "  Setup Flags: ${flags}"
+    fi
+
+    echo "  Test Script: $(get_test_script "${feature_key}")"
+    echo "  Cleanup Pattern: $(get_cleanup_pattern "${feature_key}")"
+}
+
+# Export functions if sourced
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    # Script is being executed directly
+    case "${1:-}" in
+        list)
+            list_all_features
+            ;;
+        info)
+            if [ -z "${2:-}" ]; then
+                echo "Usage: $0 info <feature-key>"
+                exit 1
+            fi
+            show_feature_info "$2"
+            ;;
+        check-available)
+            if [ -z "${2:-}" ] || [ -z "${3:-}" ]; then
+                echo "Usage: $0 check-available <feature-key> <k8s-minor-version>"
+                exit 1
+            fi
+            if is_feature_available "$2" "$3"; then
+                echo "✓ Feature $2 is available on K8s 1.$3"
+                exit 0
+            else
+                echo "✗ Feature $2 is NOT available on K8s 1.$3"
+                exit 1
+            fi
+            ;;
+        *)
+            echo "DRA Feature Metadata Helper"
+            echo ""
+            echo "Usage:"
+            echo "  $0 list                                    # List all features"
+            echo "  $0 info <feature-key>                      # Show feature info"
+            echo "  $0 check-available <feature-key> <k8s-minor>  # Check if feature is available"
+            echo ""
+            echo "Or source this script to use functions:"
+            echo "  source $0"
+            echo "  get_feature_name partitionable"
+            exit 1
+            ;;
+    esac
+fi

--- a/plugins/dra-ocp-validator/tools/install-dra-example.sh
+++ b/plugins/dra-ocp-validator/tools/install-dra-example.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Install dra-example-driver for testing without physical GPUs
+# Based on: https://github.com/openshift/release/blob/master/ci-operator/step-registry/dra-example-driver/install/dra-example-driver-install-commands.sh
+
+set -euo pipefail
+
+KUBECONFIG_PATH=$1
+DRA_EXAMPLE_DRIVER_VERSION="${2:-v0.3.0}"  # Default version, can be overridden
+GPU_PARTITIONS="${3:-0}"  # Default to 0 partitions (disabled unless explicitly enabled via setup --enable-dynamic-mig)
+
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "========================================="
+echo "dra-example-driver Installation via Helm"
+echo "========================================="
+echo "Version: ${DRA_EXAMPLE_DRIVER_VERSION}"
+echo ""
+
+DRA_EXAMPLE_DRIVER_NAMESPACE="dra-example-driver"
+
+# Verify required tools
+for cmd in oc kubectl curl tar; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "ERROR: Required command not found: $cmd"
+        exit 1
+    fi
+done
+
+# Check if dra-example-driver is already installed
+if oc get namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" &>/dev/null; then
+  echo "INFO: ${DRA_EXAMPLE_DRIVER_NAMESPACE} namespace already exists"
+  if helm list -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null | grep -q dra-example-driver; then
+    echo "INFO: dra-example-driver is already installed, skipping installation"
+    echo "To reinstall, first run:"
+    echo "  helm uninstall dra-example-driver -n ${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+    echo "  oc delete namespace ${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+    exit 0
+  fi
+fi
+
+# Install Helm if not present
+if ! command -v helm &> /dev/null; then
+  echo "Installing Helm..."
+  HELM_VERSION="3.17.3"
+  HELM_ARCHIVE="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+  curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}" -o "/tmp/${HELM_ARCHIVE}"
+  curl -fsSL "https://get.helm.sh/${HELM_ARCHIVE}.sha256sum" -o "/tmp/${HELM_ARCHIVE}.sha256sum"
+  echo "Verifying checksum..."
+  (cd /tmp && sha256sum --check --status "${HELM_ARCHIVE}.sha256sum") || {
+    echo "ERROR: Helm checksum verification failed"
+    rm -rf "/tmp/${HELM_ARCHIVE}" "/tmp/${HELM_ARCHIVE}.sha256sum"
+    exit 1
+  }
+  tar -xzf "/tmp/${HELM_ARCHIVE}" -C /tmp
+  mkdir -p /tmp/bin
+  mv /tmp/linux-amd64/helm /tmp/bin/helm
+  chmod +x /tmp/bin/helm
+  export PATH="/tmp/bin:$PATH"
+  rm -rf "/tmp/${HELM_ARCHIVE}" "/tmp/${HELM_ARCHIVE}.sha256sum" /tmp/linux-amd64
+  echo "Helm installed: $(helm version --short)"
+else
+  echo "Helm already installed: $(helm version --short)"
+fi
+
+echo ""
+
+# Download dra-example-driver source tarball for the Helm chart
+echo "Downloading dra-example-driver ${DRA_EXAMPLE_DRIVER_VERSION}..."
+curl -fsSL "https://github.com/kubernetes-sigs/dra-example-driver/archive/refs/tags/${DRA_EXAMPLE_DRIVER_VERSION}.tar.gz" -o /tmp/dra-example-driver.tar.gz
+tar -xzf /tmp/dra-example-driver.tar.gz -C /tmp
+DRA_CHART_DIR="/tmp/dra-example-driver-${DRA_EXAMPLE_DRIVER_VERSION#v}/deployments/helm/dra-example-driver"
+echo "Chart directory: ${DRA_CHART_DIR}"
+ls "${DRA_CHART_DIR}/Chart.yaml"
+
+echo ""
+
+# Create namespace
+echo "Creating namespace ${DRA_EXAMPLE_DRIVER_NAMESPACE}..."
+oc create namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" 2>/dev/null || true
+
+# Grant privileged SCC for dra-example-driver service account (required for OpenShift)
+echo "Adding privileged SCC for dra-example-driver service account..."
+oc adm policy add-scc-to-user privileged -z dra-example-driver-service-account -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+
+echo ""
+
+# Install dra-example-driver via Helm from local chart
+echo "Installing dra-example-driver ${DRA_EXAMPLE_DRIVER_VERSION}..."
+if [ "${GPU_PARTITIONS}" -gt 0 ]; then
+  echo "  - GPU Partitions: ${GPU_PARTITIONS} (SharedCounters enabled for DRAPartitionableDevices)"
+else
+  echo "  - GPU Partitions: ${GPU_PARTITIONS} (SharedCounters disabled)"
+fi
+helm upgrade --install \
+  --namespace "${DRA_EXAMPLE_DRIVER_NAMESPACE}" \
+  dra-example-driver \
+  "${DRA_CHART_DIR}" \
+  --set kubeletPlugin.gpuPartitions=${GPU_PARTITIONS} \
+  --set kubeletPlugin.containers.plugin.securityContext.privileged=true \
+  --wait \
+  --timeout 10m
+
+echo ""
+echo "dra-example-driver installed successfully"
+
+# Wait for dra-example-driver pods to be ready
+echo ""
+echo "Waiting for dra-example-driver pods to be ready..."
+oc wait --for=condition=Ready pods \
+  --all \
+  -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}" \
+  --timeout=10m
+
+echo "All dra-example-driver pods are ready"
+
+# List pods
+echo ""
+echo "dra-example-driver pods:"
+oc get pods -n "${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+
+# Wait for DeviceClass to be created
+echo ""
+echo "Waiting for DeviceClass to be created..."
+timeout 5m bash -c '
+while true; do
+  if oc get deviceclass gpu.example.com &>/dev/null; then
+    echo "DeviceClass created: gpu.example.com"
+    break
+  fi
+  echo "Waiting for DeviceClass..."
+  sleep 10
+done
+'
+
+# Wait for ResourceSlices to be published
+echo ""
+echo "Waiting for dra-example-driver ResourceSlices..."
+timeout 5m bash -c '
+while true; do
+  RESOURCE_SLICES=$(oc get resourceslice -o json 2>/dev/null | grep -c "example.com" || true)
+  if [ "${RESOURCE_SLICES}" -gt 0 ]; then
+    echo "Found dra-example-driver ResourceSlice(s)"
+    break
+  fi
+  echo "Waiting for ResourceSlices..."
+  sleep 10
+done
+'
+
+echo ""
+echo "ResourceSlices:"
+oc get resourceslice
+
+echo ""
+echo "========================================="
+echo "dra-example-driver Installation Complete"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "  - Namespace: ${DRA_EXAMPLE_DRIVER_NAMESPACE}"
+echo "  - Version: ${DRA_EXAMPLE_DRIVER_VERSION}"
+echo "  - DeviceClass: gpu.example.com"
+echo ""
+
+# Cleanup temporary files
+rm -rf /tmp/dra-example-driver.tar.gz /tmp/dra-example-driver-*

--- a/plugins/dra-ocp-validator/tools/install-nfd.sh
+++ b/plugins/dra-ocp-validator/tools/install-nfd.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Install Node Feature Discovery (NFD) on OpenShift cluster
+# Required for GPU auto-detection
+
+set -euo pipefail
+
+# Retry helper for transient API errors
+retry_command() {
+    local max_attempts=3
+    local delay=5
+    local attempt=1
+    local cmd="$@"
+
+    while [ ${attempt} -le ${max_attempts} ]; do
+        if eval "${cmd}"; then
+            return 0
+        else
+            if [ ${attempt} -lt ${max_attempts} ]; then
+                echo "  Retry ${attempt}/${max_attempts} after ${delay}s..."
+                sleep ${delay}
+                attempt=$((attempt + 1))
+            else
+                return 1
+            fi
+        fi
+    done
+}
+
+KUBECONFIG_PATH="${1:-}"
+
+if [ -z "${KUBECONFIG_PATH}" ]; then
+    echo "ERROR: Missing required argument: kubeconfig-path"
+    echo "Usage: $0 <kubeconfig-path>"
+    exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "========================================="
+echo "Installing Node Feature Discovery (NFD)"
+echo "========================================="
+echo ""
+
+# Check if NFD is already installed
+if oc get namespace openshift-nfd &>/dev/null; then
+    if oc get nodefeaturediscovery -n openshift-nfd &>/dev/null 2>&1; then
+        echo "✓ NFD already installed"
+
+        # Wait for NFD pods to be ready
+        echo "Waiting for NFD pods to be ready..."
+        if oc wait --for=condition=ready pod -l app=nfd -n openshift-nfd --timeout=60s &>/dev/null; then
+            echo "✓ NFD pods are ready"
+        else
+            echo "⚠ NFD pods not ready yet, continuing anyway..."
+        fi
+
+        exit 0
+    fi
+fi
+
+# Create namespace
+echo "Creating openshift-nfd namespace..."
+retry_command "oc create namespace openshift-nfd --dry-run=client -o yaml | oc apply -f -"
+echo "✓ Namespace created"
+echo ""
+
+# Create OperatorGroup
+echo "Creating OperatorGroup..."
+retry_command "cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nfd-operator
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+  - openshift-nfd
+EOF"
+echo "✓ OperatorGroup created"
+echo ""
+
+# Create Subscription
+echo "Creating Subscription for NFD..."
+retry_command "cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: stable
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF"
+echo "✓ Subscription created"
+echo ""
+
+# Wait for CSV to be ready
+echo "Waiting for NFD operator installation (this may take 2-3 minutes)..."
+TIMEOUT=300
+ELAPSED=0
+INTERVAL=10
+
+# Check if CSV already exists and is succeeded (handle re-runs)
+CSV_NAME=$(oc get csv -n openshift-nfd -o jsonpath='{.items[?(@.spec.displayName=="Node Feature Discovery Operator")].metadata.name}' 2>/dev/null || echo "")
+if [ -n "${CSV_NAME}" ]; then
+    CSV_PHASE=$(oc get csv ${CSV_NAME} -n openshift-nfd -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "${CSV_PHASE}" = "Succeeded" ]; then
+        echo "✓ NFD operator already installed (CSV: ${CSV_NAME})"
+        ELAPSED=${TIMEOUT}  # Skip the wait loop
+    fi
+fi
+
+while [ ${ELAPSED} -lt ${TIMEOUT} ]; do
+    CSV_NAME=$(oc get csv -n openshift-nfd -o jsonpath='{.items[?(@.spec.displayName=="Node Feature Discovery Operator")].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -n "${CSV_NAME}" ]; then
+        CSV_PHASE=$(oc get csv ${CSV_NAME} -n openshift-nfd -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+        if [ "${CSV_PHASE}" = "Succeeded" ]; then
+            echo "✓ NFD operator installed successfully (CSV: ${CSV_NAME})"
+            break
+        else
+            echo "  Status: ${CSV_PHASE:-Installing...} (${ELAPSED}s elapsed)"
+        fi
+    else
+        echo "  Waiting for CSV creation... (${ELAPSED}s elapsed)"
+    fi
+
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+if [ ${ELAPSED} -ge ${TIMEOUT} ] && [ "${CSV_PHASE}" != "Succeeded" ]; then
+    echo "ERROR: NFD operator installation timed out after ${TIMEOUT}s"
+    echo ""
+    echo "Debug information:"
+    echo "  Subscriptions:"
+    oc get subscription -n openshift-nfd -o wide 2>&1 || echo "    Failed to get subscriptions"
+    echo ""
+    echo "  InstallPlans:"
+    oc get installplan -n openshift-nfd 2>&1 || echo "    Failed to get installplans"
+    echo ""
+    echo "  CSVs:"
+    oc get csv -n openshift-nfd 2>&1 || echo "    Failed to get CSVs"
+    exit 1
+fi
+
+echo ""
+
+# Create NodeFeatureDiscovery CR
+echo "Creating NodeFeatureDiscovery CR..."
+retry_command "cat <<EOF | oc apply -f -
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  operand:
+    imagePullPolicy: Always
+  workerConfig:
+    configData: |
+      sources:
+        pci:
+          deviceClassWhitelist:
+            - \"03\"
+            - \"0200\"
+            - \"0207\"
+          deviceLabelFields:
+            - vendor
+EOF"
+echo "✓ NodeFeatureDiscovery CR created"
+echo ""
+
+# Wait for NFD pods to be ready
+echo "Waiting for NFD pods to be ready..."
+TIMEOUT=180
+ELAPSED=0
+INTERVAL=5
+
+while [ ${ELAPSED} -lt ${TIMEOUT} ]; do
+    READY_PODS=$(oc get pods -n openshift-nfd -l app=nfd --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+
+    if [ ${READY_PODS} -gt 0 ]; then
+        echo "✓ NFD pods are running (${READY_PODS} pods)"
+        break
+    else
+        echo "  Waiting for NFD pods... (${ELAPSED}s elapsed)"
+    fi
+
+    sleep ${INTERVAL}
+    ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+if [ ${ELAPSED} -ge ${TIMEOUT} ]; then
+    echo "⚠ NFD pods not ready after ${TIMEOUT}s, but continuing..."
+    echo "  You may need to wait a bit longer for node labeling to complete"
+else
+    # Wait additional time for node labeling to complete
+    echo ""
+    echo "Waiting for NFD to label nodes (30s)..."
+    sleep 30
+    echo "✓ Node labeling should be complete"
+fi
+
+echo ""
+echo "========================================="
+echo "NFD Installation Complete!"
+echo "========================================="
+echo ""
+
+# Show labeled nodes summary
+TOTAL_NODES=$(oc get nodes --no-headers 2>/dev/null | wc -l)
+LABELED_NODES=$(oc get nodes -l feature.node.kubernetes.io/cpu-cpuid.AVX --no-headers 2>/dev/null | wc -l || echo "0")
+
+echo "Nodes labeled: ${LABELED_NODES}/${TOTAL_NODES}"
+
+# Check for GPU labels
+NVIDIA_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-10de.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+AMD_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-1002.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+if [ ${NVIDIA_NODES} -gt 0 ]; then
+    echo "GPU Detection: ${NVIDIA_NODES} nodes with NVIDIA GPUs"
+elif [ ${AMD_NODES} -gt 0 ]; then
+    echo "GPU Detection: ${AMD_NODES} nodes with AMD GPUs"
+else
+    echo "GPU Detection: No GPUs detected (will use example driver)"
+fi
+
+echo ""

--- a/plugins/dra-ocp-validator/tools/install-nvidia-stack.sh
+++ b/plugins/dra-ocp-validator/tools/install-nvidia-stack.sh
@@ -1,0 +1,679 @@
+#!/bin/bash
+# Install NVIDIA GPU Operator + DRA Driver on OpenShift
+# Based on: https://github.com/openshift/release/pull/74984
+
+set -euo pipefail
+
+# First argument is always kubeconfig
+KUBECONFIG_PATH=$1
+shift
+
+# Parse remaining flags
+NVIDIA_DRA_DRIVER_VERSION="v0.10.0"
+MIG_STRATEGY=""
+NVIDIA_DRA_FEATURE_GATES=""
+ENABLE_DYNAMIC_MIG=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --driver-version)
+      NVIDIA_DRA_DRIVER_VERSION="$2"
+      shift 2
+      ;;
+    --enable-dynamic-mig)
+      ENABLE_DYNAMIC_MIG=true
+      MIG_STRATEGY="mixed"
+      shift
+      ;;
+    --feature-gates)
+      NVIDIA_DRA_FEATURE_GATES="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+echo "========================================="
+echo "NVIDIA GPU Stack Installation"
+echo "========================================="
+echo "GPU Operator + DRA Driver"
+echo ""
+echo "Configuration:"
+echo "  DRA Driver Version: ${NVIDIA_DRA_DRIVER_VERSION}"
+if [ -n "${MIG_STRATEGY}" ]; then
+  echo "  MIG Strategy: ${MIG_STRATEGY}"
+fi
+if [ -n "${NVIDIA_DRA_FEATURE_GATES}" ]; then
+  echo "  Feature Gates: ${NVIDIA_DRA_FEATURE_GATES}"
+fi
+echo ""
+
+# Verify required tools
+for cmd in oc kubectl; do
+    if ! command -v $cmd &>/dev/null; then
+        echo "ERROR: Required command not found: $cmd"
+        exit 1
+    fi
+done
+
+#=========================================
+# Install jq if needed
+#=========================================
+if ! command -v jq &>/dev/null; then
+  echo "Installing jq..."
+  JQ_VERSION="1.7.1"
+  curl -sL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -o /tmp/jq
+  chmod +x /tmp/jq
+  export PATH="/tmp:${PATH}"
+fi
+
+#=========================================
+# Install Helm if needed
+#=========================================
+if ! command -v helm &>/dev/null; then
+  echo "Installing Helm..."
+  HELM_VERSION="3.14.0"
+  curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz
+  tar -xzf /tmp/helm.tar.gz -C /tmp
+  mkdir -p /tmp/bin
+  mv /tmp/linux-amd64/helm /tmp/bin/helm
+  chmod +x /tmp/bin/helm
+  export PATH="/tmp/bin:$PATH"
+  rm -rf /tmp/helm.tar.gz /tmp/linux-amd64
+  echo "Helm installed: $(helm version --short)"
+else
+  echo "Helm already installed: $(helm version --short)"
+fi
+
+echo ""
+
+#=========================================
+# Step 1: Install Node Feature Discovery (NFD)
+#=========================================
+echo "=== Step 1: Install Node Feature Discovery (NFD) ==="
+echo ""
+
+# Check if NFD is already installed
+SKIP_NFD=false
+if oc get namespace openshift-nfd &>/dev/null; then
+  echo "INFO: openshift-nfd namespace already exists"
+  if oc get csv -n openshift-nfd -l operators.coreos.com/nfd.openshift-nfd &>/dev/null; then
+    CSV_NAME=$(oc get csv -n openshift-nfd -l operators.coreos.com/nfd.openshift-nfd -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    if [ -n "${CSV_NAME}" ]; then
+      CSV_PHASE=$(oc get csv -n openshift-nfd "${CSV_NAME}" -o jsonpath='{.status.phase}')
+      if [ "${CSV_PHASE}" == "Succeeded" ]; then
+        echo "INFO: NFD Operator is already installed: ${CSV_NAME}"
+        if oc get nodefeaturediscovery -n openshift-nfd &>/dev/null; then
+          echo "INFO: NodeFeatureDiscovery CR already exists"
+          SKIP_NFD=true
+        fi
+      fi
+    fi
+  fi
+fi
+
+if [ "${SKIP_NFD}" != "true" ]; then
+  # Create namespace
+  echo "Creating openshift-nfd namespace..."
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nfd
+EOF
+
+  # Create OperatorGroup
+  echo "Creating OperatorGroup..."
+  oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nfd-group
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+  - openshift-nfd
+EOF
+
+  # Wait for redhat-operators catalog
+  echo "Waiting for redhat-operators catalog source..."
+  CATALOG_READY=false
+  for retry in $(seq 1 60); do
+    if ! oc get catalogsource redhat-operators -n openshift-marketplace &>/dev/null; then
+      echo "  Waiting for catalog... (${retry}/60)"
+      sleep 10
+      continue
+    fi
+
+    CATALOG_STATUS=$(oc get catalogsource redhat-operators -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
+    if [ "${CATALOG_STATUS}" == "READY" ]; then
+      CATALOG_READY=true
+      echo "✓ Catalog source is READY"
+      break
+    fi
+    echo "  Waiting... (${retry}/60) Status: ${CATALOG_STATUS}"
+    sleep 10
+  done
+
+  if [ "${CATALOG_READY}" != "true" ]; then
+    echo "ERROR: redhat-operators catalog did not become READY"
+    exit 1
+  fi
+
+  # Wait for NFD packagemanifest
+  echo "Waiting for NFD packagemanifest..."
+  PACKAGE_EXISTS=false
+  for retry in $(seq 1 30); do
+    if oc get packagemanifest nfd -n openshift-marketplace &>/dev/null; then
+      PACKAGE_EXISTS=true
+      echo "✓ NFD packagemanifest found"
+      break
+    fi
+    echo "  Waiting... (${retry}/30)"
+    sleep 10
+  done
+
+  if [ "${PACKAGE_EXISTS}" != "true" ]; then
+    echo "ERROR: NFD packagemanifest not found"
+    exit 1
+  fi
+
+  # Get default channel
+  CHANNEL=$(oc get packagemanifest nfd -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')
+  echo "NFD channel: ${CHANNEL}"
+
+  # Create Subscription
+  echo "Creating NFD subscription..."
+  oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: ${CHANNEL}
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+  # Wait for CSV
+  echo "Waiting for NFD CSV..."
+  NFD_CSV=""
+  for retry in $(seq 1 60); do
+    NFD_CSV=$(oc get subscription nfd -n openshift-nfd -o jsonpath='{.status.currentCSV}' 2>/dev/null || echo "")
+    if [ -n "${NFD_CSV}" ]; then
+      echo "✓ CSV found: ${NFD_CSV}"
+      break
+    fi
+    echo "  Waiting... (${retry}/60)"
+    sleep 10
+  done
+
+  if [ -z "${NFD_CSV}" ]; then
+    echo "ERROR: CSV not created"
+    exit 1
+  fi
+
+  # Wait for CSV to be ready
+  echo "Waiting for CSV to be ready..."
+  for retry in $(seq 1 40); do
+    CSV_PHASE=$(oc get csv -n openshift-nfd "${NFD_CSV}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "${CSV_PHASE}" == "Succeeded" ]; then
+      echo "✓ CSV is ready"
+      break
+    fi
+    echo "  Waiting... (${retry}/40) Phase: ${CSV_PHASE}"
+    sleep 15
+  done
+
+  if [ "${CSV_PHASE}" != "Succeeded" ]; then
+    echo "ERROR: CSV did not reach Succeeded phase"
+    exit 1
+  fi
+
+  # Create NodeFeatureDiscovery CR
+  echo "Creating NodeFeatureDiscovery CR..."
+  oc get csv -n openshift-nfd "${NFD_CSV}" -o jsonpath='{.metadata.annotations.alm-examples}' | \
+    jq '.[] | select(.kind=="NodeFeatureDiscovery")' | \
+    oc apply -f -
+
+  # Wait for NFD to be available
+  echo "Waiting for NodeFeatureDiscovery to be available..."
+  if ! oc wait nodefeaturediscovery -n openshift-nfd --for=condition=Available --timeout=15m --all; then
+    echo "ERROR: NodeFeatureDiscovery did not become available"
+    exit 1
+  fi
+
+  echo "✓ NodeFeatureDiscovery is available"
+  echo ""
+
+  # Wait for NFD to detect NVIDIA GPUs
+  echo "Waiting for NFD to detect NVIDIA GPUs..."
+  NFD_GPU_NODES=0
+  for retry in $(seq 1 30); do
+    NFD_GPU_NODES=$(oc get nodes -l feature.node.kubernetes.io/pci-10de.present=true -o name 2>/dev/null | wc -l)
+    if [ "${NFD_GPU_NODES}" -gt 0 ]; then
+      echo "✓ NFD detected ${NFD_GPU_NODES} node(s) with NVIDIA GPUs"
+      break
+    fi
+    echo "  Waiting... (${retry}/30)"
+    sleep 10
+  done
+
+  if [ "${NFD_GPU_NODES}" -eq 0 ]; then
+    echo "WARNING: NFD did not detect any NVIDIA GPUs"
+    echo "This may be expected if there are no physical GPUs in the cluster"
+  else
+    # Label GPU nodes for GPU operator
+    echo "Labeling GPU nodes with nvidia.com/gpu.present=true..."
+    GPU_NODE_NAMES=$(oc get nodes -l feature.node.kubernetes.io/pci-10de.present=true -o jsonpath='{.items[*].metadata.name}')
+    for node in ${GPU_NODE_NAMES}; do
+      echo "  Labeling node: ${node}"
+      oc label node "${node}" nvidia.com/gpu.present=true --overwrite
+    done
+    echo "✓ ${NFD_GPU_NODES} GPU node(s) labeled"
+  fi
+
+  echo ""
+  echo "NFD installation complete!"
+else
+  echo "Skipping NFD installation (already installed)"
+fi
+
+echo ""
+
+#=========================================
+# Step 2: Install NVIDIA GPU Operator via OLM
+#=========================================
+echo "=== Step 2: Install NVIDIA GPU Operator ==="
+echo ""
+
+# Check if already installed
+SKIP_GPU_OPERATOR=false
+if oc get namespace nvidia-gpu-operator &>/dev/null; then
+  echo "INFO: nvidia-gpu-operator namespace already exists"
+  if oc get csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator &>/dev/null; then
+    CSV_NAME=$(oc get csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    if [ -n "${CSV_NAME}" ]; then
+      CSV_PHASE=$(oc get csv -n nvidia-gpu-operator "${CSV_NAME}" -o jsonpath='{.status.phase}')
+      if [ "${CSV_PHASE}" == "Succeeded" ]; then
+        echo "INFO: GPU Operator is already installed: ${CSV_NAME}"
+
+        # Check if ClusterPolicy exists and verify CDI
+        if oc get clusterpolicy gpu-cluster-policy &>/dev/null; then
+          CDI_ENABLED=$(oc get clusterpolicy gpu-cluster-policy -o jsonpath='{.spec.cdi.enabled}' 2>/dev/null || echo "false")
+          if [ "${CDI_ENABLED}" == "true" ]; then
+            echo "INFO: ClusterPolicy exists with CDI enabled"
+            SKIP_GPU_OPERATOR=true
+          else
+            echo "WARNING: ClusterPolicy exists but CDI not enabled, patching..."
+            oc patch clusterpolicy gpu-cluster-policy --type=merge -p '{"spec":{"operator":{"defaultRuntime":"crio"},"cdi":{"enabled":true,"default":false}}}'
+            echo "INFO: ClusterPolicy patched with CDI enabled"
+            SKIP_GPU_OPERATOR=true
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
+if [ "${SKIP_GPU_OPERATOR}" != "true" ]; then
+  # Create namespace
+  echo "Creating nvidia-gpu-operator namespace..."
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-gpu-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: "privileged"
+EOF
+
+  # Create OperatorGroup
+  echo "Creating OperatorGroup..."
+  oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+  - nvidia-gpu-operator
+EOF
+
+  # Wait for certified-operators catalog source
+  echo "Waiting for certified-operators catalog source to be READY..."
+  CATALOG_READY=false
+  for retry in $(seq 1 60); do
+    CATALOG_STATE=$(oc get catalogsource certified-operators -n openshift-marketplace -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "UNKNOWN")
+    if [ "${CATALOG_STATE}" == "READY" ]; then
+      CATALOG_READY=true
+      echo "✓ Catalog source is READY"
+      break
+    fi
+    echo "  Waiting... (${retry}/60) State: ${CATALOG_STATE}"
+    sleep 5
+  done
+
+  if [ "${CATALOG_READY}" != "true" ]; then
+    echo "ERROR: Catalog source did not become READY in time"
+    exit 1
+  fi
+
+  # Create Subscription
+  echo "Creating GPU Operator subscription..."
+  oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: "stable"
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+
+  # Wait for CSV to be ready
+  echo "Waiting for GPU Operator CSV to be ready..."
+  CSV_READY=false
+  for retry in $(seq 1 60); do
+    CSV_NAME=$(oc get csv -n nvidia-gpu-operator -l operators.coreos.com/gpu-operator-certified.nvidia-gpu-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    if [ -n "${CSV_NAME}" ]; then
+      CSV_PHASE=$(oc get csv -n nvidia-gpu-operator "${CSV_NAME}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+      if [ "${CSV_PHASE}" == "Succeeded" ]; then
+        CSV_READY=true
+        echo "✓ GPU Operator CSV is ready: ${CSV_NAME}"
+        break
+      fi
+      echo "  Waiting... (${retry}/60) Phase: ${CSV_PHASE}"
+    else
+      echo "  Waiting for CSV... (${retry}/60)"
+    fi
+    sleep 10
+  done
+
+  if [ "${CSV_READY}" != "true" ]; then
+    echo "ERROR: GPU Operator CSV did not become ready in time"
+    exit 1
+  fi
+
+  # Create ClusterPolicy with CDI enabled
+  echo "Creating ClusterPolicy for DRA with partitionable devices..."
+
+  if [ -n "${MIG_STRATEGY}" ]; then
+    echo "DRA mode: Traditional device plugin disabled, MIG manager disabled"
+    echo "DRA driver will handle dynamic MIG partitioning"
+  fi
+
+  cat <<EOF | oc apply -f -
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  daemonsets:
+    rollingUpdate:
+      maxUnavailable: '1'
+    updateStrategy: RollingUpdate
+  operator:
+    runtimeClass: nvidia
+    use_ocp_driver_toolkit: true
+    defaultRuntime: crio
+  driver:
+    enabled: true
+    use_ocp_driver_toolkit: true
+    licensingConfig:
+      nlsEnabled: true
+    kernelModuleType: auto
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        enable: false
+      maxParallelUpgrades: 1
+  toolkit:
+    enabled: true
+    installDir: /usr/local/nvidia
+  devicePlugin:
+    enabled: false
+    config:
+      default: ''
+      name: ''
+  dcgm:
+    enabled: true
+  dcgmExporter:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  gfd:
+    enabled: true
+  migManager:
+    enabled: false
+    config:
+      default: all-disabled
+  mig:
+    strategy: none
+  nodeStatusExporter:
+    enabled: true
+  cdi:
+    enabled: true
+    default: false
+    nriPluginEnabled: false
+  vfioManager:
+    enabled: true
+  ccManager:
+    enabled: true
+  sandboxDevicePlugin:
+    enabled: true
+  kataSandboxDevicePlugin:
+    enabled: true
+  vgpuDeviceManager:
+    enabled: true
+    config:
+      default: default
+  validator:
+    plugin:
+      env: []
+EOF
+
+  # Wait for ClusterPolicy to be ready
+  echo "Waiting for ClusterPolicy to be ready..."
+  sleep 30
+
+  for retry in $(seq 1 60); do
+    POLICY_STATE=$(oc get clusterpolicy gpu-cluster-policy -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+    if [ "${POLICY_STATE}" == "ready" ]; then
+      echo "✓ ClusterPolicy is ready"
+      break
+    fi
+    echo "  Waiting... (${retry}/60) State: ${POLICY_STATE}"
+    sleep 10
+  done
+
+  echo ""
+  echo "GPU Operator installation complete!"
+else
+  echo "Skipping GPU Operator installation (already installed)"
+fi
+
+echo ""
+
+#=========================================
+# Step 3: Install NVIDIA DRA Driver
+#=========================================
+echo "=== Step 3: Install NVIDIA DRA Driver ==="
+echo ""
+
+NVIDIA_DRA_DRIVER_NAMESPACE="nvidia-dra-driver"
+
+# Check if DRA driver is already installed
+if oc get namespace "${NVIDIA_DRA_DRIVER_NAMESPACE}" &>/dev/null; then
+  echo "INFO: ${NVIDIA_DRA_DRIVER_NAMESPACE} namespace already exists"
+  if helm list -n "${NVIDIA_DRA_DRIVER_NAMESPACE}" 2>/dev/null | grep -q nvidia-dra-driver; then
+    INSTALLED_VERSION=$(helm list -n "${NVIDIA_DRA_DRIVER_NAMESPACE}" -o json | jq -r '.[] | select(.name=="nvidia-dra-driver") | .app_version')
+    echo "INFO: NVIDIA DRA driver is already installed (version: ${INSTALLED_VERSION})"
+    echo "Skipping DRA driver installation"
+    exit 0
+  fi
+fi
+
+# Verify GPU Operator prerequisites
+echo "Verifying GPU Operator is installed..."
+if ! oc get clusterpolicy gpu-cluster-policy &>/dev/null; then
+  echo "ERROR: GPU Operator ClusterPolicy not found!"
+  echo "Please ensure GPU Operator is installed first"
+  exit 1
+fi
+
+CDI_ENABLED=$(oc get clusterpolicy gpu-cluster-policy -o jsonpath='{.spec.cdi.enabled}' 2>/dev/null || echo "false")
+if [ "${CDI_ENABLED}" != "true" ]; then
+  echo "ERROR: CDI is not enabled in GPU Operator ClusterPolicy"
+  echo "DRA requires CDI to be enabled"
+  exit 1
+fi
+
+echo "✓ GPU Operator is installed with CDI enabled"
+echo ""
+
+# Create namespace
+echo "Creating namespace ${NVIDIA_DRA_DRIVER_NAMESPACE}..."
+oc create namespace "${NVIDIA_DRA_DRIVER_NAMESPACE}" || true
+oc label namespace "${NVIDIA_DRA_DRIVER_NAMESPACE}" \
+  openshift.io/cluster-monitoring=true \
+  pod-security.kubernetes.io/enforce=privileged \
+  --overwrite
+
+# Add privileged SCC for DRA driver service accounts (required for OpenShift)
+echo "Adding privileged SCC for DRA driver service accounts..."
+oc adm policy add-scc-to-user privileged -z nvidia-dra-driver-gpu-service-account-controller -n "${NVIDIA_DRA_DRIVER_NAMESPACE}"
+oc adm policy add-scc-to-user privileged -z nvidia-dra-driver-gpu-service-account-kubeletplugin -n "${NVIDIA_DRA_DRIVER_NAMESPACE}"
+oc adm policy add-scc-to-user privileged -z compute-domain-daemon-service-account -n "${NVIDIA_DRA_DRIVER_NAMESPACE}"
+
+# Add NVIDIA Helm repository
+echo "Adding NVIDIA Helm repository..."
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia || true
+helm repo update
+
+echo ""
+
+# Prepare feature gate arguments
+FEATURE_GATE_ARGS=""
+
+# Add DynamicMIG feature gate if enabled
+if [ "${ENABLE_DYNAMIC_MIG}" = true ]; then
+  FEATURE_GATE_ARGS="${FEATURE_GATE_ARGS} --set featureGates.DynamicMIG=true"
+  echo "Enabling DynamicMIG feature gate for partitionable devices"
+fi
+
+# Add any additional feature gates from command line
+if [ -n "${NVIDIA_DRA_FEATURE_GATES}" ]; then
+  echo "Additional feature gates: ${NVIDIA_DRA_FEATURE_GATES}"
+  IFS=',' read -ra GATES <<< "${NVIDIA_DRA_FEATURE_GATES}"
+  for gate in "${GATES[@]}"; do
+    key="${gate%%=*}"
+    value="${gate#*=}"
+    FEATURE_GATE_ARGS="${FEATURE_GATE_ARGS} --set featureGates.${key}=${value}"
+  done
+fi
+
+if [ -n "${FEATURE_GATE_ARGS}" ]; then
+  echo "Helm feature gate arguments: ${FEATURE_GATE_ARGS}"
+  echo ""
+fi
+
+# Install NVIDIA DRA driver
+echo "Installing NVIDIA DRA driver ${NVIDIA_DRA_DRIVER_VERSION}..."
+helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+  --namespace "${NVIDIA_DRA_DRIVER_NAMESPACE}" \
+  --version "${NVIDIA_DRA_DRIVER_VERSION}" \
+  --set nvidiaDriverRoot=/run/nvidia/driver \
+  --set resources.gpus.enabled=true \
+  --set gpuResourcesEnabledOverride=true \
+  --set resources.computeDomains.enabled=false \
+  --set 'controller.tolerations[0].key=node-role.kubernetes.io/master' \
+  --set 'controller.tolerations[0].operator=Exists' \
+  --set 'controller.tolerations[0].effect=NoSchedule' \
+  --set 'controller.tolerations[1].key=node-role.kubernetes.io/control-plane' \
+  --set 'controller.tolerations[1].operator=Exists' \
+  --set 'controller.tolerations[1].effect=NoSchedule' \
+  ${FEATURE_GATE_ARGS} \
+  --wait \
+  --timeout 10m
+
+echo ""
+echo "✓ NVIDIA DRA driver installed successfully"
+
+# Wait for pods to be ready
+echo ""
+echo "Waiting for DRA driver pods to be ready..."
+oc wait --for=condition=Ready pods \
+  --all \
+  -n "${NVIDIA_DRA_DRIVER_NAMESPACE}" \
+  --timeout=10m
+
+echo "✓ All DRA driver pods are ready"
+
+# List pods
+echo ""
+echo "DRA driver pods:"
+oc get pods -n "${NVIDIA_DRA_DRIVER_NAMESPACE}"
+
+# Wait for DeviceClass
+echo ""
+echo "Waiting for DeviceClass to be created..."
+timeout 5m bash -c '
+while true; do
+  if oc get deviceclass gpu.nvidia.com &>/dev/null; then
+    echo "✓ DeviceClass created: gpu.nvidia.com"
+    break
+  fi
+  echo "  Waiting for DeviceClass..."
+  sleep 10
+done
+'
+
+# Wait for ResourceSlices
+echo ""
+echo "Waiting for ResourceSlices to be published..."
+timeout 5m bash -c '
+while true; do
+  RESOURCE_SLICES=$(oc get resourceslice -o json 2>/dev/null | jq -r ".items[] | select(.spec.driver == \"nvidia.com/gpu\" or .spec.driver == \"mig.nvidia.com\") | .metadata.name" | wc -l)
+  if [ "${RESOURCE_SLICES}" -gt 0 ]; then
+    echo "✓ Found ${RESOURCE_SLICES} NVIDIA ResourceSlice(s)"
+    break
+  fi
+  echo "  Waiting for ResourceSlices..."
+  sleep 10
+done
+'
+
+echo ""
+echo "ResourceSlices:"
+oc get resourceslice
+
+echo ""
+echo "========================================="
+echo "NVIDIA GPU Stack Installation Complete"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "  ✓ GPU Operator installed (namespace: nvidia-gpu-operator)"
+echo "  ✓ NVIDIA DRA Driver installed (namespace: ${NVIDIA_DRA_DRIVER_NAMESPACE})"
+echo "  ✓ DRA Driver Version: ${NVIDIA_DRA_DRIVER_VERSION}"
+echo "  ✓ CDI enabled: true"
+if [ -n "${MIG_STRATEGY}" ]; then
+  echo "  ✓ MIG Strategy: ${MIG_STRATEGY}"
+fi
+echo "  ✓ DeviceClass: gpu.nvidia.com"
+echo ""

--- a/plugins/dra-ocp-validator/tools/list-features.sh
+++ b/plugins/dra-ocp-validator/tools/list-features.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+set -euo pipefail
+
+# Parse arguments
+KUBECONFIG_PATH="${1:-}"
+DETAILED="${2:-false}"
+
+# Get the plugin root directory (parent of tools/)
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Source common utilities
+COMMON_LIB="${PLUGIN_ROOT}/tools/common.sh"
+if [ ! -f "${COMMON_LIB}" ]; then
+  echo "ERROR: common.sh not found at ${COMMON_LIB}"
+  exit 1
+fi
+source "${COMMON_LIB}"
+
+# Validate kubeconfig
+if [ -z "${KUBECONFIG_PATH}" ]; then
+    echo "ERROR: Missing required argument: kubeconfig-path"
+    echo "Usage: $0 <kubeconfig-path> [--detailed]"
+    exit 1
+fi
+
+KUBECONFIG_PATH="${KUBECONFIG_PATH/#\~/$HOME}"
+if [ ! -f "${KUBECONFIG_PATH}" ]; then
+    echo "ERROR: Kubeconfig not found: ${KUBECONFIG_PATH}"
+    exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+# Check for --detailed flag
+if [ "${2:-}" == "--detailed" ]; then
+    DETAILED="true"
+fi
+
+# Source the metadata helper
+METADATA_HELPER="${PLUGIN_ROOT}/tools/feature-metadata.sh"
+if [ ! -f "${METADATA_HELPER}" ]; then
+    echo "ERROR: feature-metadata.sh not found at ${METADATA_HELPER}"
+    exit 1
+fi
+source "${METADATA_HELPER}"
+
+# Get cluster version
+echo "=========================================="
+echo "DRA Features - Cluster Analysis"
+echo "=========================================="
+echo ""
+
+# Check cluster connectivity (non-required for offline mode)
+CLUSTER_ONLINE=false
+if validate_cluster_connectivity "false"; then
+    CLUSTER_ONLINE=true
+fi
+
+# Get cluster version info if online
+if [ "${CLUSTER_ONLINE}" == "true" ]; then
+    VERSION_JSON=$(oc version -o json 2>/dev/null)
+    OCP_VERSION=$(echo "${VERSION_JSON}" | jq -r '.openshiftVersion // "unknown"')
+    K8S_VERSION=$(echo "${VERSION_JSON}" | jq -r '.serverVersion.gitVersion // "unknown"')
+    K8S_VERSION_FULL=$(echo "${K8S_VERSION}" | sed -E 's/v(1\.[0-9]+)\..*/\1/')
+    K8S_MINOR=$(echo "${K8S_VERSION}" | sed -E 's/v1\.([0-9]+)\..*/\1/')
+
+    echo "Cluster: OCP ${OCP_VERSION}, Kubernetes ${K8S_VERSION}"
+    echo ""
+
+    # Check if DRA driver is installed
+    DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l || echo "0")
+    if [ "${DEVICECLASS_COUNT}" -gt 0 ]; then
+        DRIVER_NAME=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+        echo "DRA Driver: ✓ Installed (${DRIVER_NAME})"
+    else
+        echo "DRA Driver: ✗ Not installed"
+    fi
+else
+    echo "Cluster: ⚠ Offline (cluster unavailable)"
+    echo "Mode: Displaying feature metadata only"
+    K8S_MINOR="36"  # Default to latest supported version for offline mode
+    K8S_VERSION_FULL="1.36"  # Default for offline mode
+    K8S_VERSION="v1.36.0"  # Default for offline mode
+    echo ""
+fi
+
+echo ""
+echo "=========================================="
+echo "Available DRA Features"
+echo "=========================================="
+echo ""
+
+# Get all features
+FEATURES=$(list_all_features)
+
+# Header for table
+printf "%-20s %-12s %-10s %-15s %-30s\n" "FEATURE" "GRADUATION" "MIN K8S" "GATE STATUS" "DESCRIPTION"
+printf "%-20s %-12s %-10s %-15s %-30s\n" "-------" "----------" "-------" "-----------" "-----------"
+
+# Iterate through features
+for feature in ${FEATURES}; do
+    # Get feature metadata
+    FEATURE_NAME=$(get_feature_name "${feature}" 2>/dev/null || echo "Unknown")
+    DESCRIPTION=$(get_feature_description "${feature}" 2>/dev/null || echo "")
+    MIN_VERSION=$(get_min_k8s_version "${feature}" 2>/dev/null || echo "N/A")
+
+    # Check if feature is available on this cluster
+    if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
+        # Get graduation level for current K8s version
+        GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || echo "unavailable")
+
+        # Check feature gate status
+        GATE_STATUS=$(check_feature_gate_status "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || echo "unknown")
+
+        case "${GATE_STATUS}" in
+            enabled)
+                GATE_DISPLAY="✓ Enabled"
+                ;;
+            ga_always_enabled)
+                GATE_DISPLAY="✓ GA (always)"
+                ;;
+            no_gate_required)
+                GATE_DISPLAY="N/A"
+                ;;
+            not_enabled:alpha)
+                GATE_DISPLAY="✗ Not enabled"
+                ;;
+            not_enabled:beta)
+                GATE_DISPLAY="⚠ Check needed"
+                ;;
+            feature_unavailable)
+                GATE_DISPLAY="N/A (old K8s)"
+                ;;
+            *)
+                GATE_DISPLAY="Unknown"
+                ;;
+        esac
+
+        # Color code graduation level
+        case "${GRADUATION}" in
+            alpha)
+                GRAD_DISPLAY="Alpha"
+                ;;
+            beta)
+                GRAD_DISPLAY="Beta"
+                ;;
+            ga)
+                GRAD_DISPLAY="GA"
+                ;;
+            *)
+                GRAD_DISPLAY="${GRADUATION}"
+                ;;
+        esac
+    else
+        GRAD_DISPLAY="N/A"
+        GATE_DISPLAY="N/A (K8s < ${MIN_VERSION})"
+    fi
+
+    # Truncate description for table view
+    DESC_SHORT=$(echo "${DESCRIPTION}" | cut -c1-30)
+    if [ ${#DESCRIPTION} -gt 30 ]; then
+        DESC_SHORT="${DESC_SHORT}..."
+    fi
+
+    printf "%-20s %-12s %-10s %-15s %-30s\n" \
+        "${feature}" "${GRAD_DISPLAY}" "${MIN_VERSION}" "${GATE_DISPLAY}" "${DESC_SHORT}"
+done
+
+echo ""
+
+# Detailed view
+if [ "${DETAILED}" == "true" ]; then
+    echo "=========================================="
+    echo "Detailed Feature Information"
+    echo "=========================================="
+    echo ""
+
+    for feature in ${FEATURES}; do
+        # Check if available
+        if ! is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
+            continue
+        fi
+
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "Feature: ${feature}"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+        FEATURE_NAME=$(get_feature_name "${feature}" 2>/dev/null)
+        DESCRIPTION=$(get_feature_description "${feature}" 2>/dev/null)
+        MIN_VERSION=$(get_min_k8s_version "${feature}" 2>/dev/null)
+        GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null)
+
+        echo "Name:        ${FEATURE_NAME}"
+        echo "Description: ${DESCRIPTION}"
+        echo "Min K8s:     ${MIN_VERSION}"
+        echo "Graduation:  ${GRADUATION} (on K8s ${K8S_VERSION_FULL})"
+
+        # Feature gate info
+        GATE_NAME=$(get_feature_gate "${feature}" 2>/dev/null)
+        if [ "${GATE_NAME}" != "null" ] && [ -n "${GATE_NAME}" ]; then
+            echo "Feature Gate: ${GATE_NAME}"
+
+            GATE_STATUS=$(check_feature_gate_status "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || true)
+            case "${GATE_STATUS}" in
+                enabled)
+                    echo "Gate Status:  ✓ Enabled in cluster"
+                    ;;
+                not_enabled:alpha)
+                    echo "Gate Status:  ✗ Not enabled (Alpha - requires enablement)"
+                    echo ""
+                    echo "To enable:"
+                    ENABLE_CMD=$(get_enablement_command "${feature}" 2>/dev/null | sed 's/^/  /')
+                    echo "${ENABLE_CMD}"
+                    ;;
+                not_enabled:beta)
+                    echo "Gate Status:  ⚠ Not enabled (Beta - may need CustomNoUpgrade)"
+                    echo ""
+                    echo "To enable:"
+                    ENABLE_CMD=$(get_enablement_command "${feature}" 2>/dev/null | sed 's/^/  /')
+                    echo "${ENABLE_CMD}"
+                    ;;
+                ga_always_enabled)
+                    echo "Gate Status:  ✓ Always enabled (GA)"
+                    ;;
+            esac
+        else
+            echo "Feature Gate: None (Beta by default)"
+        fi
+
+        # Setup flags
+        SETUP_FLAGS=$(get_setup_flags "${feature}" 2>/dev/null)
+        if [ -n "${SETUP_FLAGS}" ]; then
+            echo "Setup Flags:  ${SETUP_FLAGS}"
+        fi
+
+        # Test script
+        TEST_SCRIPT=$(get_test_script "${feature}" 2>/dev/null)
+        if [ -n "${TEST_SCRIPT}" ]; then
+            TEST_BASENAME=$(basename "${TEST_SCRIPT}")
+            echo "Test Script:  ${TEST_BASENAME}"
+        fi
+
+        echo ""
+    done
+fi
+
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+
+# Count features by graduation level
+ALPHA_COUNT=0
+BETA_COUNT=0
+GA_COUNT=0
+UNAVAILABLE_COUNT=0
+
+for feature in ${FEATURES}; do
+    if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
+        GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null)
+        case "${GRADUATION}" in
+            alpha) ALPHA_COUNT=$((ALPHA_COUNT + 1)) ;;
+            beta) BETA_COUNT=$((BETA_COUNT + 1)) ;;
+            ga) GA_COUNT=$((GA_COUNT + 1)) ;;
+        esac
+    else
+        UNAVAILABLE_COUNT=$((UNAVAILABLE_COUNT + 1))
+    fi
+done
+
+echo "Features available on K8s ${K8S_VERSION}:"
+echo "  Alpha: ${ALPHA_COUNT}"
+echo "  Beta:  ${BETA_COUNT}"
+echo "  GA:    ${GA_COUNT}"
+if [ ${UNAVAILABLE_COUNT} -gt 0 ]; then
+    echo "  Unavailable (K8s too old): ${UNAVAILABLE_COUNT}"
+fi
+
+echo ""
+echo "Commands:"
+echo "  • View detailed info:  /dra-ocp-validator:list-features ${KUBECONFIG_PATH} --detailed"
+echo "  • Setup DRA driver:    /dra-ocp-validator:setup ${KUBECONFIG_PATH}"
+echo "  • Run tests:           /dra-ocp-validator:test ${KUBECONFIG_PATH}"
+
+exit 0

--- a/plugins/dra-ocp-validator/tools/list-features.sh
+++ b/plugins/dra-ocp-validator/tools/list-features.sh
@@ -248,31 +248,64 @@ echo "=========================================="
 echo "Summary"
 echo "=========================================="
 
-# Count features by graduation level
-ALPHA_COUNT=0
-BETA_COUNT=0
-GA_COUNT=0
-UNAVAILABLE_COUNT=0
+# Group features by graduation level
+ALPHA_FEATURES=()
+BETA_FEATURES=()
+GA_FEATURES=()
+UNAVAILABLE_FEATURES=()
 
 for feature in ${FEATURES}; do
     if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
         GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null)
         case "${GRADUATION}" in
-            alpha) ALPHA_COUNT=$((ALPHA_COUNT + 1)) ;;
-            beta) BETA_COUNT=$((BETA_COUNT + 1)) ;;
-            ga) GA_COUNT=$((GA_COUNT + 1)) ;;
+            alpha) ALPHA_FEATURES+=("${feature}") ;;
+            beta) BETA_FEATURES+=("${feature}") ;;
+            ga) GA_FEATURES+=("${feature}") ;;
         esac
     else
-        UNAVAILABLE_COUNT=$((UNAVAILABLE_COUNT + 1))
+        UNAVAILABLE_FEATURES+=("${feature}")
     fi
 done
 
 echo "Features available on K8s ${K8S_VERSION}:"
-echo "  Alpha: ${ALPHA_COUNT}"
-echo "  Beta:  ${BETA_COUNT}"
-echo "  GA:    ${GA_COUNT}"
-if [ ${UNAVAILABLE_COUNT} -gt 0 ]; then
-    echo "  Unavailable (K8s too old): ${UNAVAILABLE_COUNT}"
+echo ""
+
+if [ ${#GA_FEATURES[@]} -gt 0 ]; then
+    echo "GA (${#GA_FEATURES[@]}):"
+    for feature in "${GA_FEATURES[@]}"; do
+        FEATURE_NAME=$(get_feature_name "${feature}")
+        echo "  • ${feature} - ${FEATURE_NAME}"
+    done
+    echo ""
+fi
+
+if [ ${#BETA_FEATURES[@]} -gt 0 ]; then
+    echo "Beta (${#BETA_FEATURES[@]}):"
+    for feature in "${BETA_FEATURES[@]}"; do
+        FEATURE_NAME=$(get_feature_name "${feature}")
+        echo "  • ${feature} - ${FEATURE_NAME}"
+    done
+    echo ""
+fi
+
+if [ ${#ALPHA_FEATURES[@]} -gt 0 ]; then
+    echo "Alpha (${#ALPHA_FEATURES[@]}) - Require manual feature gate enablement:"
+    for feature in "${ALPHA_FEATURES[@]}"; do
+        FEATURE_NAME=$(get_feature_name "${feature}")
+        GATE_NAME=$(get_feature_gate "${feature}")
+        echo "  • ${feature} - ${FEATURE_NAME} (${GATE_NAME})"
+    done
+    echo ""
+fi
+
+if [ ${#UNAVAILABLE_FEATURES[@]} -gt 0 ]; then
+    echo "Unavailable (${#UNAVAILABLE_FEATURES[@]}) - K8s version too old:"
+    for feature in "${UNAVAILABLE_FEATURES[@]}"; do
+        FEATURE_NAME=$(get_feature_name "${feature}")
+        MIN_VERSION=$(yq eval ".features.${feature}.kubernetes.introduced" "${METADATA_FILE}")
+        echo "  • ${feature} - ${FEATURE_NAME} (requires K8s ${MIN_VERSION}+)"
+    done
+    echo ""
 fi
 
 echo ""

--- a/plugins/dra-ocp-validator/tools/run-tests.sh
+++ b/plugins/dra-ocp-validator/tools/run-tests.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# DRA OCP Validator - Test runner (assumes setup already done)
+# Runs DRA feature tests on a cluster with prerequisites already installed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+# Source common utilities
+if [ -f "${SCRIPT_DIR}/common.sh" ]; then
+    source "${SCRIPT_DIR}/common.sh"
+fi
+
+# Parse arguments
+KUBECONFIG_PATH=""
+FEATURES="all"
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --features)
+      FEATURES="${2}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2}"
+      shift 2
+      ;;
+    *)
+      if [ -z "${KUBECONFIG_PATH}" ]; then
+        KUBECONFIG_PATH="${1}"
+      else
+        echo "ERROR: Unknown argument: ${1}"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Missing required argument: kubeconfig-path"
+  echo "Usage: $0 <kubeconfig-path> [options]"
+  exit 1
+fi
+
+# Expand tilde
+KUBECONFIG_PATH="${KUBECONFIG_PATH/#\~/$HOME}"
+
+# Validate kubeconfig exists
+if [ ! -f "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Kubeconfig not found: ${KUBECONFIG_PATH}"
+  exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+# Set output directory
+if [ -z "${OUTPUT_DIR}" ]; then
+  OUTPUT_DIR="./dra-test-$(date +%Y%m%d-%H%M%S)"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "========================================="
+echo "DRA OCP Validator - Test Suite"
+echo "========================================="
+echo ""
+
+# Step 1: Verify cluster access
+echo "=== Step 1: Cluster verification ==="
+
+if ! validate_cluster_connectivity "true"; then
+  exit 1
+fi
+
+# Extract cluster info
+OCP_VERSION=$(oc version -o json | jq -r '.openshiftVersion // "unknown"')
+K8S_VERSION=$(oc version -o json | jq -r '.serverVersion.gitVersion // "unknown"')
+
+echo "✓ Cluster accessible (OCP ${OCP_VERSION}, K8s ${K8S_VERSION})"
+echo ""
+
+# Step 2: Verify DRA driver is installed
+echo "=== Step 2: DRA driver verification ==="
+
+DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l || echo "0")
+RESOURCESLICE_COUNT=$(oc get resourceslice --no-headers 2>/dev/null | wc -l || echo "0")
+
+if [ "${DEVICECLASS_COUNT}" -eq 0 ]; then
+  echo "❌ ERROR: No DeviceClass found - DRA driver not installed"
+  echo ""
+  echo "Please run setup first:"
+  echo "  /dra-ocp-validator:setup ${KUBECONFIG_PATH}"
+  exit 1
+fi
+
+DEVICECLASS_NAME=$(oc get deviceclass -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+echo "✓ DRA driver ready (DeviceClass: ${DEVICECLASS_NAME}, ResourceSlices: ${RESOURCESLICE_COUNT})"
+echo ""
+
+# Step 3: Detect available features based on K8s version
+echo "=== Step 3: Feature detection ==="
+
+# Source the feature metadata helper first
+METADATA_HELPER="${SCRIPT_DIR}/feature-metadata.sh"
+if [ ! -f "${METADATA_HELPER}" ]; then
+  echo "❌ ERROR: feature-metadata.sh not found at ${METADATA_HELPER}"
+  exit 1
+fi
+source "${METADATA_HELPER}"
+
+K8S_MINOR=$(echo "${K8S_VERSION}" | sed -E 's/v1\.([0-9]+)\..*/\1/')
+
+# Use metadata system to discover available features
+AVAILABLE_FEATURES=()
+for feature in $(list_all_features); do
+  if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
+    AVAILABLE_FEATURES+=("${feature}")
+  fi
+done
+
+echo "Available features on K8s ${K8S_VERSION}: ${AVAILABLE_FEATURES[*]}"
+echo ""
+
+# Parse features to test
+TEST_FEATURES=()
+if [ "${FEATURES}" = "all" ]; then
+  TEST_FEATURES=("${AVAILABLE_FEATURES[@]}")
+else
+  IFS=',' read -ra REQUESTED_FEATURES <<< "${FEATURES}"
+  for feature in "${REQUESTED_FEATURES[@]}"; do
+    if [[ " ${AVAILABLE_FEATURES[@]} " =~ " ${feature} " ]]; then
+      TEST_FEATURES+=("${feature}")
+    else
+      echo "⚠ Feature '${feature}' not available on K8s ${K8S_VERSION} - skipping"
+    fi
+  done
+fi
+
+echo "Features to test: ${TEST_FEATURES[*]}"
+echo ""
+
+# Step 3.5: Check feature prerequisites and filter out features that can't run
+echo "=== Step 3.5: Checking feature prerequisites ==="
+
+RUNNABLE_FEATURES=()
+SKIPPED_FEATURES=()
+
+for feature in "${TEST_FEATURES[@]}"; do
+  SKIP_REASON=""
+
+  # Use metadata-driven prerequisite checking if available
+  if declare -f get_feature_gate > /dev/null 2>&1; then
+    # Get K8s version for graduation detection
+    K8S_VERSION_FULL=$(echo "${K8S_VERSION}" | sed -E 's/v(1\.[0-9]+)\..*/\1/')
+
+    # Check feature gate status based on graduation level
+    GATE_STATUS=$(check_feature_gate_status "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || echo "error")
+
+    case "${GATE_STATUS}" in
+      enabled|ga_always_enabled|no_gate_required)
+        # Feature gate satisfied, check additional prerequisites
+        case "${feature}" in
+          partitionable)
+            # Check if driver has partition support via dual-check:
+            # Primary: SharedCounters (KEP-4815 partitionable devices)
+            # Fallback: Driver-specific partition configuration
+            #   - NVIDIA: DynamicMIG feature gate + MIG devices present
+            #   - Example: gpuPartitions > 0
+
+            # Check for SharedCounters
+            SLICES_WITH_COUNTERS=$(oc get resourceslice -o json 2>/dev/null | \
+              jq -r '.items[] | select(.spec.sharedCounters != null) | .metadata.name' | wc -l || echo "0")
+
+            PARTITION_CONFIGURED=false
+
+            # Detect driver type and check partition configuration
+            if helm list -n nvidia-dra-driver 2>/dev/null | grep -q nvidia-dra-driver; then
+              # NVIDIA driver - check DynamicMIG feature gate
+              DYNAMIC_MIG_VALUE=$(helm get values nvidia-dra-driver -n nvidia-dra-driver -o json 2>/dev/null | \
+                jq -r '.featureGates.DynamicMIG // false')
+              MIG_DEVICES=$(oc get resourceslice -o json 2>/dev/null | \
+                jq -r '.items[].spec.devices[]? | select(.name | contains("mig")) | .name' | wc -l || echo "0")
+
+              if [ "${DYNAMIC_MIG_VALUE}" = "true" ] && [ "${MIG_DEVICES}" -gt 0 ]; then
+                PARTITION_CONFIGURED=true
+                echo "  ℹ ${feature}: NVIDIA DynamicMIG enabled, ${MIG_DEVICES} MIG devices detected"
+              fi
+            elif helm list -n dra-example-driver 2>/dev/null | grep -q dra-example-driver; then
+              # Example driver - check gpuPartitions value
+              GPU_PARTITIONS=$(helm get values dra-example-driver -n dra-example-driver -o json 2>/dev/null | \
+                jq -r '.kubeletPlugin.gpuPartitions // 0')
+
+              if [ "${GPU_PARTITIONS}" -gt 0 ]; then
+                PARTITION_CONFIGURED=true
+                echo "  ℹ ${feature}: Example driver gpuPartitions=${GPU_PARTITIONS}"
+              fi
+            fi
+
+            # Determine if partition support is available
+            if [ "${SLICES_WITH_COUNTERS}" -eq 0 ]; then
+              # SharedCounters not present - check fallback indicators
+              if [ "${PARTITION_CONFIGURED}" = true ]; then
+                # Driver partition config detected - consider it configured
+                echo "  ℹ Note: SharedCounters not populated in ResourceSlice (may populate after first claim)"
+              else
+                GRADUATION=$(get_feature_graduation "${feature}" "${K8S_VERSION_FULL}" 2>/dev/null || echo "unknown")
+                SKIP_REASON="Driver does not have partition support (${GRADUATION} feature, use --enable-dynamic-mig during setup)"
+              fi
+            fi
+            ;;
+        esac
+        ;;
+
+      not_enabled:alpha)
+        GATE_NAME=$(get_feature_gate "${feature}")
+        SKIP_REASON="${GATE_NAME} feature gate not enabled (Alpha feature - requires explicit enablement)"
+        ;;
+
+      not_enabled:beta)
+        GATE_NAME=$(get_feature_gate "${feature}")
+        SKIP_REASON="${GATE_NAME} feature gate not enabled (Beta feature - use --enable-dynamic-mig during setup)"
+        ;;
+
+      feature_unavailable)
+        SKIP_REASON="Feature not available in K8s ${K8S_VERSION}"
+        ;;
+
+      error)
+        # Metadata helper error, fall back to legacy checks
+        SKIP_REASON=""
+        ;;
+    esac
+  fi
+
+  if [ -n "${SKIP_REASON}" ]; then
+    SKIPPED_FEATURES+=("${feature}")
+    echo "  ⚠ ${feature}: Prerequisites not met - ${SKIP_REASON}"
+  else
+    RUNNABLE_FEATURES+=("${feature}")
+  fi
+done
+
+echo ""
+
+# Update TEST_FEATURES to only include runnable features
+TEST_FEATURES=("${RUNNABLE_FEATURES[@]}")
+
+# Step 4: Run feature tests
+echo "=== Step 4: Running tests ==="
+echo ""
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+for feature in "${TEST_FEATURES[@]}"; do
+  # Get test script path and feature name from metadata
+  TEST_SCRIPT=$(get_test_script "${feature}" 2>/dev/null || echo "")
+  TEST_NAME=$(get_feature_name "${feature}" 2>/dev/null || echo "${feature}")
+
+  if [ -z "${TEST_SCRIPT}" ] || [ ! -f "${TEST_SCRIPT}" ]; then
+    echo "  ⚠ ${TEST_NAME}: SKIP (test not found: ${TEST_SCRIPT})"
+    ((SKIPPED++))
+    continue
+  fi
+
+  echo "Testing: ${TEST_NAME}..."
+
+  TEST_OUTPUT="${OUTPUT_DIR}/${feature}-test.log"
+
+  if "${TEST_SCRIPT}" "${KUBECONFIG_PATH}" > "${TEST_OUTPUT}" 2>&1; then
+    echo "  ✅ ${TEST_NAME}: PASS"
+    PASSED=$((PASSED + 1))
+  else
+    EXIT_CODE=$?
+    echo "  ❌ ${TEST_NAME}: FAIL (exit code: ${EXIT_CODE})"
+    echo "     See: ${TEST_OUTPUT}"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+
+# Step 5: Collect artifacts
+echo "=== Step 5: Collecting artifacts ==="
+
+"${SCRIPT_DIR}/collect-artifacts.sh" "${KUBECONFIG_PATH}" "${OUTPUT_DIR}"
+
+echo "✓ Artifacts collected: ${OUTPUT_DIR}/"
+echo ""
+
+# Summary
+echo "========================================="
+echo "Testing Complete!"
+echo "========================================="
+echo ""
+echo "Results:"
+echo "  ✅ Passed:  ${PASSED}"
+echo "  ❌ Failed:  ${FAILED}"
+echo "  ⚠ Skipped: ${SKIPPED} (prerequisite checks) + ${#SKIPPED_FEATURES[@]} (feature gates)"
+echo ""
+
+if [ "${#SKIPPED_FEATURES[@]}" -gt 0 ]; then
+  echo "Skipped due to prerequisites:"
+  for feature in "${SKIPPED_FEATURES[@]}"; do
+    echo "  - ${feature}"
+  done
+  echo ""
+fi
+
+echo "Total: $((PASSED + FAILED + SKIPPED + ${#SKIPPED_FEATURES[@]})) features processed"
+echo ""
+
+if [ "${FAILED}" -gt 0 ]; then
+  echo "⚠ Some tests failed - see logs in ${OUTPUT_DIR}/"
+  exit 1
+else
+  echo "✓ All tests passed or skipped with valid reasons"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Review artifacts: ${OUTPUT_DIR}/"
+  echo "  2. Clean up: /dra-ocp-validator:cleanup ${KUBECONFIG_PATH}"
+  exit 0
+fi

--- a/plugins/dra-ocp-validator/tools/run-tests.sh
+++ b/plugins/dra-ocp-validator/tools/run-tests.sh
@@ -114,8 +114,11 @@ fi
 source "${METADATA_HELPER}"
 
 K8S_MINOR=$(echo "${K8S_VERSION}" | sed -E 's/v1\.([0-9]+)\..*/\1/')
+K8S_VERSION_NORMALIZED="1.${K8S_MINOR}"
 
 # Use metadata system to discover available features
+# Note: is_feature_available expects minor version number only (e.g., "35")
+# get_feature_graduation expects full version (e.g., "1.35")
 AVAILABLE_FEATURES=()
 for feature in $(list_all_features); do
   if is_feature_available "${feature}" "${K8S_MINOR}" 2>/dev/null; then
@@ -128,17 +131,70 @@ echo ""
 
 # Parse features to test
 TEST_FEATURES=()
+ALPHA_FEATURES_REQUESTED=()
+
 if [ "${FEATURES}" = "all" ]; then
-  TEST_FEATURES=("${AVAILABLE_FEATURES[@]}")
+  # Default: Only test Beta + GA features (exclude Alpha)
+  echo "Default mode: Testing Beta and GA features only"
+  for feature in "${AVAILABLE_FEATURES[@]}"; do
+    graduation=$(get_feature_graduation "${feature}" "${K8S_VERSION_NORMALIZED}")
+    if [ "${graduation}" != "alpha" ]; then
+      TEST_FEATURES+=("${feature}")
+    fi
+  done
 else
+  # User specified features - check for Alpha features
   IFS=',' read -ra REQUESTED_FEATURES <<< "${FEATURES}"
   for feature in "${REQUESTED_FEATURES[@]}"; do
     if [[ " ${AVAILABLE_FEATURES[@]} " =~ " ${feature} " ]]; then
-      TEST_FEATURES+=("${feature}")
+      graduation=$(get_feature_graduation "${feature}" "${K8S_VERSION_NORMALIZED}")
+      if [ "${graduation}" = "alpha" ]; then
+        ALPHA_FEATURES_REQUESTED+=("${feature}")
+      else
+        TEST_FEATURES+=("${feature}")
+      fi
     else
       echo "⚠ Feature '${feature}' not available on K8s ${K8S_VERSION} - skipping"
     fi
   done
+fi
+
+# Error out if Alpha features requested
+if [ ${#ALPHA_FEATURES_REQUESTED[@]} -gt 0 ]; then
+  echo ""
+  echo "❌ ERROR: Alpha features requested but not enabled"
+  echo ""
+  echo "The following Alpha features require feature gate enablement:"
+  for feature in "${ALPHA_FEATURES_REQUESTED[@]}"; do
+    gate_name=$(get_feature_gate "${feature}")
+    echo "  - ${feature} → requires '${gate_name}' feature gate"
+  done
+  echo ""
+  echo "⚠️  IMPORTANT: OpenShift only allows ONE featureset at a time:"
+  echo "  - TechPreviewNoUpgrade (for officially supported tech preview features)"
+  echo "  - CustomNoUpgrade (for upstream Alpha features not in downstream)"
+  echo ""
+  echo "You cannot enable features from different featuresets simultaneously."
+  echo ""
+  echo "To enable Alpha features, you must:"
+  echo "  1. Determine which featureset each feature requires"
+  echo "  2. Choose features from the SAME featureset"
+  echo "  3. Enable the feature gate(s) manually via:"
+  echo ""
+  echo "     For TechPreviewNoUpgrade (e.g., DRAPartitionableDevices):"
+  echo "       oc patch featuregate cluster --type=merge \\"
+  echo "         -p '{\"spec\":{\"featureSet\":\"TechPreviewNoUpgrade\"}}'"
+  echo ""
+  echo "     For CustomNoUpgrade (e.g., DRADeviceTaints, DRAConsumableCapacity):"
+  echo "       oc patch featuregate cluster --type=merge \\"
+  echo "         -p '{\"spec\":{\"customNoUpgrade\":{\"enabled\":[\"<GATE_NAME>\"]}}}'"
+  echo ""
+  echo "  4. Re-run setup if driver configuration is needed:"
+  echo "       /dra-ocp-validator:setup ${KUBECONFIG_PATH} [--enable-dynamic-mig]"
+  echo ""
+  echo "  5. Re-run tests with the same --features flag"
+  echo ""
+  exit 1
 fi
 
 echo "Features to test: ${TEST_FEATURES[*]}"
@@ -257,6 +313,8 @@ echo ""
 PASSED=0
 FAILED=0
 SKIPPED=0
+PASSED_FEATURES=()
+FAILED_FEATURES=()
 
 for feature in "${TEST_FEATURES[@]}"; do
   # Get test script path and feature name from metadata
@@ -276,11 +334,13 @@ for feature in "${TEST_FEATURES[@]}"; do
   if "${TEST_SCRIPT}" "${KUBECONFIG_PATH}" > "${TEST_OUTPUT}" 2>&1; then
     echo "  ✅ ${TEST_NAME}: PASS"
     PASSED=$((PASSED + 1))
+    PASSED_FEATURES+=("${feature}")
   else
     EXIT_CODE=$?
     echo "  ❌ ${TEST_NAME}: FAIL (exit code: ${EXIT_CODE})"
     echo "     See: ${TEST_OUTPUT}"
     FAILED=$((FAILED + 1))
+    FAILED_FEATURES+=("${feature}")
   fi
 done
 
@@ -305,10 +365,32 @@ echo "  ❌ Failed:  ${FAILED}"
 echo "  ⚠ Skipped: ${SKIPPED} (prerequisite checks) + ${#SKIPPED_FEATURES[@]} (feature gates)"
 echo ""
 
+# List passed features
+if [ ${#PASSED_FEATURES[@]} -gt 0 ]; then
+  echo "Passed (${#PASSED_FEATURES[@]}):"
+  for feature in "${PASSED_FEATURES[@]}"; do
+    FEATURE_NAME=$(get_feature_name "${feature}" 2>/dev/null || echo "${feature}")
+    echo "  ✅ ${feature} - ${FEATURE_NAME}"
+  done
+  echo ""
+fi
+
+# List failed features
+if [ ${#FAILED_FEATURES[@]} -gt 0 ]; then
+  echo "Failed (${#FAILED_FEATURES[@]}):"
+  for feature in "${FAILED_FEATURES[@]}"; do
+    FEATURE_NAME=$(get_feature_name "${feature}" 2>/dev/null || echo "${feature}")
+    echo "  ❌ ${feature} - ${FEATURE_NAME}"
+  done
+  echo ""
+fi
+
+# List skipped features with reasons
 if [ "${#SKIPPED_FEATURES[@]}" -gt 0 ]; then
-  echo "Skipped due to prerequisites:"
+  echo "Skipped (${#SKIPPED_FEATURES[@]}) - Prerequisites not met:"
   for feature in "${SKIPPED_FEATURES[@]}"; do
-    echo "  - ${feature}"
+    FEATURE_NAME=$(get_feature_name "${feature}" 2>/dev/null || echo "${feature}")
+    echo "  ⚠ ${feature} - ${FEATURE_NAME}"
   done
   echo ""
 fi
@@ -318,6 +400,15 @@ echo ""
 
 if [ "${FAILED}" -gt 0 ]; then
   echo "⚠ Some tests failed - see logs in ${OUTPUT_DIR}/"
+  echo ""
+  echo "For detailed failure analysis, check:"
+  for feature in "${FAILED_FEATURES[@]}"; do
+    LOG_FILE=$(find "${OUTPUT_DIR}" -name "*${feature}*test.log" -o -name "*${feature}*output.log" 2>/dev/null | head -1)
+    if [ -n "${LOG_FILE}" ]; then
+      echo "  • ${feature}: ${LOG_FILE}"
+    fi
+  done
+  echo ""
   exit 1
 else
   echo "✓ All tests passed or skipped with valid reasons"

--- a/plugins/dra-ocp-validator/tools/setup-dra.sh
+++ b/plugins/dra-ocp-validator/tools/setup-dra.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# DRA OCP Validator - Setup workflow
+# Installs NFD, detects hardware, and installs appropriate DRA driver
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common utilities
+if [ -f "${SCRIPT_DIR}/common.sh" ]; then
+    source "${SCRIPT_DIR}/common.sh"
+fi
+
+# Parse arguments
+KUBECONFIG_PATH=""
+DRIVER=""
+ENABLE_DYNAMIC_MIG=false
+DRIVER_VERSION=""  # Will be set based on driver type
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --driver)
+      DRIVER="${2}"
+      shift 2
+      ;;
+    --enable-dynamic-mig)
+      ENABLE_DYNAMIC_MIG=true
+      shift
+      ;;
+    --driver-version)
+      DRIVER_VERSION="${2}"
+      shift 2
+      ;;
+    *)
+      if [ -z "${KUBECONFIG_PATH}" ]; then
+        KUBECONFIG_PATH="${1}"
+      else
+        echo "ERROR: Unknown argument: ${1}"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Missing required argument: kubeconfig-path"
+  echo "Usage: $0 <kubeconfig-path> [options]"
+  exit 1
+fi
+
+# Expand tilde
+KUBECONFIG_PATH="${KUBECONFIG_PATH/#\~/$HOME}"
+
+# Validate kubeconfig exists
+if [ ! -f "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Kubeconfig not found: ${KUBECONFIG_PATH}"
+  exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "========================================="
+echo "DRA OCP Validator - Setup"
+echo "========================================="
+echo ""
+
+# Step 1: Verify cluster access
+echo "=== Step 1: Cluster verification ==="
+
+if ! validate_cluster_connectivity "true"; then
+  exit 1
+fi
+
+OCP_VERSION=$(oc version -o json | jq -r '.openshiftVersion // "unknown"')
+K8S_VERSION=$(oc version -o json | jq -r '.serverVersion.gitVersion // "unknown"')
+
+echo "✓ Cluster accessible (OCP ${OCP_VERSION}, K8s ${K8S_VERSION})"
+echo ""
+
+# Step 2: Install NFD (always required for hardware auto-detection)
+echo "=== Step 2: Installing NFD for hardware detection ==="
+
+# Check if NFD is already installed
+if oc get namespace openshift-nfd &>/dev/null && oc get nodefeaturediscovery -n openshift-nfd &>/dev/null 2>&1; then
+  echo "ℹ NFD is already installed, skipping installation"
+  echo ""
+else
+  echo "Installing NFD..."
+  "${SCRIPT_DIR}/install-nfd.sh" "${KUBECONFIG_PATH}"
+  echo ""
+fi
+
+# Step 3: Hardware detection (now that NFD is installed)
+echo "=== Step 3: Hardware detection ==="
+echo ""
+
+# Auto-detect driver if not specified (requires NFD)
+if [ -z "${DRIVER}" ]; then
+  # Check for NVIDIA GPUs via NFD labels
+  NVIDIA_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-10de.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+  # Check for AMD GPUs via NFD labels
+  AMD_NODES=$(oc get nodes -l 'feature.node.kubernetes.io/pci-1002.present=true' --no-headers 2>/dev/null | wc -l || echo "0")
+
+  if [ ${NVIDIA_NODES} -gt 0 ]; then
+    DRIVER="nvidia"
+    echo "✓ Hardware detected: NVIDIA GPUs on ${NVIDIA_NODES} node(s)"
+    echo "  → Auto-selecting NVIDIA DRA driver"
+  elif [ ${AMD_NODES} -gt 0 ]; then
+    DRIVER="amd"
+    echo "⚠ Hardware detected: AMD GPUs on ${AMD_NODES} node(s)"
+    echo "ERROR: AMD driver support not yet implemented"
+    exit 1
+  else
+    echo "ℹ No physical GPUs detected on this cluster"
+    echo ""
+    echo "  Checked for:"
+    echo "    • NVIDIA GPUs (PCI vendor ID 0x10de): Not found"
+    echo "    • AMD GPUs (PCI vendor ID 0x1002): Not found"
+    echo ""
+    echo "  → Proceeding with dra-example-driver (software-only testing)"
+    echo "    This driver simulates GPU resources without requiring physical hardware."
+    echo ""
+    DRIVER="example"
+  fi
+else
+  echo "ℹ Using user-specified driver: ${DRIVER}"
+fi
+
+echo ""
+
+# Step 4: Enable OCP feature gate if partitionable devices requested
+if [ "${ENABLE_DYNAMIC_MIG}" = true ]; then
+  echo "=== Step 4a: Enable DRAPartitionableDevices feature gate ==="
+  echo ""
+  echo "Partitionable devices require OCP cluster feature gate enablement."
+  echo ""
+
+  # Enable feature gate via CustomNoUpgrade
+  FEATURE_GATE="DRAPartitionableDevices"
+  CURRENT_GATES=$(oc get featuregate cluster -o json | jq -r '.spec.customNoUpgrade.enabled[]?' 2>/dev/null | tr '\n' ' ' || true)
+
+  if [[ ! " ${CURRENT_GATES} " =~ " ${FEATURE_GATE} " ]]; then
+    echo "Enabling ${FEATURE_GATE} feature gate..."
+    ALL_GATES=$(echo "${CURRENT_GATES} ${FEATURE_GATE}" | tr ' ' '\n' | grep -v '^$' | sort -u | jq -R . | jq -s .)
+    oc patch featuregate cluster --type=merge -p "{\"spec\":{\"customNoUpgrade\":{\"enabled\":${ALL_GATES}}}}"
+    echo "✓ Feature gate enabled, waiting for propagation..."
+    sleep 30
+  else
+    echo "✓ Feature gate '${FEATURE_GATE}' is already enabled"
+  fi
+  echo ""
+fi
+
+# Step 5: Install DRA driver
+echo "=== Step 5: Installing DRA driver ==="
+
+case "${DRIVER}" in
+  nvidia)
+    # Default NVIDIA DRA driver chart version if not specified
+    # This is the Helm chart version, not the CUDA driver version
+    NVIDIA_DRA_CHART_VERSION="${DRIVER_VERSION:-25.12.0}"
+
+    INSTALL_FLAGS=()
+    if [ "${ENABLE_DYNAMIC_MIG}" = true ]; then
+      INSTALL_FLAGS+=("--enable-dynamic-mig")
+      echo "Installing NVIDIA driver with DYNAMIC_MIG support for partitionable devices"
+    fi
+    INSTALL_FLAGS+=("--driver-version" "${NVIDIA_DRA_CHART_VERSION}")
+
+    "${SCRIPT_DIR}/install-nvidia-stack.sh" "${KUBECONFIG_PATH}" "${INSTALL_FLAGS[@]}"
+    ;;
+
+  example)
+    # Example driver version (matches upstream releases)
+    EXAMPLE_VERSION="${DRIVER_VERSION:-v0.3.0}"
+
+    if [ "${ENABLE_DYNAMIC_MIG}" = true ]; then
+      # For example driver, enable partitions
+      GPU_PARTITIONS="4"
+      echo "Installing example driver with partition support (4 partitions)"
+    else
+      GPU_PARTITIONS="0"
+      echo "Installing example driver without partition support"
+    fi
+
+    "${SCRIPT_DIR}/install-dra-example.sh" "${KUBECONFIG_PATH}" "${EXAMPLE_VERSION}" "${GPU_PARTITIONS}"
+    ;;
+
+  amd)
+    echo "ERROR: AMD driver support not yet implemented"
+    exit 1
+    ;;
+
+  *)
+    echo "ERROR: Unknown driver type: ${DRIVER}"
+    echo "Supported: nvidia, example"
+    exit 1
+    ;;
+esac
+
+echo ""
+
+# Step 6: Verification
+echo "=== Step 6: Installation verification ==="
+
+# Check DeviceClasses
+DEVICECLASS_COUNT=$(oc get deviceclass --no-headers 2>/dev/null | wc -l || echo "0")
+echo "DeviceClasses: ${DEVICECLASS_COUNT}"
+
+# Check ResourceSlices
+RESOURCESLICE_COUNT=$(oc get resourceslice --no-headers 2>/dev/null | wc -l || echo "0")
+echo "ResourceSlices: ${RESOURCESLICE_COUNT}"
+
+if [ ${DEVICECLASS_COUNT} -eq 0 ]; then
+  echo ""
+  echo "⚠ WARNING: No DeviceClasses found - DRA driver may not be ready yet"
+  echo "  Wait a few minutes and check: oc get deviceclass"
+fi
+
+echo ""
+echo "========================================="
+echo "Setup Complete!"
+echo "========================================="
+echo ""
+echo "DRA driver installed and ready for testing."
+echo ""
+echo "Next steps:"
+echo "  1. Run tests: /dra-ocp-validator:test ${KUBECONFIG_PATH}"
+echo "  2. Full validation: /dra-ocp-validator:validate ${KUBECONFIG_PATH}"
+echo "  3. Cleanup: /dra-ocp-validator:cleanup ${KUBECONFIG_PATH}"
+echo ""

--- a/plugins/dra-ocp-validator/tools/setup-partitionable-prerequisites.sh
+++ b/plugins/dra-ocp-validator/tools/setup-partitionable-prerequisites.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Setup prerequisites for DRAPartitionableDevices testing (Tech Preview feature)
+# This is ONLY needed for partitionable devices - other DRA features work out-of-box
+#
+# Two-step setup:
+# 1. OCP cluster: Enable DRAPartitionableDevices feature gate
+# 2. Driver: Verify driver has partition support enabled
+
+set -euo pipefail
+
+KUBECONFIG_PATH="${1:-}"
+AUTO_ENABLE="${2:-}"
+
+if [ -z "${KUBECONFIG_PATH}" ]; then
+    echo "ERROR: Missing required argument: kubeconfig-path"
+    exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+echo "=========================================="
+echo "DRAPartitionableDevices Prerequisites"
+echo "=========================================="
+echo ""
+echo "⚠ ALPHA/TECH PREVIEW FEATURE"
+echo ""
+echo "DRAPartitionableDevices requires:"
+echo "  1. OCP cluster feature gate (CustomNoUpgrade for granular control)"
+echo "  2. Driver installed with partition support"
+echo ""
+
+# Check OCP version
+OCP_VERSION=$(oc version -o json | jq -r '.openshiftVersion // "unknown"')
+OCP_MAJOR=$(echo "${OCP_VERSION}" | cut -d. -f1)
+OCP_MINOR=$(echo "${OCP_VERSION}" | cut -d. -f2)
+
+echo "OCP Version: ${OCP_VERSION}"
+echo ""
+
+#==============================================
+# Step 1: Check OCP cluster feature gate
+#==============================================
+echo "=== Step 1: OCP Cluster Feature Gate ==="
+echo ""
+
+FEATURE_GATE="DRAPartitionableDevices"
+
+# Determine feature gate strategy based on OCP version
+# OCP 4.21 (K8s 1.34): DRAPartitionableDevices is Alpha upstream - requires TechPreviewNoUpgrade
+# OCP 4.22+: May be Beta/GA, check status
+# OCP 5.0+: Feature is GA/Beta, auto-enabled
+if [ "${OCP_MAJOR}" -ge 5 ]; then
+    echo "OCP 5.0+ detected: DRAPartitionableDevices is enabled by default"
+    echo "✓ No feature gate configuration needed"
+    echo ""
+elif [ "${OCP_MAJOR}" -eq 4 ] && [ "${OCP_MINOR}" -eq 21 ]; then
+    echo "OCP 4.21 (K8s 1.34) detected: DRAPartitionableDevices is Alpha upstream"
+    echo "  Requires TechPreviewNoUpgrade feature set for alpha Kubernetes features"
+    echo ""
+
+    # Check if TechPreviewNoUpgrade is already set
+    CURRENT_FEATURE_SET=$(oc get featuregate cluster -o json 2>/dev/null | \
+        jq -r '.spec.featureSet // ""' || true)
+
+    if [ "${CURRENT_FEATURE_SET}" = "TechPreviewNoUpgrade" ]; then
+        echo "✓ TechPreviewNoUpgrade is enabled - DRAPartitionableDevices is available"
+        echo ""
+    else
+        echo "⚠ TechPreviewNoUpgrade is NOT enabled (current: ${CURRENT_FEATURE_SET:-none})"
+        echo ""
+
+        if [ "${AUTO_ENABLE}" != "--auto-enable" ]; then
+            # Check if running in non-interactive mode (stdin not a terminal)
+            if [ ! -t 0 ]; then
+                echo "Running in non-interactive mode - skipping prompt"
+                echo ""
+                echo "To enable DRAPartitionableDevices on OCP 4.21, run:"
+                echo "  oc patch featuregate cluster --type=merge \\"
+                echo "    -p '{\"spec\":{\"featureSet\":\"TechPreviewNoUpgrade\"}}'"
+                echo ""
+                echo "Or use --enable-dynamic-mig during setup:"
+                echo "  /dra-ocp-validator:setup <kubeconfig> --enable-dynamic-mig"
+                exit 1
+            fi
+
+            echo "⚠ WARNING: TechPreviewNoUpgrade enables ALL tech preview features."
+            echo "           This will prevent cluster upgrades and is only for test clusters."
+            echo ""
+        fi
+
+        echo "Enabling TechPreviewNoUpgrade feature set..."
+
+        # Patch featuregate to TechPreviewNoUpgrade
+        oc patch featuregate cluster --type=merge -p '{"spec":{"featureSet":"TechPreviewNoUpgrade"}}'
+
+        echo ""
+        echo "✓ TechPreviewNoUpgrade enabled"
+        echo ""
+        echo "⚠ Cluster components will restart:"
+        echo "  - API server: ~3-6 minutes"
+        echo "  - Kubelets: ~2-4 minutes per node"
+        echo ""
+        echo "Waiting 120 seconds for API server rollout to begin..."
+        sleep 120
+    fi
+
+elif [ "${OCP_MAJOR}" -eq 4 ] && [ "${OCP_MINOR}" -ge 22 ]; then
+    echo "OCP 4.${OCP_MINOR} detected: Checking DRAPartitionableDevices availability"
+    echo ""
+
+    # Check if feature is in status (may be Beta/GA in later versions)
+    FEATURE_IN_STATUS=$(oc get featuregate cluster -o json 2>/dev/null | \
+        jq -r --arg fg "${FEATURE_GATE}" '.status.featureGates[].enabled[]? | select(.name == $fg).name' || true)
+
+    if [ -n "${FEATURE_IN_STATUS}" ]; then
+        echo "✓ Feature gate '${FEATURE_GATE}' is enabled by default"
+        echo ""
+    else
+        echo "⚠ Feature gate '${FEATURE_GATE}' not found in default feature set"
+        echo ""
+        echo "For OCP 4.22+, consult documentation for proper enablement method."
+        echo "It may require TechPreviewNoUpgrade or a version-specific feature set."
+        exit 1
+    fi
+
+else
+    echo "⚠ OCP version < 4.21 or > 4.23 detected"
+    echo "DRAPartitionableDevices may not be available or may have different enablement"
+    echo ""
+fi
+
+#==============================================
+# Step 2: Verify driver partition support
+#==============================================
+echo "=== Step 2: Driver Partition Support ==="
+echo ""
+
+# Detect which driver is installed
+NVIDIA_DRIVER=$(oc get namespace nvidia-dra-driver 2>/dev/null && echo "true" || echo "false")
+EXAMPLE_DRIVER=$(oc get namespace dra-example-driver 2>/dev/null && echo "true" || echo "false")
+
+if [ "${NVIDIA_DRIVER}" = "true" ]; then
+    echo "Detected: NVIDIA DRA driver"
+    echo ""
+
+    # Check if DYNAMIC_MIG is enabled
+    DYNAMIC_MIG=$(oc get configmap -n nvidia-dra-driver nvidia-dra-driver-config -o jsonpath='{.data.config\.yaml}' 2>/dev/null | grep -i "DYNAMIC_MIG" || true)
+
+    if [ -n "${DYNAMIC_MIG}" ]; then
+        echo "✓ NVIDIA driver has DYNAMIC_MIG configuration"
+        echo ""
+    else
+        echo "⚠ NVIDIA driver may not have DYNAMIC_MIG enabled"
+        echo ""
+        echo "To enable partitionable devices on NVIDIA, reinstall with:"
+        echo "  /dra-ocp-validator:setup --driver nvidia --enable-dynamic-mig"
+        echo ""
+        exit 1
+    fi
+
+elif [ "${EXAMPLE_DRIVER}" = "true" ]; then
+    echo "Detected: dra-example-driver"
+    echo ""
+
+    # Check if partitions are configured
+    PARTITIONS=$(helm get values dra-example-driver -n dra-example-driver -o json 2>/dev/null | \
+        jq -r '.kubeletPlugin.gpuPartitions // 0' || echo "0")
+
+    if [ "${PARTITIONS}" -gt 0 ]; then
+        echo "✓ Example driver has ${PARTITIONS} GPU partitions configured"
+        echo ""
+    else
+        echo "⚠ Example driver does not have partitions configured"
+        echo ""
+        echo "To enable partitionable devices, reinstall with:"
+        echo "  /dra-ocp-validator:cleanup --keep-operator"
+        echo "  /dra-ocp-validator:setup --driver example"
+        echo ""
+        echo "(setup script automatically configures partitions)"
+        exit 1
+    fi
+
+else
+    echo "❌ No DRA driver found"
+    echo ""
+    echo "Install a driver first:"
+    echo "  /dra-ocp-validator:setup"
+    exit 1
+fi
+
+# Verify SharedCounters exist in ResourceSlices
+echo "=== Step 3: Verify SharedCounters ==="
+echo ""
+
+SLICES_WITH_COUNTERS=$(oc get resourceslice -o json | \
+    jq -r '.items[] | select(.spec.sharedCounters != null) | .metadata.name' | wc -l || echo "0")
+
+if [ "${SLICES_WITH_COUNTERS}" -gt 0 ]; then
+    echo "✓ Found ${SLICES_WITH_COUNTERS} ResourceSlices with SharedCounters"
+    echo ""
+else
+    echo "⚠ No SharedCounters found in ResourceSlices"
+    echo ""
+    echo "This may indicate:"
+    echo "  1. Driver needs restart after feature gate enabled"
+    echo "  2. Driver not configured with partitioning"
+    echo ""
+    echo "Try restarting driver pods:"
+    if [ "${NVIDIA_DRIVER}" = "true" ]; then
+        echo "  oc delete pods -n nvidia-dra-driver --all"
+    elif [ "${EXAMPLE_DRIVER}" = "true" ]; then
+        echo "  oc delete pods -n dra-example-driver --all"
+    fi
+    echo ""
+    echo "Wait 30 seconds, then check ResourceSlices again:"
+    echo "  oc get resourceslice -o json | jq '.items[0].spec.sharedCounters'"
+    echo ""
+    exit 1
+fi
+
+echo "=========================================="
+echo "Prerequisites Complete!"
+echo "=========================================="
+echo ""
+echo "✓ OCP feature gate enabled"
+echo "✓ Driver partition support verified"
+echo "✓ SharedCounters present in ResourceSlices"
+echo ""
+echo "Ready to run partitionable devices tests."

--- a/plugins/dra-ocp-validator/tools/validate-dra.sh
+++ b/plugins/dra-ocp-validator/tools/validate-dra.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# DRA OCP Validator - Full validation workflow
+# Orchestrates setup, testing, and reporting for comprehensive DRA validation
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common utilities
+if [ -f "${SCRIPT_DIR}/common.sh" ]; then
+    source "${SCRIPT_DIR}/common.sh"
+fi
+
+# Parse arguments
+KUBECONFIG_PATH=""
+SETUP_ARGS=()
+TEST_ARGS=()
+SKIP_INSTALL=false
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --skip-install)
+      SKIP_INSTALL=true
+      shift
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2}"
+      TEST_ARGS+=("${1}" "${2}")
+      shift 2
+      ;;
+    --features)
+      TEST_ARGS+=("${1}" "${2}")
+      shift 2
+      ;;
+    --driver|--enable-dynamic-mig|--driver-version|--skip-nfd)
+      SETUP_ARGS+=("${1}")
+      if [[ "${1}" == "--driver" || "${1}" == "--driver-version" ]]; then
+        SETUP_ARGS+=("${2}")
+        shift
+      fi
+      shift
+      ;;
+    *)
+      if [ -z "${KUBECONFIG_PATH}" ]; then
+        KUBECONFIG_PATH="${1}"
+      else
+        echo "ERROR: Unknown argument: ${1}"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# Validate required arguments
+if [ -z "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Missing required argument: kubeconfig-path"
+  echo "Usage: $0 <kubeconfig-path> [options]"
+  exit 1
+fi
+
+# Expand tilde
+KUBECONFIG_PATH="${KUBECONFIG_PATH/#\~/$HOME}"
+
+# Validate kubeconfig exists
+if [ ! -f "${KUBECONFIG_PATH}" ]; then
+  echo "ERROR: Kubeconfig not found: ${KUBECONFIG_PATH}"
+  exit 1
+fi
+
+export KUBECONFIG="${KUBECONFIG_PATH}"
+
+# Set output directory
+if [ -z "${OUTPUT_DIR}" ]; then
+  OUTPUT_DIR="./dra-validation-$(date +%Y%m%d-%H%M%S)"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "========================================="
+echo "DRA OCP Validator - Full Validation"
+echo "========================================="
+echo ""
+
+# Step 1: Verify cluster access
+echo "=== Step 1: Cluster verification ==="
+
+if ! validate_cluster_connectivity "true"; then
+  exit 1
+fi
+
+OCP_VERSION=$(oc version -o json | jq -r '.openshiftVersion // "unknown"')
+K8S_VERSION=$(oc version -o json | jq -r '.serverVersion.gitVersion // "unknown"')
+echo "✓ Cluster accessible (OCP ${OCP_VERSION}, K8s ${K8S_VERSION})"
+echo ""
+
+# Step 2: Setup (unless skipped)
+if [ "${SKIP_INSTALL}" = false ]; then
+  echo "=== Step 2: Installing DRA stack ==="
+  "${SCRIPT_DIR}/setup-dra.sh" "${KUBECONFIG_PATH}" "${SETUP_ARGS[@]}" | tee "${OUTPUT_DIR}/setup.log"
+  echo ""
+else
+  echo "=== Step 2: Skipped (--skip-install) ==="
+  echo ""
+fi
+
+# Step 3: Run tests (delegates to run-tests.sh)
+echo "=== Step 3: Running tests ==="
+if "${SCRIPT_DIR}/run-tests.sh" "${KUBECONFIG_PATH}" --output-dir "${OUTPUT_DIR}" "${TEST_ARGS[@]}"; then
+  TEST_EXIT=0
+else
+  TEST_EXIT=$?
+fi
+echo ""
+
+# Step 4: Create tarball
+echo "=== Step 4: Packaging results ==="
+TARBALL="${OUTPUT_DIR}.tar.gz"
+tar -czf "${TARBALL}" -C "$(dirname "${OUTPUT_DIR}")" "$(basename "${OUTPUT_DIR}")"
+TARBALL_SIZE=$(du -h "${TARBALL}" | cut -f1)
+echo "✓ Tarball created: ${TARBALL} (${TARBALL_SIZE})"
+echo ""
+
+# Summary
+echo "========================================="
+echo "Validation Complete!"
+echo "========================================="
+echo ""
+
+if [ "${TEST_EXIT}" -ne 0 ]; then
+  echo "⚠ Some tests failed - see logs in ${OUTPUT_DIR}/"
+  exit 1
+else
+  echo "✓ All tests passed or skipped with valid reasons"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Review: ${OUTPUT_DIR}/"
+  echo "  2. Cleanup: /dra-ocp-validator:cleanup ${KUBECONFIG_PATH}"
+  exit 0
+fi


### PR DESCRIPTION
<!--

** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:
This PR adds the dra-ocp-validator plugin, a comprehensive automation tool for end-to-end validation of Dynamic Resource Allocation (DRA) features on OpenShift clusters (OCP 4.21+).

### Problem:
- No automated end-to-end validation for DRA Beta features across OCP/K8s versions
- Manual DRA testing requires expertise in NFD, GPU operators, driver installation, and feature gate configuration
- Time-consuming setup (20-30 min) and error-prone test execution
- No standardized way to generate validation reports for JIRA/bugzilla

### Capabilities:
- **Auto-detects hardware**: NVIDIA/AMD GPUs via NFD labels, or software-only mode (dra-example-driver)
- **Automated setup**: Installs NFD, GPU Operator, and DRA drivers
- **Smart test execution**:
  - Detects K8s version and filters available features
  - Checks feature gates and skips Alpha features if not enabled
- **Comprehensive testing**: Tests all Beta DRA features (Partitionable Devices, Admin Access, Prioritized List, PodResources API, Device Taints, Extended Resources)
- **Reports**: Generates markdown reports + tarball artifacts for JIRA

### Commands:
- `/dra-ocp-validator:validate` - Full end-to-end validation (setup + test + report)
- `/dra-ocp-validator:setup` - Install DRA stack (NFD + GPU operator + driver)
- `/dra-ocp-validator:test` - Run tests on pre-configured cluster
- `/dra-ocp-validator:analyze` - Debug test failures with guided troubleshooting
- `/dra-ocp-validator:cleanup` - Remove test resources and optionally drivers
- `/dra-ocp-validator:list-features` - Display DRA features with graduation status

### Usage:
Full validation with NVIDIA GPU

`/dra-ocp-validator:validate ~/kubeconfig --driver nvidia --enable-dynamic-mig`

Software-only testing (no GPU required)

`/dra-ocp-validator:validate ~/kubeconfig --driver example`

### Use cases:
- QE teams validating DRA features across OCP releases
- GPU operator developers testing driver changes
- Field engineers verifying customer cluster DRA configurations
- Automated CI/CD validation for periodic DRA regression testing

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes N/A

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a DRA OCP Validator plugin with CLI commands (setup/validate/test/cleanup/analyze), installers, uninstallers, artifact collection, debug utilities, and a NVIDIA driver Helm values template.

* **Tests**
  * Adds a comprehensive end-to-end test suite covering admin access, device taints, extended resources, partitionable devices, prioritized lists, PodResources API, and test orchestration.

* **Documentation**
  * Adds full command docs, usage examples, feature maturity matrix, troubleshooting, outputs, and contributor/maintainer checklists.

* **Chores**
  * Publishes plugin metadata to the marketplace/index and adds OWNERS/maintainer details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->