### PR TITLE
NO-JIRA: Improve AI skill quality based on review comment analysis

### DIFF
--- a/plugins/jira/commands/solve.md
+++ b/plugins/jira/commands/solve.md
@@ -92,8 +92,17 @@ This command takes a JIRA URL, fetches the issue description and requirements, a
       - Do NOT run `go test ./changed/package/` instead of `make test` — running only the packages you changed misses cross-package regressions
       - Do NOT skip `make test` because `make lint-fix` had unrelated failures
       - Do NOT assume targeted package tests are "good enough" as a substitute for the full test suite
+      - Do NOT leave TODO comments in validation regex or CEL rules — resolve character sets and constraints before committing
+      - Do NOT export functions that are only used by tests — keep them unexported or in `_test.go` files
+      - Do NOT leave dead code (functions defined but never called) in the PR
+      - Do NOT include cosmetic formatting or import reordering changes in files unrelated to the JIRA issue — these increase review surface and make the PR harder to revert
 
-4. **Commit Creation**: 
+4. **Commit Creation**:
+   - **Pre-commit code quality checks**:
+     - Search the codebase for how similar problems are already solved before implementing a novel approach. Use `grep -r` and `find` to locate existing patterns, utilities, and helpers.
+     - Verify that every new exported function has at least one unit test covering the happy path and primary error path.
+     - Verify that no functions are defined but never called (dead code). Search for each new function name across the codebase — if it's only referenced at its definition, remove it.
+     - For API validation (regex, CEL): verify character classes match the upstream specification exactly. Do not over-broaden with catch-all classes. Test edge cases: empty string, max-length string, strings with special characters.
    - Create feature branch using the jira-key $1 as the branch name. For example: "git checkout -b fix-{jira-key}"
    - Break commits into logical components based on the nature of the changes
    - Each commit should honor https://www.conventionalcommits.org/en/v1.0.0/ and always include a commit message body articulating the "why"
@@ -116,8 +125,9 @@ This command takes a JIRA URL, fetches the issue description and requirements, a
      - Documentation: Changes in `docs/` directory
        - Example: `git commit -m"docs: Document X feature" -m"Help users understand how to configure and use the new capability"`
 
-5. **PR Creation**: 
+5. **PR Creation**:
    - Push the branch with all commits against the remote specified in argument $2
+   - **After pushing, verify the push succeeded**: Run `git log -1 --format='%H'` locally and `git ls-remote <remote> <branch>` to confirm the remote SHA matches. If they differ, the push failed — diagnose and retry. Do NOT proceed to PR creation with unpushed code.
    - Create pull request with:
      - Clear title referencing JIRA issue as a prefix. For example: "OCPBUGS-12345: ..."
      - The PR description should satisfy the template within .github/PULL_REQUEST_TEMPLATE.md if the file exists

--- a/plugins/utils/commands/address-reviews.md
+++ b/plugins/utils/commands/address-reviews.md
@@ -286,6 +286,8 @@ Show user:
 - Ensure code builds and passes tests after changes
 - When in doubt, ask the user
 - Use TodoWrite to track progress through multiple comments
+- **Never claim work is done without verifying the push**: After posting replies that say changes were made, the push in Step 4b MUST succeed and be verified in Step 4c. If the push fails or is skipped, the replies become lies — reviewers will see "Done" but find no code changes. This has been the single most repeated process failure.
+- **Use the restructure-commits skill when asked**: When a reviewer requests commit reorganization (e.g., "restructure commits", "reorganize commits"), use the `restructure-commits` or `restructure-hypershift-commits` skill rather than manually rebasing. Reviewers have had to ask for this multiple times across PRs.
 
 ## Duplicate Prevention
 


### PR DESCRIPTION
## Summary

Automated analysis of review comments from the JIRA Agent Dashboard
identified recurring patterns in PR feedback. This PR updates jira:solve
and address-reviews skills to address the most common issues.

### Analysis Period
2025-01-01 to 2026-06-05 — 78 comments analyzed, 62 actionable
(after filtering nitpick/approval/unclassified)

### Changes

#### Change 1: Anti-patterns for dead code and unrelated changes

**File:** `plugins/jira/commands/solve.md`

**Pattern:** style + process — 15 comments across multiple PRs

**Evidence:**
> "mustParseCRD is dead code — defined but never called anywhere. Remove it."
> — @bryan-cox, PR openshift/hypershift#8535

> "This cosmetic formatting change is completely unrelated to Azure role assignment validation."
> — @bryan-cox, PR openshift/hypershift#8319

> "It looks like the valid character set TODO here wasn't resolved."
> — @everettraven, PR openshift/hypershift#8211

**Reasoning:** Added 4 explicit anti-patterns to the forbidden list:
unresolved TODO comments in validation, exported test-only functions,
dead code, and unrelated cosmetic changes.

---

#### Change 2: Pre-commit code quality checks

**File:** `plugins/jira/commands/solve.md`

**Pattern:** logic_bug + architecture_design — 28 comments total

**Evidence:**
> "We have been moving away from using the service-ca operator at all."
> — @bryan-cox, PR openshift/hypershift#7943

> "CompareCRDs is exported but only used in tests."
> — @bryan-cox, PR openshift/hypershift#8535

**Reasoning:** Added a pre-commit checklist requiring agents to search
for existing patterns, verify test coverage of new exports, check for
dead code, and validate regex character classes before committing.

---

#### Change 3: Push verification in solve.md

**File:** `plugins/jira/commands/solve.md`

**Pattern:** process — 5 required_change comments about unpushed code

**Evidence:**
> "I see [comment] but I don't see where you pushed changes for this"
> — @bryan-cox, PR openshift/hypershift#7836

> "[comment] wasn't actually done, nothing was pushed"
> — @bryan-cox, PR openshift/hypershift#8319

**Reasoning:** jira:solve claimed work was done but never pushed. Added
explicit push verification step matching what address-reviews already has.

---

#### Change 4: Push verification and restructure-commits in address-reviews.md

**File:** `plugins/utils/commands/address-reviews.md`

**Pattern:** process — 4 suggestion comments about commit organization

**Evidence:**
> "can you reorganize the commits please"
> — @bryan-cox, PR openshift/hypershift#8319

> "Use the /restructure-commits command out of the hypershift repo"
> — @bryan-cox, PR openshift/hypershift#7943

> "Can you use the restructure commits skill in this repo to redo the commits please?"
> — @bryan-cox, PR openshift/hypershift#8106

**Reasoning:** Reviewers had to ask for commit restructuring across 3
different PRs. Added explicit guidance to use the restructure-commits
skill when requested, and strengthened the push verification guideline.

## Test Plan
- [ ] Verify skill markdown files parse correctly
- [ ] Next jira-solve and address-reviews runs should show fewer process and style comments
- [ ] Compare comment counts week-over-week in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `improve-ai-quality` skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced validation rules for commit creation processes with stricter guidelines.
  * Added branch push verification step to confirm successful remote synchronization before proceeding.
  * Updated operational guidelines to leverage restructuring skills for commit organization tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->