### PR TITLE
ci: default OCP 5.x fresh installs to RHCOS 10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -487,7 +487,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/references/jobs.md
+++ b/plugins/ci/references/jobs.md
@@ -41,7 +41,7 @@ Job names may contain fragments that indicate which RHCOS variant the cluster us
    - Example: `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-rhcos9`
 4. **No fragment** — default by OCP major version **at install time** (not the payload/target version):
    - OCP 4.x → RHCOS 9
-   - OCP 5.x → RHCOS 9 (current default, will change to RHCOS 10)
+   - OCP 5.x → RHCOS 10
 
 For upgrade jobs, use the **install-time** OCP version (see "Upgrade Jobs" above), not the payload/target version. This matters for major upgrades: a major upgrade job in a 5.x payload installs OCP 4.x, so its RHCOS default follows OCP 4.x rules.
 

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -100,7 +100,7 @@ From `summary.json` top-level fields:
 
 From `summary.json` → `blocking_jobs.failed_jobs[]`, each entry contains:
 - `name`, `state`, `prow_url`, `gcs_url`, `is_aggregated`, `retries`
-- `rhcos_version`: the RHCOS variant for this job (`rhcos9`, `rhcos10`, `rhcos9_10`, or `rhcos9-default`)
+- `rhcos_version`: the RHCOS variant for this job (`rhcos9`, `rhcos10`, `rhcos9_10`, `rhcos9-default`, or `rhcos10-default`)
 - `streak`: `streak_length`, `originating_payload`, `is_new_failure`, `failure_pattern`
 - `build_log_errors`, `test_failure_count`
 - Paths: `job_json`, `junit_results`, `build_log`
@@ -157,7 +157,7 @@ You MUST use the following prompt verbatim (substituting the placeholder values)
 
 Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed job entry, and `<rhcos_context>` is one of:
 - For **`rhcos9`** or **`rhcos9-default`**: "RHCOS 9 is based on RHEL 9 — the standard CoreOS variant for this OCP version."
-- For **`rhcos10`**: "RHCOS 10 is based on RHEL 10 with a different kernel, systemd, SELinux policy, and package versions than RHCOS 9. If the failure involves OS-level components (kernel, bootloader, rpm-ostree, MCO, Ignition), consider whether RHEL 10 differences could be the root cause."
+- For **`rhcos10`** or **`rhcos10-default`**: "RHCOS 10 is based on RHEL 10 with a different kernel, systemd, SELinux policy, and package versions than RHCOS 9. If the failure involves OS-level components (kernel, bootloader, rpm-ostree, MCO, Ignition), consider whether RHEL 10 differences could be the root cause."
 - For **`rhcos9_10`** (heterogeneous): "This is a heterogeneous cluster with both RHCOS 9 and RHCOS 10 nodes. Failures may be specific to one node variant — check whether failing nodes are RHCOS 9 or RHCOS 10 when node-level logs are available."
 
 **Structured Return Format**: Instruct each subagent to include an `ANALYSIS_RESULT` block at the end of its response:
@@ -172,7 +172,7 @@ ANALYSIS_RESULT:
 - underlying_job_name: <for aggregated jobs only, extracted from junit artifacts>
 - retries_consistent: yes|no|no_retries|only_final_examined
 - retry_summary: <brief comparison of failure modes across attempts, e.g. "all 3 attempts failed with same KAS crashloop" or "attempt 1 infra timeout, attempts 2-3 test failure", or "no retries" when there was only a single attempt>
-- rhcos_version: rhcos9|rhcos10|rhcos9_10|rhcos9-default
+- rhcos_version: rhcos9|rhcos10|rhcos9_10|rhcos9-default|rhcos10-default
 ```
 
 **Note for aggregated jobs**: Since only the final attempt is examined (retries re-run aggregation only), set `retries_consistent: only_final_examined` and `retry_summary: "Aggregated job — only final attempt examined (retries re-run aggregation only)"`.
@@ -189,6 +189,7 @@ After collecting subagent results, look for patterns across multiple jobs:
   - It appears in one or more RHCOS 10 jobs but in zero RHCOS 9 jobs → `failure_scope: "rhcos10-only"`
   - It appears in one or more RHCOS 9 jobs but in zero RHCOS 10 jobs → `failure_scope: "rhcos9-only"`
   - Jobs with `rhcos9-default` count as RHCOS 9 for this check
+  - Jobs with `rhcos10-default` count as RHCOS 10 for this check
   - Jobs with `rhcos9_10` (heterogeneous) count toward both variants for this check
   - Variant isolation is strong diagnostic context — it narrows the root cause to OS-specific changes (kernel, systemd, SELinux, package differences between RHEL 9 and RHEL 10).
 
@@ -311,7 +312,7 @@ The report must include the following sections:
 
 A table showing ALL blocking jobs with columns:
 - Job Name
-- RHCOS (the RHCOS version badge for this job from the snapshot's `rhcos_version` field: use `badge-rhcos9` / `badge-rhcos10` / `badge-rhcos-mixed` CSS classes; `rhcos9-default` renders with `badge-rhcos9`. When a failure is variant-isolated, add a `variant-isolated` class to highlight the badge)
+- RHCOS (the RHCOS version badge for this job from the snapshot's `rhcos_version` field: use `badge-rhcos9` / `badge-rhcos10` / `badge-rhcos-mixed` CSS classes; `rhcos9-default` renders with `badge-rhcos9`, `rhcos10-default` renders with `badge-rhcos10`. When a failure is variant-isolated, add a `variant-isolated` class to highlight the badge)
 - Status (color-coded: green for passed, red for failed)
 - Streak (consecutive failing payloads; "N/A" for passed)
 - History (the `failure_pattern` from the snapshot, e.g., "F F F S F F", with color-coded markers)

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -193,7 +193,8 @@ The `rhcos_version` field is determined from the job name and OCP version:
 - `rhcos9_10` — heterogeneous cluster (mixed RHCOS 9 and 10 node pools)
 - `rhcos10` — RHCOS 10 only
 - `rhcos9` — RHCOS 9 (explicit)
-- `rhcos9-default` — no explicit fragment; currently defaults to RHCOS 9 when no fragment is present
+- `rhcos9-default` — no explicit fragment; defaults to RHCOS 9 for OCP 4.x installs (including major upgrades to 5.x)
+- `rhcos10-default` — no explicit fragment; defaults to RHCOS 10 for OCP 5.x fresh installs
 
 ### `build_log.json` (failed blocking jobs only)
 

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -1975,7 +1975,7 @@ def _determine_rhcos_version(job_name: str, version: str) -> str:
 
     major = int(install_version.split(".")[0])
     if major >= 5:
-        return "rhcos9-default"
+        return "rhcos10-default"
     return "rhcos9-default"
 
 


### PR DESCRIPTION
OCP 5.x clusters installed fresh now default to RHCOS 10 (`rhcos10-default`) instead of RHCOS 9. Clusters installed as OCP 4.x (including major upgrades to 5.x) remain on RHCOS 9 (`rhcos9-default`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the **ci** plugin version to **0.0.51** (including marketplace and site metadata).

* **Documentation**
  * Updated RHCOS defaulting guidance: **OCP 5.x now defaults to RHCOS 10**.
  * Refreshed RHCOS variant detection and payload-snapshot/payload-analysis documentation.
  * Added “Step 3b: Confirm RHCOS Version” guidance for install-failure and test-failure analysis flows.

* **Improvements**
  * Improved handling of the **rhcos10-default** RHCOS variant, including fallback behavior and clearer reporting/badge mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->