### PR TITLE
Fix agent color frontmatter for opencode >= 1.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.46",
+      "version": "0.0.47",
       "category": "ci",
       "keywords": [
         "prow",

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -88,12 +88,18 @@ rules:
     enabled: true
     severity: error
 
+  # Agent color frontmatter must be hex or opencode preset (not CSS names)
+  opencode-agent-color:
+    enabled: true
+    severity: error
+
 
 # Load custom rules from these files
 custom-rules:
   - ".skillsaw/plugindocs_rule.py"
   - ".skillsaw/owners_rule.py"
   - ".skillsaw/promptfoo_budget_rule.py"
+  - ".skillsaw/opencode_color_rule.py"
 
 # Exclude patterns (glob format)
 # Use exclude: [] to disable all excludes including defaults

--- a/.skillsaw/opencode_color_rule.py
+++ b/.skillsaw/opencode_color_rule.py
@@ -1,0 +1,98 @@
+"""
+Validate agent color frontmatter for opencode compatibility.
+
+opencode >= 1.16 requires color values to be either a hex code (#RRGGBB)
+or a preset name (primary, secondary, accent, success, warning, error, info).
+CSS color names like "cyan" or "yellow" crash opencode on startup.
+"""
+
+import re
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from skillsaw import RepositoryContext, Rule, RuleViolation, Severity
+from skillsaw.lint_target import PluginNode
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+_PRESET_NAMES = frozenset(
+    {"primary", "secondary", "accent", "success", "warning", "error", "info"}
+)
+
+
+class OpencodeAgentColorRule(Rule):
+    """Agent color frontmatter must be a hex code or opencode preset name."""
+
+    @property
+    def rule_id(self) -> str:
+        return "opencode-agent-color"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Agent color must be a #RRGGBB hex code or an opencode preset "
+            "(primary, secondary, accent, success, warning, error, info)."
+        )
+
+    def default_severity(self) -> Severity:
+        return Severity.ERROR
+
+    def check(self, context: RepositoryContext) -> List[RuleViolation]:
+        violations = []
+
+        for node in context.lint_tree.find(PluginNode):
+            agents_dir = node.path / "agents"
+            if not agents_dir.is_dir():
+                continue
+
+            for agent_file in sorted(agents_dir.glob("*.md")):
+                violation = self._check_agent_file(agent_file)
+                if violation:
+                    violations.append(violation)
+
+        return violations
+
+    def _check_agent_file(self, path: Path):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+        if not text.startswith("---"):
+            return None
+
+        end = text.find("---", 3)
+        if end == -1:
+            return None
+
+        frontmatter_text = text[3:end]
+        try:
+            frontmatter = yaml.safe_load(frontmatter_text)
+        except yaml.YAMLError:
+            return None
+
+        if not isinstance(frontmatter, dict):
+            return None
+
+        color = frontmatter.get("color")
+        if color is None:
+            return None
+
+        color_str = str(color)
+        if _HEX_COLOR_RE.match(color_str) or color_str in _PRESET_NAMES:
+            return None
+
+        color_line = None
+        for i, line in enumerate(text.splitlines(), 1):
+            if line.startswith("color:"):
+                color_line = i
+                break
+
+        return self.violation(
+            f"Agent '{path.name}' has invalid color '{color_str}'. "
+            f"Use a #RRGGBB hex code or a preset "
+            f"(primary, secondary, accent, success, warning, error, info).",
+            file_path=path,
+            line=color_line,
+        )

--- a/docs/index.html
+++ b/docs/index.html
@@ -487,7 +487,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.46",
+      "version": "0.0.47",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/agents/step-registry-analyzer.md
+++ b/plugins/ci/agents/step-registry-analyzer.md
@@ -2,7 +2,7 @@
 name: step-registry-analyzer
 description: Use this agent when you need to understand and list OpenShift CI components including workflows, chains, and refs in a hierarchical structure.
 model: sonnet
-color: cyan
+color: "#00FFFF"
 ---
 
 ## Role and Expertise

--- a/plugins/ci/agents/test-porter.md
+++ b/plugins/ci/agents/test-porter.md
@@ -2,7 +2,7 @@
 name: test-porter
 description: |
   Automated Ginkgo e2e test porting agent. Ports tests from openshift-tests-private to openshift/origin, creates PRs, monitors CI, responds to review feedback, pushes fixes, and escalates to humans when needed. Use this agent for any task related to porting tests between these repos.
-color: yellow
+color: "#FFFF00"
 ---
 
 You are the OpenShift Test Porter — an agent that ports Ginkgo e2e tests from `openshift-tests-private` to `openshift/origin`, then shepherds the resulting PRs through CI and review.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,9 @@ def _load_rule_module(filename):
 def owners_rule():
     mod = _load_rule_module("owners_rule.py")
     return mod.PluginOwnersRequiredRule
