### PR TITLE
Add claude-latest binary via multi-stage build

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ $ ln -s ai-helpers ~/.cursor/commands/ai-helpers
 
 ## Using the Docker Container
 
-A container is available with Claude Code and all plugins pre-installed.
+A container is available with Claude Code and all plugins pre-installed. The image includes two Claude Code binaries:
+
+- **`claude`** (default entrypoint) — installed from the **stable** RPM channel
+- **`claude-latest`** — installed from the **latest** RPM channel, for trying newer features or comparing behavior between versions
 
 ### Building the Container
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -30,7 +30,8 @@ RUN dnf install -y \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && alternatives --set python3 /usr/bin/python3.11
 
-# Copy the latest Claude Code binary from the builder stage
+# The "latest" channel binary lets users try newer features not yet in stable,
+# or compare behavior between versions, without disrupting the default entrypoint.
 COPY --from=claude-latest /usr/bin/claude /usr/local/bin/claude-latest
 
 # Install Python tools and PCP bindings

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS claude-unstable
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS claude-latest
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
@@ -31,8 +31,8 @@ RUN dnf install -y \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && alternatives --set python3 /usr/bin/python3.11
 
-# Copy the latest/unstable Claude Code binary from the builder stage
-COPY --from=claude-unstable /usr/bin/claude /usr/local/bin/claude-unstable
+# Copy the latest Claude Code binary from the builder stage
+COPY --from=claude-latest /usr/bin/claude /usr/local/bin/claude-latest
 
 # Install Python tools and PCP bindings
 RUN python3 -m pip install --no-cache-dir \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS 
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
-    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --enablerepo='claude-code-latest' claude-code && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS 
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
-    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
+    sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/claude-code-latest.repo && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' claude-code && \
     dnf clean all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -3,8 +3,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
-    sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/claude-code-latest.repo && \
-    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' claude-code && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -3,7 +3,7 @@ ENV ART_DNF_WRAPPER_POLICY=append
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
-    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --enablerepo='claude-code-latest' claude-code && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS 
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \
-    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' claude-code && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
@@ -18,7 +18,6 @@ COPY images/repos/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
 # cross-architecture dependency resolution failures in CI.
 RUN dnf install -y \
     --disablerepo='*-ppc64le' --disablerepo='*-s390x' \
-    --disablerepo='claude-code-latest' \
     python3.11 \
     python3.11-pip \
     python3.11-devel \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS claude-latest
+ENV ART_DNF_WRAPPER_POLICY=append
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
 RUN rm /etc/yum.repos.d/ubi.repo && \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,3 +1,10 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS claude-unstable
+COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
+COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
+RUN rm /etc/yum.repos.d/ubi.repo && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' claude-code && \
+    dnf clean all
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 
 # Copy external rpm repos into the image, and tell the ART wrapper to append them
@@ -11,6 +18,7 @@ COPY images/repos/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
 # cross-architecture dependency resolution failures in CI.
 RUN dnf install -y \
     --disablerepo='*-ppc64le' --disablerepo='*-s390x' \
+    --disablerepo='claude-code-latest' \
     python3.11 \
     python3.11-pip \
     python3.11-devel \
@@ -22,6 +30,9 @@ RUN dnf install -y \
     && dnf clean all \
     && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
     && alternatives --set python3 /usr/bin/python3.11
+
+# Copy the latest/unstable Claude Code binary from the builder stage
+COPY --from=claude-unstable /usr/bin/claude /usr/local/bin/claude-unstable
 
 # Install Python tools and PCP bindings
 RUN python3 -m pip install --no-cache-dir \

--- a/images/repos/claude-code-latest.repo
+++ b/images/repos/claude-code-latest.repo
@@ -1,7 +1,7 @@
 [claude-code-latest]
 name=Claude Code (Latest/Unstable)
 baseurl=https://downloads.claude.ai/claude-code/rpm/latest
-enabled=1
+enabled=0
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-claude-code

--- a/images/repos/claude-code-latest.repo
+++ b/images/repos/claude-code-latest.repo
@@ -1,0 +1,7 @@
+[claude-code-latest]
+name=Claude Code (Latest/Unstable)
+baseurl=https://downloads.claude.ai/claude-code/rpm/latest
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-claude-code


### PR DESCRIPTION
## Summary
- Adds a builder stage to the Dockerfile that installs Claude Code from the `latest` RPM channel
- Copies the binary into the final image as `/usr/local/bin/claude-unstable`
- The main stage continues to install the stable version as `claude` (with `--disablerepo=claude-code-latest` to avoid version mixing)
- Adds `images/repos/claude-code-latest.repo` pointing at `https://downloads.claude.ai/claude-code/rpm/latest`, using the same GPG key already committed in the repo

Currently stable is at 2.1.153, latest is at 2.1.177.

## Test plan
- [ ] Verify container image builds successfully with multi-stage build
- [ ] Verify `claude --version` returns stable version
- [ ] Verify `claude-unstable --version` returns latest version
- [ ] Verify both binaries are functional standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Docker container to include an additional Claude Code binary, `claude-latest`, alongside the existing `claude`.
* **Documentation**
  * Amended the “Using the Docker Container” section to clarify that the image provides both `claude` and `claude-latest`.
* **Chores**
  * Added support for installing the latest/unstable RPM feed with GPG and repository metadata verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->