### PR TITLE
Restructure node plugins with shared data and umbrella commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -375,7 +375,7 @@
       "name": "node-cve",
       "source": "./plugins/node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.2"
+      "version": "0.0.3"
     },
     {
       "name": "bigquery",
@@ -518,7 +518,7 @@
       "name": "node-team",
       "source": "./plugins/node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1977,7 +1977,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "has_readme": true,
       "commands": [
         {
@@ -2017,9 +2017,34 @@ footer a { color: var(--primary); }
     {
       "name": "node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "has_readme": true,
-      "commands": [],
+      "commands": [
+        {
+          "name": "overview",
+          "full_name": "node-team:overview",
+          "description": "Show Node team component ownership, repos, sub-teams, and specialized plugin routing",
+          "description_html": "Show Node team component ownership, repos, sub-teams, and specialized plugin routing",
+          "synopsis": "/node-team:overview [--sub-team core|dra]",
+          "body_html": "\u003cp\u003eDisplays a structured overview of the OpenShift Node team: which components\u003cbr\u003ethe team owns, which repos map to each component, sub-team assignments, active\u003cbr\u003esprint info, and which specialized plugins handle which domain.\u003c/p\u003e\u003cp\u003eThis is the entry point for understanding the Node team&#x27;s scope and navigating\u003cbr\u003eto the right tool for a given task.\u003c/p\u003e"
+        },
+        {
+          "name": "preflight",
+          "full_name": "node-team:preflight",
+          "description": "Verify that GitHub and Jira tokens are valid and the environment is ready for Node team workflows",
+          "description_html": "Verify that GitHub and Jira tokens are valid and the environment is ready for Node team workflows",
+          "synopsis": "/node-team:preflight [--fix]",
+          "body_html": "\u003cp\u003eTests all authentication tokens and CLI tools required by Node team workflows\u003cbr\u003ein a single pass. Reports pass/fail for each check so you can fix all auth\u003cbr\u003eissues at once instead of discovering them one at a time.\u003c/p\u003e\u003cp\u003eRun this before \u003ccode\u003e/node-team:setup\u003c/code\u003e or \u003ccode\u003e/node-cve:triage\u003c/code\u003e to catch expired or\u003cbr\u003emissing credentials early.\u003c/p\u003e"
+        },
+        {
+          "name": "setup",
+          "full_name": "node-team:setup",
+          "description": "Clone a Node team repo and set up a worktree for development",
+          "description_html": "Clone a Node team repo and set up a worktree for development",
+          "synopsis": "/node-team:setup \u003ccomponent\u003e [--ticket OCPNODE-1234] [--pr 456]",
+          "body_html": "\u003cp\u003eSets up a development environment for a Node team component. Clones the\u003cbr\u003eappropriate downstream or upstream repo (based on the component-to-repo\u003cbr\u003emapping), creates a git worktree for the task, and installs the node-team\u003cbr\u003eplugin locally in the worktree.\u003c/p\u003e\u003cp\u003eWhen given a Jira ticket or PR number, names the worktree after it and (for\u003cbr\u003etickets) fetches the issue summary to confirm the right component.\u003c/p\u003e"
+        }
+      ],
       "skills": [
         {
           "name": "node",

--- a/plugins/node-cve/.claude-plugin/plugin.json
+++ b/plugins/node-cve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-cve",
   "description": "CVE triage for OpenShift Node team components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -92,24 +92,12 @@ spec:
 
 ## Node Team Components
 
-The plugin covers all OCPBUGS components owned by the Node team. Analysis targets downstream forks at version-specific release branches. If the downstream fork or branch does not exist, the CVE is classified as Uncertain and analysis is skipped for that version.
-
-| Component | Downstream Fork | Upstream Repo | Branch Pattern | Language |
-|-----------|----------------|--------------|---------------|----------|
-| Node / CRI-O | openshift/cri-o | cri-o/cri-o | `release-1.X` | Go |
-| Node / Kubelet | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / CPU manager | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Device Manage | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Memory manager | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Numa aware Scheduling | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Pod resource API | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Topology manager | openshift/kubernetes | kubernetes/kubernetes | `release-1.X` | Go |
-| Driver Toolkit | openshift/driver-toolkit | - | `release-4.Y` | Go |
-| Machine Config Operator | openshift/machine-config-operator | - | `release-4.Y` | Go |
-
-Additional repos detected via `pscomponent:` labels: openshift/google-cadvisor (Go), openshift/conmon (C), openshift/conmon-rs (Rust + Go), openshift/cri-tools / kubernetes-sigs/cri-tools (Go).
-
-For OCP 4.Y, the K8s/CRI-O version is `1.(Y+13)` (e.g., OCP 4.18 -> K8s/CRI-O 1.31). This mapping will change for OCP 5.x.
+The plugin covers all CVE-tracked OCPBUGS components owned by the Node team.
+See the [node-team shared components reference](../node-team/skills/node/references/shared/components.md)
+for the full mapping including downstream forks, branch patterns, languages,
+and `pscomponent:` label mappings. See the
+[node-team shared version map](../node-team/skills/node/references/shared/version-map.md)
+for OCP-to-K8s/CRI-O version mappings.
 
 ## Reachability Classification
 

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -57,10 +57,10 @@ Designed for both interactive use and headless execution via `claude --print`.
 
 **Steps:**
 
-1. Build the JQL query using OCPBUGS component names from the Node team in `team_component_map.json`:
+1. Build the JQL query using the CVE-tracked component list from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md) (the full Jira component list plus Driver Toolkit and Machine Config Operator):
 
    ```bash
-   jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (\"Node / CRI-O\", \"Node / Kubelet\", \"Node / CPU manager\", \"Node / Device Manage\", \"Node / Memory manager\", \"Node / Numa aware Scheduling\", \"Node / Pod resource API\", \"Node / Topology manager\", \"Driver Toolkit\", \"Machine Config Operator\") AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
+   jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (<components from shared reference>) AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
    ```
 
    If `--component` is specified, replace the component list with the single component.
@@ -127,46 +127,9 @@ Print which CVEs are skipped or partially cached: "CVE-XXXX-XXXXX: reusing prior
 
 Analysis must target the release branch that corresponds to each affected OpenShift version. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in older release branches. Analysis targets downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
 
-**Component to repository mapping:**
+**Component to repository mapping:** Read from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md). Use the "Component to Repository Mapping" table for downstream forks and branch patterns, and the "pscomponent Label Mapping" table for label-based repo resolution.
 
-| Component | Downstream Fork | Upstream Repo | Branch Pattern | Language |
-|-----------|----------------|--------------|---------------|----------|
-| Node / CRI-O | https://github.com/openshift/cri-o | https://github.com/cri-o/cri-o | `release-1.X` | Go |
-| Node / Kubelet | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / CPU manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Device Manage | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Memory manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Numa aware Scheduling | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Pod resource API | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Topology manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Driver Toolkit | https://github.com/openshift/driver-toolkit | - | `release-4.Y` | Go |
-| Machine Config Operator | https://github.com/openshift/machine-config-operator | - | `release-4.Y` | Go |
-
-Also check labels for `pscomponent:` and map to repos:
-- `pscomponent:cadvisor` -> https://github.com/openshift/google-cadvisor (`release-4.Y`) (Go)
-- `pscomponent:conmon` -> https://github.com/openshift/conmon (`release-4.Y`) (C)
-- `pscomponent:conmon-rs` -> https://github.com/openshift/conmon-rs (`release-4.Y`) (Rust + Go)
-- `pscomponent:cri-tools` -> downstream: https://github.com/openshift/cri-tools, upstream: https://github.com/kubernetes-sigs/cri-tools (`release-1.X`) (Go)
-
-**OpenShift version to release branch mapping:**
-
-Each OCP version maps to a specific Kubernetes/CRI-O minor version. For OCP 4.Y, the formula is `K8s/CRI-O minor = Y + 13`. When OCP 5.x is released, the formula will change; check the OCP release notes or `go.mod` in the downstream fork to determine the correct Kubernetes version. Branch naming depends on the repo:
-
-| OpenShift | K8s/CRI-O | CRI-O branch | Kubernetes branch | MCO branch | Driver Toolkit branch |
-|-----------|-----------|-------------|-------------------|------------|----------------------|
-| 4.21 | 1.34 | `release-1.34` | `release-1.34` | `release-4.21` | `release-4.21` |
-| 4.20 | 1.33 | `release-1.33` | `release-1.33` | `release-4.20` | `release-4.20` |
-| 4.19 | 1.32 | `release-1.32` | `release-1.32` | `release-4.19` | `release-4.19` |
-| 4.18 | 1.31 | `release-1.31` | `release-1.31` | `release-4.18` | `release-4.18` |
-| 4.17 | 1.30 | `release-1.30` | `release-1.30` | `release-4.17` | `release-4.17` |
-| 4.16 | 1.29 | `release-1.29` | `release-1.29` | `release-4.16` | `release-4.16` |
-| 4.15 | 1.28 | `release-1.28` | `release-1.28` | `release-4.15` | `release-4.15` |
-| 4.14 | 1.27 | `release-1.27` | `release-1.27` | `release-4.14` | `release-4.14` |
-| 4.13 | 1.26 | `release-1.26` | `release-1.26` | `release-4.13` | `release-4.13` |
-| 4.12 | 1.25 | `release-1.25` | `release-1.25` | `release-4.12` | `release-4.12` |
-
-Repos using K8s-aligned versioning (`release-1.X`): openshift/cri-o, openshift/kubernetes, openshift/cri-tools.
-Repos using OCP-aligned versioning (`release-4.Y`): openshift/machine-config-operator, openshift/driver-toolkit, openshift/google-cadvisor, openshift/conmon, openshift/conmon-rs.
+**OpenShift version to release branch mapping:** Read from the [node-team shared version map](../../node-team/skills/node/references/shared/version-map.md). For OCP 4.Y, the formula is `K8s/CRI-O minor = Y + 13`. Use the formula and branch naming conventions to derive the correct release branch for each repo.
 
 **Clone strategy:**
 
@@ -337,7 +300,7 @@ The headline format depends on whether cached results were used. On first run (a
 
 ## Notes
 
-- The Jira query uses OCPBUGS component names from `team_component_map.json` in the teams plugin.
+- The Jira query uses OCPBUGS component names from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md).
 - Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and analyzes ALL affected release branches. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another.
 - Analysis targets downstream forks only (e.g., openshift/cri-o). If the downstream fork or branch does not exist, the CVE is classified as Uncertain. Dependency versions and Go toolchain versions differ across releases, so version-specific branches are used.
 - Each version tracker receives the analysis result specific to its release branch. The overall classification for a CVE is the most severe result across all analyzed branches.

--- a/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
+++ b/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
@@ -18,28 +18,9 @@ Use this skill when Phase 2 of the `node-cve:triage` command needs to determine 
 
 Analysis must target the release branch corresponding to the affected OpenShift version. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in shipped releases. Analysis must target downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
 
-**Component to repository mapping:**
+**Component to repository mapping:** Read the component-to-repo table and `pscomponent:` label mappings from the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md).
 
-| OCPBUGS Component | Downstream Fork | Upstream Repo | Branch Pattern | Language |
-|---|---|---|---|---|
-| Node / CRI-O | https://github.com/openshift/cri-o | https://github.com/cri-o/cri-o | `release-1.X` | Go |
-| Node / Kubelet | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / CPU manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Device Manage | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Memory manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Numa aware Scheduling | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Pod resource API | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Topology manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Driver Toolkit | https://github.com/openshift/driver-toolkit | - | `release-4.Y` | Go |
-| Machine Config Operator | https://github.com/openshift/machine-config-operator | - | `release-4.Y` | Go |
-
-Also check `pscomponent:` labels for additional repo mapping:
-- `pscomponent:cadvisor` -> https://github.com/openshift/google-cadvisor (`release-4.Y`) (Go)
-- `pscomponent:conmon` -> https://github.com/openshift/conmon (`release-4.Y`) (C)
-- `pscomponent:conmon-rs` -> https://github.com/openshift/conmon-rs (`release-4.Y`) (Rust + Go)
-- `pscomponent:cri-tools` -> downstream: https://github.com/openshift/cri-tools, upstream: https://github.com/kubernetes-sigs/cri-tools (`release-1.X`) (Go)
-
-**Version mapping:** Determine the Kubernetes/CRI-O minor version for each OCP release. For OCP 4.Y, the formula is `K8s/CRI-O minor = Y + 13` (e.g., OCP 4.18 -> 1.31). When OCP 5.x is released, the formula will change; check the OCP release notes or `go.mod` in the downstream fork to determine the correct Kubernetes version. Repos using K8s-aligned versioning use `release-1.X`; repos using OCP-aligned versioning use `release-4.Y` (or `release-5.Y` for OCP 5.x).
+**Version mapping:** Read from the [node-team shared version map](../../../node-team/skills/node/references/shared/version-map.md). For OCP 4.Y, the formula is `K8s/CRI-O minor = Y + 13`. Use the formula and branch naming conventions to derive the correct release branch for each repo.
 
 If the component does not map to a known repo, classify as Uncertain and skip analysis. If the downstream fork or release branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -17,29 +17,18 @@ Use this skill when Phase 1 of the `node-cve:triage` command needs to fetch all 
 
 ### Step 1: Load Node team components
 
-The Node team components are defined in the teams plugin's `team_component_map.json`. The full list:
-
-- Node / CRI-O
-- Node / Kubelet
-- Node / CPU manager
-- Node / Device Manage
-- Node / Memory manager
-- Node / Numa aware Scheduling
-- Node / Pod resource API
-- Node / Topology manager
-- Driver Toolkit
-- Machine Config Operator
+Read the CVE-tracked component list from the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md). Use the full "Jira Components (OCPBUGS)" list plus the additional CVE triage components (Driver Toolkit, Machine Config Operator).
 
 If `--component` was specified, use only that component instead of the full list.
 
-**Alternative:** A shared Jira filter named "Node Components" could replace the hardcoded list, making it a single place to update when components change. However, as of 2026-05-20, that filter does not include "Driver Toolkit" and "Machine Config Operator", so the explicit list is used to ensure completeness. If the filter gets updated to match the full list, prefer using `filter = "Node Components"` in the JQL instead.
+The Jira saved filter "Node Components" (ID 91645) does not include Driver Toolkit and Machine Config Operator, so the explicit list from the shared reference is used for CVE queries to ensure completeness.
 
 ### Step 2: Query Jira
 
 Build and execute the JQL query:
 
 ```bash
-jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (\"Node / CRI-O\", \"Node / Kubelet\", \"Node / CPU manager\", \"Node / Device Manage\", \"Node / Memory manager\", \"Node / Numa aware Scheduling\", \"Node / Pod resource API\", \"Node / Topology manager\", \"Driver Toolkit\", \"Machine Config Operator\") AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
+jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (<components from shared reference>) AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
 ```
 
 If `--days N` was specified, add `AND updated >= -${N}d` to the JQL.

--- a/plugins/node-team/.claude-plugin/plugin.json
+++ b/plugins/node-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-team",
   "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-team/README.md
+++ b/plugins/node-team/README.md
@@ -1,8 +1,8 @@
 # Node Team Plugin
 
-An OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across the node layer — kubelet, MCO, CRI-O, crun, conmonrs, the Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.
+An OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across the node layer: kubelet, MCO, CRI-O, crun, conmonrs, the Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.
 
-This plugin is the team's umbrella: a hierarchical overview of how the Node team works, routing specialized work to dedicated plugins (e.g. CVE triage → [`node-cve`](../node-cve/)) rather than duplicating them. Over time it will absorb the team's onboarding docs, making it the starting point for understanding what the team does and which tool to use for what.
+This plugin is the team's umbrella: it owns canonical shared data (component lists, repo mappings, version tables) and routes specialized work to dedicated plugins rather than duplicating them. Specialized plugins like [`node-cve`](../node-cve/) reference the shared data here instead of maintaining parallel copies.
 
 ## Installation
 
@@ -10,24 +10,59 @@ This plugin is the team's umbrella: a hierarchical overview of how the Node team
 /plugin install node-team@ai-helpers
 ```
 
+## Shared Data
+
+The `skills/node/references/shared/` directory contains canonical data used by
+all Node team plugins:
+
+- **[components.md](skills/node/references/shared/components.md)**: full component list, downstream fork mappings, branch patterns, pscomponent labels, sub-teams
+- **[version-map.md](skills/node/references/shared/version-map.md)**: OCP-to-K8s/CRI-O version formula, branch naming conventions
+
+Other plugins (e.g. `node-cve`) reference these files instead of maintaining
+their own copies. When component ownership or version mappings change, update
+the shared files here.
+
+## Commands
+
+### `node-team:overview`
+
+Shows team component ownership, repos, sub-teams, sprint info, and which specialized plugins handle which domain.
+
+### `node-team:setup`
+
+Clones a Node team repo and sets up a git worktree for development, optionally tied to a Jira ticket or PR.
+
+### `node-team:preflight`
+
+Tests all authentication tokens (GitHub, Jira) and CLI tools required by Node team workflows in a single pass. Run before `setup` or `node-cve:triage` to catch expired or missing credentials early.
+
 ## Skill
 
 ### `node`
 
-A single skill that activates on any OpenShift node-layer task. It routes through a set of reference documents that capture tribal knowledge and non-obvious nuances rather than discoverable details (which Claude reads from source directly).
+Activates on any OpenShift node-layer task. Routes through reference documents that capture tribal knowledge and non-obvious nuances. Starts at [`skills/node/references/INDEX.md`](skills/node/references/INDEX.md):
 
-The skill starts at [`skills/node/references/INDEX.md`](skills/node/references/INDEX.md), which maps topics to the relevant reference:
+- **Shared Data**: canonical component/version data for all Node plugins
+- **Setup**: environment and access prerequisites
+- **Development**: per-component dev notes for kubelet, MCO, CRI-O, crun/conmon, the Kueue operator, and git worktrees
+- **Deployment**: deploying debug binaries to RHCOS nodes (cross-compile, SSH bastion, bind-mount deploy, rollback)
+- **Jira**: Red Hat Jira REST API reference (auth, endpoints, ADF, custom fields, JQL recipes, OCPNODE/OCPBUGS triage)
+- **Red Hat Support**: KB articles and support cases
+- **Platform Documentation**: version-aware Kubernetes and OpenShift docs lookup
+- **Prometheus**: node-layer metrics queries
 
-- **Setup** — environment and access prerequisites (`SETUP.md`)
-- **Development** — per-component dev notes for kubelet, MCO, CRI-O, crun/conmon, the Kueue operator, and git worktrees
-- **Deployment** — deploying debug binaries to RHCOS nodes (cross-compile, SSH bastion, bind-mount deploy, rollback)
-- **Jira** — Red Hat Jira REST API reference (auth, endpoints, ADF, custom fields, JQL recipes, OCPNODE/OCPBUGS triage)
-- **Red Hat Support** — KB articles and support cases (`support.md`)
-- **Platform Documentation** — version-aware Kubernetes and OpenShift docs lookup (`platform-docs.md`)
-- **Prometheus** — node-layer metrics queries (`prometheus.md`)
+## Plugin Routing
+
+| Domain | Plugin | Command |
+|--------|--------|---------|
+| CVE triage | `node-cve` | `/node-cve:triage` |
+| General development | `node-team` | `node-team:node` skill |
+| Team overview | `node-team` | `/node-team:overview` |
+| Repo setup | `node-team` | `/node-team:setup` |
+| Auth verification | `node-team` | `/node-team:preflight` |
 
 ## Configuration
 
-Jira access uses a token from the `JIRA_API_TOKEN` environment variable or the macOS Keychain. See [`skills/node/references/jira.md`](skills/node/references/jira.md) for details.
+Jira access uses a token from `JIRA_API_TOKEN` or the macOS Keychain. See [`jira.md`](skills/node/references/jira.md) for details.
 
-Team rosters are maintained as `team-roster-*.json` attachments on the Jira config issue `OCPNODE-4230` (override with the `NODE_ASSISTANT_CONFIG_ISSUE` environment variable) and synced to `~/.node-assistant/`; see the Team Roster section of [`jira.md`](skills/node/references/jira.md).
+Team rosters are maintained as `team-roster-*.json` attachments on the Jira config issue `OCPNODE-4230`. Override with the `NODE_ASSISTANT_CONFIG_ISSUE` environment variable. Synced to `~/.node-assistant/`; see the Team Roster section of [`jira.md`](skills/node/references/jira.md).

--- a/plugins/node-team/commands/overview.md
+++ b/plugins/node-team/commands/overview.md
@@ -1,0 +1,61 @@
+---
+description: Show Node team component ownership, repos, sub-teams, and specialized plugin routing
+argument-hint: "[--sub-team core|dra]"
+---
+
+## Name
+node-team:overview
+
+## Synopsis
+```text
+/node-team:overview [--sub-team core|dra]
+```
+
+## Description
+
+Displays a structured overview of the OpenShift Node team: which components
+the team owns, which repos map to each component, sub-team assignments, active
+sprint info, and which specialized plugins handle which domain.
+
+This is the entry point for understanding the Node team's scope and navigating
+to the right tool for a given task.
+
+## Implementation
+
+1. Read the component list and repo mappings from
+   [shared/components.md](../skills/node/references/shared/components.md).
+2. Read sprint and board info from
+   [jira.md](../skills/node/references/jira.md) (boards section, sprint
+   naming conventions).
+3. If `--sub-team` is specified, filter to that sub-team's components using
+   the sub-teams table in `shared/components.md`.
+4. Present a structured summary:
+   - Component ownership table (component, downstream fork, sub-team)
+   - Active sprint names (query the Jira Agile API per the jira.md reference)
+   - Specialized plugin routing:
+     - CVE triage: `/node-cve:triage`
+     - General development/deployment/debugging: `node-team:node` skill
+5. If a team roster file exists at `~/.node-assistant/team-roster-{core,dra}.json`,
+   include a member count per sub-team.
+
+## Return Value
+
+- Formatted text summary of team components, repos, sub-teams, sprint info,
+  and plugin routing
+
+## Examples
+
+1. **Full team overview**:
+   ```text
+   /node-team:overview
+   ```
+
+2. **DRA/Devices sub-team only**:
+   ```text
+   /node-team:overview --sub-team dra
+   ```
+
+## Arguments
+
+- `--sub-team <name>`: Filter to a specific sub-team (`core` or `dra`).
+  Optional; shows all components when omitted.

--- a/plugins/node-team/commands/preflight.md
+++ b/plugins/node-team/commands/preflight.md
@@ -1,0 +1,115 @@
+---
+description: Verify that GitHub and Jira tokens are valid and the environment is ready for Node team workflows
+argument-hint: "[--fix]"
+---
+
+## Name
+node-team:preflight
+
+## Synopsis
+```text
+/node-team:preflight [--fix]
+```
+
+## Description
+
+Tests all authentication tokens and CLI tools required by Node team workflows
+in a single pass. Reports pass/fail for each check so you can fix all auth
+issues at once instead of discovering them one at a time.
+
+Run this before `/node-team:setup` or `/node-cve:triage` to catch expired or
+missing credentials early.
+
+## Implementation
+
+Run these checks in order and collect results:
+
+### 1. GitHub CLI (`gh`)
+
+```bash
+gh auth status
+```
+
+- Pass: output contains "Logged in to github.com"
+- Fail: not installed, not logged in, or token expired
+
+### 2. GitHub API access
+
+```bash
+gh api user -q .login
+```
+
+- Pass: returns a username
+- Fail: token lacks required scopes or is expired
+
+### 3. Jira API token
+
+Resolve the token using the same chain as
+[jira.md](../skills/node/references/jira.md) (env var, macOS Keychain,
+Linux secret-tool):
+
+```bash
+JIRA_API_TOKEN="${JIRA_API_TOKEN:-$(security find-generic-password -s "JIRA_API_TOKEN" -w 2>/dev/null || secret-tool lookup service redhat key JIRA_API_TOKEN 2>/dev/null)}"
+```
+
+- Pass: non-empty value resolved
+- Fail: no token found in any source
+
+### 4. Jira API connectivity
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -u "$JIRA_USER:$JIRA_API_TOKEN" \
+  "https://redhat.atlassian.net/rest/api/3/myself"
+```
+
+- Pass: HTTP 200
+- Fail: 401 (bad token), 403 (permissions), or connection error
+
+### 5. Jira CLI (`jira`)
+
+```bash
+jira me
+```
+
+- Pass: returns current user info
+- Fail: not installed or not configured (this is optional since the
+  `node-team` plugin uses `curl` directly, but `node-cve` requires it)
+
+### Summary
+
+Print a table of results:
+
+```text
+Check                 Status
+-----                 ------
+GitHub CLI            PASS
+GitHub API            PASS
+Jira API token        PASS
+Jira API connectivity PASS
+Jira CLI              PASS (optional)
+```
+
+If any required check fails and `--fix` is specified, print the remediation
+steps for each failure (e.g., `gh auth login`, how to set `JIRA_API_TOKEN`).
+If `--fix` is not specified, print a hint to re-run with `--fix` for guidance.
+
+## Return Value
+
+- Summary table with pass/fail status for each check
+- Exit status: all required checks pass or list of failures with remediation
+
+## Examples
+
+1. **Quick check**:
+   ```text
+   /node-team:preflight
+   ```
+
+2. **Check with remediation guidance**:
+   ```text
+   /node-team:preflight --fix
+   ```
+
+## Arguments
+
+- `--fix`: Show remediation steps for each failing check. Optional.

--- a/plugins/node-team/commands/setup.md
+++ b/plugins/node-team/commands/setup.md
@@ -1,0 +1,82 @@
+---
+description: Clone a Node team repo and set up a worktree for development
+argument-hint: "<component> [--ticket OCPNODE-1234] [--pr 456]"
+---
+
+## Name
+node-team:setup
+
+## Synopsis
+```text
+/node-team:setup <component> [--ticket OCPNODE-1234] [--pr 456]
+```
+
+## Description
+
+Sets up a development environment for a Node team component. Clones the
+appropriate downstream or upstream repo (based on the component-to-repo
+mapping), creates a git worktree for the task, and installs the node-team
+plugin locally in the worktree.
+
+When given a Jira ticket or PR number, names the worktree after it and (for
+tickets) fetches the issue summary to confirm the right component.
+
+## Implementation
+
+0. Run the checks from `/node-team:preflight` to confirm GitHub and Jira tokens
+   are valid. If any required check fails, stop and show remediation steps
+   before proceeding.
+1. Read the component-to-repo mapping from
+   [shared/components.md](../skills/node/references/shared/components.md).
+   Match the `<component>` argument against the "Day-to-Day Dev Shorthand"
+   table or the full component names (case-insensitive, partial match OK).
+   If ambiguous, ask the user to clarify.
+2. Determine the repo URL. For OpenShift-specific work, use the downstream
+   fork. For upstream contributions, use the upstream repo. If unclear, ask
+   the user.
+3. Clone the repo if not already present in the current directory:
+   ```bash
+   git clone <repo-url>
+   cd <repo-name>
+   ```
+4. Create a worktree following the workflow in
+   [SETUP.md](../skills/node/references/SETUP.md):
+   - `--ticket OCPNODE-1234`: name the worktree after the ticket
+     (`wt/ocpnode-1234`), fetch issue details from Jira to confirm the
+     component matches
+   - `--pr 456`: fetch the PR and create a worktree for it
+     (`pr-456`)
+   - Neither: deduce a name from the task context
+5. Install the node-team plugin in the worktree:
+   ```bash
+   claude plugin install node-team@ai-helpers --scope local
+   ```
+6. Print the worktree path and a short summary of what was set up.
+
+## Return Value
+
+- The path to the created worktree and confirmation of plugin installation
+
+## Examples
+
+1. **Set up CRI-O for a Jira ticket**:
+   ```text
+   /node-team:setup crio --ticket OCPNODE-5678
+   ```
+
+2. **Set up kubelet for PR review**:
+   ```text
+   /node-team:setup kubelet --pr 12345
+   ```
+
+3. **Set up MCO for general development**:
+   ```text
+   /node-team:setup mco
+   ```
+
+## Arguments
+
+- `<component>`: Component short name (e.g., `crio`, `kubelet`, `mco`,
+  `kueue`, `conmonrs`, `crun`). Required.
+- `--ticket <key>`: Jira issue key to associate with the worktree. Optional.
+- `--pr <number>`: PR number to fetch and review. Optional.

--- a/plugins/node-team/skills/node/references/INDEX.md
+++ b/plugins/node-team/skills/node/references/INDEX.md
@@ -4,6 +4,13 @@ Reference files contain only tribal knowledge and non-obvious nuances. For disco
 
 Root: `./`
 
+## Shared Data
+
+Canonical data used by this and other Node team plugins (e.g. `node-cve`).
+Other plugins reference these files instead of maintaining their own copies.
+
+|shared:{components.md,version-map.md}
+
 ## Setup
 
 |SETUP.md

--- a/plugins/node-team/skills/node/references/SETUP.md
+++ b/plugins/node-team/skills/node/references/SETUP.md
@@ -42,7 +42,7 @@ To investigate or fix a Jira issue:
    ```bash
    curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" "https://redhat.atlassian.net/rest/api/3/issue/OCPNODE-1234?fields=summary,components"
    ```
-2. Map the component to a repo (see Repo URLs below), confirm with the user, and clone if needed.
+2. Map the component to a repo (see [shared/components.md](shared/components.md)), confirm with the user, and clone if needed.
 3. Create a worktree named after the ticket:
    ```bash
    git worktree add .worktrees/ocpnode-1234 -b wt/ocpnode-1234
@@ -51,19 +51,12 @@ To investigate or fix a Jira issue:
 
 ## Component to Repo Mapping
 
-| Jira Label / Component | Repo |
-|-------------------------|------|
-| `crio` | cri-o |
-| `kubelet` | kubernetes |
-| `mco` | machine-config-operator |
-| `crun` | crun |
-| `conmonrs` | conmon-rs |
-| `kueue` | kueue-operator |
+See [shared/components.md](shared/components.md) for the full component list,
+downstream fork URLs, branch patterns, and languages. The "Day-to-Day Dev
+Shorthand" section there provides a quick lookup for common dev tasks.
 
-> For CVE analysis, the `node-cve` plugin maintains its own more detailed
-> mapping (downstream forks, branch patterns, languages) in
-> `plugins/node-cve/skills/analyze-cve-repos/SKILL.md` — that one is
-> authoritative for CVE work; this table only routes day-to-day dev tasks.
+For upstream features and bug fixes, clone upstream. For OpenShift-specific
+work, clone downstream.
 
 ## Enable the Node Team Plugin in the Worktree
 
@@ -73,19 +66,6 @@ After creating a worktree, install the plugin locally so it's available when you
 cd .worktrees/<name>
 claude plugin install node-team@ai-helpers --scope local
 ```
-
-## Repo URLs
-
-| Component | Upstream | Downstream (OpenShift) |
-|-----------|----------|------------------------|
-| CRI-O | `https://github.com/cri-o/cri-o.git` | `https://github.com/openshift/cri-o.git` |
-| Kubelet | `https://github.com/kubernetes/kubernetes.git` | `https://github.com/openshift/kubernetes.git` |
-| MCO | — | `https://github.com/openshift/machine-config-operator.git` |
-| crun | `https://github.com/containers/crun.git` | — |
-| conmon-rs | `https://github.com/containers/conmon-rs.git` | — |
-| Kueue Operator | `https://github.com/kubernetes-sigs/kueue.git` | `https://github.com/openshift/kueue-operator.git` |
-
-For upstream features and bug fixes, clone upstream. For OpenShift-specific work, clone downstream.
 
 ## Cleanup
 

--- a/plugins/node-team/skills/node/references/development/crio-dev.md
+++ b/plugins/node-team/skills/node/references/development/crio-dev.md
@@ -7,17 +7,9 @@ For build commands, repo layout, dependencies, and test targets — browse the r
 
 ## Branch Mapping
 
-**CRI-O's minor version tracks the Kubernetes minor version shipped in the OCP
-release.** This rule holds across OCP major versions (including 5.x) — find
-the Kubernetes version via `oc version` or the OCP release notes.
-
-| OCP | Kubernetes | CRI-O |
-|-----|------------|-------|
-| 5.0 | 1.36 | 1.36.x |
-| 4.23 | 1.36 | 1.36.x (shares the 5.0 base) |
-| 4.18 | 1.31 | 1.31.x |
-| 4.17 | 1.30 | 1.30.x |
-| 4.16 | 1.29 | 1.29.x |
+CRI-O's minor version tracks the Kubernetes minor version shipped in the OCP
+release. See [../shared/version-map.md](../shared/version-map.md) for the full
+OCP-to-K8s/CRI-O version table and branch naming conventions.
 
 Shortcut for OCP 4.x only: CRI-O minor = OCP minor + 13.
 

--- a/plugins/node-team/skills/node/references/jira.md
+++ b/plugins/node-team/skills/node/references/jira.md
@@ -69,14 +69,13 @@ When **reading** ADF from responses: recursively walk `content` arrays, extract 
 
 ## Components We Own
 
+See [shared/components.md](shared/components.md) for the full component list,
+repo mappings, and sub-team assignments.
+
 The canonical definition is the Jira saved filter **"Node Components"** (ID
-91645) — prefer `filter = "Node Components"` in JQL over hardcoding the list.
-Mirrored here for reference:
-
-Node, Node / CRI-O, Node / Kubelet, Node / CPU manager, Node / Memory manager, Node / Topology manager, Node / Numa aware Scheduling, Node / Device Manager, Node / Pod resource API, Node / Node Problem Detector, Node / Kueue, Node / Instaslice-operator
-
+91645). Prefer `filter = "Node Components"` in JQL over hardcoding the list.
 The team additionally owns **Driver Toolkit** and **Machine Config Operator**
-for CVE triage; those are not in filter 91645 (see the node-cve plugin).
+for CVE triage; those are not in filter 91645.
 
 ## Boards & Sprints
 

--- a/plugins/node-team/skills/node/references/platform-docs.md
+++ b/plugins/node-team/skills/node/references/platform-docs.md
@@ -1,6 +1,6 @@
 # Platform Documentation Lookup
 
-Prefer retrieval over pre-training for Kubernetes and OpenShift specifics — docs change across versions. Use `gh api` to fetch raw markdown.
+Prefer retrieval over pre-training for Kubernetes and OpenShift specifics, docs change across versions. Use `gh api` to fetch raw content.
 
 ## Kubernetes
 
@@ -12,9 +12,10 @@ Prefer retrieval over pre-training for Kubernetes and OpenShift specifics — do
 
 ## OpenShift
 
-- Repo: `harche/openshift-docs-md`, path: `docs/{version}/`
-- Versions are directories (e.g. `4.22`) — discover latest by listing `docs/`, filter numeric names, take highest by version (`sort -V`, not lexicographic — e.g. 4.10 > 4.9)
-- Each version has an **`AGENTS.md`** index mapping topics to doc files — always start here
+- Repo: `openshift/openshift-docs`, path: varies by topic area
+- Format: AsciiDoc (`.adoc`); fetch/read raw `.adoc` content for OpenShift pages
+- Versioning: git branches named `enterprise-X.Y` (e.g. `enterprise-4.18`). Discover latest by listing branches, grep `^enterprise-`, version-sort, take last
+- Topic map files (`_topic_map.yml`) list all pages per section
 
 ## Common
 

--- a/plugins/node-team/skills/node/references/shared/components.md
+++ b/plugins/node-team/skills/node/references/shared/components.md
@@ -1,0 +1,79 @@
+# Node Team Components
+
+Canonical component and repository data for all Node team plugins. Other
+plugins (e.g. `node-cve`) reference this file instead of maintaining their own
+copies.
+
+## Jira Components (OCPBUGS)
+
+The Jira saved filter **"Node Components"** (ID 91645) defines the general team
+components. Prefer `filter = "Node Components"` in JQL over hardcoding this
+list.
+
+Full list (filter 91645): Node, Node / CRI-O, Node / Kubelet, Node / CPU
+manager, Node / Memory manager, Node / Topology manager, Node / Numa aware
+Scheduling, Node / Device Manage, Node / Pod resource API, Node / Node Problem
+Detector, Node / Kueue, Node / Instaslice-operator
+
+Additional components owned for CVE triage (not in filter 91645):
+Driver Toolkit, Machine Config Operator
+
+## Component to Repository Mapping
+
+Analysis and CVE triage must target downstream forks at release branches. The
+`main` branch may have newer dependencies that mask vulnerabilities present in
+shipped releases.
+
+| OCPBUGS Component | Downstream Fork | Upstream Repo | Branch Pattern | Language |
+|---|---|---|---|---|
+| Node / CRI-O | https://github.com/openshift/cri-o | https://github.com/cri-o/cri-o | `release-1.X` | Go |
+| Node / Kubelet | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / CPU manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Device Manage | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Memory manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Numa aware Scheduling | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Pod resource API | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Topology manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Driver Toolkit | https://github.com/openshift/driver-toolkit | - | `release-4.Y` | Go |
+| Machine Config Operator | https://github.com/openshift/machine-config-operator | - | `release-4.Y` | Go |
+| Node / Kueue | - | https://github.com/kubernetes-sigs/kueue | - | Go |
+| Node / Kueue (operator) | https://github.com/openshift/kueue-operator | - | `release-4.Y` | Go |
+| Node / Node Problem Detector | https://github.com/openshift/node-problem-detector | https://github.com/kubernetes/node-problem-detector | `release-4.Y` | Go |
+| Node / Instaslice-operator | https://github.com/openshift/instaslice-operator | - | `release-4.Y` | Go |
+
+## pscomponent Label Mapping
+
+Some CVE trackers use `pscomponent:` labels instead of Jira component names.
+Map these to downstream forks:
+
+| Label | Downstream Fork | Branch Pattern | Language |
+|---|---|---|---|
+| `pscomponent:cadvisor` | https://github.com/openshift/google-cadvisor | `release-4.Y` | Go |
+| `pscomponent:conmon` | https://github.com/openshift/conmon | `release-4.Y` | C |
+| `pscomponent:conmon-rs` | https://github.com/openshift/conmon-rs | `release-4.Y` | Rust + Go |
+| `pscomponent:cri-tools` | https://github.com/openshift/cri-tools | `release-1.X` | Go |
+
+Upstream repos for pscomponent-mapped projects: conmon (`github.com/containers/conmon`),
+conmon-rs (`github.com/containers/conmon-rs`), cri-tools (`github.com/kubernetes-sigs/cri-tools`),
+cadvisor (`github.com/google/cadvisor`).
+
+## Day-to-Day Dev Shorthand
+
+Quick lookup for development tasks (clone the downstream fork for OCP work,
+upstream for community contributions):
+
+| Jira Label / Component | Repo short name |
+|-------------------------|-----------------|
+| `crio` | cri-o |
+| `kubelet` | kubernetes |
+| `mco` | machine-config-operator |
+| `crun` | crun |
+| `conmonrs` | conmon-rs |
+| `kueue` | kueue-operator |
+
+## Sub-teams
+
+| Team | Sprint filter | Roster file | Bug components |
+|------|--------------|-------------|----------------|
+| Core | `Node Core` | `team-roster-core.json` | All Node components |
+| DRA/Devices | `Node Devices` | `team-roster-dra.json` | Node / Device Manage, Node / Instaslice-operator |

--- a/plugins/node-team/skills/node/references/shared/version-map.md
+++ b/plugins/node-team/skills/node/references/shared/version-map.md
@@ -1,0 +1,33 @@
+# OpenShift to Kubernetes/CRI-O Version Mapping
+
+Canonical version mapping for all Node team plugins. Other plugins (e.g.
+`node-cve`) reference this file instead of maintaining their own copies.
+
+## Formula
+
+For OCP 4.Y: `K8s/CRI-O minor = Y + 13` (e.g., OCP 4.18 ships K8s 1.31).
+
+Apply the formula to derive branch names (see Branch Naming Conventions below).
+For example, OCP 4.18: K8s minor = 18 + 13 = 31, so CRI-O branch is
+`release-1.31` and MCO branch is `release-4.18`.
+
+## OCP 5.x Formula
+
+For OCP 5.Y: `K8s/CRI-O minor = Y + 36` (e.g., OCP 5.0 ships K8s 1.36,
+OCP 5.1 ships K8s 1.37).
+
+## Exceptions
+
+OCP 4.23 and 5.0 share the same K8s/CRI-O base (1.36). This is the transition
+point between the two formulas.
+
+## Branch Naming Conventions
+
+Repos using K8s-aligned versioning (`release-1.X`): openshift/cri-o,
+openshift/kubernetes, openshift/cri-tools.
+
+Repos using OCP-aligned versioning (`release-4.Y` or `release-5.Y`):
+openshift/machine-config-operator, openshift/driver-toolkit,
+openshift/google-cadvisor, openshift/conmon, openshift/conmon-rs,
+openshift/kueue-operator, openshift/node-problem-detector,
+openshift/instaslice-operator.


### PR DESCRIPTION
## What this PR does / why we need it:
Addresses review feedback from #457 by extracting shared data into a canonical location owned by `node-team` and updating `node-cve` to reference it instead of maintaining parallel copies.
- Extract component lists, repo mappings, and version tables into `plugins/node-team/skills/node/references/shared/`
- Update `node-cve` skills and commands to reference shared data
- Add `overview`, `setup`, and `preflight` commands to `node-team`
- Add `preflight` command for single-pass auth token verification (GitHub CLI/API, Jira token/API, jira CLI)
- Add OCP 5.x version formula (`K8s/CRI-O minor = Y + 36`)
- Simplify version map to formula + exceptions instead of a full table
- Fix personal fork reference (`harche/openshift-docs-md` replaced with `openshift/openshift-docs`)
- Fix stale "Repo URLs" reference in SETUP.md
- Replace inline component table in node-cve README with shared reference
- Bump node-team 0.15.0 -> 0.16.0, node-cve 0.0.2 -> 0.0.3

## Which issue(s) this PR fixes:
Fixes review comments on #457

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Node Team commands: `node-team:overview` (team structure and active sprints), `node-team:setup` (prepare git worktrees), and `node-team:preflight` (verify workflow prerequisites).
* **Documentation**
  * Centralized canonical shared references for Node components and OpenShift→Kubernetes/CRI-O version mappings.
  * Updated Node CVE triage and Node Team docs to pull mappings from the shared references.
* **Chores**
  * Bumped plugin versions: `node-cve` to **0.0.3** and `node-team` to **0.16.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->