+
+
+@pytest.fixture
+def opencode_color_rule():
+    mod = _load_rule_module("opencode_color_rule.py")
+    return mod.OpencodeAgentColorRule

--- a/tests/test_opencode_color_rule.py
+++ b/tests/test_opencode_color_rule.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+
+def _make_plugin_with_agent(temp_dir, plugin_name, agent_name, frontmatter):
+    plugin_dir = temp_dir / "plugins" / plugin_name
+    plugin_dir.mkdir(parents=True)
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text(
+        f'{{"name": "{plugin_name}", "version": "0.0.1", '
+        f'"description": "test", "author": "test"}}'
+    )
+    agents_dir = plugin_dir / "agents"
+    agents_dir.mkdir()
+    agent_file = agents_dir / f"{agent_name}.md"
+    agent_file.write_text(f"---\n{frontmatter}\n---\n\nAgent body.\n")
+    return agent_file
+
+
+class TestOpencodeAgentColor:
+    def test_hex_color_valid(self, temp_dir, opencode_color_rule):
+        _make_plugin_with_agent(
+            temp_dir, "my-plugin", "my-agent",
+            'name: my-agent\ncolor: "#00FFFF"',
+        )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 0
+
+    def test_preset_color_valid(self, temp_dir, opencode_color_rule):
+        _make_plugin_with_agent(
+            temp_dir, "my-plugin", "my-agent",
+            "name: my-agent\ncolor: primary",
+        )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 0
+
+    def test_css_color_name_invalid(self, temp_dir, opencode_color_rule):
+        _make_plugin_with_agent(
+            temp_dir, "my-plugin", "my-agent",
+            "name: my-agent\ncolor: cyan",
+        )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 1
+        assert "cyan" in violations[0].message
+
+    def test_no_color_field_valid(self, temp_dir, opencode_color_rule):
+        _make_plugin_with_agent(
+            temp_dir, "my-plugin", "my-agent",
+            "name: my-agent\ndescription: no color",
+        )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 0
+
+    def test_all_presets_valid(self, temp_dir, opencode_color_rule):
+        presets = ["primary", "secondary", "accent", "success", "warning", "error", "info"]
+        for i, preset in enumerate(presets):
+            _make_plugin_with_agent(
+                temp_dir, f"plugin-{i}", "agent",
+                f"name: agent\ncolor: {preset}",
+            )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 0
+
+    def test_multiple_agents_mixed(self, temp_dir, opencode_color_rule):
+        plugin_dir = temp_dir / "plugins" / "my-plugin"
+        plugin_dir.mkdir(parents=True)
+        claude_dir = plugin_dir / ".claude-plugin"
+        claude_dir.mkdir()
+        (claude_dir / "plugin.json").write_text(
+            '{"name": "my-plugin", "version": "0.0.1", '
+            '"description": "test", "author": "test"}'
+        )
+        agents_dir = plugin_dir / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "good.md").write_text(
+            '---\nname: good\ncolor: "#FF0000"\n---\n\nBody.\n'
+        )
+        (agents_dir / "bad.md").write_text(
+            "---\nname: bad\ncolor: red\n---\n\nBody.\n"
+        )
+        from skillsaw import RepositoryContext
+        ctx = RepositoryContext(temp_dir)
+        violations = opencode_color_rule().check(ctx)
+        assert len(violations) == 1
+        assert "red" in violations[0].message


### PR DESCRIPTION
## Summary
- opencode 1.16 tightened schema validation for the agent `color:` frontmatter field — CSS color names like `cyan` and `yellow` now crash opencode on startup with a `ConfigInvalidError`
- Replace `cyan` → `#00FFFF` and `yellow` → `#FFFF00` in the two affected agent files
- Add a custom skillsaw lint rule (`opencode-agent-color`) to catch invalid color values going forward
- Bump ci plugin version to 0.0.47

## Crash output

```
SchemaError: Expected a string matching the RegExp ^#[0-9a-fA-F]{6}$, got "cyan"
  at ["color"]
Expected "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info", got "cyan"
  at ["color"]
```

```
Error: 4 of 5 requests failed: Unexpected server error. Check server logs for details.
Affected startup requests: config.providers, provider.list, app.agents, config.get
```

## Test plan
- [x] `make test` — 11/11 tests pass (6 new for the color rule)
- [x] `make lint` — 42 rules, 0 errors, 0 warnings
- [ ] Install the fixed agents and verify opencode launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled validation of agent color metadata to require hex (`#RRGGBB`) or preset names (primary, secondary, accent, success, warning, error, info).

* **Tests**
  * Added tests covering valid/invalid color values and multi-agent scenarios.

* **Chores**
  * Updated agent color values to comply with the new rule.
  * Bumped plugin version and updated marketplace/docs to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->