### PR TITLE
feat(eval): add solve-pipeline eval harness with case-003

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1474,7 +1474,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "has_readme": true,
       "commands": [
         {
@@ -1612,6 +1612,14 @@ footer a { color: var(--primary); }
           "description_html": "Analyze a JIRA issue and create a pull request to solve it.",
           "synopsis": "/jira:solve \u003cjira-issue-id\u003e [remote] [--ci]",
           "body_html": "\u003cp\u003eThe \u003ccode\u003ejira:solve\u003c/code\u003e command analyzes a JIRA issue and creates a pull request to solve it.\u003c/p\u003e\u003cp\u003eThis command takes a JIRA URL, fetches the issue description and requirements, analyzes the codebase to understand how to implement the solution, and creates a comprehensive pull request with the necessary changes.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eUsage Examples:\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e1. \u003cstrong\u003eSolve a specific JIRA issue\u003c/strong\u003e:\u003cbr\u003e   ``\u003ccode\u003e\u003cbr\u003e   /jira:solve OCPBUGS-12345 origin\u003cbr\u003e   \u003c/code\u003e``\u003c/p\u003e"
+        },
+        {
+          "name": "solve-pipeline",
+          "full_name": "jira:solve-pipeline",
+          "description": "Run the 3-phase jira-agent pipeline (solve → review → address-review) for eval.",
+          "description_html": "Run the 3-phase jira-agent pipeline (solve → review → address-review) for eval.",
+          "synopsis": "/jira:solve-pipeline \u003cissue_key\u003e \u003crepo_url\u003e \u003ceval_branch\u003e",
+          "body_html": "Runs the full jira-agent pipeline against a snapshot branch for evaluation purposes.\u003cbr\u003eDoes NOT create PRs or push code."
         },
         {
           "name": "status-rollup",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/solve-pipeline.md
+++ b/plugins/jira/commands/solve-pipeline.md
@@ -1,0 +1,34 @@
+---
+description: Run the 3-phase jira-agent pipeline (solve → review → address-review) for eval.
+---
+
+## Name
+jira:solve-pipeline
+
+## Synopsis
+```
+/jira:solve-pipeline <issue_key> <repo_url> <eval_branch>
+```
+
+## Description
+
+Runs the full jira-agent pipeline against a snapshot branch for evaluation purposes.
+Does NOT create PRs or push code.
+
+## Implementation
+
+Run the pipeline script and wait for it to complete. This is a long-running operation (30-60 minutes).
+
+Execute this exact command, substituting the arguments:
+
+```bash
+AI_HELPERS_DIR=$(pwd) WORK_DIR=$(pwd)/eval-output \
+  bash plugins/jira/evals/scripts/run-solve-pipeline.sh "$1" "$2" "$3"
+```
+
+Do NOT modify the script. Do NOT interpret its output. Do NOT create PRs or push code.
+
+## Arguments
+- $1: Jira issue key or URL (required)
+- $2: Repository clone URL (required)
+- $3: Snapshot branch name (required)

--- a/plugins/jira/evals/cases/solve-pipeline/case-003/annotations.yaml
+++ b/plugins/jira/evals/cases/solve-pipeline/case-003/annotations.yaml
@@ -1,0 +1,12 @@
+expected_files_changed:
+  - control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+  - control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+  - control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_controller.go
+  - control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_controller_test.go
+expected_tests_pass: true
+min_coverage_pct: 40
+difficulty: simple
+category: bug
+notes: >
+  Manage AWS EBS CSI driver metrics certs via CPO, following the
+  Azure CSI pattern. Adds PKI reconcile function and unit test.

--- a/plugins/jira/evals/cases/solve-pipeline/case-003/input.yaml
+++ b/plugins/jira/evals/cases/solve-pipeline/case-003/input.yaml
@@ -1,0 +1,4 @@
+issue_key: "https://redhat.atlassian.net/browse/OCPBUGS-34662"
+repo_url: "https://github.com/enxebre/hypershift"
+eval_branch: "eval/jira-solve-pipeline/case-003"
+known_good_pr: "https://github.com/openshift/hypershift/pull/7538"

--- a/plugins/jira/evals/eval-solve-pipeline.yaml
+++ b/plugins/jira/evals/eval-solve-pipeline.yaml
@@ -1,0 +1,352 @@
+name: jira-solve-pipeline-eval
+description: >
+  End-to-end eval of the jira-agent pipeline (solve → code-review →
+  address-review). Runs 3 phases against snapshot branches, judges
+  per-phase quality and final output (make verify, make test, coverage).
+skill: jira:solve-pipeline
+
+execution:
+  mode: case
+  arguments: "{issue_key} {repo_url} {eval_branch}"
+  timeout: 3600
+  max_budget_usd: 25.0
+
+runner:
+  type: claude-code
+  plugin_dirs:
+    - plugins/jira
+    - plugins/code-review
+    - plugins/utils
+  system_prompt: |
+    You are an eval runner. Load and execute the jira:solve-pipeline skill.
+    Do NOT create PRs or push code.
+
+models:
+  skill: claude-opus-4-6
+  judge: claude-opus-4-6
+
+permissions:
+  allow:
+    - "Bash"
+    - "Read"
+    - "Write"
+    - "Glob"
+    - "Grep"
+  deny:
+    - "Agent"
+    - "mcp__*"
+
+mlflow:
+  experiment: jira-solve-pipeline-eval
+
+dataset:
+  path: plugins/jira/evals/cases/solve-pipeline
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+      - 'issue_key' — Jira issue key (e.g., OCPBUGS-12345)
+      - 'repo_url' — target repo clone URL
+      - 'eval_branch' — snapshot branch (e.g., eval/jira-solve-pipeline/case-001)
+      - 'issue_description' — full issue text (fallback if Jira unavailable)
+      - 'known_good_pr' — URL of the merged human-reviewed PR (optional)
+    - annotations.yaml: Expected outcomes and metadata:
+      - 'expected_files_changed': list of file paths the fix should touch
+      - 'expected_tests_pass': boolean
+      - 'min_coverage_pct': integer (e.g., 40)
+      - 'difficulty': simple|medium|complex
+      - 'category': bug|feature|refactor
+      - 'notes': context for LLM judges
+
+outputs:
+  - path: "output"
+    schema: |
+      The pipeline script produces these files in the working directory:
+
+      Per-phase:
+        phase1-diff.patch — diff after solve (before review/fix)
+        phase1-diffstat.txt — diffstat after solve
+        phase1-tokens.json — token usage for solve phase
+        review-findings.txt — code review output text
+        phase2-tokens.json — token usage for review phase
+        phase3-tokens.json — token usage for fix phase
+
+      Final state (after all 3 phases):
+        diff.patch — full diff
+        files-changed.txt — list of modified files
+        commit-log.txt — git log of all commits
+        make-test.log — test output
+        make-test-exit — test exit code (0 = pass)
+        make-verify.log — verify output
+        make-verify-exit — verify exit code (0 = pass)
+        coverage.txt — go test -cover output
+        total-cost.json — aggregated token/cost metrics
+
+      Judges should check outputs["files"] and outputs["modified_files"]
+      for files matching these naming patterns.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  # ── Final-output deterministic judges (hard gates) ──
+
+  - name: has_code_changes
+    description: Verify the pipeline produced code changes (non-empty diff)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      diff_files = {k: v for k, v in all_f.items() if k.endswith("diff.patch") and "phase1" not in k}
+      if not diff_files:
+          return (False, "No diff.patch found")
+      content = list(diff_files.values())[0]
+      if not content or not content.strip():
+          return (False, "diff.patch is empty — no code changes produced")
+      lines = len(content.strip().splitlines())
+      return (True, f"diff.patch has {lines} lines")
+
+  - name: make_verify_passes
+    description: Verify make verify passes (exit code 0)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      exit_files = {k: v for k, v in all_f.items() if k.endswith("make-verify-exit")}
+      if not exit_files:
+          return (False, "No make-verify-exit file found")
+      code = list(exit_files.values())[0].strip()
+      if code == "0":
+          return (True, "make verify passed (exit 0)")
+      log_files = {k: v for k, v in all_f.items() if k.endswith("make-verify.log")}
+      log_tail = ""
+      if log_files:
+          log_tail = list(log_files.values())[0].strip()[-500:]
+      return (False, f"make verify failed (exit {code}). Tail: {log_tail}")
+
+  - name: make_test_passes
+    description: Verify make test passes (exit code 0)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      exit_files = {k: v for k, v in all_f.items() if k.endswith("make-test-exit")}
+      if not exit_files:
+          return (False, "No make-test-exit file found")
+      code = list(exit_files.values())[0].strip()
+      if code == "0":
+          return (True, "make test passed (exit 0)")
+      log_files = {k: v for k, v in all_f.items() if k.endswith("make-test.log")}
+      log_tail = ""
+      if log_files:
+          log_tail = list(log_files.values())[0].strip()[-500:]
+      return (False, f"make test failed (exit {code}). Tail: {log_tail}")
+
+  - name: commit_message_format
+    description: "Verify commit messages use conventional-commit style (type(scope): or type:)"
+    check: |
+      import re
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      log_files = {k: v for k, v in all_f.items() if k.endswith("commit-log.txt")}
+      if not log_files:
+          return (False, "No commit-log.txt found")
+      content = list(log_files.values())[0].strip()
+      if not content:
+          return (False, "commit-log.txt is empty")
+      lines = content.splitlines()
+      conv_pattern = r'(feat|fix|refactor|chore|test|docs|style|perf|ci|build|revert)(\(.+?\))?:'
+      bad = []
+      for line in lines:
+          parts = line.split(" ", 1)
+          if len(parts) < 2:
+              bad.append(line)
+              continue
+          msg = parts[1]
+          if not re.match(conv_pattern, msg):
+              bad.append(line)
+      if bad:
+          return (False, f"{len(bad)}/{len(lines)} commits lack conventional-commit format: {bad[0][:80]}")
+      return (True, f"All {len(lines)} commits use conventional-commit format")
+
+  - name: coverage_meets_threshold
+    description: Verify diff coverage (changed lines) meets minimum threshold
+    check: |
+      import re
+      ann = outputs.get("annotations", {})
+      min_pct = ann.get("min_coverage_pct", 0)
+      if min_pct == 0:
+          return (True, "No coverage threshold set in annotations")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      cov_files = {k: v for k, v in all_f.items() if k.endswith("coverage.txt")}
+      if not cov_files:
+          return (False, "No coverage.txt found")
+      content = list(cov_files.values())[0]
+      if "no go" in content.lower():
+          return (True, "No Go source files changed")
+      diff_match = re.search(r'diff-coverage:\s+([\d.]+)%', content)
+      if diff_match:
+          pct = float(diff_match.group(1))
+          if pct < min_pct:
+              return (False, f"Diff coverage {pct}% below threshold {min_pct}%")
+          return (True, f"Diff coverage {pct}% >= {min_pct}%")
+      coverages = re.findall(r'coverage:\s+([\d.]+)%', content)
+      if not coverages:
+          return (False, "Could not parse coverage from output")
+      pcts = [float(c) for c in coverages]
+      avg = sum(pcts) / len(pcts)
+      if avg < min_pct:
+          return (False, f"Avg package coverage {avg:.1f}% below threshold {min_pct}%")
+      return (True, f"Avg package coverage {avg:.1f}% >= {min_pct}%")
+
+  # ── Per-phase LLM judges ──
+
+  - name: solve_quality
+    description: |
+      Assess Phase 1 (solve) — does the initial implementation address the
+      issue with reasonable changes?
+    prompt: |
+      You are evaluating Phase 1 (solve) of a jira-agent pipeline. The agent
+      was given a Jira issue and asked to implement a fix.
+
+      Below are the pipeline outputs. Focus on "phase1-diff.patch" for the
+      Phase 1 diff (before review/fix phases). If "known-good.patch" is present,
+      it contains the human-reviewed reference PR diff — compare the agent's
+      approach against it structurally (same files, same pattern, same fix).
+
+      {{ outputs }}
+
+      Expected outcomes from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: No meaningful changes, or changes completely unrelated to the issue.
+      Score 2: Some relevant changes but major gaps — missing test coverage,
+               incomplete fix, or wrong approach.
+      Score 3: Reasonable first attempt — addresses the core issue, may have
+               minor gaps the review phase should catch.
+      Score 4: Good implementation — correct fix, includes tests, changes are
+               scoped to the issue. Minor style issues acceptable.
+      Score 5: Excellent — correct, complete, well-tested, idiomatic code.
+
+  - name: review_thoroughness
+    description: |
+      Assess Phase 2 (review) — did it catch real issues and provide
+      actionable feedback?
+    prompt: |
+      You are evaluating Phase 2 (code review) of a jira-agent pipeline.
+
+      Below are the pipeline outputs. Focus on "phase1-diff.patch" for the
+      code that was reviewed, and "review-findings.txt" for the review output.
+
+      {{ outputs }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: No findings, or findings are generic/irrelevant to the actual code.
+      Score 2: Superficial — mentions obvious issues but misses important ones.
+      Score 3: Adequate — catches some real issues with specific references.
+      Score 4: Thorough — identifies important issues with file:line references.
+      Score 5: Excellent — catches subtle issues, prioritized findings.
+
+  - name: fix_completeness
+    description: |
+      Assess Phase 3 (address review) — were review findings actually fixed?
+    prompt: |
+      You are evaluating Phase 3 (address review findings) of a jira-agent
+      pipeline.
+
+      Below are the pipeline outputs. Focus on "review-findings.txt" for the
+      Phase 2 findings, and "diff.patch" for the final diff after all 3 phases.
+      Compare the findings against the final diff to assess whether the review
+      issues were addressed.
+
+      {{ outputs }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Review findings completely ignored.
+      Score 2: Some findings addressed but most blocking issues remain.
+      Score 3: Most blocking issues addressed, some suggestions skipped.
+      Score 4: All blocking issues and most suggestions addressed.
+      Score 5: All findings fully addressed with high-quality fixes.
+
+  # ── Final-output LLM judges ──
+
+  - name: solution_correctness
+    description: |
+      Does the final output correctly solve the original Jira issue?
+    prompt: |
+      You are evaluating whether a jira-agent pipeline correctly solved a
+      Jira issue.
+
+      Below are the pipeline outputs. Focus on "diff.patch" for the final diff
+      and "files-changed.txt" for the list of modified files. If
+      "known-good.patch" is present, it contains the human-reviewed reference
+      PR diff — compare the agent's solution against it for correctness,
+      completeness, and approach.
+
+      {{ outputs }}
+
+      Expected outcomes from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Does not address the issue at all, or introduces new bugs.
+      Score 2: Partially addresses the issue with significant gaps.
+      Score 3: Addresses the core issue correctly with minor gaps.
+      Score 4: Correctly and completely addresses the issue with good tests.
+      Score 5: Excellent — correct, complete, well-tested, matches or exceeds
+               the known-good PR approach.
+
+  - name: code_quality
+    description: |
+      Overall code quality — idiomatic Go, error handling, test quality.
+    prompt: |
+      You are a senior Go engineer reviewing the final output of a
+      jira-agent pipeline.
+
+      Below are the pipeline outputs. Focus on "diff.patch" for the final
+      diff to review.
+
+      {{ outputs }}
+
+      Evaluate code quality on a 1-5 scale:
+
+      Score 1: Broken code or fundamental Go mistakes.
+      Score 2: Works but has significant issues: no error handling, no tests,
+               non-idiomatic patterns.
+      Score 3: Acceptable — compiles, passes tests, room for improvement.
+      Score 4: Good — idiomatic Go, proper error handling, meaningful tests.
+      Score 5: Excellent — clean, idiomatic, well-tested, proper godoc.
+
+thresholds:
+  has_code_changes:
+    min_pass_rate: 1.0
+  make_verify_passes:
+    min_pass_rate: 1.0
+  make_test_passes:
+    min_pass_rate: 1.0
+  commit_message_format:
+    min_pass_rate: 1.0
+  coverage_meets_threshold:
+    min_pass_rate: 0.8
+  solve_quality:
+    min_mean: 3.0
+  review_thoroughness:
+    min_mean: 3.0
+  fix_completeness:
+    min_mean: 3.0
+  solution_correctness:
+    min_mean: 3.5
+  code_quality:
+    min_mean: 3.5

--- a/plugins/jira/evals/scripts/run-solve-pipeline.sh
+++ b/plugins/jira/evals/scripts/run-solve-pipeline.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+set -euo pipefail
+
+# run-solve-pipeline.sh — eval runner for the jira-agent 3-phase pipeline
+#
+# Runs: solve → code-review → address-review against a snapshot branch.
+# Produces output files for agent-eval-harness judges to evaluate.
+# Does NOT push or create PRs.
+#
+# Usage:
+#   run-solve-pipeline.sh <issue_key> <repo_url> <eval_branch> [model]
+#
+# Env vars:
+#   AI_HELPERS_DIR  — path to ai-helpers checkout (default: auto-detect)
+#   WORK_DIR        — output directory (default: mktemp)
+
+ISSUE_KEY=${1:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+REPO_URL=${2:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+EVAL_BRANCH=${3:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+SKILL_MODEL=${4:-claude-opus-4-6}
+AI_HELPERS_DIR=${AI_HELPERS_DIR:-$(cd "$(dirname "$0")/../../../.." && pwd)}
+WORK_DIR=${WORK_DIR:-$(mktemp -d)}
+
+echo "=== Solve Pipeline Eval: $ISSUE_KEY ==="
+echo "Repo: $REPO_URL"
+echo "Branch: $EVAL_BRANCH"
+echo "Model: $SKILL_MODEL"
+echo "Workdir: $WORK_DIR"
+echo "ai-helpers: $AI_HELPERS_DIR"
+
+# Validate ai-helpers has the required plugins
+if [ ! -f "$AI_HELPERS_DIR/plugins/jira/commands/solve.md" ]; then
+  echo "ERROR: solve.md not found at $AI_HELPERS_DIR/plugins/jira/commands/solve.md"
+  exit 1
+fi
+REVIEW_PLUGIN_DIR="$AI_HELPERS_DIR/plugins/code-review"
+if [ ! -d "$REVIEW_PLUGIN_DIR/.claude-plugin" ]; then
+  echo "ERROR: code-review plugin not found at $REVIEW_PLUGIN_DIR/.claude-plugin"
+  exit 1
+fi
+
+# Helper: extract token/cost JSON from stream-json output
+extract_tokens() {
+  local file=$1
+  grep '"type":"result"' "$file" 2>/dev/null \
+    | head -1 \
+    | jq '{
+        total_cost_usd: (.total_cost_usd // 0),
+        duration_ms: (.duration_ms // 0),
+        num_turns: (.num_turns // 0),
+        input_tokens: (.usage.input_tokens // 0),
+        output_tokens: (.usage.output_tokens // 0),
+        cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+        cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+        model: ((.modelUsage // {} | keys | first) // "unknown")
+      }' 2>/dev/null \
+    || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"model":"unknown"}'
+}
+
+# Helper: extract assistant text from stream-json
+extract_text() {
+  local file=$1
+  jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$file" 2>/dev/null || true
+}
+
+# ── Install tool dependencies ──
+echo ""
+echo "--- Installing dependencies ---"
+GOFLAGS="" go install golang.org/x/tools/gopls@latest 2>&1 | tail -1 || true
+python3 -m pip install --user pre-commit 2>&1 | tail -1 || true
+export PATH="${GOPATH:-$HOME/go}/bin:$HOME/.local/bin:$PATH"
+
+echo "Installing Claude Code plugins..."
+claude plugin marketplace add openshift-eng/ai-helpers 2>/dev/null || true
+claude plugin install utils@ai-helpers 2>/dev/null || true
+claude plugin install golang@ai-helpers 2>/dev/null || true
+claude plugin marketplace add enxebre/ai-scripts 2>/dev/null || true
+claude plugin install git@enxebre 2>/dev/null || true
+
+# ── Setup: clone repo and prepare workspace ──
+echo ""
+echo "--- Setup ---"
+git clone "$REPO_URL" "$WORK_DIR/repo"
+cd "$WORK_DIR/repo"
+git checkout "$EVAL_BRANCH"
+BASE_SHA=$(git rev-parse HEAD)
+
+git config user.name "Eval Runner"
+git config user.email "eval@test.local"
+
+mkdir -p .claude/commands
+cp "$AI_HELPERS_DIR/plugins/jira/commands/solve.md" .claude/commands/jira-solve.md
+
+SKILL_CONTENT=$(cat .claude/commands/jira-solve.md)
+
+# ── Phase 1: Solve ──
+echo ""
+echo "=========================================="
+echo "Phase 1: Solve ($ISSUE_KEY)"
+echo "=========================================="
+
+SOLVE_CONTEXT="IMPORTANT: Do NOT create a Pull Request. Do NOT push to any remote. Just implement the changes, run tests, and commit to the local branch."
+
+PHASE1_START=$(date +%s)
+
+set +e
+claude -p "$ISSUE_KEY origin --ci. $SOLVE_CONTEXT" \
+  --system-prompt "$SKILL_CONTENT" \
+  --allowedTools "Bash Read Write Edit Grep Glob WebFetch" \
+  --max-turns 200 \
+  --effort max \
+  --model "$SKILL_MODEL" \
+  --output-format stream-json \
+  --verbose \
+  2>"$WORK_DIR/phase1-stderr.log" \
+  | tee "$WORK_DIR/phase1-output.json"
+PHASE1_EXIT=$?
+set -e
+
+PHASE1_END=$(date +%s)
+echo "Phase 1 duration: $((PHASE1_END - PHASE1_START))s (exit $PHASE1_EXIT)"
+
+# Capture phase 1 state (committed + uncommitted changes)
+{ git diff "$BASE_SHA"..HEAD 2>/dev/null; git diff HEAD 2>/dev/null; } > "$WORK_DIR/phase1-diff.patch" || true
+{ git diff "$BASE_SHA"..HEAD --stat 2>/dev/null; git diff HEAD --stat 2>/dev/null; } > "$WORK_DIR/phase1-diffstat.txt" || true
+extract_tokens "$WORK_DIR/phase1-output.json" > "$WORK_DIR/phase1-tokens.json"
+extract_text "$WORK_DIR/phase1-output.json" > "$WORK_DIR/phase1-text.txt"
+
+BRANCH=$(git branch --show-current)
+
+CHANGED_FILES=$( { git diff "$BASE_SHA"..HEAD --name-only 2>/dev/null; git diff HEAD --name-only 2>/dev/null; } | sort -u || echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No code changes produced by Phase 1"
+  echo "no_changes" > "$WORK_DIR/phase1-result.txt"
+  # Write empty outputs so judges can still evaluate
+  touch "$WORK_DIR/diff.patch" "$WORK_DIR/files-changed.txt" "$WORK_DIR/commit-log.txt"
+  touch "$WORK_DIR/review-findings.txt" "$WORK_DIR/coverage.txt"
+  echo "1" > "$WORK_DIR/make-test-exit"
+  echo "No code changes — make test not run" > "$WORK_DIR/make-test.log"
+  echo "1" > "$WORK_DIR/make-verify-exit"
+  echo "No code changes — make verify not run" > "$WORK_DIR/make-verify.log"
+  echo '{"total_cost_usd":0}' > "$WORK_DIR/phase2-tokens.json"
+  echo '{"total_cost_usd":0}' > "$WORK_DIR/phase3-tokens.json"
+  jq -s '{total_cost_usd: (map(.total_cost_usd // 0) | add), phases: length}' \
+    "$WORK_DIR"/phase*-tokens.json > "$WORK_DIR/total-cost.json" 2>/dev/null || true
+  echo "=== Pipeline complete (no changes). Outputs in $WORK_DIR ==="
+  exit 0
+fi
+
+echo "Changes on branch '$BRANCH':"
+echo "$CHANGED_FILES" | sed 's/^/  /'
+echo "changes_on_branch=$BRANCH" > "$WORK_DIR/phase1-result.txt"
+
+# ── Phase 2: Code Review ──
+echo ""
+echo "=========================================="
+echo "Phase 2: Code Review"
+echo "=========================================="
+
+PHASE2_START=$(date +%s)
+
+set +e
+claude -p "/code-review:pre-commit-review --language go --profile hypershift" \
+  --plugin-dir "$REVIEW_PLUGIN_DIR" \
+  --allowedTools "Bash Read Grep Glob Task" \
+  --max-turns 75 \
+  --effort max \
+  --model "$SKILL_MODEL" \
+  --output-format stream-json \
+  --verbose \
+  2>"$WORK_DIR/phase2-stderr.log" \
+  | tee "$WORK_DIR/phase2-output.json"
+PHASE2_EXIT=$?
+set -e
+
+PHASE2_END=$(date +%s)
+echo "Phase 2 duration: $((PHASE2_END - PHASE2_START))s (exit $PHASE2_EXIT)"
+
+extract_text "$WORK_DIR/phase2-output.json" > "$WORK_DIR/review-findings.txt"
+extract_tokens "$WORK_DIR/phase2-output.json" > "$WORK_DIR/phase2-tokens.json"
+
+# ── Phase 3: Address Review ──
+echo ""
+echo "=========================================="
+echo "Phase 3: Address Review Findings"
+echo "=========================================="
+
+REVIEW_FINDINGS=$(cat "$WORK_DIR/review-findings.txt" 2>/dev/null || echo "")
+
+PHASE3_START=$(date +%s)
+
+if [ -n "$REVIEW_FINDINGS" ]; then
+  FIX_PROMPT="A code review was performed on the changes in the current branch. Below are the review findings. Address all actions and improvements by editing the code. After making all fixes, commit the changes.
+
+REVIEW FINDINGS:
+${REVIEW_FINDINGS}
+
+IMPORTANT:
+- Fix every issue identified in the review — all actions and improvements.
+- Run 'make test' and 'make verify' after fixes to verify nothing is broken.
+- If 'make verify' generates new files, commit those too and run 'make verify' again.
+- Commit all fixes.
+- Do NOT push to any remote. Do NOT create a Pull Request."
+
+  set +e
+  claude -p "$FIX_PROMPT" \
+    --allowedTools "Bash Read Write Edit Grep Glob" \
+    --max-turns 75 \
+    --effort max \
+    --model "$SKILL_MODEL" \
+    --output-format stream-json \
+    --verbose \
+    2>"$WORK_DIR/phase3-stderr.log" \
+    | tee "$WORK_DIR/phase3-output.json"
+  PHASE3_EXIT=$?
+  set -e
+else
+  echo "No review findings to address, skipping Phase 3"
+  echo '{}' > "$WORK_DIR/phase3-output.json"
+  PHASE3_EXIT=0
+fi
+
+PHASE3_END=$(date +%s)
+echo "Phase 3 duration: $((PHASE3_END - PHASE3_START))s (exit $PHASE3_EXIT)"
+extract_tokens "$WORK_DIR/phase3-output.json" > "$WORK_DIR/phase3-tokens.json"
+
+# ── Capture final outputs ──
+echo ""
+echo "=========================================="
+echo "Final Output Capture"
+echo "=========================================="
+
+# Capture committed + uncommitted changes
+{ git diff "$BASE_SHA"..HEAD 2>/dev/null; git diff HEAD 2>/dev/null; } > "$WORK_DIR/diff.patch"
+{ git diff "$BASE_SHA"..HEAD --name-only 2>/dev/null; git diff HEAD --name-only 2>/dev/null; } | sort -u > "$WORK_DIR/files-changed.txt"
+git log --oneline "$BASE_SHA"..HEAD > "$WORK_DIR/commit-log.txt"
+
+echo "Final diff: $(wc -l < "$WORK_DIR/diff.patch") lines"
+echo "Files changed: $(wc -l < "$WORK_DIR/files-changed.txt")"
+echo "Commits: $(wc -l < "$WORK_DIR/commit-log.txt")"
+
+# Clean up skill workspace artifacts that cause make verify to reject untracked files
+rm -rf .claude/commands/jira-solve.md .work/ 2>/dev/null || true
+rmdir .claude/commands .claude 2>/dev/null || true
+git checkout -- .work/ .claude/ 2>/dev/null || true
+git clean -fd .work/ .claude/ 2>/dev/null || true
+
+# Run make test and make verify independently (not relying on what the agent ran)
+echo ""
+echo "Running make test..."
+set +e
+make test 2>&1 | tee "$WORK_DIR/make-test.log"
+echo $? > "$WORK_DIR/make-test-exit"
+echo "make test exit: $(cat "$WORK_DIR/make-test-exit")"
+
+echo "Running make verify..."
+make verify 2>&1 | tee "$WORK_DIR/make-verify.log"
+echo $? > "$WORK_DIR/make-verify-exit"
+echo "make verify exit: $(cat "$WORK_DIR/make-verify-exit")"
+set -e
+
+# Diff coverage — coverage of changed lines only (requires cov-diff)
+CHANGED_PKGS=$( { git diff "$BASE_SHA"..HEAD --name-only -- '*.go' 2>/dev/null; git diff HEAD --name-only -- '*.go' 2>/dev/null; } \
+  | grep -v '_test.go$' \
+  | xargs -I{} dirname {} 2>/dev/null \
+  | sort -u \
+  | sed 's|^|./|' || echo "")
+if [ -n "$CHANGED_PKGS" ]; then
+  echo "Running diff coverage for changed packages..."
+  set +e
+  go test -coverprofile="$WORK_DIR/cover.out" $CHANGED_PKGS 2>&1 | tee "$WORK_DIR/coverage-raw.txt"
+  if command -v cov-diff >/dev/null 2>&1 && [ -f "$WORK_DIR/cover.out" ]; then
+    git diff "$BASE_SHA"..HEAD > "$WORK_DIR/pr.diff"
+    GO_MODULE=$(grep "^module " go.mod | awk '{print $2}')
+    DIFF_COV=$(cov-diff -coverprofile "$WORK_DIR/cover.out" -diff "$WORK_DIR/pr.diff" -path . -module "$GO_MODULE" 2>/dev/null | sed -n 's/.*: \([0-9]*\)%.*/\1/p' || echo "")
+    if [ -n "$DIFF_COV" ]; then
+      echo "diff-coverage: ${DIFF_COV}% of changed lines covered" > "$WORK_DIR/coverage.txt"
+    else
+      echo "diff-coverage: could not compute" > "$WORK_DIR/coverage.txt"
+      cat "$WORK_DIR/coverage-raw.txt" >> "$WORK_DIR/coverage.txt"
+    fi
+  else
+    cp "$WORK_DIR/coverage-raw.txt" "$WORK_DIR/coverage.txt"
+  fi
+  set -e
+else
+  echo "no go source files changed" > "$WORK_DIR/coverage.txt"
+fi
+
+# Aggregate cost across all phases
+jq -s '{
+  total_cost_usd: (map(.total_cost_usd // 0) | add),
+  total_duration_ms: (map(.duration_ms // 0) | add),
+  total_turns: (map(.num_turns // 0) | add),
+  total_input_tokens: (map(.input_tokens // 0) | add),
+  total_output_tokens: (map(.output_tokens // 0) | add),
+  phases: length
+}' "$WORK_DIR"/phase*-tokens.json > "$WORK_DIR/total-cost.json" 2>/dev/null \
+  || echo '{"total_cost_usd":0,"phases":0}' > "$WORK_DIR/total-cost.json"
+
+# Fetch known-good PR diff for judge comparison (if input.yaml specifies one)
+KNOWN_PR=$(grep 'known_good_pr' "${WORK_DIR}/../input.yaml" 2>/dev/null | sed 's/.*: *//' | tr -d '"' || echo "")
+if [ -n "$KNOWN_PR" ]; then
+  echo "Fetching known-good PR diff: $KNOWN_PR"
+  PR_NUM=$(echo "$KNOWN_PR" | grep -oE '[0-9]+$')
+  PR_REPO=$(echo "$KNOWN_PR" | sed 's|https://github.com/||;s|/pull/.*||')
+  set +e
+  gh pr diff "$PR_NUM" --repo "$PR_REPO" > "$WORK_DIR/known-good.patch" 2>/dev/null
+  set -e
+  if [ -s "$WORK_DIR/known-good.patch" ]; then
+    echo "Known-good PR diff: $(wc -l < "$WORK_DIR/known-good.patch") lines"
+  else
+    echo "Could not fetch known-good PR diff"
+    rm -f "$WORK_DIR/known-good.patch"
+  fi
+fi
+
+# Copy judge-relevant files to output/ (excludes large JSON/log blobs)
+# The eval harness reads output/ for {{ outputs }} in LLM judge prompts.
+JUDGE_DIR="${WORK_DIR}/../output"
+if [ -d "$JUDGE_DIR" ]; then
+  for f in diff.patch phase1-diff.patch phase1-diffstat.txt files-changed.txt \
+           commit-log.txt review-findings.txt coverage.txt phase1-text.txt \
+           make-test-exit make-verify-exit total-cost.json \
+           phase1-tokens.json phase2-tokens.json phase3-tokens.json \
+           known-good.patch; do
+    [ -f "$WORK_DIR/$f" ] && cp "$WORK_DIR/$f" "$JUDGE_DIR/$f"
+  done
+fi
+
+# Remove large files that blow up {{ outputs }} if the _modified collector picks them up
+rm -f "$WORK_DIR"/phase*-output.json
+
+echo ""
+echo "=== Pipeline complete. Outputs in $WORK_DIR ==="
+echo "Cost: $(jq -r '.total_cost_usd' "$WORK_DIR/total-cost.json") USD"

--- a/plugins/jira/evals/scripts/run-solve-pipeline.sh
+++ b/plugins/jira/evals/scripts/run-solve-pipeline.sh
@@ -63,19 +63,11 @@ extract_text() {
   jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$file" 2>/dev/null || true
 }
 
-# ── Install tool dependencies ──
-echo ""
-echo "--- Installing dependencies ---"
-GOFLAGS="" go install golang.org/x/tools/gopls@latest 2>&1 | tail -1 || true
-python3 -m pip install --user pre-commit 2>&1 | tail -1 || true
+# ── Verify tool dependencies ──
 export PATH="${GOPATH:-$HOME/go}/bin:$HOME/.local/bin:$PATH"
-
-echo "Installing Claude Code plugins..."
-claude plugin marketplace add openshift-eng/ai-helpers 2>/dev/null || true
-claude plugin install utils@ai-helpers 2>/dev/null || true
-claude plugin install golang@ai-helpers 2>/dev/null || true
-claude plugin marketplace add enxebre/ai-scripts 2>/dev/null || true
-claude plugin install git@enxebre 2>/dev/null || true
+for cmd in gopls cov-diff; do
+  command -v "$cmd" >/dev/null 2>&1 || echo "WARNING: $cmd not found — install before running eval"
+done
 
 # ── Setup: clone repo and prepare workspace ──
 echo ""


### PR DESCRIPTION
## Summary

- Adds a 3-phase eval pipeline (solve → code-review → address-review) for the `jira:solve` skill
- Includes `run-solve-pipeline.sh` that orchestrates 3 headless Claude phases, runs `make test`/`make verify`, computes diff coverage via `cov-diff`, and fetches known-good PR diffs for grounded comparison
- 10 judges: 5 deterministic (has_code_changes, make_verify, make_test, commit_format, coverage) + 5 LLM (solve_quality, review_thoroughness, fix_completeness, solution_correctness, code_quality)
- Reference case: OCPBUGS-34662 (AWS EBS CSI driver cert management) — validated at 10/10 with opus-4-6

## Test plan

- [x] Run eval against [case-003](https://redhat.atlassian.net/browse/case-003) with `claude-opus-4-6` — 10/10 judges pass
- [x] `make test` passes (exit 0) — validated with Go 1.26
- [x] `make verify` passes (exit 0) — workspace cleanup via `git clean`
- [x] Diff coverage: 44% of changed lines covered (threshold: 40%)
- [x] Known-good PR diff comparison: judges score 4-5/5 when grounded against reference
- [x] LLM judge templates render correctly via `{{ outputs }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/jira:solve-pipeline` command to the Jira plugin for executing a 3-phase evaluation pipeline without creating PRs or pushing code.

* **Chores**
  * Bumped Jira plugin version to 0.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->