### PR TITLE
chore(jira): restrict Atlassian MCP to Jira/Confluence capabilities

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1474,7 +1474,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "has_readme": true,
       "commands": [
         {
@@ -1758,7 +1758,7 @@ footer a { color: var(--primary); }
         {
           "name": "atlassian",
           "type": "http",
-          "endpoint": "https://mcp.atlassian.com/v1/mcp",
+          "endpoint": "https://mcp.atlassian.com/v1/mcp?capabilities=READ_JIRA,WRITE_JIRA,SEARCH_JIRA,READ_CONFLUENCE,WRITE_CONFLUENCE,SEARCH_CONFLUENCE,SEARCH_ATLASSIAN",
           "source": ".mcp.json"
         }
       ],

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/.mcp.json
+++ b/plugins/jira/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "atlassian": {
       "type": "http",
-      "url": "https://mcp.atlassian.com/v1/mcp"
+      "url": "https://mcp.atlassian.com/v1/mcp?capabilities=READ_JIRA,WRITE_JIRA,SEARCH_JIRA,READ_CONFLUENCE,WRITE_CONFLUENCE,SEARCH_CONFLUENCE,SEARCH_ATLASSIAN"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `capabilities` query parameter to the Atlassian MCP server URL, scoping tool exposure to Jira, Confluence, and Atlassian search only
- Drops `READ_COMPASS`, `WRITE_COMPASS`, `READ_JSM`, and `WRITE_JSM` tool families that we don't use
- Bumps jira plugin to v0.7.0

## Test plan

- [x] Verify `make lint` passes
- [x] Install the updated plugin and confirm Jira/Confluence MCP tools are available
- [x] Confirm Compass and JSM tools are no longer exposed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Jira plugin upgraded to version 0.7.0 with substantially expanded capabilities
  * Enhanced permissions now enabling comprehensive read, write, and search operations across Jira, Confluence, and Atlassian search platforms
  * Improved integration and operational flexibility for users managing Atlassian environments and content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->