### PR TITLE
ci: add stream and version validation to autodl validate.py

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -487,7 +487,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-autodl-json/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-autodl-json/scripts/test_validate.py
@@ -30,6 +30,8 @@ if __name__ == "__main__":
         ("invalid no table_name", f"{TESTDATA}/invalid_no_table_name.json", 1),
         ("invalid non-string values", f"{TESTDATA}/invalid_non_string_values.json", 1),
         ("invalid empty rows", f"{TESTDATA}/invalid_empty_rows.json", 1),
+        ("invalid stream", f"{TESTDATA}/invalid_stream.json", 1),
+        ("invalid version", f"{TESTDATA}/invalid_version.json", 1),
         ("file not found", f"{TESTDATA}/nonexistent.json", 1),
     ]
 

--- a/plugins/ci/skills/payload-autodl-json/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-autodl-json/scripts/test_validate.py
@@ -32,6 +32,8 @@ if __name__ == "__main__":
         ("invalid empty rows", f"{TESTDATA}/invalid_empty_rows.json", 1),
         ("invalid stream", f"{TESTDATA}/invalid_stream.json", 1),
         ("invalid version", f"{TESTDATA}/invalid_version.json", 1),
+        ("empty stream", f"{TESTDATA}/empty_stream.json", 1),
+        ("empty version", f"{TESTDATA}/empty_version.json", 1),
         ("file not found", f"{TESTDATA}/nonexistent.json", 1),
     ]
 

--- a/plugins/ci/skills/payload-autodl-json/scripts/testdata/empty_stream.json
+++ b/plugins/ci/skills/payload-autodl-json/scripts/testdata/empty_stream.json
@@ -1,0 +1,17 @@
+{
+    "table_name": "payload_triage",
+    "schema": {"payload_tag": "string"},
+    "rows": [
+        {
+            "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
+            "version": "4.22",
+            "stream": "",
+            "architecture": "amd64",
+            "phase": "Rejected",
+            "job_name": "some-job",
+            "prow_url": "https://prow.ci.openshift.org/...",
+            "failure_type": "test",
+            "root_cause_summary": "something broke"
+        }
+    ]
+}

--- a/plugins/ci/skills/payload-autodl-json/scripts/testdata/empty_version.json
+++ b/plugins/ci/skills/payload-autodl-json/scripts/testdata/empty_version.json
@@ -1,0 +1,17 @@
+{
+    "table_name": "payload_triage",
+    "schema": {"payload_tag": "string"},
+    "rows": [
+        {
+            "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
+            "version": "",
+            "stream": "nightly",
+            "architecture": "amd64",
+            "phase": "Rejected",
+            "job_name": "some-job",
+            "prow_url": "https://prow.ci.openshift.org/...",
+            "failure_type": "test",
+            "root_cause_summary": "something broke"
+        }
+    ]
+}

--- a/plugins/ci/skills/payload-autodl-json/scripts/testdata/invalid_stream.json
+++ b/plugins/ci/skills/payload-autodl-json/scripts/testdata/invalid_stream.json
@@ -1,0 +1,17 @@
+{
+    "table_name": "payload_triage",
+    "schema": {"payload_tag": "string"},
+    "rows": [
+        {
+            "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
+            "version": "4.22",
+            "stream": "4.22.0-0.nightly",
+            "architecture": "amd64",
+            "phase": "Rejected",
+            "job_name": "some-job",
+            "prow_url": "https://prow.ci.openshift.org/...",
+            "failure_type": "test",
+            "root_cause_summary": "something broke"
+        }
+    ]
+}

