### PR TITLE
Fix continue-session project path encoding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -487,7 +487,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.45",
+      "version": "0.0.46",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/commands/continue-session.md
+++ b/plugins/ci/commands/continue-session.md
@@ -108,13 +108,13 @@ Use AskUserQuestion to let the user select a session by number.
 
 The extracted archive contains sessions under a CI-specific project path (e.g., `projects/-home-prow-go-src-github.com-org-repo/`). This path reflects where the repo was checked out in CI and will not match the local project path.
 
-Determine the **local project path** that Claude uses for the current working directory. Claude's projects directory structure encodes the absolute path of the project by replacing `/` with `-` and stripping the leading slash. For example, if the current working directory is `/Users/stbenjam/git/my-repo`, the local project path is:
+Determine the **local project path** that Claude uses for the current working directory. Claude's projects directory structure encodes the absolute path of the project by replacing both `/` and `.` with `-` and stripping the leading slash. For example, if the current working directory is `/Users/stbenjam/git/github.com/my-repo`, the local project path is:
 
 ```text
-~/.claude/projects/-Users-stbenjam-git-my-repo/
+~/.claude/projects/-Users-stbenjam-git-github-com-my-repo/
 ```
 
-Compute this by taking `pwd` and replacing all `/` with `-`. Since absolute paths start with `/`, this naturally produces a leading `-`.
+Compute this by taking `pwd` and replacing all `/` and `.` with `-`. Since absolute paths start with `/`, this naturally produces a leading `-`.
 
 Before copying, check if the session UUID already exists locally (either the `.jsonl` file or the directory). If it does, warn the user that a local session with this UUID already exists and ask whether to overwrite it. If the user declines, stop.
 
@@ -122,7 +122,7 @@ Copy both the selected session's JSONL file and its corresponding directory into
 
 ```bash
 # Determine local project path
-LOCAL_PROJECT_DIR="$HOME/.claude/projects/$(pwd | tr '/' '-')"
+LOCAL_PROJECT_DIR="$HOME/.claude/projects/$(pwd | tr '/.' '--')"
 mkdir -p "$LOCAL_PROJECT_DIR"
 
 # Copy the session JSONL file


### PR DESCRIPTION
## Summary
- Claude Code encodes project paths by replacing both `/` and `.` with `-`, but `/ci:continue-session` only replaced `/`
- This caused `--resume` to fail for any project path containing dots (e.g. `github.com` in the path)
- Fix: `tr '/' '-'` → `tr '/.' '--'`

## Test plan
- [x] Reproduced the bug: session copied with wrong path encoding, `claude --resume` failed
- [x] Fixed encoding, `claude --resume` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI plugin version bumped to 0.0.46.

* **Documentation**
  * Updated continue-session documentation regarding local project path encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->