### PR TITLE
Support OKD payload tags in payload snapshot

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -512,7 +512,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -57,9 +57,11 @@ class PayloadTag:
     """Parsed representation of an OpenShift payload tag.
 
     Example tags:
-        4.22.0-0.nightly-2026-02-25-152806          -> amd64
-        4.22.0-0.nightly-arm64-2026-02-25-152806    -> arm64
-        4.18.0-0.ci-2026-01-15-114134               -> amd64, ci stream
+        4.22.0-0.nightly-2026-02-25-152806              -> amd64, OCP
+        4.22.0-0.nightly-arm64-2026-02-25-152806        -> arm64, OCP
+        4.18.0-0.ci-2026-01-15-114134                   -> amd64, OCP ci stream
+        4.22.0-0.okd-scos-nightly-2026-06-10-015300     -> amd64, OKD SCOS nightly
+        4.22.0-0.okd-scos-2026-06-10-003203             -> amd64, OKD SCOS ci stream
     """
 
     raw: str
@@ -80,7 +82,7 @@ class PayloadTag:
         timestamp = m.group(2)
 
         sm = re.match(
-            r"^(\d+\.\d+)\.0-0\.(\w+?)(?:-(arm64|ppc64le|s390x|multi))?$",
+            r"^(\d+\.\d+)\.0-0\.([\w-]+?)(?:-(arm64|ppc64le|s390x|multi))?$",
             stream_name,
         )
         if not sm:
@@ -175,9 +177,12 @@ def try_fetch_json(url: str, timeout: int = 10) -> Optional[dict]:
 class ReleaseController:
     """Client for the OpenShift release controller API."""
 
-    def __init__(self, architecture: str = "amd64"):
+    def __init__(self, architecture: str = "amd64", stream: str = ""):
         self.architecture = architecture
-        self.domain = f"{architecture}.ocp.releases.ci.openshift.org"
+        if stream.startswith("okd"):
+            self.domain = f"{architecture}.origin.releases.ci.openshift.org"
+        else:
+            self.domain = f"{architecture}.ocp.releases.ci.openshift.org"
         self._base = f"https://{self.domain}/api/v1"
 
     def fetch_tags(self, stream_name: str) -> list[dict]:
@@ -298,7 +303,7 @@ class SippyClient:
             else:
                 informing_jobs[name] = entry
 
-        rc = ReleaseController(tag.architecture)
+        rc = ReleaseController(tag.architecture, stream=tag.stream)
         return {
             "phase": phase,
             "results": {
@@ -1410,7 +1415,7 @@ class Snapshotter:
         self.workers = workers
         self.collect_junit = collect_junit
         self.use_sippy = use_sippy
-        self.rc = ReleaseController(tag.architecture)
+        self.rc = ReleaseController(tag.architecture, stream=tag.stream)
         self.sippy: Optional[SippyClient] = None
         if use_sippy:
             self.sippy = SippyClient(tag.version)


### PR DESCRIPTION
## Summary

The `payload_snapshot.py` script currently only supports OCP payload tags. This PR adds support for OKD SCOS payload tags so the payload agent can analyze OKD releases.

This is a prerequisite for [openshift/release#80392](https://github.com/openshift/release/pull/80392), which adds `claude-payload-agent` to OKD SCOS 4.22 and 5.0 release controllers. Without this fix, the snapshot step crashes before Claude is even invoked.

## Changes

### 1. Fix `PayloadTag.parse()` regex

The stream name regex used `(\w+?)` which only matches word characters (`[a-zA-Z0-9_]`). OKD stream names contain hyphens (e.g., `okd-scos-nightly`), causing a `ValueError: Cannot parse stream name` crash.

**Fix:** Changed to `([\w-]+?)` to allow hyphens in stream names.

| Tag | Before | After |
|-----|--------|-------|
| `4.22.0-0.nightly-2026-02-25-152806` | `stream=nightly` | `stream=nightly` (unchanged) |
| `4.22.0-0.okd-scos-nightly-2026-06-10-015300` | **crash** | `stream=okd-scos-nightly` |
| `4.22.0-0.okd-scos-2026-06-10-003203` | **crash** | `stream=okd-scos` |

### 2. Fix `ReleaseController` domain

The release controller domain was hardcoded to `{arch}.ocp.releases.ci.openshift.org`. OKD uses `{arch}.origin.releases.ci.openshift.org`.

**Fix:** Added a `stream` parameter to `ReleaseController.__init__()`. When the stream starts with `okd`, it uses `origin.releases`; otherwise it uses `ocp.releases` (default, backward compatible).

Updated two call sites that have a parsed `PayloadTag` available to pass `stream=tag.stream`. The third call site (`StreamsCollector`) is for OCP stream discovery and keeps the default.

## Test plan

- [x] Verified all 7 tag formats parse correctly (OCP nightly, OCP arm64, OCP CI, OKD nightly, OKD CI, 5.0 nightly, 5.0 CI)
- [x] Verified OCP tags produce `ocp.releases` domain (no regression)
- [x] Verified OKD tags produce `origin.releases` domain
- [ ] End-to-end: run snapshot against a real OKD payload tag after merge

## Related

- [openshift/release#80392](https://github.com/openshift/release/pull/80392) — adds `claude-payload-agent` to OKD SCOS release controllers (depends on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OKD stream variants in payload snapshot functionality

* **Improvements**
  * Enhanced stream name parsing to allow hyphens in stream identifiers
  * Updated payload snapshot behavior to route OKD-related streams (including OKD SCOS) to the correct release-controller API endpoint

* **Documentation**
  * Expanded PayloadTag docstring examples to include additional stream variants

* **Chores**
  * Bumped the CI plugin version to `0.0.52`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->