### PR TITLE
payload-snapshot: retry with exponential backoff for release controller HTTP errors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -487,7 +487,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -11,11 +11,13 @@ import gzip
 import io
 import json
 import os
+import random
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -122,11 +124,40 @@ class JobInfo:
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
-def fetch_json(url: str, timeout: int = 30) -> dict:
-    """Fetch JSON from a URL. Raises on error."""
+def _retry_delay(attempt: int, http_error=None) -> float:
+    """Compute retry delay: use Retry-After for 429s, otherwise exponential backoff."""
+    if http_error and http_error.code == 429:
+        retry_after = http_error.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return float(retry_after)
+            except ValueError:
+                pass
+    return 2 ** (attempt + 1) + random.uniform(0, 1)
+
+
+def fetch_json(url: str, timeout: int = 30, max_retries: int = 4) -> dict:
+    """Fetch JSON from a URL with retries for transient errors."""
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    for attempt in range(max_retries + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            retryable = e.code >= 500 or e.code == 429
+            if not retryable or attempt >= max_retries:
+                raise
+            delay = _retry_delay(attempt, e if e.code == 429 else None)
+            reason = f"HTTP {e.code}"
+        except urllib.error.URLError:
+            if attempt >= max_retries:
+                raise
+            delay = _retry_delay(attempt)
+            reason = "connection error"
+        else:
+            continue
+        print(f"  Retry {attempt + 1}/{max_retries}: {reason} from {url}, waiting {delay:.1f}s", file=sys.stderr)
+        time.sleep(delay)
 
 
 def try_fetch_json(url: str, timeout: int = 10) -> Optional[dict]:


### PR DESCRIPTION
## Summary

- Adds retry logic with exponential backoff to `fetch_json()` in the payload snapshot script
- Retries 5xx errors and 429 (Too Many Requests) up to 4 times with exponential backoff (2s, 4s, 8s, 16s + jitter)
- Respects `Retry-After` header on 429 responses when present
- Connection errors (`URLError`) are also retried
- Each retry is logged to stderr for CI visibility

Fixes failures like:
```
=== Creating payload snapshot ===
Payload:  5.0.0-0.nightly-2026-06-09-180352
Version:  5.0
Stream:   nightly (5.0.0-0.nightly)
Arch:     amd64
Fetching streams list...
Error: HTTP 504: Gateway Time-out
Copying reports to artifact directory.
```

## Test plan

- [ ] Verify script parses correctly (`python3 -c "import ast; ast.parse(open(...).read())"`)
- [ ] Run payload agent against release controller and confirm retries work on transient errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network resilience for remote fetches with retrying, exponential backoff with jitter, and honoring Retry-After—reduces transient failures and timeouts.
* **Chores**
  * Bumped plugin release version to 0.0.48.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->