### PR TITLE
TRT-2611: Fix OTEL tool call counting for real Claude Code telemetry

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2360,7 +2360,7 @@ footer a { color: var(--primary); }
     {
       "name": "prow-agent",
       "description": "Utilities for Claude Code sessions running inside Prow CI jobs",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "has_readme": true,
       "commands": [],
       "skills": [],

--- a/plugins/prow-agent/.claude-plugin/plugin.json
+++ b/plugins/prow-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prow-agent",
   "description": "Utilities for Claude Code sessions running inside Prow CI jobs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/prow-agent/scripts/extract_metrics.py
+++ b/plugins/prow-agent/scripts/extract_metrics.py
@@ -33,6 +33,7 @@ def parse_otel(path):
     cost_totals = defaultdict(float)
     active_time = defaultdict(float)
     api_requests = []
+    tool_uses = []
 
     for rec in records:
         rpath = rec.get("path", "")
@@ -78,8 +79,12 @@ def parse_otel(path):
                             event_attrs[key] = v
                             if key == "event.name":
                                 event_name = v
-                        if event_name == "claude_code.api_request":
+                        if event_name in ("api_request", "claude_code.api_request"):
                             api_requests.append(event_attrs)
+                        elif event_name == "tool_decision":
+                            tool = event_attrs.get("tool_name", "")
+                            if tool:
+                                tool_uses.append(tool)
 
     total_cost_usd = sum(cost_totals.values())
     input_tokens = int(sum(v for (m, t), v in token_totals.items() if t == "input"))
@@ -91,10 +96,13 @@ def parse_otel(path):
     cache_hit_rate = (cache_read_tokens / total_input * 100) if total_input > 0 else 0
 
     tool_counts = Counter()
-    for req in api_requests:
-        tool = req.get("tool_name", "")
-        if tool:
-            tool_counts[tool] += 1
+    if tool_uses:
+        tool_counts.update(tool_uses)
+    else:
+        for req in api_requests:
+            tool = req.get("tool_name", "")
+            if tool:
+                tool_counts[tool] += 1
     total_tool_calls = sum(tool_counts.values())
 
     duration_api_s = active_time.get("api", 0)

--- a/plugins/prow-agent/scripts/otel_collector.py
+++ b/plugins/prow-agent/scripts/otel_collector.py
@@ -131,7 +131,7 @@ def parse_metrics(log_file):
                             event_attrs[key] = v
                             if key == "event.name":
                                 event_name = v
-                        if event_name == "claude_code.api_request":
+                        if event_name in ("api_request", "claude_code.api_request"):
                             api_requests.append(event_attrs)
 
     return dict(token_totals), dict(cost_totals), api_requests, dict(active_time)

--- a/plugins/prow-agent/scripts/test_extract_metrics.py
+++ b/plugins/prow-agent/scripts/test_extract_metrics.py
@@ -160,10 +160,77 @@ def test_missing_stream_log():
         os.unlink(out_path)
 
 
+def test_tool_decision_events():
+    """Tool counts should come from tool_decision events (real Claude Code format)."""
+    otel_data = [
+        {"ts": "2026-06-16T00:00:00Z", "path": "/v1/metrics", "payload": {
+            "resourceMetrics": [{"scopeMetrics": [{"metrics": [
+                {"name": "claude_code.cost.usage", "sum": {"dataPoints": [
+                    {"attributes": [{"key": "model", "value": {"stringValue": "claude-opus-4-6"}}], "asDouble": 1.0}
+                ]}},
+                {"name": "claude_code.token.usage", "sum": {"dataPoints": [
+                    {"attributes": [{"key": "model", "value": {"stringValue": "claude-opus-4-6"}},
+                                    {"key": "type", "value": {"stringValue": "input"}}], "asInt": 1000},
+                    {"attributes": [{"key": "model", "value": {"stringValue": "claude-opus-4-6"}},
+                                    {"key": "type", "value": {"stringValue": "output"}}], "asInt": 500},
+                ]}}
+            ]}]}]
+        }},
+        {"ts": "2026-06-16T00:00:01Z", "path": "/v1/logs", "payload": {
+            "resourceLogs": [{"scopeLogs": [{"logRecords": [
+                {"attributes": [
+                    {"key": "event.name", "value": {"stringValue": "api_request"}},
+                    {"key": "model", "value": {"stringValue": "claude-opus-4-6"}},
+                    {"key": "duration_ms", "value": {"intValue": 2000}},
+                ]},
+                {"attributes": [
+                    {"key": "event.name", "value": {"stringValue": "tool_decision"}},
+                    {"key": "tool_name", "value": {"stringValue": "Read"}},
+                    {"key": "decision", "value": {"stringValue": "accept"}},
+                ]},
+                {"attributes": [
+                    {"key": "event.name", "value": {"stringValue": "tool_decision"}},
+                    {"key": "tool_name", "value": {"stringValue": "Read"}},
+                    {"key": "decision", "value": {"stringValue": "accept"}},
+                ]},
+                {"attributes": [
+                    {"key": "event.name", "value": {"stringValue": "tool_decision"}},
+                    {"key": "tool_name", "value": {"stringValue": "Bash"}},
+                    {"key": "decision", "value": {"stringValue": "accept"}},
+                ]},
+                {"attributes": [
+                    {"key": "event.name", "value": {"stringValue": "tool_result"}},
+                    {"key": "tool_name", "value": {"stringValue": "Read"}},
+                ]},
+            ]}]}]
+        }},
+    ]
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tmp:
+        for record in otel_data:
+            tmp.write(json.dumps(record) + "\n")
+        log_path = tmp.name
+    with tempfile.NamedTemporaryFile(suffix="-autodl.json", delete=False) as tmp:
+        out_path = tmp.name
+    try:
+        r = run_script(log_path, out_path)
+        assert r.returncode == 0, f"Script failed: {r.stderr}"
+        data = load_autodl(out_path)
+        row = data["rows"][0]
+        assert row["total_tool_calls"] == "3", f"Got {row['total_tool_calls']}"
+        breakdown = json.loads(row["tool_call_breakdown"])
+        assert breakdown["Read"] == 2, f"Got Read={breakdown.get('Read')}"
+        assert breakdown["Bash"] == 1, f"Got Bash={breakdown.get('Bash')}"
+        print("PASS: test_tool_decision_events")
+    finally:
+        os.unlink(log_path)
+        os.unlink(out_path)
+
+
 if __name__ == "__main__":
     test_otel_input()
     test_otel_with_stream_enrichment()
     test_otel_schema_matches_row()
     test_empty_otel_log()
     test_missing_stream_log()
+    test_tool_decision_events()
     print("\nAll tests passed.")


### PR DESCRIPTION
## Summary
- Claude Code emits `tool_decision` events for tool usage, not `claude_code.api_request` with a `tool_name` attribute. The parser now counts tools from `tool_decision` events, falling back to `api_request` `tool_name` for backwards compatibility.
- Also matches the unprefixed `api_request` event name that production Claude Code uses (was only matching `claude_code.api_request`).
- Verified against real CI OTEL data from [rehearsal job 2066675059740643328](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80547/rehearse-80547-periodic-ci-openshift-release-main-payload-agent-analyze/2066675059740643328) — tool count goes from 0 to 79 (Bash:56, Read:11, Skill:3, Write:3, Agent:2, Grep:2, Glob:1, WebFetch:1).

## Test plan
- [x] All existing tests pass (backwards compatible with old fixture format)
- [x] New `test_tool_decision_events` test covers the real event format
- [x] Tested against real CI OTEL JSONL — correct tool breakdown
- [x] `uvx skillsaw lint` passes (A+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.0.4

* **Bug Fixes**
  * Improved tool usage metrics collection by recognizing additional log event types
  * Enhanced tool call breakdown reporting with support for more reliable counting from multiple sources

* **Tests**
  * Added test coverage for tool decision event metrics to ensure accurate reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->