### PR TITLE
feat(ci): add openshift-ci-mcp MCP server to new ci-extras plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -60,6 +60,21 @@
       ]
     },
     {
+      "name": "ci-extras",
+      "source": "./plugins/ci-extras",
+      "description": "MCP server and extended tooling for OpenShift CI data access",
+      "version": "0.0.1",
+      "category": "ci",
+      "keywords": [
+        "openshift-ci",
+        "mcp",
+        "ci",
+        "sippy",
+        "prow",
+        "test-failures"
+      ]
+    },
+    {
       "name": "teams",
       "source": "./plugins/teams",
       "description": "Team structure knowledge and health analysis commands for OpenShift teams",

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -26,6 +26,7 @@ rules:
     allowlist:
       - gopls
       - atlassian
+      - openshift-ci-mcp
 
   # Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) must be valid, non-empty with valid references
   instruction-file-valid:
@@ -56,7 +57,7 @@ rules:
   context-budget:
     enabled: false
   # Detect critical instructions in the middle of files where LLM attention is lowest
-  content-critical-position:  # unsure if actually useful here
+  content-critical-position: # unsure if actually useful here
     enabled: false
 
   # Detect potential API keys, tokens, and passwords in instruction files
@@ -71,7 +72,7 @@ rules:
 
   # Detect prohibitions without a positive alternative (agent has no path forward)
   content-negative-only:
-    enabled: false  # TODO: enable
+    enabled: false # TODO: enable
 
   # Detect bare path-like strings not wrapped in markdown link syntax
   content-unlinked-internal-reference:
@@ -108,7 +109,6 @@ rules:
     enabled: true
     severity: error
 
-
 # Load custom rules from these files
 custom-rules:
   - ".skillsaw/plugindocs_rule.py"
@@ -119,10 +119,10 @@ custom-rules:
 # Exclude patterns (glob format)
 # Use exclude: [] to disable all excludes including defaults
 exclude:
-    - "node_modules/**"
-    - "**/template/**"
-    - "**/templates/**"
-    - "**/_template/**"
+  - "node_modules/**"
+  - "**/template/**"
+  - "**/templates/**"
+  - "**/_template/**"
 
 # Additional markdown files to run content rules on (glob format)
 content-paths: []

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -6,6 +6,7 @@ This document lists all available Claude Code plugins and their commands in the 
 - [Operator Dashboard](#operator-dashboard-plugin)
 - [Bigquery](#bigquery-plugin)
 - [Ci](#ci-plugin)
+- [Ci Extras](#ci-extras-plugin)
 - [Code Review](#code-review-plugin)
 - [Compliance](#compliance-plugin)
 - [Etcd](#etcd-plugin)
@@ -86,6 +87,15 @@ Tools for working with OpenShift CI and analyzing Prow job results
 - **`/ci:trigger-presubmit` `<job-name> <org> <repo> <base-ref> <base-sha> <pr-number> <pr-sha> [ENV_VAR=value ...]`** - Trigger a presubmit gangway job (typically use GitHub Prow commands instead)
 
 See [plugins/ci/README.md](plugins/ci/README.md) for detailed documentation.
+
+### Ci Extras Plugin
+
+MCP server and extended tooling for OpenShift CI data access. Bundles the [openshift-ci-mcp](https://github.com/openshift-eng/openshift-ci-mcp) server, exposing 19 tools covering releases, payloads, jobs, tests, PRs, and CI log search.
+
+**Commands:**
+- **`/ci-extras:check-release-health` `<release version>`** - Summarize the CI health of an OpenShift release using live data from the openshift-ci-mcp server (example command)
+
+See [plugins/ci-extras/README.md](plugins/ci-extras/README.md) for detailed documentation.
 
 ### Code Review Plugin
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -912,6 +912,46 @@ footer a { color: var(--primary); }
       }
     },
     {
+      "name": "ci-extras",
+      "description": "MCP server and extended tooling for OpenShift CI data access",
+      "version": "0.0.1",
+      "has_readme": true,
+      "commands": [
+        {
+          "name": "check-release-health",
+          "full_name": "ci-extras:check-release-health",
+          "description": "Summarize the CI health of an OpenShift release using live data from the openshift-ci-mcp server",
+          "description_html": "Summarize the CI health of an OpenShift release using live data from the openshift-ci-mcp server",
+          "synopsis": "/ci-extras:check-release-health \u003crelease version\u003e",
+          "body_html": "\u003cp\u003eFetches live CI health data for a given OpenShift release and produces a concise summary covering payload acceptance, test regressions, and recent failures.\u003c/p\u003e\u003cp\u003eUseful for a quick read on overall release quality before a payload promotion decision or during a release readiness review.\u003c/p\u003e"
+        }
+      ],
+      "skills": [],
+      "agents": [],
+      "hooks": [],
+      "mcp_servers": [
+        {
+          "name": "openshift-ci-mcp",
+          "type": "stdio",
+          "endpoint": "go",
+          "source": ".mcp.json"
+        }
+      ],
+      "rules": [],
+      "category": "ci",
+      "keywords": [
+        "openshift-ci",
+        "mcp",
+        "ci",
+        "sippy",
+        "prow",
+        "test-failures"
+      ],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
+    },
+    {
       "name": "code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
       "version": "0.0.10",

--- a/plugins/ci-extras/.claude-plugin/plugin.json
+++ b/plugins/ci-extras/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ci-extras",
+  "description": "MCP server and extended tooling for OpenShift CI data access",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/ci-extras/.mcp.json
+++ b/plugins/ci-extras/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "openshift-ci-mcp": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/openshift-eng/openshift-ci-mcp/cmd/openshift-ci-mcp@latest"
+      ]
+    }
+  }
+}

--- a/plugins/ci-extras/OWNERS
+++ b/plugins/ci-extras/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- ai-helpers-admins
+- jogeo
+- kasturinarra
+- petr-muller
+- smg247
+reviewers:
+- ai-helpers-admins
+- jogeo
+- kasturinarra
+- petr-muller
+- smg247

--- a/plugins/ci-extras/README.md
+++ b/plugins/ci-extras/README.md
@@ -1,0 +1,75 @@
+# CI Extras Plugin
+
+Extended OpenShift CI tooling, providing an MCP server for direct access to CI data APIs.
+
+## Commands
+
+### check-release-health
+
+> **Example command** — demonstrates how to use the bundled openshift-ci-mcp server tools directly from a plugin command.
+
+Fetches live CI health data for a given OpenShift release and produces a concise summary covering payload acceptance, test regressions, and recent failures.
+
+**Usage:**
+```bash
+/ci-extras:check-release-health <release version>
+```
+
+**Example:**
+```bash
+/ci-extras:check-release-health 4.18
+```
+
+**What it does:**
+- Fetches overall release health metrics and pass rate trends
+- Checks recent payload acceptance status
+- Summarizes active regressions
+- Highlights notable recent test failures
+
+**Prerequisites:** Requires the openshift-ci-mcp server (bundled with this plugin).
+
+## MCP Server
+
+This plugin bundles the [openshift-ci-mcp](https://github.com/openshift-eng/openshift-ci-mcp) server, which exposes OpenShift CI data directly as tools.
+
+**Prerequisites:** Go toolchain (`go` must be on your `PATH`). The server is fetched and compiled on first use.
+
+**Tools enabled by default:**
+
+| Group | Tool | Description |
+|-------|------|-------------|
+| core | `get_releases` | OpenShift releases with availability and dev cycle dates |
+| core | `get_release_health` | Health data for a release: success rates, variant summary, payload acceptance |
+| core | `get_variants` | Variants and their possible values (arch, topology, platform, network) |
+| core | `get_tool_fields` | Discover field names returned by a tool |
+| payload | `get_payload_status` | Recent payload acceptance status from the Release Controller |
+| payload | `get_payload_diff` | PR changes between payload tags |
+| payload | `get_payload_test_failures` | Test failures for payload job runs |
+| payload | `get_component_readiness` | Component readiness report for the current dev cycle |
+| payload | `get_regressions` | Tests performing significantly worse than the previous release |
+| payload | `get_regression_detail` | Regression detail with triages and Jiras |
+| jobs | `get_job_report` | Job pass rates with filtering and pagination |
+| jobs | `get_job_runs` | Results, timings, and risk analysis for recent job runs |
+| jobs | `get_job_run_summary` | Test failures and cluster operator status for a single job run |
+| tests | `get_ci_test_report` | Pass/fail/flake rates for tests with optional filtering |
+| tests | `get_test_details` | Pass rates broken down by variant and job |
+| tests | `get_recent_test_failures` | Tests that recently started failing |
+| prs | `get_release_prs` | Pull requests for a specific release or presubmits |
+| prs | `get_pr_impact` | Test failure impact for a specific PR (rate-limited: 20 req/hr) |
+| search | `search_ci_logs` | Search logs and JUnit output across OpenShift CI |
+
+**Proxy tools (disabled by default):**
+
+Raw API passthroughs to Sippy, the Release Controller, and search.ci. Enable with `ENABLE_PROXY_TOOLS=true`:
+
+```bash
+export ENABLE_PROXY_TOOLS=true
+```
+
+> **Note:** Restart the MCP server after setting this variable for the proxy tools to become available.
+
+| Tool | Description |
+|------|-------------|
+| `sippy_api` | Raw passthrough to any Sippy API endpoint |
+| `release_controller_api` | Raw passthrough to the Release Controller API |
+| `search_ci_api` | Raw passthrough to the Search.CI API |

--- a/plugins/ci-extras/commands/check-release-health.md
+++ b/plugins/ci-extras/commands/check-release-health.md
@@ -1,0 +1,37 @@
+---
+description: Summarize the CI health of an OpenShift release using live data from the openshift-ci-mcp server
+argument-hint: <release version>
+allowed-tools:
+  - mcp__plugin_ci-extras_openshift-ci-mcp__get_release_health
+  - mcp__plugin_ci-extras_openshift-ci-mcp__get_payload_status
+  - mcp__plugin_ci-extras_openshift-ci-mcp__get_recent_test_failures
+  - mcp__plugin_ci-extras_openshift-ci-mcp__get_regressions
+---
+
+## Name
+
+ci-extras:check-release-health
+
+## Synopsis
+
+```bash
+/ci-extras:check-release-health <release version>
+```
+
+## Description
+
+Fetches live CI health data for a given OpenShift release and produces a concise summary covering payload acceptance, test regressions, and recent failures.
+
+Useful for a quick read on overall release quality before a payload promotion decision or during a release readiness review.
+
+## Implementation
+
+1. Retrieve release health metrics with `get_release_health` for the specified version.
+2. Obtain payload acceptance status with `get_payload_status` and gather recent test failures via `get_recent_test_failures`.
+3. Collect active regressions with `get_regressions`.
+4. Synthesize the data into a brief health summary covering:
+   - Overall pass rate trend
+   - Payload acceptance rate and last accepted payload
+   - Count and severity of active regressions
+   - Notable recent test failures
+5. Highlight any signals that warrant immediate investigation.


### PR DESCRIPTION
## Summary

- Bundles the [openshift-ci-mcp](https://github.com/openshift-eng/openshift-ci-mcp) server with the ci plugin via `.mcp.json`
- Exposes 19 tools covering releases, payloads, jobs, tests, PRs, and CI log search — all enabled by default
- Proxy tools (`sippy_api`, `release_controller_api`, `search_ci_api`) are opt-in via `ENABLE_PROXY_TOOLS=true`
- Documents the MCP server, its tool inventory, and the proxy opt-in in the plugin README

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "CI Extras" plugin with the `check-release-health` command for monitoring OpenShift CI release health metrics, including payload acceptance, test failures, and regression status.

* **Documentation**
  * Added plugin documentation, command usage guides, and tools reference for the new CI Extras plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->