### PR TITLE
Extend /metrics:ai-docs-telemetry analysis, accuracy and coverage in metrics plugin

### DIFF
--- a/plugins/metrics/README.md
+++ b/plugins/metrics/README.md
@@ -1,0 +1,349 @@
+# Metrics Plugin
+
+Anonymous usage metrics collection for ai-helpers slash commands, skills, and sessions.
+
+## Overview
+
+The `metrics` plugin provides anonymous usage tracking for:
+- **Events**: Individual slash commands and skill invocations
+- **Sessions**: Aggregate session-level metrics (duration, tool usage, conversation patterns)
+- **AI Docs Usage**: Track how agentic documentation is used during development
+
+This helps maintainers understand usage patterns and make data-driven decisions about feature development and improvements.
+
+## Commands
+
+### `/metrics:ai-docs-telemetry`
+
+Analyze Claude Code session logs to track ai-docs usage patterns. See [ai-docs-telemetry.md](commands/ai-docs-telemetry.md) for full documentation.
+
+**Quick examples:**
+```bash
+# Scan all recent sessions
+/metrics:ai-docs-telemetry -scan
+
+# Scan only enhancements repo
+/metrics:ai-docs-telemetry -scan -project enhancements
+
+# Analyze specific session
+/metrics:ai-docs-telemetry -session ~/.claude/projects/<project>/<session-id>.jsonl
+
+# Pipe to jq for analysis
+/metrics:ai-docs-telemetry -scan | jq -r '.[] | "\(.documentation.entry_point): \(.documentation.total_files)"'
+```
+
+## How It Works
+
+The plugin uses Claude Code's [hook system](https://docs.claude.com/en/docs/claude-code/hooks) to automatically track usage:
+
+### Event Tracking (Slash Commands & Skills)
+
+1. **Hook Triggers**:
+   - `UserPromptSubmit`: Fires when you submit a prompt that starts with `/` (slash commands)
+   - `PreToolUse`: Fires when Claude invokes a Skill tool
+2. **Data Collection**: The `send_metrics.py` script extracts the command/skill name and system information
+3. **Background Transmission**: Events are sent asynchronously to the events endpoint
+4. **Local Logging**: If verbose mode is enabled, all activity is logged to `metrics.log`
+
+### Session Tracking (Session-Level Aggregates)
+
+1. **Hook Trigger**: `SessionEnd` fires when your Claude Code session ends
+2. **Transcript Parsing**: The `send_session_metrics.py` script parses the session transcript file
+3. **Metrics Extraction**: Aggregates are calculated (tool usage, conversation turns, duration, etc.)
+4. **Background Transmission**: Session metrics are sent asynchronously to the sessions endpoint
+5. **Privacy**: Only counts and aggregates are collected - no command arguments, file paths, or message content
+
+### Hook Configuration
+
+The plugin is defined in `plugins/metrics/hooks/hooks.json`:
+
+```json
+{
+  "description": "Anonymous Usage Metric Collection",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/send_metrics.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": {
+          "tool": "Skill"
+        },
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/send_metrics.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/send_session_metrics.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## What Data is Collected
+
+The plugin collects two types of anonymous data:
+
+### Event Metrics (Slash Commands & Skills)
+
+Collected when you use a slash command or invoke a skill:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `type` | Metric type | `"slash_command"` or `"skill"` |
+| `name` | The command or skill name | `"jira:solve"` or `"ci:prow-job-analyze-install-failure"` |
+| `engine` | Always "claude" | `"claude"` |
+| `version` | Plugin version | `"1.0"` |
+| `timestamp` | UTC timestamp | `"2025-10-30T12:34:56Z"` |
+| `session_id` | Claude session identifier | `"abc123..."` |
+| `user_id` | Persistent anonymous UUID | `"550e8400-e29b-41d4-a716-446655440000"` |
+| `os` | Operating system | `"darwin"`, `"linux"`, `"windows"` |
+| `mac` | SHA256 hash of session_id + timestamp | `"a1b2c3..."` |
+| `prompt_length` | Character count of the prompt | `42` |
+
+**Privacy Guarantees:**
+- No command arguments or sensitive data are transmitted
+- No personal identifying information (PII) is collected
+- Session IDs are ephemeral and rotate between Claude sessions
+- A persistent anonymous UUID is stored locally in `.anonymous_id`, used only to correlate events across sessions
+- The `user_id` contains no PII and can be regenerated/cleared by deleting the `.anonymous_id` file
+- The `user_id` is treated as anonymous for analytics and integrity purposes
+- The MAC is used for data integrity verification only
+
+**Example payloads:**
+
+Slash command:
+```json
+{
+  "type": "slash_command",
+  "name": "jira:solve",
+  "engine": "claude",
+  "version": "1.0",
+  "timestamp": "2025-10-30T12:34:56Z",
+  "session_id": "abc123...",
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "os": "darwin",
+  "mac": "a1b2c3...",
+  "prompt_length": 42
+}
+```
+
+Skill invocation:
+```json
+{
+  "type": "skill",
+  "name": "ci:prow-job-analyze-install-failure",
+  "engine": "claude",
+  "version": "1.0",
+  "timestamp": "2025-10-30T12:34:56Z",
+  "session_id": "abc123...",
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "os": "darwin",
+  "mac": "a1b2c3...",
+  "prompt_length": 0
+}
+```
+
+### Session Metrics (Session-Level Aggregates)
+
+Collected when your Claude Code session ends:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `session_id` | Session identifier | `"abc123..."` |
+| `user_id` | Persistent anonymous UUID | `"550e8400-e29b-41d4-a716-446655440000"` |
+| `os` | Operating system | `"darwin"`, `"linux"`, `"windows"` |
+| `engine` | Always "claude" | `"claude"` |
+| `start_timestamp` | Session start time (UTC) | `"2025-10-30T12:00:00Z"` |
+| `end_timestamp` | Session end time (UTC) | `"2025-10-30T14:30:00Z"` |
+| `session_duration` | Duration in seconds | `9000` |
+| `exit_reason` | How session ended | `"clear"`, `"logout"`, `"prompt_input_exit"`, `"other"` |
+| `turn_count` | User-assistant exchanges | `42` |
+| `user_message_count` | Total user messages | `45` |
+| `assistant_message_count` | Total assistant messages | `48` |
+| `total_tool_calls` | Total tool invocations | `156` |
+| `tool_error_count` | Failed tool calls | `3` |
+| `bash_call_count` | Bash tool usage | `28` |
+| `file_read_count` | Read tool usage | `42` |
+| `file_edit_count` | Edit tool usage | `18` |
+| `file_write_count` | Write tool usage | `5` |
+| `grep_call_count` | Grep tool usage | `12` |
+| `glob_call_count` | Glob tool usage | `8` |
+| `web_fetch_call_count` | WebFetch tool usage | `2` |
+| `web_search_call_count` | WebSearch tool usage | `1` |
+| `total_input_tokens` | Total input tokens (nullable) | `50000` |
+| `total_output_tokens` | Total output tokens (nullable) | `12000` |
+| `cache_creation_tokens` | Cache creation tokens (nullable) | `15000` |
+| `cache_read_tokens` | Cache read tokens (nullable) | `35000` |
+| `had_errors` | Whether errors occurred | `true` or `false` |
+
+**Privacy Guarantees for Session Metrics:**
+- **Only aggregates**: Tool usage counts, not what tools were used for
+- **No content**: Command arguments, file paths, or message content are never collected
+- **No identifiable patterns**: Git operations, specific bash commands, or file names are excluded
+- **Optional tokens**: Token metrics are only included if non-zero and can be omitted for privacy
+
+**Example session payload:**
+```json
+{
+  "session_id": "abc123...",
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "os": "darwin",
+  "engine": "claude",
+  "start_timestamp": "2025-10-30T12:00:00Z",
+  "end_timestamp": "2025-10-30T14:30:00Z",
+  "session_duration": 9000,
+  "exit_reason": "clear",
+  "turn_count": 42,
+  "user_message_count": 45,
+  "assistant_message_count": 48,
+  "total_tool_calls": 156,
+  "tool_error_count": 3,
+  "bash_call_count": 28,
+  "file_read_count": 42,
+  "file_edit_count": 18,
+  "file_write_count": 5,
+  "grep_call_count": 12,
+  "glob_call_count": 8,
+  "web_fetch_call_count": 2,
+  "web_search_call_count": 1,
+  "total_input_tokens": 50000,
+  "total_output_tokens": 12000,
+  "cache_creation_tokens": 15000,
+  "cache_read_tokens": 35000,
+  "had_errors": false
+}
+```
+
+## Enabling the Plugin
+
+If you've installed ai-helpers from the marketplace:
+
+```bash
+# Enable the plugin
+/plugin enable metrics@ai-helpers
+
+# Verify it's enabled
+/plugin list
+```
+
+## Disabling the Plugin
+
+If you wish to opt out of metrics collection:
+
+```bash
+/plugin disable metrics@ai-helpers
+```
+
+## Configuration
+
+The plugin can be configured using environment variables:
+
+### `CLAUDE_METRICS_URL`
+
+Override the metrics endpoint URL (useful for testing or custom deployments):
+
+```bash
+export CLAUDE_METRICS_URL=https://localhost:8080/metrics
+```
+
+The plugin will automatically append `/events` for event metrics and `/sessions` for session metrics.
+
+**Default**: `https://us-central1-openshift-ci-data-analysis.cloudfunctions.net/metrics-upload`
+
+### `CLAUDE_METRICS_VERBOSE`
+
+Enable verbose logging to see all metrics activity in the log file:
+
+```bash
+export CLAUDE_METRICS_VERBOSE=1
+# or
+export CLAUDE_METRICS_VERBOSE=true
+# or
+export CLAUDE_METRICS_VERBOSE=yes
+```
+
+**Logging behavior:**
+- **Normal mode** (default): Only errors are logged to `metrics.log` with full details including:
+  - HTTP error codes and response bodies
+  - Network/timeout errors
+  - The complete payload that failed to send
+- **Verbose mode**: All activity is logged, including:
+  - Successful transmissions
+  - API request details (URL, headers, payload)
+  - Response status codes and bodies
+
+**Log location**: `${CLAUDE_PLUGIN_ROOT}/metrics.log`
+
+**Example verbose log entry:**
+```
+[2025-10-30T12:34:56+00:00] Sending metrics: {"type": "slash_command", "name": "jira:solve", ...}
+[2025-10-30T12:34:56+00:00] API Request: POST https://...
+[2025-10-30T12:34:56+00:00] Response: HTTP 200 - {"status": "ok"}
+```
+
+**Example error log entry (always logged):**
+```
+[2025-10-30T12:34:56+00:00] ERROR: HTTP 500 - Internal Server Error
+Data sent: {
+  "type": "slash_command",
+  "name": "jira:solve",
+  ...
+}
+```
+
+## Network Behavior
+
+- **Event Endpoint**: `https://us-central1-openshift-ci-data-analysis.cloudfunctions.net/metrics-upload/events`
+- **Session Endpoint**: `https://us-central1-openshift-ci-data-analysis.cloudfunctions.net/metrics-upload/sessions`
+- **Async**: Runs in a background thread so it doesn't delay command execution
+- **Resilience**: Network failures are logged but don't interrupt your work
+
+## Source Code
+
+All metrics collection logic is open source and available in this repository:
+
+- **Hook definition**: `plugins/metrics/hooks/hooks.json`
+- **Event collection script**: `plugins/metrics/scripts/send_metrics.py`
+- **Session collection script**: `plugins/metrics/scripts/send_session_metrics.py`
+- **AI docs telemetry script**: `plugins/metrics/scripts/ai_docs_telemetry.py`
+- **Plugin metadata**: `plugins/metrics/.claude-plugin/plugin.json`
+- **Commands**: `plugins/metrics/commands/`
+
+## Data Usage
+
+The collected metrics help us:
+
+**Event metrics:**
+- Understand which commands and skills are most valuable to users
+- Identify commands that may need better documentation
+- Make data-driven decisions about feature prioritization and deprecations
+
+**Session metrics:**
+- Understand typical session patterns (duration, tool usage, conversation depth)
+- Identify workflow bottlenecks and optimization opportunities
+- Measure developer productivity patterns without revealing specific work content
+- Optimize tool performance and caching strategies based on actual usage
+
+**Aggregate metrics may be shared publicly** (e.g., "The average session uses 42 tool calls" or "The most popular command is `/jira:solve` with 1,234 uses this month"), but individual usage data remains private.

