### PR TITLE
feat(jira): add ARO HCP skill and project-specific skill loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1474,7 +1474,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "has_readme": true,
       "commands": [
         {
@@ -1631,6 +1631,12 @@ footer a { color: var(--primary); }
         }
       ],
       "skills": [
+        {
+          "name": "aro-hcp",
+          "description": "ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components",
+          "description_html": "ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components",
+          "meta": ""
+        },
         {
           "name": "catch-me-up",
           "description": "Gather and classify recent Jira activity to surface what needs attention",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1632,12 +1632,6 @@ footer a { color: var(--primary); }
       ],
       "skills": [
         {
-          "name": "aro-hcp",
-          "description": "ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components",
-          "description_html": "ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components",
-          "meta": ""
-        },
-        {
           "name": "catch-me-up",
           "description": "Gather and classify recent Jira activity to surface what needs attention",
           "description_html": "Gather and classify recent Jira activity to surface what needs attention",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -64,6 +64,32 @@ The command executes in two phases:
    - Use `searchJiraIssuesUsingJql` with JQL: `project = "{project-key}" AND status != Closed`
    - Verify the project exists and is accessible
 
+#### Step 1b. Load Project-Specific Skill (if available)
+
+After determining the project key, check if a project-specific skill exists that overrides default behavior. Project-specific skills can change issue type filtering, status format, milestone prioritization, and data gathering JQL.
+
+**Known project-skill mappings:**
+
+| Project Key | Skill | Key Overrides |
+|-------------|-------|---------------|
+| ARO | `jira:aro-hcp` | Only Features/Initiatives; milestone tiers (HPSTRAT-63/130); prepend format with date stamp |
+| CNTRLPLANE | `jira:cntrlplane` | CNTRLPLANE-specific conventions |
+| GCP | `jira:gcp-hcp` | GCP HCP team requirements |
+| OCPBUGS | `jira:ocpbugs` | OCPBUGS bug conventions |
+
+**Implementation:**
+
+1. Match the resolved project key against the table above
+2. If a match is found, load the skill: `Skill(jira:{skill-name})`
+3. The loaded skill's conventions **override** the defaults in this command for:
+   - **Issue type filter**: Which issue types to process (e.g., ARO → only Features and Initiatives)
+   - **Issue discovery**: How to find target issues (e.g., ARO → milestone-based JQL instead of generic component query)
+   - **Status format**: How to format the status update (e.g., ARO → prepend with date stamp instead of replace)
+   - **Update method**: How to write to Jira (e.g., ARO → ADF via REST API)
+4. If no match is found, use default behavior (all issue types, generic component query, replace format)
+
+**IMPORTANT**: The project-specific skill MUST be loaded before Step 2 (component selection) and before Step 4 (data gathering), because it can change both the JQL used and the issue types collected.
+
 #### Step 2. Determine Target Component(s)
 
 1. **If `--component` parameter is provided:**

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -64,31 +64,31 @@ The command executes in two phases:
    - Use `searchJiraIssuesUsingJql` with JQL: `project = "{project-key}" AND status != Closed`
    - Verify the project exists and is accessible
 
-#### Step 1b. Load Project-Specific Skill (if available)
+#### Step 1b. Load Project-Specific Conventions (if available)
 
-After determining the project key, check if a project-specific skill exists that overrides default behavior. Project-specific skills can change issue type filtering, status format, milestone prioritization, and data gathering JQL.
+After determining the project key, check if project-specific conventions exist that override default behavior. These can change issue type filtering, status format, milestone prioritization, and data gathering JQL.
 
-**Known project-skill mappings:**
+**Known project mappings:**
 
-| Project Key | Skill | Key Overrides |
-|-------------|-------|---------------|
-| ARO | `jira:aro-hcp` | Only Features/Initiatives; milestone tiers (HPSTRAT-63/130); prepend format with date stamp |
-| CNTRLPLANE | `jira:cntrlplane` | CNTRLPLANE-specific conventions |
-| GCP | `jira:gcp-hcp` | GCP HCP team requirements |
-| OCPBUGS | `jira:ocpbugs` | OCPBUGS bug conventions |
+| Project Key | Source | Key Overrides |
+|-------------|--------|---------------|
+| ARO | Read [../reference/aro-hcp.md](../reference/aro-hcp.md) | Only Features/Initiatives; milestone tiers (HPSTRAT-63/130); prepend format with date stamp |
+| CNTRLPLANE | `Skill(jira:cntrlplane)` | CNTRLPLANE-specific conventions |
+| GCP | `Skill(jira:gcp-hcp)` | GCP HCP team requirements |
+| OCPBUGS | `Skill(jira:ocpbugs)` | OCPBUGS bug conventions |
 
 **Implementation:**
 
 1. Match the resolved project key against the table above
-2. If a match is found, load the skill: `Skill(jira:{skill-name})`
-3. The loaded skill's conventions **override** the defaults in this command for:
+2. If a match is found, load the conventions using the source method shown (either `Read` the reference file or invoke the `Skill`)
+3. The loaded conventions **override** the defaults in this command for:
    - **Issue type filter**: Which issue types to process (e.g., ARO → only Features and Initiatives)
    - **Issue discovery**: How to find target issues (e.g., ARO → milestone-based JQL instead of generic component query)
    - **Status format**: How to format the status update (e.g., ARO → prepend with date stamp instead of replace)
    - **Update method**: How to write to Jira (e.g., ARO → ADF via REST API)
 4. If no match is found, use default behavior (all issue types, generic component query, replace format)
 
-**IMPORTANT**: The project-specific skill MUST be loaded before Step 2 (component selection) and before Step 4 (data gathering), because it can change both the JQL used and the issue types collected.
+**IMPORTANT**: The project-specific conventions MUST be loaded before Step 2 (component selection) and before Step 4 (data gathering), because they can change both the JQL used and the issue types collected.
 
 #### Step 2. Determine Target Component(s)
 

--- a/plugins/jira/reference/aro-hcp.md
+++ b/plugins/jira/reference/aro-hcp.md
@@ -1,20 +1,12 @@
----
-name: aro-hcp
-description: ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components
----
-
 # ARO HCP Jira Conventions
 
-This skill provides ARO HCP team-specific conventions for working with Jira issues in the ARO project.
+This file provides ARO HCP team-specific conventions for working with Jira issues in the ARO project.
 
-## When to Use This Skill
+## When to Use
 
-This skill is automatically invoked when:
+This file is loaded automatically by `/jira:update-weekly-status` when:
 - Project key is "ARO"
 - Component is one of: `aro-hcp-qe`, `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east`, `aro-hcp-clusters-service-west`
-- User explicitly requests ARO HCP conventions
-
-**IMPORTANT**: When any Jira command targets the ARO project, load this skill first to apply ARO-specific conventions.
 
 ## Project Information
 
@@ -36,30 +28,6 @@ This skill is automatically invoked when:
 
 ## Weekly Status Updates (`/jira:update-weekly-status`)
 
-### Component Expansion
-
-When the user specifies any single CS component, **always expand to include all three**:
-
-| User specifies | Expand to |
-|---------------|-----------|
-| `aro-hcp-clusters-service` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east`, `aro-hcp-clusters-service-west` |
-| `aro-hcp-clusters-service-east` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east` |
-| `aro-hcp-clusters-service-west` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-west` |
-
-Issues are often tagged with only `aro-hcp-clusters-service-east` or `aro-hcp-clusters-service-west` (without the parent `aro-hcp-clusters-service`), so querying a single component will miss them.
-
-**Data gatherer invocation** with expanded components:
-```bash
-python3 gather_status_data.py \
-  --project ARO \
-  --component "aro-hcp-clusters-service" \
-  --component "aro-hcp-clusters-service-east" \
-  --component "aro-hcp-clusters-service-west" \
-  --verbose
-```
-
-**JQL equivalent**: `component IN ("aro-hcp-clusters-service", "aro-hcp-clusters-service-east", "aro-hcp-clusters-service-west")`
-
 ### Issue Type Filter
 
 When running `/jira:update-weekly-status` against the ARO project, **only process Features and Initiatives**. The Status Summary field (`customfield_10814`) is only available on these issue types in the ARO project — it cannot be set on Epics, Stories, Tasks, or Bugs.
@@ -79,24 +47,25 @@ Status updates are prioritized by milestone. Process issues in this order:
 To find issues by milestone, use `parent = HPSTRAT-63` and `parent = HPSTRAT-130` JQL queries. These milestones are parents of the Features/Initiatives.
 
 **Step 1**: Fetch HPSTRAT-63 children (mandatory updates):
-```
+```jql
 parent = HPSTRAT-63 AND project = ARO AND issuetype in (Feature, Initiative) AND status != Closed
 ```
 With component filter, add: `AND component = "{component}"`
 
 **Step 2**: Fetch HPSTRAT-130 children updated this week (optional updates):
-```
+```jql
 parent = HPSTRAT-130 AND project = ARO AND issuetype in (Feature, Initiative) AND status != Closed AND updated >= -7d
 ```
+With component filter, add: `AND component = "{component}"`
 
 **Step 3**: Fetch remaining active items not under either milestone:
-```
+```jql
 project = ARO AND issuetype in (Feature, Initiative) AND status != Closed AND updated >= -7d AND NOT parent = HPSTRAT-63 AND NOT parent = HPSTRAT-130
 ```
 With component filter, add: `AND component = "{component}"`
 
 **Presentation**: Group issues by tier in the processing workflow:
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 HPSTRAT-63 (Public Preview) — {N} Features/Initiatives [ALL require update]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -119,7 +88,7 @@ The ARO project uses a **prepend** model for Status Summary — new updates are 
 
 **Format for each update entry:**
 
-```
+```text
 {YYYY-MM-DD}: Color Status: {Green|Yellow|Red}
 - {Current state bullet 1 — what happened this week}
 - {Current state bullet 2}
@@ -135,7 +104,7 @@ The ARO project uses a **prepend** model for Status Summary — new updates are 
 
 **Example of a Status Summary field after 3 weeks:**
 
-```
+```text
 2026-06-05: Color Status: Green
 - ARO-17759 (Frontend Private KAS) closed. ARO-26913 (api.listening wiring) in review.
 - 72% complete (18/25 descendants closed).
@@ -164,7 +133,7 @@ When writing to `customfield_10814`:
 If the current value is null/empty, just write the new entry.
 
 **MCP call:**
-```
+```javascript
 editJiraIssue(
   cloudId: "redhat.atlassian.net",
   issueIdOrKey: "{ISSUE_KEY}",
@@ -177,7 +146,7 @@ editJiraIssue(
 
 ## Jira Hierarchy (ARO Project)
 
-```
+```text
 Initiative
   └── Feature          ← Status Summary lives here
         └── Epic

--- a/plugins/jira/skills/aro-hcp/SKILL.md
+++ b/plugins/jira/skills/aro-hcp/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: aro-hcp
+description: ARO HCP project-specific Jira conventions for the ARO project — issue type filtering, status summary format, components
+---
+
+# ARO HCP Jira Conventions
+
+This skill provides ARO HCP team-specific conventions for working with Jira issues in the ARO project.
+
+## When to Use This Skill
+
+This skill is automatically invoked when:
+- Project key is "ARO"
+- Component is one of: `aro-hcp-qe`, `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east`, `aro-hcp-clusters-service-west`
+- User explicitly requests ARO HCP conventions
+
+**IMPORTANT**: When any Jira command targets the ARO project, load this skill first to apply ARO-specific conventions.
+
+## Project Information
+
+| Field | Value |
+|-------|-------|
+| **Project Key** | ARO |
+| **Project Name** | Azure Red Hat OpenShift |
+| **Managed by** | Senior Engineering Manager |
+| **Teams** | CS West, CS East (separate engineering lead), QE |
+
+## Components
+
+| Component | Team | Description |
+|-----------|------|-------------|
+| `aro-hcp-qe` | QE | Test automation and quality coverage |
+| `aro-hcp-clusters-service` | CS (shared) | Overall cluster service before east/west assignment |
+| `aro-hcp-clusters-service-east` | CS East | Cluster service (east region) |
+| `aro-hcp-clusters-service-west` | CS West | Cluster service (west region) |
+
+## Weekly Status Updates (`/jira:update-weekly-status`)
+
+### Component Expansion
+
+When the user specifies any single CS component, **always expand to include all three**:
+
+| User specifies | Expand to |
+|---------------|-----------|
+| `aro-hcp-clusters-service` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east`, `aro-hcp-clusters-service-west` |
+| `aro-hcp-clusters-service-east` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-east` |
+| `aro-hcp-clusters-service-west` | `aro-hcp-clusters-service`, `aro-hcp-clusters-service-west` |
+
+Issues are often tagged with only `aro-hcp-clusters-service-east` or `aro-hcp-clusters-service-west` (without the parent `aro-hcp-clusters-service`), so querying a single component will miss them.
+
+**Data gatherer invocation** with expanded components:
+```bash
+python3 gather_status_data.py \
+  --project ARO \
+  --component "aro-hcp-clusters-service" \
+  --component "aro-hcp-clusters-service-east" \
+  --component "aro-hcp-clusters-service-west" \
+  --verbose
+```
+
+**JQL equivalent**: `component IN ("aro-hcp-clusters-service", "aro-hcp-clusters-service-east", "aro-hcp-clusters-service-west")`
+
+### Issue Type Filter
+
+When running `/jira:update-weekly-status` against the ARO project, **only process Features and Initiatives**. The Status Summary field (`customfield_10814`) is only available on these issue types in the ARO project — it cannot be set on Epics, Stories, Tasks, or Bugs.
+
+### Milestone-Based Prioritization
+
+Status updates are prioritized by milestone. Process issues in this order:
+
+**Tier 1 — HPSTRAT-63 (MSFT Public Preview)**: ALL Features/Initiatives that are children of this milestone MUST have their Status Summary updated, regardless of whether they had activity this week. This is the current active milestone.
+
+**Tier 2 — HPSTRAT-130 (General Availability)**: Features/Initiatives under this milestone get a status update only if they had activity this week. Update is optional for inactive items.
+
+**Tier 3 — Everything else**: Features/Initiatives not under either milestone but with activity in the last 7 days should also be updated.
+
+### Implementation: Gathering Issues by Milestone
+
+To find issues by milestone, use `parent = HPSTRAT-63` and `parent = HPSTRAT-130` JQL queries. These milestones are parents of the Features/Initiatives.
+
+**Step 1**: Fetch HPSTRAT-63 children (mandatory updates):
+```
+parent = HPSTRAT-63 AND project = ARO AND issuetype in (Feature, Initiative) AND status != Closed
+```
+With component filter, add: `AND component = "{component}"`
+
+**Step 2**: Fetch HPSTRAT-130 children updated this week (optional updates):
+```
+parent = HPSTRAT-130 AND project = ARO AND issuetype in (Feature, Initiative) AND status != Closed AND updated >= -7d
+```
+
+**Step 3**: Fetch remaining active items not under either milestone:
+```
+project = ARO AND issuetype in (Feature, Initiative) AND status != Closed AND updated >= -7d AND NOT parent = HPSTRAT-63 AND NOT parent = HPSTRAT-130
+```
+With component filter, add: `AND component = "{component}"`
+
+**Presentation**: Group issues by tier in the processing workflow:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+HPSTRAT-63 (Public Preview) — {N} Features/Initiatives [ALL require update]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {list issues}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+HPSTRAT-130 (GA) — {N} with activity this week [update optional]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {list issues}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Other active — {N} with activity this week
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {list issues}
+```
+
+### Status Summary Format (ARO-specific)
+
+The ARO project uses a **prepend** model for Status Summary — new updates are added at the top, preserving the history of previous updates. This differs from the default OCPSTRAT behavior which replaces the entire field.
+
+**Format for each update entry:**
+
+```
+{YYYY-MM-DD}: Color Status: {Green|Yellow|Red}
+- {Current state bullet 1 — what happened this week}
+- {Current state bullet 2}
+- Risks: {risk or "None at this time"}
+
+```
+
+**Rules:**
+1. **Prepend, don't replace**: New status goes at the top of the existing Status Summary text. Keep all previous entries intact.
+2. **Date stamp**: Each entry starts with the date in `YYYY-MM-DD` format.
+3. **No duplication**: Only include what changed since the last update. If something was reported last week and hasn't changed, don't repeat it. Focus on: what's new, what moved, what's blocked.
+4. **Concise**: 2-4 bullets per update. One sentence per bullet.
+
+**Example of a Status Summary field after 3 weeks:**
+
+```
+2026-06-05: Color Status: Green
+- ARO-17759 (Frontend Private KAS) closed. ARO-26913 (api.listening wiring) in review.
+- 72% complete (18/25 descendants closed).
+- Risks: None at this time
+
+2026-05-29: Color Status: Yellow
+- Blocked on HyperShift PR for private KAS topology support.
+- ARO-26777 (CS changes for private KAS) started.
+- Risks: Dependency on OCPSTRAT-3193 (HyperShift upstream)
+
+2026-05-22: Color Status: Green
+- Swift networking rollout complete across all prod regions.
+- E2E tests for private KV cluster merged (PR #4674).
+- Risks: None at this time
+```
+
+### Updating the Status Summary Field
+
+When writing to `customfield_10814`:
+
+1. Read the current value first (from the pre-gathered JSON `issue.current_status_summary`)
+2. Generate the new entry (date + color + bullets)
+3. Prepend the new entry to the existing text with a blank line separator
+4. Write the combined text back via `editJiraIssue`
+
+If the current value is null/empty, just write the new entry.
+
+**MCP call:**
+```
+editJiraIssue(
+  cloudId: "redhat.atlassian.net",
+  issueIdOrKey: "{ISSUE_KEY}",
+  fields: {"customfield_10814": "{new_entry}\n\n{existing_text}"},
+  contentFormat: "markdown"
+)
+```
+
+**IMPORTANT**: If `editJiraIssue` fails with "Field cannot be set" error, the issue is not a Feature or Initiative. Skip it and log a warning — do not fall back to adding a comment.
+
+## Jira Hierarchy (ARO Project)
+
+```
+Initiative
+  └── Feature          ← Status Summary lives here
+        └── Epic
+              └── Story / Task / Bug
+                    └── Sub-task
+```
+
+- **Status Summary** is set on Features and Initiatives only
+- **PRs/MRs** should be linked to Stories, Tasks, or Bugs (not Epics or above)
+- Use `/jira:trace-work` to ensure PR→Jira linking at the correct level
+
+## See Also
+
+- `/jira:update-weekly-status` — Weekly status updates (applies ARO conventions automatically)
+- `/jira:trace-work` — Trace PRs/MRs to Jira issues
+- `/jira:grooming` — Backlog grooming with component filter
+- `gcp-hcp` skill — Similar conventions for the GCP project


### PR DESCRIPTION
## Summary
- Adds a new `aro-hcp` project-specific skill defining ARO conventions for `update-weekly-status`: issue type filtering (Features/Initiatives only), milestone-based tiering ([HPSTRAT-63](https://redhat.atlassian.net/browse/HPSTRAT-63)/130), prepend status format with date stamps, and component expansion for east/west sub-components.
- Adds Step 1b to `update-weekly-status` command to automatically detect and load project-specific skills based on the project key. Without this, project conventions were silently ignored.

## Test plan
- [ ] Run `/jira:update-weekly-status ARO --component "aro-hcp-clusters-service"` and verify the aro-hcp skill is loaded automatically
- [ ] Verify only Features and Initiatives are processed (not Stories/Tasks/Bugs)
- [ ] Verify milestone-based tiering groups issues correctly ([HPSTRAT-63](https://redhat.atlassian.net/browse/HPSTRAT-63) tier 1, [HPSTRAT-130](https://redhat.atlassian.net/browse/HPSTRAT-130) tier 2)
- [ ] Verify status updates use the prepend format with date stamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for project-specific Jira skills in the weekly status update command, with automatic mapping for multiple projects.
  * Introduced ARO HCP conventions documentation with milestone-based prioritization and custom status formatting.

* **Documentation**
  * Enhanced command documentation with project-specific skill loading workflow.
  * Added reference guide for ARO HCP Jira conventions including issue types, JQL templates, and update procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->