--- a/plugins/ci/skills/payload-autodl-json/scripts/testdata/invalid_version.json
+++ b/plugins/ci/skills/payload-autodl-json/scripts/testdata/invalid_version.json
@@ -1,0 +1,17 @@
+{
+    "table_name": "payload_triage",
+    "schema": {"payload_tag": "string"},
+    "rows": [
+        {
+            "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
+            "version": "4.22.0-0.nightly-2026-05-14-204304",
+            "stream": "nightly",
+            "architecture": "amd64",
+            "phase": "Rejected",
+            "job_name": "some-job",
+            "prow_url": "https://prow.ci.openshift.org/...",
+            "failure_type": "test",
+            "root_cause_summary": "something broke"
+        }
+    ]
+}

--- a/plugins/ci/skills/payload-autodl-json/scripts/validate.py
+++ b/plugins/ci/skills/payload-autodl-json/scripts/validate.py
@@ -2,12 +2,16 @@
 """Validate a payload-analysis autodl JSON file against the canonical schema."""
 
 import json
+import re
 import sys
 
 REQUIRED_ROW_FIELDS = [
     "payload_tag", "version", "stream", "architecture", "phase",
     "job_name", "prow_url", "failure_type", "root_cause_summary",
 ]
+
+VALID_STREAMS = {"ci", "nightly"}
+VERSION_RE = re.compile(r"^\d+\.\d+$")
 
 
 def validate(path):
@@ -49,6 +53,12 @@ def validate(path):
             non_string = [k for k, v in row.items() if not isinstance(v, str)]
             if non_string:
                 errors.append(f"rows[{i}] has non-string values: {', '.join(non_string)}")
+            stream = row.get("stream", "")
+            if stream and stream not in VALID_STREAMS:
+                errors.append(f"rows[{i}] invalid stream '{stream}' (must be 'ci' or 'nightly')")
+            version = row.get("version", "")
+            if version and not VERSION_RE.match(version):
+                errors.append(f"rows[{i}] invalid version '{version}' (must be 'X.Y')")
 
     if errors:
         print(f"FAIL: {len(errors)} error(s)")

--- a/plugins/ci/skills/payload-autodl-json/scripts/validate.py
+++ b/plugins/ci/skills/payload-autodl-json/scripts/validate.py
@@ -53,11 +53,11 @@ def validate(path):
             non_string = [k for k, v in row.items() if not isinstance(v, str)]
             if non_string:
                 errors.append(f"rows[{i}] has non-string values: {', '.join(non_string)}")
-            stream = row.get("stream", "")
-            if stream and stream not in VALID_STREAMS:
+            stream = row.get("stream")
+            if isinstance(stream, str) and stream not in VALID_STREAMS:
                 errors.append(f"rows[{i}] invalid stream '{stream}' (must be 'ci' or 'nightly')")
-            version = row.get("version", "")
-            if version and not VERSION_RE.match(version):
+            version = row.get("version")
+            if isinstance(version, str) and not VERSION_RE.fullmatch(version):
                 errors.append(f"rows[{i}] invalid version '{version}' (must be 'X.Y')")
 
     if errors:


### PR DESCRIPTION
## Summary
- Add stream validation: `stream` field must be exactly `"ci"` or `"nightly"`, rejecting full release stream names like `"4.19.0-0.nightly"`
- Add version validation: `version` field must match `X.Y` pattern (e.g. `"4.22"`, `"5.0"`), rejecting full version strings like `"5.0.0"` or `"4.16.0-0.nightly-2026-05-14-204304"`
- Add test data files and test cases for both new validations
- Bump ci plugin version to 0.0.51

## Test plan
- [x] All 8 existing + new tests pass (`python3 test_validate.py` -> 8/8 passed)
- [x] `make lint` passes with A+ grade
- [x] `make update` syncs marketplace.json correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened payload validation: `stream` is now limited to specific allowed values, and `version` must match an `X.Y` numeric format.

* **Tests**
  * Added new fixtures and negative test cases covering invalid and empty `stream`/`version` inputs, ensuring validation fails as expected.

* **Chores**
  * Bumped the `ci` plugin version to **0.0.51** across published metadata and marketplace listings (including the main docs page).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->