--- a/plugins/metrics/README.md
+++ b/plugins/metrics/README.md
@@ -29,7 +29,7 @@ Analyze Claude Code session logs to track ai-docs usage patterns. See [ai-docs-t
 /metrics:ai-docs-telemetry -session ~/.claude/projects/<project>/<session-id>.jsonl
 
 # Pipe to jq for analysis
-/metrics:ai-docs-telemetry -scan | jq -r '.[] | "\(.documentation.entry_point): \(.documentation.total_files)"'
+/metrics:ai-docs-telemetry -scan | jq -r '.[] | "\(.session_id): \(.documentation.total_files) files"'
 ```
 
 ## How It Works

--- a/plugins/metrics/commands/ai-docs-telemetry.md
+++ b/plugins/metrics/commands/ai-docs-telemetry.md
@@ -18,7 +18,6 @@ The `metrics:ai-docs-telemetry` command analyzes Claude Code session logs to tra
 This helps measure:
 - Documentation effectiveness and usage patterns
 - Which files are accessed most frequently
-- Entry points for documentation discovery (AGENTS.md, direct search, etc.)
 - Navigation paths through documentation
 
 All output is JSON to stdout, making it easy to pipe to `jq` for analysis.
@@ -32,7 +31,6 @@ The script:
 - Parses `~/.claude/projects/` JSONL files
 - Detects Read tool calls to files matching `ai-docs/`, `AGENTS.md`, or `CLAUDE.md`
 - Tracks access sequence and timestamps
-- Identifies entry points (AGENTS.md vs direct search)
 - Privacy-first: Only file paths tracked, no code/prompts/user data
 
 ## Return Value
@@ -52,7 +50,6 @@ The script:
        "event_type": "ai_docs_usage",
        "session_id": "a0350e3f-1853-4a56-be01-865cd0df1944",
        "documentation": {
-         "entry_point": "AGENTS.md",
          "files_accessed": [...],
          "total_files": 5
        }
@@ -77,12 +74,9 @@ The script:
 
 5. **Pipe to jq for analysis**:
    ```bash
-   # Count files by entry point
-   /metrics:ai-docs-telemetry -scan | jq -r '.[] | "\(.documentation.entry_point): \(.documentation.total_files)"'
-   
    # List most accessed files
    /metrics:ai-docs-telemetry -scan | jq -r '.[] | .documentation.files_accessed[].path' | sort | uniq -c | sort -rn
-   
+
    # Filter sessions with >5 files accessed
    /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.total_files > 5)'
    ```

--- a/plugins/metrics/commands/ai-docs-telemetry.md
+++ b/plugins/metrics/commands/ai-docs-telemetry.md
@@ -29,8 +29,8 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/ai_docs_telemetry.py "$@"
 
 The script:
 - Parses `~/.claude/projects/` JSONL files
-- Detects Read tool calls to files matching `ai-docs/`, `AGENTS.md`, or `CLAUDE.md`
-- Tracks access sequence and timestamps
+- Detects `Read`, `Grep`, and `Glob` tool calls referencing `ai-docs/`, `AGENTS.md`, or `CLAUDE.md`
+- Tracks access sequence, tool used, and timestamps
 - Privacy-first: Only file paths tracked, no code/prompts/user data
 
 ## Return Value
@@ -51,7 +51,11 @@ The script:
        "session_id": "a0350e3f-1853-4a56-be01-865cd0df1944",
        "documentation": {
          "files_accessed": [...],
-         "total_files": 5
+         "unique_files": [...],
+         "total_accesses": 7,
+         "unique_file_count": 5,
+         "total_files": 5,
+         "sub_agents": []
        }
      }
    ]
@@ -74,11 +78,20 @@ The script:
 
 5. **Pipe to jq for analysis**:
    ```bash
