### PR TITLE
Fix address-reviews duplicate detection and add real-data evals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -435,7 +435,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2308,7 +2308,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/annotations.yaml
@@ -1,0 +1,6 @@
+expected_should_reply: false
+expected_should_change_code: false
+notes: >
+  Both github-actions and hypershift-jira-solve-ci are bot accounts that already
+  replied. The thread does NOT need another reply since the suggestion has already
+  been addressed by two separate bot replies.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/input.yaml
@@ -1,0 +1,18 @@
+prompt: |
+  Using the address-reviews skill, analyze this review thread from PR #8535 and determine if it needs a reply. The thread has these comments in order:
+
+  Thread ID: PRRT_kwDOE7ekcc6GaP_v
+  Resolved: false, Outdated: true
+
+  Comment 1 (2026-06-02T11:36:47Z) by bryan-cox:
+    "[suggestion] Recursive scan fragility. The recursive descent into subdirectories relies on isCRDYAML() content-based filtering to skip non-CRD files."
+
+  Comment 2 (2026-06-02T11:50:11Z) by github-actions:
+    "Done. Added a doc comment on checkCRDsInDir documenting that non-CRD YAML files are filtered out via isCRDYAML content check.
+    ---
+    *AI-assisted response via Claude Code*"
+
+  Comment 3 (2026-06-02T14:14:15Z) by hypershift-jira-solve-ci:
+    "Done. Added a doc comment on checkCRDsInDir documenting that non-CRD YAML files are filtered via isCRDYAML content-based detection."
+
+  Should you post another reply to this thread? Explain your reasoning about each commenter's identity.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-001-duplicate-bot-reply/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "SUGGESTION",
+  "should_reply": false,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": true,
+  "priority_order": null,
+  "reply_draft": null,
+  "rationale": "No reply needed. The thread already has two responses acknowledging the suggestion. Comment 1 is by bryan-cox (the human reviewer who raised the suggestion). Comment 2 is by github-actions — a bot account that posted an AI-assisted 'Done' reply. Comment 3 is by hypershift-jira-solve-ci — another bot/CI account that posted a near-identical AI-assisted 'Done' reply. Both bot responses already confirmed the suggestion was addressed (doc comment added to checkCRDsInDir). Posting a third reply would be redundant and spammy. The thread is also marked as outdated, meaning the underlying code has changed since the suggestion was made. There is nothing unresolved that requires further human engagement."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/annotations.yaml
@@ -1,0 +1,6 @@
+expected_should_reply: false
+expected_should_change_code: false
+notes: >
+  Severe duplication problem — the thread was already addressed by the first
+  reply but kept getting re-processed. 28 bot replies on a single suggestion.
+  Thread is resolved. No further reply needed.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/input.yaml
@@ -1,0 +1,14 @@
+prompt: |
+  Using the address-reviews skill, analyze this review thread timeline from PR #8535. The first 5 of 28 comments are shown:
+
+  Thread ID: PRRT_kwDOE7ekcc6GaQAO
+  Resolved: true, Outdated: true
+
+  [2026-06-02T11:36:47Z] bryan-cox: "[suggestion] Recursive scan fragility..."
+  [2026-06-02T11:50:11Z] github-actions: "Done. Added a doc comment on checkCRDsInDir..."
+  [2026-06-02T14:14:15Z] hypershift-jira-solve-ci: "Done. Added a doc comment on checkCRDsInDir..."
+  [2026-06-02T17:07:22Z] hypershift-jira-solve-ci: "Done. Added a doc comment on checkCRDsInDir..."
+  [2026-06-02T20:07:16Z] hypershift-jira-solve-ci: "Done. Documented the assumption in the checkCRDsInDir function comment..."
+  ... (23 more identical bot replies follow, posted every ~3 hours through June 18)
+
+  This thread has been resolved. Should you reply? What went wrong here?

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-002-duplicate-extreme/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "SUGGESTION",
+  "should_reply": false,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": true,
+  "priority_order": null,
+  "reply_draft": null,
+  "rationale": "Thread is resolved and outdated. The original suggestion from bryan-cox was addressed by the first bot reply, but hypershift-jira-solve-ci then entered a reply loop, posting 23+ duplicate responses every ~3 hours from June 2 through June 18. This is a bot misconfiguration — likely re-triggering on its own replies or on webhook events without deduplication. No human action is needed: the thread is already resolved, the suggestion was already addressed, and adding another reply would only contribute more noise to an already spammed thread. This thread should be filtered out entirely."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/annotations.yaml
@@ -1,0 +1,7 @@
+expected_category: QUESTION
+expected_should_reply: true
+expected_should_change_code: false
+acceptable_categories: [QUESTION]
+notes: >
+  Interrogative phrasing — "why do we need" and "is this how" are questions,
+  not imperative requests. Should reply with explanation, not code changes.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real comment from PR #8535. State the category name explicitly:
+
+  Author: bryan-cox
+  Comment: "If there is already a library at openshift/crd-schema-checker, why do we need the go files? Is this how that repo says to set it up?"
+  Type: issue_comment (general PR comment)

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-003-categorize-question/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "QUESTION",
+  "should_reply": true,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Good question — the Go files are typically needed because openshift/crd-schema-checker is consumed as a Go module dependency, and the Go files provide the integration point (e.g., test harness or CLI invocation) that wires the checker into this repo's CI or validation workflow. The library provides the checking logic, but you still need local Go code to call it with the correct schema paths and configuration for this project. That said, I'll double-check the crd-schema-checker repo's recommended setup instructions to confirm this follows their documented integration pattern.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The reviewer is asking two clarifying questions: (1) why Go files are needed alongside an existing library, and (2) whether this follows the upstream repo's recommended setup. This is a QUESTION, not a direct change request — the reviewer wants to understand the rationale before deciding if changes are needed. A reply explaining the integration pattern is appropriate. No code changes or pushes are warranted until the reviewer confirms whether the explanation is satisfactory or requests a different approach."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/annotations.yaml
@@ -1,0 +1,7 @@
+expected_category: QUESTION
+expected_should_reply: true
+expected_should_change_code: false
+acceptable_categories: [QUESTION]
+notes: >
+  Design question about architectural choice. "Why do we need" is interrogative,
+  not imperative. Should reply with explanation, not make code changes.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real comment from PR #8535. State the category name explicitly:
+
+  Author: bryan-cox
+  Comment: "Why do we need our own main.go. Why are we not just calling the cli from https://github.com/kubernetes-sigs/crdify?"
+  Type: issue_comment (general PR comment)

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-004-categorize-question-2/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "QUESTION",
+  "should_reply": true,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": null,
+  "rationale": "The comment is phrased as two questions asking for justification of a design decision: why a custom main.go exists instead of calling the CLI from the upstream kubernetes-sigs/crdify package. While there is an implicit suggestion that the upstream CLI should be used instead, the primary form is a QUESTION seeking rationale. No reply draft is provided because answering requires knowledge of the specific technical reasons the PR author chose to create a custom main.go (e.g., custom flags, additional logic, embedding in a larger tool), which is not available from this comment alone. The PR author or someone with context on the implementation should respond."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/annotations.yaml
@@ -1,0 +1,8 @@
+expected_category: CHANGE_REQUEST
+expected_should_reply: true
+expected_should_change_code: true
+acceptable_categories: [CHANGE_REQUEST, BLOCKING, SUGGESTION]
+notes: >
+  Reviewer indicates a policy that may require updating code behavior.
+  The reviewer is saying a check should be disabled, implying a code change.
+  CHANGE_REQUEST, BLOCKING, or SUGGESTION are all acceptable.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/input.yaml
@@ -1,0 +1,7 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real review comment from PR #8535. State the category name explicitly:
+
+  Author: JoelSpeed
+  Comment: "We disabled this check in o/api as while it is technically breaking, we allow it in most instances"
+  Type: review_thread (inline code comment)
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-005-categorize-change-request/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Disabled this check to align with o/api. Since it's technically breaking but allowed in most instances, keeping it enabled here would create unnecessary friction.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The reviewer (JoelSpeed) is pointing out that this same check was intentionally disabled in openshift/api because, while technically a breaking change, it is accepted in most cases. This is an implicit CHANGE_REQUEST — the reviewer is signaling that this check should be disabled here as well to stay consistent with the upstream policy. It requires a code change (disabling the check) and a reply acknowledging alignment with the o/api decision."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/annotations.yaml
@@ -1,0 +1,7 @@
+expected_category: CHANGE_REQUEST
+expected_should_reply: true
+expected_should_change_code: true
+acceptable_categories: [CHANGE_REQUEST, BLOCKING]
+notes: >
+  Dead code where tests validate a path that never runs is a correctness
+  issue requiring a code change. Either CHANGE_REQUEST or BLOCKING is acceptable.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/input.yaml
@@ -1,0 +1,7 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real review comment from PR #8535. State the category name explicitly:
+
+  Author: jparrill
+  Comment: "compareCRDs() exists at the bottom of this file as a testable wrapper around crdifyRunner.Run(), but this line calls the runner directly — so compareCRDs() is never executed in production. The tests for compareCRDs validate a code path that never runs. Either call compareCRDs(oldCRD, newCRD, crdifyRunner) here instead, or remove compareCRDs() and adjust the tests to call crdifyRunner.Run() directly."
+  Type: review_thread (inline code comment)
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-006-categorize-dead-code/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Updated to call `compareCRDs(oldCRD, newCRD, crdifyRunner)` instead of calling `crdifyRunner.Run()` directly. This ensures the production code path matches what the tests validate, eliminating the dead-code gap.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "This is a CHANGE_REQUEST: the reviewer identified a concrete bug where compareCRDs() is defined and tested but never called in production — the main code calls crdifyRunner.Run() directly, making the tests validate a code path that never executes. The reviewer gives two explicit fix options (call compareCRDs or remove it). This requires a code change and a reply acknowledging the fix."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/annotations.yaml
@@ -1,0 +1,8 @@
+expected_category: SUGGESTION
+expected_should_reply: true
+expected_should_change_code: true
+acceptable_categories: [CHANGE_REQUEST, SUGGESTION]
+notes: >
+  Concrete code improvement request with a proposed fix. Either
+  CHANGE_REQUEST or SUGGESTION is acceptable since it includes
+  both the problem and the specific fix.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/input.yaml
@@ -1,0 +1,7 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real review comment from PR #8535. State the category name explicitly:
+
+  Author: coderabbitai
+  Comment: "Move process success output off stdout. Line 104 prints to stdout from main.go; this should not emit non-JSON process output. Proposed fix: fmt.Fprintf(os.Stderr, ...) instead of fmt.Printf(...)"
+  Type: review_thread (inline code comment)
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-007-categorize-suggestion/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Switched `fmt.Printf` to `fmt.Fprintf(os.Stderr, ...)` at line 104 in `hack/tools/crd-schema-check/main.go`. Process success output should go to stderr to keep stdout clean for JSON output.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "This is a CHANGE_REQUEST: coderabbitai identifies a concrete problem (non-JSON output on stdout) and proposes a specific code fix (use fmt.Fprintf(os.Stderr, ...) instead of fmt.Printf). It is actionable, has a clear proposed fix, and represents a legitimate correctness concern about stdout cleanliness. Not filtered because the review raises a valid issue worth addressing."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/annotations.yaml
@@ -1,0 +1,7 @@
+expected_category: ACTION_INSTRUCTION
+expected_should_reply: true
+expected_should_change_code: false
+acceptable_categories: [ACTION_INSTRUCTION]
+notes: >
+  "The PR description needs updated" is a repo-level operation on the
+  PR itself, not a code change. ACTION_INSTRUCTION is the only correct category.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill categories (ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION), categorize this real comment from PR #8535. State the category name explicitly:
+
+  Author: bryan-cox
+  Comment: "The PR description needs updated"
+  Type: issue_comment (general PR comment)

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-008-categorize-action-instruction/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "ACTION_INSTRUCTION",
+  "should_reply": true,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Updated the PR description. This was a direct request from the reviewer to improve the PR metadata.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The comment is a direct instruction to update the PR description text, not a code change request. Categorized as ACTION_INSTRUCTION because the reviewer is telling the author what to do ('needs updated'). No code changes or pushes are needed since this concerns PR metadata only. A reply is appropriate to acknowledge the instruction."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/annotations.yaml
@@ -1,0 +1,9 @@
+expected_priority_order: [A, B, C]
+expected_category_a: ACTION_INSTRUCTION
+expected_category_b: CHANGE_REQUEST
+expected_category_c: QUESTION
+notes: >
+  Comment A (update PR description) is prioritized first as ACTION_INSTRUCTION.
+  Comment B (dead code fix) is prioritized second as CHANGE_REQUEST or BLOCKING.
+  Comment C (architecture question) is prioritized last as QUESTION.
+  Key check is the ordering: A first, B second, C last.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/input.yaml
@@ -1,0 +1,11 @@
+prompt: |
+  Using the address-reviews skill priority order (ACTION_INSTRUCTION → BLOCKING → CHANGE_REQUEST → QUESTION → SUGGESTION), prioritize these real comments from PR #8535. List them in the order you would address them:
+
+  Comment A (bryan-cox, issue_comment):
+    "The PR description needs updated"
+
+  Comment B (jparrill, review_thread on main.go):
+    "compareCRDs() exists at the bottom of this file as a testable wrapper around crdifyRunner.Run(), but this line calls the runner directly — so compareCRDs() is never executed in production."
+
+  Comment C (bryan-cox, issue_comment):
+    "Why do we need our own main.go. Why are we not just calling the cli from https://github.com/kubernetes-sigs/crdify?"

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-009-prioritize-mixed/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "BLOCKING",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": ["A", "B", "C"],
+  "reply_draft": "Addressing all three comments:\n\n**Comment A (ACTION_INSTRUCTION):** Done. Updated the PR description to accurately reflect the current implementation.\n\n**Comment B (BLOCKING):** Done. Changed the call site to use `compareCRDs()` instead of calling `crdifyRunner.Run()` directly. This ensures the testable wrapper is exercised in production and tests actually cover the real code path.\n\n**Comment C (QUESTION):** We maintain our own `main.go` rather than calling the crdify CLI directly because we need a testable wrapper (`compareCRDs()`) around the runner and control over how arguments and configuration are passed. Importing the CLI binary would couple us to its argument parsing and wouldn't allow us to intercept or customize the execution flow.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "Comment A is ACTION_INSTRUCTION (author directing a PR description update — highest priority). Comment B is BLOCKING (jparrill identified dead code: compareCRDs() is defined as a testable wrapper but never called in production because the call site invokes crdifyRunner.Run() directly — this means tests don't cover the actual production path, a significant correctness issue). Comment C is QUESTION (bryan-cox asking about the architectural choice of maintaining a custom main.go vs using crdify's CLI). Priority order follows ACTION_INSTRUCTION → BLOCKING → QUESTION."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/annotations.yaml
@@ -1,0 +1,6 @@
+expected_should_filter: false
+expected_should_reply: true
+notes: >
+  coderabbitai comments should be kept and addressed since coderabbit
+  provides code review insights. The comment identifies a real bug
+  (missing continue statement causing fallthrough).

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill filtering rules, should this comment be addressed or filtered out?
+
+  Author: coderabbitai
+  Comment: "Missing continue after 'skipping comparison' log. The code logs 'skipping comparison' but falls through to Compare() on line 175 anyway."
+  Type: review_thread (inline code comment)

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-010-filter-coderabbit-kept/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "BLOCKING",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": ["BLOCKING"],
+  "reply_draft": "Done. Added `continue` after the 'skipping comparison' log to prevent falling through to `Compare()`. The missing control flow would cause comparisons to run on items that should be skipped.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "coderabbitai is explicitly kept per filtering rules (only openshift-ci-robot and openshift-ci are filtered as bots). The comment identifies a genuine bug: a missing 'continue' statement causes code to fall through to Compare() even after logging that the comparison should be skipped. This is a logic error categorized as BLOCKING (bug)."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/annotations.yaml
@@ -1,0 +1,6 @@
+expected_reply_contains: ["Done", "AI-assisted response via Claude Code"]
+expected_reply_max_sentences: 3
+notes: >
+  Reply must start with "Done.", be concise (3 sentences max before
+  signature), mention calling compareCRDs instead of the runner directly,
+  and include the "AI-assisted response via Claude Code" footer.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Following the address-reviews skill reply template ("Done. [1-line what changed]. [Optional 1-line why]" with "---\n*AI-assisted response via Claude Code*" footer), draft the exact reply you would post for this real review comment from PR #8535:
+
+  Author: jparrill
+  Comment: "compareCRDs() exists at the bottom of this file as a testable wrapper around crdifyRunner.Run(), but this line calls the runner directly — so compareCRDs() is never executed in production. Either call compareCRDs(oldCRD, newCRD, crdifyRunner) here instead."
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-011-reply-format/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Replaced direct `crdifyRunner.Run()` call with `compareCRDs(oldCRD, newCRD, crdifyRunner)`. This ensures the testable wrapper is actually exercised in production, not just in tests.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The reviewer identifies dead code: compareCRDs() exists as a testable wrapper but is bypassed in production. This is a clear change request with a specific fix (call the wrapper instead of the runner directly). The change is straightforward and the reviewer's reasoning is sound — if the wrapper is only called in tests, any bug in how it invokes the runner would go undetected in production."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/annotations.yaml
@@ -1,0 +1,6 @@
+expected_should_push: false
+expected_should_change_code: true
+notes: >
+  The response should plan to make the code change and post a reply,
+  but explicitly state it will skip pushing because the instruction
+  says pushing is handled automatically. Tests the CI override behavior.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/input.yaml
@@ -1,0 +1,8 @@
+prompt: |
+  IMPORTANT: Do NOT push changes - pushing will be handled automatically after you finish.
+
+  Using the address-reviews skill, process this real comment from PR #8535. Describe what steps you would take, specifically addressing what happens at the push step:
+
+  Author: jparrill
+  Comment: "compareCRDs() exists at the bottom of this file as a testable wrapper around crdifyRunner.Run(), but this line calls the runner directly — so compareCRDs() is never executed in production."
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-012-ci-push-override/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Done. Changed the direct `crdifyRunner.Run()` call to use `compareCRDs()` instead. The wrapper function was already defined for testability but was being bypassed in the main execution path.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The reviewer identified that compareCRDs() exists as a testable wrapper around crdifyRunner.Run(), but the main code path calls the runner directly, making the wrapper dead code in production. This is a legitimate code defect that should be fixed by routing through the wrapper. Push is set to false because the instructions explicitly state pushing will be handled automatically."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/annotations.yaml
@@ -1,0 +1,7 @@
+expected_category: QUESTION
+expected_should_reply: true
+expected_should_change_code: false
+notes: >
+  This is a directional question about project strategy. The response
+  should plan to reply with an explanation or ask for user guidance,
+  and would NOT immediately make code changes.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill response rules (questions get explanations, only imperative requests get code changes), what action would you take for this real comment from PR #8535? State clearly whether you would make code changes or only reply:
+
+  Author: JoelSpeed
+  Comment: "We are moving away from crd-schema-checker towards the upstream crdify project, and in fact, in o/api we have disabled the majority of checks in crd-schema-checker because they are implemented in crdify already. Could you weigh in on whether to switch this PR to crdify?"
+  Type: issue_comment (general PR comment)

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-013-response-question-no-change/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "QUESTION",
+  "should_reply": true,
+  "should_change_code": false,
+  "should_push": false,
+  "should_filter": false,
+  "priority_order": null,
+  "reply_draft": "Thanks for the heads-up on the migration to crdify. Since o/api has already disabled most crd-schema-checker checks in favor of crdify, it makes sense to align this PR with that direction. I'm happy to switch this PR over to use crdify instead — could you point me to any examples or documentation for integrating crdify in a similar context so I can make the transition smoothly?\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "JoelSpeed is asking for the author's opinion ('Could you weigh in on whether to switch this PR to crdify?') — this is a question seeking input, not an imperative instruction to change code. Per address-reviews rules, questions receive explanations and discussion, not code changes. The reply acknowledges the migration direction, expresses willingness to switch, and asks for guidance to move forward. No code changes should be made until the direction is confirmed and specifics are provided."
+}

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/annotations.yaml
@@ -1,0 +1,6 @@
+expected_category: CHANGE_REQUEST
+expected_should_reply: true
+expected_should_change_code: true
+notes: >
+  The reviewer gave a direct imperative instruction with specific
+  alternatives to implement. This requires a code change, not just a reply.

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/input.yaml
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/input.yaml
@@ -1,0 +1,6 @@
+prompt: |
+  Using the address-reviews skill response rules, would you make a code change or only reply for this real comment? State clearly:
+
+  Author: jparrill
+  Comment: "Either call compareCRDs(oldCRD, newCRD, crdifyRunner) here instead, or remove compareCRDs() and adjust the tests to call crdifyRunner.Run() directly."
+  File: hack/tools/crd-schema-check/main.go

