### PR TITLE
Add eval suite for classify-review-comment skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -419,7 +419,7 @@
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "category": "development",
       "keywords": [
         "code-review",

--- a/docs/index.html
+++ b/docs/index.html
@@ -897,7 +897,7 @@ footer a { color: var(--primary); }
     {
       "name": "code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/annotations.yaml
@@ -1,0 +1,8 @@
+expected_severity: nitpick
+expected_topic: style
+expected_confidence_min: 0.85
+acceptable_severities: [nitpick]
+acceptable_topics: [style]
+notes: >
+  Classic nitpick — reviewer suggests grouping variables for consistency.
+  The signal word "nit" appears explicitly. Cosmetic, not functional.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/input.yaml
@@ -1,0 +1,4 @@
+comment: >
+  small nit: I would move the vars `key`, `log` and `cloudName` to `var (`
+  section just to be consistent.
+author: jparrill

--- a/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-001-nitpick-style/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "nitpick",
+  "topic": "style",
+  "confidence": 1.00,
+  "rationale": "Reviewer suggests grouping variables into a var block for consistency — cosmetic, not functional"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/annotations.yaml
@@ -1,0 +1,8 @@
+expected_severity: question
+expected_topic: api_design
+expected_confidence_min: 0.75
+acceptable_severities: [question, suggestion]
+acceptable_topics: [api_design]
+notes: >
+  Reviewer asks about API choice for client options. Phrased as a question
+  ("Why not use...") but could also be interpreted as a suggestion.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/input.yaml
@@ -1,0 +1,2 @@
+comment: "Why not use NewARMClientOptions here for the clientOptions?"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-002-question-api-design/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "question",
+  "topic": "api_design",
+  "confidence": 0.95,
+  "rationale": "Reviewer asks about API choice for client options construction — 'Why not use X?' is a clarification question about API surface design"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: required_change
+expected_topic: logic_bug
+expected_confidence_min: 0.90
+acceptable_severities: [required_change]
+acceptable_topics: [logic_bug]
+notes: >
+  Clear-cut: nil pointer dereference would cause runtime panic.
+  Signal words "panic" and "needs" indicate required_change.
+  This is a textbook logic_bug — missing nil check.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/input.yaml
@@ -1,0 +1,2 @@
+comment: "This will panic if `items` is nil — needs a nil check before the loop"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-003-required-change-nil-panic/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "logic_bug",
+  "confidence": 1.00,
+  "rationale": "Nil pointer dereference would cause runtime panic — must be fixed before merge"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: required_change
+expected_topic: logic_bug
+expected_confidence_min: 0.75
+acceptable_severities: [required_change]
+acceptable_topics: [logic_bug, ci]
+notes: >
+  Installation failure with error message. Primary topic is logic_bug (missing
+  required roleRef fields), but ci is acceptable since it manifests during
+  install. The "failing" signal word indicates required_change severity.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/input.yaml
@@ -1,0 +1,6 @@
+comment: |
+  failing during `hypershift install`
+  ```
+  ClusterRoleBinding is invalid: roleRef.kind: Unsupported value
+  ```
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-004-required-change-install-failure/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "logic_bug",
+  "confidence": 0.90,
+  "rationale": "Installation fails due to invalid ClusterRoleBinding roleRef.kind — misconfigured RBAC resource causes hypershift install to break"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: required_change
+expected_topic: test_gap
+expected_confidence_min: 0.75
+acceptable_severities: [required_change]
+acceptable_topics: [test_gap]
+notes: >
+  Directed at a bot but should be classified by the underlying problem:
+  unit tests failing. Topic is test_gap, not process or ci. Signal words
+  "failing" and "needs fixed" indicate required_change.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/input.yaml
@@ -1,0 +1,2 @@
+comment: "hypershift-jira-solve-ci - the unit test job is failing and needs fixed"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-005-required-change-test-gap/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "test_gap",
+  "confidence": 0.95,
+  "rationale": "Unit tests are failing — the bot made code changes without ensuring tests pass"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: suggestion
+expected_topic: ci
+expected_confidence_min: 0.70
+acceptable_severities: [suggestion, required_change]
+acceptable_topics: [ci]
+notes: >
+  PR needs rebasing to resolve CI pipeline issues. Classify by the problem
+  (CI), not the recipient (bot). Severity could be suggestion or
+  required_change depending on interpretation of urgency.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/input.yaml
@@ -1,0 +1,2 @@
+comment: "hypershift-jira-solve-ci - rebase the PR to fix the konflux issues"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-006-suggestion-ci-rebase/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "suggestion",
+  "topic": "ci",
+  "confidence": 0.85,
+  "rationale": "PR needs rebasing to resolve Konflux CI pipeline issues — classify by the problem (CI), not the recipient (bot)"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/annotations.yaml
@@ -1,0 +1,8 @@
+expected_severity: required_change
+expected_topic: process
+expected_confidence_min: 0.70
+acceptable_severities: [required_change]
+acceptable_topics: [process]
+notes: >
+  Code changes were not committed/pushed — a process failure, not a code
+  issue. The underlying problem is "code not pushed" which is a process topic.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/input.yaml
@@ -1,0 +1,2 @@
+comment: "hypershift-jira-solve-ci - this still needs fixed since the code did not get pushed"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-007-required-change-process/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "process",
+  "confidence": 0.85,
+  "rationale": "Code changes were not committed/pushed — a process failure, not a code issue"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: suggestion
+expected_topic: ci
+expected_confidence_min: 0.60
+acceptable_severities: [suggestion, unclassified]
+acceptable_topics: [ci]
+notes: >
+  Mixed content: substantive CI failure analysis followed by a slash command.
+  Should classify based on the substantive text (CI analysis), not the
+  /override command. Lower confidence expected due to ambiguity.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/input.yaml
@@ -1,0 +1,4 @@
+comment: |
+  `e2e-aws-4-21` failed on `Teardown` but due to uncleaned cloud resources, not VPC endpoint blocking the finalizer
+  /override ci/prow/e2e-aws-4-21
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-008-suggestion-ci-override/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "suggestion",
+  "topic": "ci",
+  "confidence": 0.75,
+  "rationale": "Reviewer explains CI failure root cause (uncleaned cloud resources, not VPC endpoint) and overrides — substantive analysis before the slash command"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: unclassified
+expected_topic: approval
+expected_confidence_min: 0.55
+acceptable_severities: [unclassified]
+acceptable_topics: [approval, process]
+notes: >
+  Reviewer withdrawing their earlier question — an acknowledgment/retraction.
+  Low confidence expected because the comment is conversational and ambiguous.
+  Topic could be approval (withdrawing objection) or process (meta-discussion).

--- a/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/input.yaml
@@ -1,0 +1,2 @@
+comment: "Oh no that's ok. I missed that part. No changes requested."
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-009-unclassified-approval/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "unclassified",
+  "topic": "approval",
+  "confidence": 0.70,
+  "rationale": "Reviewer withdrawing their earlier question — acknowledgment with no changes requested"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: unclassified
+expected_topic: process
+expected_confidence_min: 0.75
+acceptable_severities: [unclassified]
+acceptable_topics: [process]
+notes: >
+  Marking PR as duplicate of another — a process meta-comment. Clear
+  process topic (duplicate tracking). Severity is unclassified because
+  it's not requesting a code change or asking a question.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/input.yaml
@@ -1,0 +1,2 @@
+comment: "dup of https://github.com/openshift/hypershift/pull/7727"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-010-unclassified-process-dup/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "unclassified",
+  "topic": "process",
+  "confidence": 0.90,
+  "rationale": "Marking PR as duplicate of another — process meta-comment"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: required_change
+expected_topic: logic_bug
+expected_confidence_min: 0.85
+acceptable_severities: [required_change]
+acceptable_topics: [logic_bug]
+notes: >
+  Detailed root cause analysis identifying a case mismatch bug. High
+  confidence expected — the comment identifies a specific code defect
+  (case mismatch) with technical specifics (AWS API vs SDK v2 enums).

--- a/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/input.yaml
@@ -1,0 +1,5 @@
+comment: >
+  The root cause of the CI failure in this PR has been identified. The fix in
+  `rejectVpcEndpointConnections` doesn't work because of a **case mismatch**
+  between AWS API responses and SDK v2 enum constants.
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-011-required-change-root-cause/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "logic_bug",
+  "confidence": 1.00,
+  "rationale": "Detailed root cause analysis identifying a case mismatch bug that causes the fix to not work — must be addressed before merge"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/annotations.yaml
@@ -1,0 +1,10 @@
+expected_severity: suggestion
+expected_topic: architecture_design
+expected_confidence_min: 0.75
+acceptable_severities: [suggestion, required_change]
+acceptable_topics: [architecture_design]
+notes: >
+  Reviewer identifies a separation-of-concerns issue at the controller level.
+  This is about system architecture (component boundaries, delegation) not
+  API design. Severity could be suggestion or required_change depending on
+  how strongly the reviewer feels about it.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/input.yaml
@@ -1,0 +1,4 @@
+comment: >
+  This controller is doing too much — the reconciler should delegate VPC
+  cleanup to a separate controller instead of inlining it
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-012-suggestion-architecture/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "suggestion",
+  "topic": "architecture_design",
+  "confidence": 0.90,
+  "rationale": "Reviewer identifies a separation-of-concerns issue — reconciler should delegate VPC cleanup to a separate controller instead of inlining it"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/annotations.yaml
@@ -1,0 +1,9 @@
+expected_severity: required_change
+expected_topic: security
+expected_confidence_min: 0.90
+acceptable_severities: [required_change]
+acceptable_topics: [security]
+notes: >
+  Sensitive credentials exposed in log output — a security vulnerability.
+  High confidence expected. Signal words "needs to be" indicate required_change,
+  and "token" + "plain text" + "redacted" are strong security signals.

--- a/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/input.yaml
@@ -1,0 +1,2 @@
+comment: "The service account token is being logged in plain text here — this needs to be redacted"
+author: reviewer

--- a/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-013-required-change-security/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "security",
+  "confidence": 1.00,
+  "rationale": "Sensitive credentials exposed in log output — security vulnerability"
+}

--- a/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/annotations.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/annotations.yaml
@@ -1,0 +1,10 @@
+expected_severity: required_change
+expected_topic: logic_bug
+expected_confidence_min: 0.70
+acceptable_severities: [required_change]
+acceptable_topics: [logic_bug]
+notes: >
+  CodeRabbit flagged a critical issue — missing pre-condition check before
+  VPC deletion. The "_Potential issue_ | _Critical_" prefix is a CodeRabbit
+  formatting pattern. The underlying issue is a logic bug (missing validation
+  before destructive API call).

--- a/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/input.yaml
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/input.yaml
@@ -1,0 +1,7 @@
+comment: |
+  _Potential issue_ | _Critical_
+
+  The `deleteVPC` function doesn't check if the VPC has active network
+  interfaces before attempting deletion. This will fail with a
+  `DependencyViolation` error from the AWS API when ENIs are still attached.
+author: "coderabbitai[bot]"

--- a/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/reference-classification.json
+++ b/plugins/code-review/evals/cases/classify-review-comment/case-014-coderabbit-logic-bug/reference-classification.json
@@ -1,0 +1,6 @@
+{
+  "severity": "required_change",
+  "topic": "logic_bug",
+  "confidence": 0.90,
+  "rationale": "CodeRabbit identified a missing precondition check: deleteVPC will fail with DependencyViolation when ENIs are still attached — a runtime bug requiring a fix before merge"
+}

--- a/plugins/code-review/evals/eval-classify-review-comment.yaml
+++ b/plugins/code-review/evals/eval-classify-review-comment.yaml
@@ -1,0 +1,256 @@
+name: classify-review-comment-eval
+description: Evaluate the classify-review-comment skill's ability to correctly classify GitHub PR review comments by severity and topic using the label taxonomy in config.json
+skill: code-review:classify-review-comment
+
+execution:
+  mode: case
+  arguments: "{comment}"
+  timeout: 120
+  max_budget_usd: 1.0
+
+runner:
+  type: claude-code
+  plugin_dirs:
+    - plugins/code-review
+  system_prompt: |
+    After classifying the comment, write ONLY the JSON classification object
+    to a file called classification.json in the current working directory.
+    The file must contain valid JSON with exactly these fields:
+    severity, topic, confidence, rationale.
+    Do not wrap the JSON in markdown code fences in the file.
+
+models:
+  judge: claude-opus-4-6
+
+permissions:
+  allow:
+    - "Read"
+    - "Write"
+    - "Skill"
+  deny:
+    - "Bash"
+    - "Agent"
+    - "mcp__*"
+
+mlflow:
+  experiment: classify-review-comment-eval
+
+dataset:
+  path: cases/classify-review-comment
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+      - 'comment' — the raw review comment text to classify
+      - 'author' (optional) — the comment author, for context
+    - annotations.yaml: Expected classification and metadata:
+      - 'expected_severity': one of nitpick, suggestion, required_change, question, unclassified
+      - 'expected_topic': one of style, logic_bug, test_gap, api_design, architecture_design,
+        security, documentation, ci, approval, process, unclassified
+      - 'expected_confidence_min': minimum acceptable confidence score (0.00-1.00)
+      - 'acceptable_severities': list of acceptable severity values (primary + reasonable alternatives)
+      - 'acceptable_topics': list of acceptable topic values (primary + reasonable alternatives)
+      - 'notes': free text explaining the expected classification
+
+outputs:
+  - path: "classification.json"
+    schema: |
+      JSON object with fields:
+      - severity: string — one of the severity values from config.json
+      - topic: string — one of the topic values from config.json
+      - confidence: float — 0.00 to 1.00
+      - rationale: string — brief explanation of classification
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: valid_output_json
+    description: Verify output is valid JSON with all required fields (severity, topic, confidence, rationale)
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Invalid JSON: {e}")
+      required = ["severity", "topic", "confidence", "rationale"]
+      missing = [f for f in required if f not in data]
+      if missing:
+          return (False, f"Missing fields: {', '.join(missing)}")
+      return (True, "Valid JSON with all required fields")
+
+  - name: labels_valid
+    description: Verify severity and topic values are from the allowed label set in config.json
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      valid_severities = ["nitpick", "suggestion", "required_change", "question", "unclassified"]
+      valid_topics = ["style", "logic_bug", "test_gap", "api_design", "architecture_design",
+                      "security", "documentation", "ci", "approval", "process", "unclassified"]
+      errors = []
+      sev = data.get("severity")
+      top = data.get("topic")
+      if sev not in valid_severities:
+          errors.append(f"Invalid severity '{sev}'")
+      if top not in valid_topics:
+          errors.append(f"Invalid topic '{top}'")
+      if errors:
+          return (False, "; ".join(errors))
+      return (True, f"severity={sev}, topic={top} — both valid labels")
+
+  - name: confidence_in_range
+    description: Verify confidence is a number between 0.00 and 1.00
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      conf = data.get("confidence")
+      if not isinstance(conf, (int, float)):
+          return (False, f"confidence is {type(conf).__name__}, expected number")
+      if conf < 0.0 or conf > 1.0:
+          return (False, f"confidence {conf} outside [0.00, 1.00]")
+      return (True, f"confidence={conf:.2f}")
+
+  - name: severity_correct
+    description: Verify predicted severity matches expected value or an acceptable alternative
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("severity", "")
+      expected = ann.get("expected_severity", "")
+      acceptable = ann.get("acceptable_severities", [expected])
+      if predicted in acceptable:
+          match = "exact" if predicted == expected else "acceptable"
+          return (True, f"{match}: predicted={predicted}, expected={expected}")
+      return (False, f"predicted={predicted}, expected={expected}, acceptable={acceptable}")
+
+  - name: topic_correct
+    description: Verify predicted topic matches expected value or an acceptable alternative
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("topic", "")
+      expected = ann.get("expected_topic", "")
+      acceptable = ann.get("acceptable_topics", [expected])
+      if predicted in acceptable:
+          match = "exact" if predicted == expected else "acceptable"
+          return (True, f"{match}: predicted={predicted}, expected={expected}")
+      return (False, f"predicted={predicted}, expected={expected}, acceptable={acceptable}")
+
+  - name: confidence_calibration
+    description: Verify confidence score meets the minimum threshold for this case
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("classification.json")}
+      if not json_files:
+          return (False, "No classification.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      conf = data.get("confidence", 0)
+      min_conf = ann.get("expected_confidence_min", 0.5)
+      if conf >= min_conf:
+          return (True, f"confidence={conf:.2f} >= min={min_conf:.2f}")
+      return (False, f"confidence={conf:.2f} < min={min_conf:.2f}")
+
+  - name: classification_quality
+    description: LLM judge assessing overall classification accuracy and rationale quality
+    prompt: |
+      You are evaluating whether a PR review comment was correctly classified
+      by severity and topic.
+
+      The skill's classification output:
+
+      {% for path, content in outputs.files.items() if path.endswith('classification.json') %}
+      {{ content }}
+      {% endfor %}
+
+      Expected classification from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Both severity and topic are wrong. Rationale is absent or nonsensical.
+      Score 2: One of severity/topic is correct but the other is wrong. Rationale
+               is generic or doesn't reference the actual comment content.
+      Score 3: Both severity and topic are in the acceptable set. Rationale mentions
+               relevant aspects of the comment but may be vague.
+      Score 4: Severity and topic match the primary expected values. Rationale
+               specifically references signal words or patterns from the comment
+               that justify the classification.
+      Score 5: Perfect match on severity and topic. Rationale is precise, citing
+               specific phrases from the comment. Confidence score is well-calibrated
+               (high for unambiguous comments, lower for ambiguous ones).
+
+thresholds:
+  valid_output_json:
+    min_pass_rate: 1.0
+  labels_valid:
+    min_pass_rate: 1.0
+  confidence_in_range:
+    min_pass_rate: 1.0
+  severity_correct:
+    min_pass_rate: 0.85
+  topic_correct:
+    min_pass_rate: 0.85
+  confidence_calibration:
+    min_pass_rate: 0.80
+  classification_quality:
+    min_mean: 3.5


### PR DESCRIPTION
## Summary

- Adds an `agent-eval-harness` evaluation config (`eval-classify-review-comment.yaml`) for the `code-review:classify-review-comment` skill
- Includes 14 test cases covering all severity and topic labels from `config.json`, derived from real-world PR review comment examples
- 7 judges: 6 deterministic (valid JSON, valid labels, confidence range, severity/topic correctness, confidence calibration) + 1 LLM quality judge

Initial run with `claude-opus-4-6`: 100% pass rate on all deterministic judges, 4.86/5.0 mean on the LLM quality judge. $7.34 total cost for 14 cases (~$0.52/case).

## Test plan

- [ ] Install `agent-eval-harness` plugin: `claude plugin install agent-eval-harness@agent-eval-harness-dev`
- [ ] Run `/eval-setup` to verify environment
- [ ] Run `/eval-run plugins/code-review/evals/eval-classify-review-comment.yaml` and confirm all judges pass
- [ ] Verify HTML report generates at `eval/runs/classify-review-comment-eval/<run-id>/report.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added 14 new evaluation cases and reference classifications for review-comment classification (multiple severities/topics) and a case-based eval harness with automated judges.

* **Documentation**
  * Updated embedded marketplace/plugin metadata in docs.

* **Chores**
  * Bumped plugin version to 0.0.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->