-   # List most accessed files
+   # List most accessed files (all accesses, including re-reads)
    /metrics:ai-docs-telemetry -scan | jq -r '.[] | .documentation.files_accessed[].path' | sort | uniq -c | sort -rn
 
-   # Filter sessions with >5 files accessed
-   /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.total_files > 5)'
+   # Sessions where re-reads occurred (total_accesses > unique_file_count)
+   /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.total_accesses > .documentation.unique_file_count)'
+
+   # Filter sessions with >5 unique files accessed
+   /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.unique_file_count > 5)'
+
+   # Sessions that spawned sub-agents
+   /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.sub_agents | length > 0)'
+
+   # Show which tools (Read/Grep/Glob) were used per session
+   /metrics:ai-docs-telemetry -scan | jq '.[] | {session: .session_id, tools: [.documentation.files_accessed[].tool] | unique}'
    ```
 
 ## Arguments

--- a/plugins/metrics/commands/ai-docs-telemetry.md
+++ b/plugins/metrics/commands/ai-docs-telemetry.md
@@ -1,0 +1,97 @@
+---
+description: Analyze Claude Code session logs for ai-docs usage patterns
+argument-hint: "[-scan] [-project <name>] [-session <path>]"
+---
+
+## Name
+metrics:ai-docs-telemetry
+
+## Synopsis
+```
+/metrics:ai-docs-telemetry -scan [-project <name>]
+/metrics:ai-docs-telemetry -session <path-to-session.jsonl>
+```
+
+## Description
+The `metrics:ai-docs-telemetry` command analyzes Claude Code session logs to track how agentic documentation (ai-docs) is used during development. It parses session JSONL files to extract Read tool calls to ai-docs files and generates telemetry events.
+
+This helps measure:
+- Documentation effectiveness and usage patterns
+- Which files are accessed most frequently
+- Entry points for documentation discovery (AGENTS.md, direct search, etc.)
+- Navigation paths through documentation
+
+All output is JSON to stdout, making it easy to pipe to `jq` for analysis.
+
+## Implementation
+```python
+${CLAUDE_PLUGIN_ROOT}/scripts/ai_docs_telemetry.py "$@"
+```
+
+The script:
+- Parses `~/.claude/projects/` JSONL files
+- Detects Read tool calls to files matching `ai-docs/`, `AGENTS.md`, or `CLAUDE.md`
+- Tracks access sequence and timestamps
+- Identifies entry points (AGENTS.md vs direct search)
+- Privacy-first: Only file paths tracked, no code/prompts/user data
+
+## Return Value
+- **JSON**: Single event or array of events
+- **Summary**: Printed to stderr with session counts
+
+## Examples
+
+1. **Scan all recent sessions (last 7 days)**:
+   ```
+   /metrics:ai-docs-telemetry -scan
+   ```
+   Output:
+   ```json
+   [
+     {
+       "event_type": "ai_docs_usage",
+       "session_id": "a0350e3f-1853-4a56-be01-865cd0df1944",
+       "documentation": {
+         "entry_point": "AGENTS.md",
+         "files_accessed": [...],
+         "total_files": 5
+       }
+     }
+   ]
+   ```
+
+2. **Scan only enhancements repository**:
+   ```
+   /metrics:ai-docs-telemetry -scan -project enhancements
+   ```
+
+3. **Scan only machine-config-operator repository**:
+   ```
+   /metrics:ai-docs-telemetry -scan -project machine-config-operator
+   ```
+
+4. **Analyze a specific session**:
+   ```
+   /metrics:ai-docs-telemetry -session ~/.claude/projects/<project>/<session-id>.jsonl
+   ```
+
+5. **Pipe to jq for analysis**:
+   ```bash
+   # Count files by entry point
+   /metrics:ai-docs-telemetry -scan | jq -r '.[] | "\(.documentation.entry_point): \(.documentation.total_files)"'
+   
+   # List most accessed files
+   /metrics:ai-docs-telemetry -scan | jq -r '.[] | .documentation.files_accessed[].path' | sort | uniq -c | sort -rn
+   
+   # Filter sessions with >5 files accessed
+   /metrics:ai-docs-telemetry -scan | jq '.[] | select(.documentation.total_files > 5)'
+   ```
+
+## Arguments
+- `-scan`: Scan all recent Claude Code sessions (last 7 days)
+- `-project <name>`: Filter sessions by project name (e.g., "enhancements", "machine-config-operator")
+- `-session <path>`: Analyze a specific session JSONL file
+
+## Related
+- Session hooks: `metrics` plugin's `SessionEnd` hook
+- General metrics: `send_session_metrics.py`

--- a/plugins/metrics/scripts/ai_docs_telemetry.py
+++ b/plugins/metrics/scripts/ai_docs_telemetry.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+AI Docs Telemetry Analysis Script
+
+Analyzes Claude Code session logs to track ai-docs usage patterns.
+Parses session JSONL files to extract tool calls (Read, Grep, Glob, Bash)
+that reference ai-docs files.
+
+Usage:
+  ai_docs_telemetry.py -scan [-project <name>]
+  ai_docs_telemetry.py -session <path-to-session.jsonl>
+"""
+
+import sys
+import json
+import pathlib
+import datetime
+import argparse
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class FileAccess:
+    """Represents a single file access in the session."""
+    path: str
+    sequence: int
+    time: str
+    tool: str = "Read"
+
+
+@dataclass
+class PlatformInfo:
+    """Platform information."""
+    name: str = "claude-code"
+    version: str = "unknown"
+
+
+@dataclass
+class RepositoryInfo:
+    """Repository information extracted from session path."""
+    name: str
+    path: str
+
+
+@dataclass
+class TelemetryEvent:
+    """Complete telemetry event."""
+    event_type: str
+    version: str
+    timestamp: str
+    session_id: str
+    platform: Dict[str, str]
+    repository: Dict[str, str]
+    documentation: Dict[str, Any]
+
+
+_AI_DOCS_MARKERS = ("ai-docs", "AGENTS.md", "CLAUDE.md")
+
+
+def _is_ai_docs_ref(value: str) -> bool:
+    """Return True if value references an ai-docs file or a known index file."""
+    return any(marker in value for marker in _AI_DOCS_MARKERS)
+
+
+def extract_repo_info(session_path: str) -> RepositoryInfo:
+    """
+    Extract repository information from session path.
+    Path format: ~/.claude/projects/<repo-path-hash>/<session-id>.jsonl
+    """
+    parts = session_path.split("/projects/")
+    if len(parts) < 2:
+        return RepositoryInfo(name="unknown", path="unknown")
+
+    # Get the project directory name
+    project_dir = parts[1].split("/")[0]
+
+    # Decode project name (simplified - just replace dashes with slashes)
+    repo_name = project_dir.replace("-", "/")
+
+    return RepositoryInfo(name=repo_name, path=project_dir)
+
+
+def detect_entry_point(files: List[FileAccess]) -> str:
+    """Determine how user discovered ai-docs."""
+    if not files:
+        return "unknown"
+
+    for f in files:
+        if f.path.endswith("AGENTS.md"):
+            return "AGENTS.md"
+        if f.path.endswith("CLAUDE.md"):
+            return "CLAUDE.md"
+        if f.path.endswith("README.md"):
+            return "README.md"
+        if f.tool in ("Grep", "Glob"):
+            return "search"
+
+    return "direct-path"
+
+
+def process_session(session_path: str) -> Optional[TelemetryEvent]:
+    """
+    Analyze a Claude Code session log and extract ai-docs usage.
+    Returns None if no ai-docs usage detected.
+    """
+    try:
+        with open(session_path, 'r') as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Error reading session: {e}", file=sys.stderr)
+        return None
+
+    lines = content.split('\n')
+    ai_docs_files: List[FileAccess] = []
+    sub_agents: List[Dict] = []
+    session_id = pathlib.Path(session_path).stem
+
+    for line in lines:
+        if not line.strip():
+            continue
+
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        # Look for Read tool calls to ai-docs files
+        if event.get("type") != "assistant":
+            continue
+
+        msg = event.get("message", {})
+        content_arr = msg.get("content", [])
+
+        for item in content_arr:
+            if not isinstance(item, dict) or item.get("type") != "tool_use":
+                continue
+
+            tool_name = item.get("name", "")
+            inp = item.get("input", {})
+
+            if tool_name == "Agent":
+                sub_agents.append({
+                    "spawned_at":  event.get("timestamp", ""),
+                    "description": inp.get("description", ""),
+                })
+                continue
+
+            # Extract the target string for each supported tool
+            if tool_name == "Read":
+                target = inp.get("file_path", "")
+            elif tool_name == "Grep":
+                target = inp.get("path", "")
+            elif tool_name == "Glob":
+                target = inp.get("pattern", "")
+            else:
+                continue
+
+            if target and _is_ai_docs_ref(target):
+                timestamp = event.get("timestamp", datetime.datetime.now().isoformat())
+                ai_docs_files.append(FileAccess(
+                    path=target,
+                    sequence=len(ai_docs_files) + 1,
+                    time=timestamp,
+                    tool=tool_name,
+                ))
+
+    if not ai_docs_files:
+        return None
+
+    # Deduplicate: keep first occurrence of each path
+    seen_paths: set = set()
+    unique_files: List[FileAccess] = []
+    for f in ai_docs_files:
+        if f.path not in seen_paths:
+            seen_paths.add(f.path)
+            unique_files.append(f)
+
+    # Extract repository info
+    repo_info = extract_repo_info(session_path)
+
+    # Build telemetry event
+    telemetry = TelemetryEvent(
+        event_type="ai_docs_usage",
+        version="1.0",
+        timestamp=datetime.datetime.now().isoformat(),
+        session_id=session_id,
+        platform=asdict(PlatformInfo()),
+        repository=asdict(repo_info),
+        documentation={
+            "entry_point":       detect_entry_point(ai_docs_files),
+            "files_accessed":    [asdict(f) for f in ai_docs_files],
+            "unique_files":      [asdict(f) for f in unique_files],
+            "total_accesses":    len(ai_docs_files),
+            "unique_file_count": len(unique_files),
+            "total_files":       len(unique_files),
+            "sub_agents":        sub_agents,
+        }
+    )
+
+    return telemetry
+
+
+def scan_recent_sessions(project_filter: Optional[str] = None) -> List[TelemetryEvent]:
+    """
+    Scan ~/.claude/projects/ for recent sessions with ai-docs usage.
+    Returns list of telemetry events.
+    """
+    home_dir = pathlib.Path.home()
+    projects_dir = home_dir / ".claude" / "projects"
+
+    if not projects_dir.exists():
+        print(f"Projects directory not found: {projects_dir}", file=sys.stderr)
+        return []
+
+    events = []
+    processed_count = 0
+    seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+
+    # Walk through all project directories
+    for session_file in projects_dir.glob("**/*.jsonl"):
+        # Skip files older than 7 days
+        mtime = datetime.datetime.fromtimestamp(session_file.stat().st_mtime)
+        if mtime < seven_days_ago:
+            continue
+
+        # Filter by project if specified
+        if project_filter and project_filter not in str(session_file):
+            continue
+
+        processed_count += 1
+
+        # Quick pre-filter: check if file contains ai-docs markers
+        try:
+            content = session_file.read_text()
+            if not any(marker in content for marker in _AI_DOCS_MARKERS):
+                continue
+        except Exception:
+            continue
+
+        # Process session
+        event = process_session(str(session_file))
+        if event:
+            events.append(event)
+
+    print(f"\n📊 Summary: {processed_count} sessions scanned, {len(events)} with ai-docs usage",
+          file=sys.stderr)
+
+    return events
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Analyze Claude Code session logs for ai-docs usage"
+    )
+    parser.add_argument("-scan", action="store_true",
+                       help="Scan all recent Claude Code sessions (last 7 days)")
+    parser.add_argument("-project", type=str,
+                       help="Filter by project name (e.g., 'enhancements', 'machine-config-operator')")
+    parser.add_argument("-session", type=str,
+                       help="Analyze a specific session JSONL file")
+
+    args = parser.parse_args()
+
+    if args.scan:
+        events = scan_recent_sessions(args.project)
+        print(json.dumps([asdict(e) for e in events], indent=2))
+    elif args.session:
+        event = process_session(args.session)
+        if event:
+            print(json.dumps(asdict(event), indent=2))
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/metrics/scripts/ai_docs_telemetry.py
+++ b/plugins/metrics/scripts/ai_docs_telemetry.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass, asdict
 
 @dataclass
 class FileAccess:
-    """Represents a single file access in the session."""
     path: str
     sequence: int
     time: str
@@ -31,21 +30,18 @@ class FileAccess:
 
 @dataclass
 class PlatformInfo:
-    """Platform information."""
     name: str = "claude-code"
     version: str = "unknown"
 
 
 @dataclass
 class RepositoryInfo:
-    """Repository information extracted from session path."""
     name: str
     path: str
 
 
 @dataclass
 class TelemetryEvent:
-    """Complete telemetry event."""
     event_type: str
     version: str
     timestamp: str
@@ -59,57 +55,30 @@ _AI_DOCS_MARKERS = ("ai-docs", "AGENTS.md", "CLAUDE.md")
 
 
 def _is_ai_docs_ref(value: str) -> bool:
-    """Return True if value references an ai-docs file or a known index file."""
     return any(marker in value for marker in _AI_DOCS_MARKERS)
 
 
 def extract_repo_info(session_path: str) -> RepositoryInfo:
-    """
-    Extract repository information from session path.
-    Path format: ~/.claude/projects/<repo-path-hash>/<session-id>.jsonl
-    """
+    # Path format: ~/.claude/projects/<repo-path-hash>/<session-id>.jsonl
     parts = session_path.split("/projects/")
     if len(parts) < 2:
         return RepositoryInfo(name="unknown", path="unknown")
 
-    # Get the project directory name
-    project_dir = parts[1].split("/")[0]
-
-    # Decode project name (simplified - just replace dashes with slashes)
+    project_dir = parts[-1].split("/")[0]
+    # Simplified: dashes are used as path separators in the encoded project dir name
     repo_name = project_dir.replace("-", "/")
 
     return RepositoryInfo(name=repo_name, path=project_dir)
 
 
-def detect_entry_point(files: List[FileAccess]) -> str:
-    """Determine how user discovered ai-docs."""
-    if not files:
-        return "unknown"
-
-    for f in files:
-        if f.path.endswith("AGENTS.md"):
-            return "AGENTS.md"
-        if f.path.endswith("CLAUDE.md"):
-            return "CLAUDE.md"
-        if f.path.endswith("README.md"):
-            return "README.md"
-        if f.tool in ("Grep", "Glob"):
-            return "search"
-
-    return "direct-path"
-
-
-def process_session(session_path: str) -> Optional[TelemetryEvent]:
-    """
-    Analyze a Claude Code session log and extract ai-docs usage.
-    Returns None if no ai-docs usage detected.
-    """
-    try:
-        with open(session_path, 'r') as f:
-            content = f.read()
-    except Exception as e:
-        print(f"Error reading session: {e}", file=sys.stderr)
-        return None
+def process_session(session_path: str, content: Optional[str] = None) -> Optional[TelemetryEvent]:
+    if content is None:
+        try:
+            with open(session_path, 'r') as f:
+                content = f.read()
+        except Exception as e:
+            print(f"Error reading session: {e}", file=sys.stderr)
+            return None
 
     lines = content.split('\n')
     ai_docs_files: List[FileAccess] = []
@@ -125,11 +94,10 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
         except json.JSONDecodeError:
             continue
 
-        # Look for Read tool calls to ai-docs files
         if event.get("type") != "assistant":
             continue
 
-        msg = event.get("message", {})
+        msg = event.get("message") or {}
         content_arr = msg.get("content", [])
 
         for item in content_arr:
@@ -137,7 +105,7 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
                 continue
 
             tool_name = item.get("name", "")
-            inp = item.get("input", {})
+            inp = item.get("input") or {}
 
             if tool_name == "Agent":
                 sub_agents.append({
@@ -146,7 +114,6 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
                 })
                 continue
 
-            # Extract the target string for each supported tool
             if tool_name == "Read":
                 target = inp.get("file_path", "")
             elif tool_name == "Grep":
@@ -168,7 +135,6 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
     if not ai_docs_files:
         return None
 
-    # Deduplicate: keep first occurrence of each path
     seen_paths: set = set()
     unique_files: List[FileAccess] = []
     for f in ai_docs_files:
@@ -176,10 +142,8 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
             seen_paths.add(f.path)
             unique_files.append(f)
 
-    # Extract repository info
     repo_info = extract_repo_info(session_path)
 
-    # Build telemetry event
     telemetry = TelemetryEvent(
         event_type="ai_docs_usage",
         version="1.0",
@@ -188,7 +152,6 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
         platform=asdict(PlatformInfo()),
         repository=asdict(repo_info),
         documentation={
-            "entry_point":       detect_entry_point(ai_docs_files),
             "files_accessed":    [asdict(f) for f in ai_docs_files],
             "unique_files":      [asdict(f) for f in unique_files],
             "total_accesses":    len(ai_docs_files),
@@ -202,10 +165,6 @@ def process_session(session_path: str) -> Optional[TelemetryEvent]:
 
 
 def scan_recent_sessions(project_filter: Optional[str] = None) -> List[TelemetryEvent]:
-    """
-    Scan ~/.claude/projects/ for recent sessions with ai-docs usage.
-    Returns list of telemetry events.
-    """
     home_dir = pathlib.Path.home()
     projects_dir = home_dir / ".claude" / "projects"
 
@@ -217,20 +176,17 @@ def scan_recent_sessions(project_filter: Optional[str] = None) -> List[Telemetry
     processed_count = 0
     seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
 
-    # Walk through all project directories
     for session_file in projects_dir.glob("**/*.jsonl"):
-        # Skip files older than 7 days
         mtime = datetime.datetime.fromtimestamp(session_file.stat().st_mtime)
         if mtime < seven_days_ago:
             continue
 
-        # Filter by project if specified
         if project_filter and project_filter not in str(session_file):
             continue
 
         processed_count += 1
 
-        # Quick pre-filter: check if file contains ai-docs markers
+        # Pre-filter: skip files that contain no ai-docs markers (avoids full parse)
         try:
             content = session_file.read_text()
             if not any(marker in content for marker in _AI_DOCS_MARKERS):
@@ -238,8 +194,7 @@ def scan_recent_sessions(project_filter: Optional[str] = None) -> List[Telemetry
         except Exception:
             continue
 
-        # Process session
-        event = process_session(str(session_file))
+        event = process_session(str(session_file), content=content)
         if event:
             events.append(event)
 
@@ -250,7 +205,6 @@ def scan_recent_sessions(project_filter: Optional[str] = None) -> List[Telemetry
 
 
 def main():
-    """Main entry point."""
     parser = argparse.ArgumentParser(
         description="Analyze Claude Code session logs for ai-docs usage"
     )

--- a/plugins/metrics/scripts/ai_docs_telemetry.py
+++ b/plugins/metrics/scripts/ai_docs_telemetry.py
@@ -3,7 +3,7 @@
 AI Docs Telemetry Analysis Script
 
 Analyzes Claude Code session logs to track ai-docs usage patterns.
-Parses session JSONL files to extract tool calls (Read, Grep, Glob, Bash)
+Parses session JSONL files to extract tool calls (Read, Grep, Glob)
 that reference ai-docs files.
 
 Usage:
@@ -65,10 +65,8 @@ def extract_repo_info(session_path: str) -> RepositoryInfo:
         return RepositoryInfo(name="unknown", path="unknown")
 
     project_dir = parts[-1].split("/")[0]
-    # Simplified: dashes are used as path separators in the encoded project dir name
-    repo_name = project_dir.replace("-", "/")
 
-    return RepositoryInfo(name=repo_name, path=project_dir)
+    return RepositoryInfo(name=project_dir, path=project_dir)
 
 
 def process_session(session_path: str, content: Optional[str] = None) -> Optional[TelemetryEvent]:
@@ -94,11 +92,11 @@ def process_session(session_path: str, content: Optional[str] = None) -> Optiona
         except json.JSONDecodeError:
             continue
 
-        if event.get("type") != "assistant":
+        if not isinstance(event, dict) or event.get("type") != "assistant":
             continue
 
         msg = event.get("message") or {}
-        content_arr = msg.get("content", [])
+        content_arr = msg.get("content") or []
 
         for item in content_arr:
             if not isinstance(item, dict) or item.get("type") != "tool_use":
@@ -191,7 +189,8 @@ def scan_recent_sessions(project_filter: Optional[str] = None) -> List[Telemetry
             content = session_file.read_text()
             if not any(marker in content for marker in _AI_DOCS_MARKERS):
                 continue
-        except Exception:
+        except Exception as e:
+            print(f"Warning: skipping {session_file}: {e}", file=sys.stderr)
             continue
 
         event = process_session(str(session_file), content=content)


### PR DESCRIPTION
Follow up for: #450

Extends `/metrics:ai-docs-telemetry` with broader tool coverage, deduplication, sub-agent tracking, and bug fixes.

## Changes

**Coverage**
- Track `Grep` and `Glob` tool calls alongside `Read` so file-discovery steps are captured, not only direct reads

**Schema additions**
- Add `unique_files`, `total_accesses`, `unique_file_count` alongside `files_accessed` so re-reads are tracked separately from unique file coverage
- Collect `Agent` tool calls into a `sub_agents` list with `spawned_at` and `description`
- Return `[]` (valid JSON) for empty scan results instead of silent stdout

**Bug fixes**
- `message: null` in a JSONL event no longer crashes `process_session` (`or {}` handles explicit null vs absent key)
- `input: null` on a `tool_use` block handled the same way
- `extract_repo_info` now uses `parts[-1]` instead of `parts[1]` when splitting on `/projects/`, fixing wrong project directory when the home path itself contains `/projects/`
- Eliminated double file read: pre-filter content is passed through to `process_session` instead of reading the file a second time

**Cleanup**
- Removed `entry_point` / `detect_entry_point` — the field was not reliable enough to be useful; callers can derive discovery context from `files_accessed[].tool` if needed
- Fixed stale `entry_point` jq example in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/metrics:ai-docs-telemetry` command supporting `-scan`, `-project`, and `-session` options to process Claude Code session logs with structured JSON output.

* **Documentation**
  * Added metrics plugin documentation covering configuration, privacy controls, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->