--- a/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/reference-analysis.json
+++ b/plugins/openshift-developer/evals/cases/address-reviews/case-014-response-imperative-change/reference-analysis.json
@@ -1,0 +1,10 @@
+{
+  "category": "CHANGE_REQUEST",
+  "should_reply": true,
+  "should_change_code": true,
+  "should_push": true,
+  "should_filter": false,
+  "priority_order": ["CHANGE_REQUEST"],
+  "reply_draft": "Done. Called `compareCRDs(oldCRD, newCRD, crdifyRunner)` directly at the call site instead of inlining the logic. Keeps the helper reusable for tests.\n\n---\n*AI-assisted response via Claude Code*",
+  "rationale": "The reviewer uses imperative language ('call...instead', 'remove', 'adjust') presenting two concrete alternatives for restructuring the code. Per response rules, imperative directives like 'call', 'remove', and 'adjust' qualify as explicit change requests requiring code modification, not just a reply. The reply draft assumes the first option (calling compareCRDs directly) as it avoids removing the function and rewriting tests, but the actual choice should be validated against the code context."
+}

--- a/plugins/openshift-developer/evals/eval-address-reviews.yaml
+++ b/plugins/openshift-developer/evals/eval-address-reviews.yaml
@@ -1,0 +1,349 @@
+name: address-reviews-eval
+description: Evaluate the address-reviews skill's ability to categorize PR review comments, prevent duplicate replies, prioritize by type, and format responses correctly
+skill: openshift-developer:address-review-pr
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+  timeout: 120
+  max_budget_usd: 1.00
+
+runner:
+  type: claude-code
+  plugin_dirs:
+    - plugins/openshift-developer
+  system_prompt: |
+    Analyze the PR review comment(s) provided and write your analysis to a file
+    called analysis.json in the current working directory. The file must contain
+    valid JSON with exactly these fields:
+    - category: string — one of ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION, or null if not applicable
+    - should_reply: boolean — whether a new reply should be posted
+    - should_change_code: boolean — whether code changes are needed
+    - should_push: boolean — whether changes should be pushed (false if CI override)
+    - should_filter: boolean — whether the comment should be filtered out
+    - priority_order: array of strings or null — ordered list if prioritizing multiple comments
+    - reply_draft: string or null — the draft reply if should_reply is true
+    - rationale: string — brief explanation of the decision
+    Do not wrap the JSON in markdown code fences in the file.
+
+models:
+  judge: claude-opus-4-6
+
+permissions:
+  allow:
+    - "Read"
+    - "Write"
+    - "Skill"
+    - "Bash"
+  deny:
+    - "Agent"
+    - "mcp__*"
+
+mlflow:
+  experiment: address-reviews-eval
+
+dataset:
+  path: cases/address-reviews
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+      - 'prompt' — the full prompt text for the skill
+    - annotations.yaml: Expected results and metadata:
+      - 'expected_category': one of ACTION_INSTRUCTION, BLOCKING, CHANGE_REQUEST, QUESTION, SUGGESTION (optional)
+      - 'expected_should_reply': boolean (optional)
+      - 'expected_should_change_code': boolean (optional)
+      - 'expected_should_push': boolean (optional)
+      - 'expected_should_filter': boolean (optional)
+      - 'expected_priority_order': list of comment labels in expected order (optional)
+      - 'expected_starts_with': expected reply prefix (optional)
+      - 'expected_contains_footer': boolean (optional)
+      - 'expected_footer_text': expected footer string (optional)
+      - 'acceptable_categories': list of acceptable category values (optional)
+      - 'notes': free text explaining the expected behavior
+    - reference-analysis.json: Gold reference output from the initial run.
+      Used as baseline for regression detection via --baseline flag.
+      Contains the same fields as analysis.json.
+
+outputs:
+  - path: "analysis.json"
+    schema: |
+      JSON object with fields:
+      - category: string or null
+      - should_reply: boolean
+      - should_change_code: boolean
+      - should_push: boolean
+      - should_filter: boolean
+      - priority_order: array or null
+      - reply_draft: string or null
+      - rationale: string
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: valid_output_json
+    description: Verify output is valid JSON with all required fields
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Invalid JSON: {e}")
+      required = ["category", "should_reply", "should_change_code", "should_push", "should_filter", "rationale"]
+      missing = [f for f in required if f not in data]
+      if missing:
+          return (False, f"Missing fields: {', '.join(missing)}")
+      return (True, "Valid JSON with all required fields")
+
+  - name: category_correct
+    description: Verify predicted category matches expected value or an acceptable alternative
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_category" not in ann:
+          return (True, "No expected_category in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("category", "")
+      expected = ann.get("expected_category", "")
+      acceptable = ann.get("acceptable_categories", [expected])
+      if predicted in acceptable:
+          match = "exact" if predicted == expected else "acceptable"
+          return (True, f"{match}: predicted={predicted}, expected={expected}")
+      return (False, f"predicted={predicted}, expected={expected}, acceptable={acceptable}")
+
+  - name: should_reply_correct
+    description: Verify should_reply decision matches expected value
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_should_reply" not in ann:
+          return (True, "No expected_should_reply in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("should_reply")
+      expected = ann.get("expected_should_reply")
+      if predicted == expected:
+          return (True, f"should_reply={predicted} matches expected")
+      return (False, f"should_reply={predicted}, expected={expected}")
+
+  - name: should_change_code_correct
+    description: Verify should_change_code decision matches expected value
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_should_change_code" not in ann:
+          return (True, "No expected_should_change_code in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("should_change_code")
+      expected = ann.get("expected_should_change_code")
+      if predicted == expected:
+          return (True, f"should_change_code={predicted} matches expected")
+      return (False, f"should_change_code={predicted}, expected={expected}")
+
+  - name: should_push_correct
+    description: Verify should_push respects CI override instructions
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_should_push" not in ann:
+          return (True, "No expected_should_push in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("should_push")
+      expected = ann.get("expected_should_push")
+      if predicted == expected:
+          return (True, f"should_push={predicted} matches expected")
+      return (False, f"should_push={predicted}, expected={expected}")
+
+  - name: should_filter_correct
+    description: Verify should_filter decision matches expected value
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_should_filter" not in ann:
+          return (True, "No expected_should_filter in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("should_filter")
+      expected = ann.get("expected_should_filter")
+      if predicted == expected:
+          return (True, f"should_filter={predicted} matches expected")
+      return (False, f"should_filter={predicted}, expected={expected}")
+
+  - name: priority_order_correct
+    description: Verify priority_order matches expected ordering
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      if "expected_priority_order" not in ann:
+          return (True, "No expected_priority_order in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      predicted = data.get("priority_order")
+      expected = ann.get("expected_priority_order")
+      if predicted == expected:
+          return (True, f"priority_order={predicted} matches expected")
+      return (False, f"priority_order={predicted}, expected={expected}")
+
+  - name: reply_format_correct
+    description: Verify reply draft matches expected format constraints
+    check: |
+      import json
+      ann = outputs.get("annotations", {})
+      has_checks = ("expected_reply_contains" in ann
+          or "expected_reply_max_sentences" in ann
+          or "expected_starts_with" in ann
+          or "expected_contains_footer" in ann)
+      if not has_checks:
+          return (True, "No reply format expectations in annotations — skipped")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("analysis.json")}
+      if not json_files:
+          return (False, "No analysis.json found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Cannot parse JSON: {e}")
+      reply = data.get("reply_draft", "")
+      if not reply:
+          return (False, "No reply_draft in output")
+      errors = []
+      contains = ann.get("expected_reply_contains", [])
+      for token in contains:
+          if token not in reply:
+              errors.append(f"Reply missing required text '{token}'")
+      starts = ann.get("expected_starts_with")
+      if starts and not reply.startswith(starts):
+          errors.append(f"Reply does not start with '{starts}'")
+      footer = ann.get("expected_footer_text")
+      if ann.get("expected_contains_footer") and footer and footer not in reply:
+          errors.append(f"Reply missing footer '{footer}'")
+      max_sent = ann.get("expected_reply_max_sentences")
+      if isinstance(max_sent, int):
+          main = reply.split("---", 1)[0]
+          sentence_count = sum(main.count(ch) for ch in ".!?")
+          if sentence_count > max_sent:
+              errors.append(f"Reply has {sentence_count} sentences; max is {max_sent}")
+      if errors:
+          return (False, "; ".join(errors))
+      return (True, "Reply format matches expectations")
+
+  - name: analysis_quality
+    description: LLM judge assessing overall analysis accuracy and rationale quality
+    prompt: |
+      You are evaluating whether a PR review comment was correctly analyzed
+      by the address-reviews skill.
+
+      The skill's analysis output:
+
+      {% for path, content in outputs.files.items() if path.endswith('analysis.json') %}
+      {{ content }}
+      {% endfor %}
+
+      Expected behavior from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Core decision (should_reply, should_change_code, category) is wrong.
+               Rationale is absent or nonsensical.
+      Score 2: One core decision is correct but another is wrong. Rationale is
+               generic and doesn't reference the actual comment content.
+      Score 3: All core decisions are correct. Rationale mentions relevant aspects
+               of the comment but may be vague.
+      Score 4: All core decisions match expected values. Rationale specifically
+               references signal words or patterns from the comment that justify
+               the analysis.
+      Score 5: Perfect match on all fields. Rationale is precise, citing specific
+               phrases from the comment. All optional fields (priority_order,
+               reply_draft) are well-formed when present.
+
+thresholds:
+  valid_output_json:
+    min_pass_rate: 1.0
+  category_correct:
+    min_pass_rate: 0.85
+  should_reply_correct:
+    min_pass_rate: 0.90
+  should_change_code_correct:
+    min_pass_rate: 0.90
+  should_push_correct:
+    min_pass_rate: 1.0
+  should_filter_correct:
+    min_pass_rate: 0.90
+  priority_order_correct:
+    min_pass_rate: 0.85
+  reply_format_correct:
+    min_pass_rate: 0.80
+  analysis_quality:
+    min_mean: 3.5

--- a/plugins/openshift-developer/skills/address-review-pr/check_replied.py
+++ b/plugins/openshift-developer/skills/address-review-pr/check_replied.py
@@ -24,6 +24,8 @@ from typing import Any
 BOT_SIGNATURES = [
     "hypershift-jira-solve-ci[bot]",
     "hypershift-jira-solve-ci",
+    "github-actions",
+    "github-actions[bot]",
 ]
 
 # Text signature that appears in bot replies


### PR DESCRIPTION
## Summary

- Add `github-actions` and `github-actions[bot]` to `BOT_SIGNATURES` in `check_replied.py` so the skill's dedup check recognizes replies posted under the GHA identity
- Add CI override instruction in `address-reviews.md` so the skill respects "Do NOT push" directives from the periodic job harness instead of attempting to push (which conflicts with the harness's separate push phase)
- Add 14 eval test cases using real PR data from openshift/hypershift PR #8535

## Context

The periodic review agent was producing 102+ duplicate replies because:
1. `github-actions` wasn't recognized as a bot in `check_replied.py`, so the skill-level dedup check didn't catch existing replies posted under that identity
2. The skill's push step conflicted with the periodic job's "Do NOT push" instruction, leading to "changed but didn't push" reports

The eval suite validates these fixes using actual review thread data from the duplicate reply storm on PR #8535, covering duplicate prevention, comment categorization, prioritization, bot filtering, reply format, CI push override, and response rules. All 14 tests pass at 100%.

Companion PR: openshift/release for the periodic job's `BOT_ACCOUNTS` fix.

## Test plan

- [x] `make eval-plugins EVAL_PLUGIN=utils` — 14/14 passing (100%)
- [x] `make lint` — passes
- [ ] Monitor periodic job runs after both PRs merge to confirm duplicate replies stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI override rule for address-reviews that avoids manual push and push verification when pushing is managed automatically.
* **Bug Fixes**
  * Improved detection of already-processed bot replies by recognizing GitHub Actions-authored comments.
* **Tests**
  * Added/updated extensive address-reviews evaluation cases and tightened expected reply/decision behavior checks.
* **Chores**
  * Bumped the utils plugin version to 0.0.12.
  * Added utils budget tracking for evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->