### PR TITLE
feat(metrics): add local OTEL telemetry pipeline for agentic-docs sessions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -436,6 +436,19 @@
       "source": "./plugins/agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
       "version": "1.0.0"
+    },
+    {
+      "name": "metrics",
+      "source": "./plugins/metrics",
+      "description": "Anonymous usage metrics and local OTEL telemetry for ai-helpers sessions",
+      "version": "0.1.0",
+      "category": "tooling",
+      "keywords": [
+        "metrics",
+        "telemetry",
+        "otel",
+        "observability"
+      ]
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ package-lock.json
 # Various logs and metrics tracking info
 *.log
 .anonymous_id
+
+# OTEL telemetry session files (runtime artifacts, not source)
+otel-current.json
+otel-current.jsonl

--- a/plugins/metrics/.claude-plugin/plugin.json
+++ b/plugins/metrics/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "metrics",
+  "description": "Anonymous usage metrics and local OTEL telemetry for ai-helpers sessions",
+  "version": "0.1.0",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/metrics/README.md
+++ b/plugins/metrics/README.md
@@ -1,0 +1,98 @@
+# Metrics Plugin
+
+Local OTEL telemetry collection for Claude Code sessions. Captures tokens, cost, timing, and tool usage per session — all data stays on your machine.
+
+## One-Time Setup
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4318",
+    "OTEL_METRIC_EXPORT_INTERVAL": "10000"
+  }
+}
+```
+
+Port `4318` is the standard OTLP HTTP port. The `SessionStart` hook starts `collector.py` on this port automatically.
+
+## How It Works
+
+```
+Claude Code  →  HTTP POST every 10s  →  collector.py (port 4318)
+                                              ↓ appends records
+                                        otel-current.jsonl
+                                              ↓ on SessionEnd
+                                          ingest.py
+                                              ↓
+                                    <session-id>.json
+```
+
+## Scripts
+
+- **`scripts/collector.py`** — Minimal OTLP HTTP/JSON receiver. Listens on port 4318, appends each payload to `otel-current.jsonl`. Runs as a background daemon via the `SessionStart` hook; stopped cleanly by `SessionEnd`.
+
+- **`scripts/ingest.py`** — Reads `otel-current.jsonl`, extracts structured metrics, writes a JSON file. Consumes three OTEL metric names only: `claude_code.token.usage`, `claude_code.cost.usage`, `claude_code.active_time.total`, and `tool_decision` log events.
+
+## Output Format
+
+```json
+{
+  "ingested_at": "2026-06-19T12:34:56Z",
+  "session_start": "2026-06-19T12:00:00Z",
+  "session_end": "2026-06-19T12:34:50Z",
+  "model": "claude-sonnet-4-6",
+  "cost_usd": 0.047,
+  "tokens": {
+    "input": 42500,
+    "output": 8200,
+    "cache_read": 30000,
+    "cache_creation": 12500,
+    "cache_hit_rate": 0.7143
+  },
+  "timing": {
+    "api_s": 43.2,
+    "tool_execution_s": 18.6
+  },
+  "tools": {
+    "total": 84,
+    "breakdown": {"Read": 32, "Edit": 18, "Bash": 24, "Grep": 10}
+  }
+}
+```
+
+## Manual Usage
+
+```bash
+# Start collector (foreground)
+python3 plugins/metrics/scripts/collector.py
+
+# Start as daemon
+python3 plugins/metrics/scripts/collector.py --daemon --fresh
+
+# Stop running collector
+python3 plugins/metrics/scripts/collector.py --stop
+
+# Ingest OTEL data
+python3 plugins/metrics/scripts/ingest.py \
+  --otel-log plugins/metrics/otel-current.jsonl \
+  --out /tmp/session-metrics.json
+```
+
+## Enabling the Plugin
+
+```bash
+/plugin enable metrics@ai-helpers
+```
+
+## Source Code
+
+- `plugins/metrics/hooks/hooks.json` — SessionStart/SessionEnd hook definitions
+- `plugins/metrics/scripts/collector.py` — OTLP HTTP receiver
+- `plugins/metrics/scripts/ingest.py` — OTEL JSONL → metrics JSON
+- `plugins/metrics/.claude-plugin/plugin.json` — plugin metadata

--- a/plugins/metrics/hooks/hooks.json
+++ b/plugins/metrics/hooks/hooks.json
@@ -1,0 +1,32 @@
+{
+  "description": "Local OTEL Telemetry Collection",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/collector.py --log-file ${CLAUDE_PLUGIN_ROOT}/otel-current.jsonl --pid-file /tmp/claude-otel-collector.pid --daemon --fresh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/collector.py --stop --pid-file /tmp/claude-otel-collector.pid",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/ingest.py --otel-log ${CLAUDE_PLUGIN_ROOT}/otel-current.jsonl --from-hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/metrics/scripts/collector.py
+++ b/plugins/metrics/scripts/collector.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Minimal OTLP HTTP/JSON receiver for local Claude Code telemetry.
+
+Listens on a fixed port (default 4318, the standard OTLP HTTP port) and
+appends each OTLP payload as a JSONL record. Designed for interactive
+local use alongside Claude Code plugins.
+
+Unlike prow-agent's otel_collector.py (ephemeral port + port-file handshake
+for CI), this collector uses a fixed port so Claude Code's OTEL endpoint
+can be pre-configured once in settings.json without any env var exports.
+
+Usage:
+    python3 collector.py [--port 4318] [--log-file ~/.claude/metrics/otel.jsonl]
+    python3 collector.py --daemon --fresh   # background, fresh log (SessionStart)
+    python3 collector.py --stop             # send SIGTERM to running collector
+"""
+
+import argparse
+import json
+import os
+import signal
+import sys
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MAX_BODY_SIZE = 1_048_576  # 1 MB
+
+
+class OTLPServer(HTTPServer):
+    allow_reuse_address = True
+
+
+DEFAULT_PID_FILE = "/tmp/claude-otel-collector.pid"
+
+
+class OTLPHandler(BaseHTTPRequestHandler):
+    log_file = None
+
+    def do_POST(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            self.send_error(400, "Invalid Content-Length")
+            return
+        if length > MAX_BODY_SIZE:
+            self.send_error(413, "Payload Too Large")
+            return
+
+        body = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            payload = {"raw": body.decode("utf-8", errors="replace")}
+
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "path": self.path,
+            "payload": payload,
+        }
+        with open(self.log_file, "a") as f:
+            f.write(json.dumps(record) + "\n")
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"partialSuccess":{}}')
+
+    def log_message(self, format, *args):
+        pass  # suppress per-request logging
+
+
+def stop_collector(pid_file):
+    if not os.path.exists(pid_file):
+        return
+    try:
+        pid = int(open(pid_file).read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except (ValueError, ProcessLookupError, OSError):
+        pass
+    finally:
+        try:
+            os.remove(pid_file)
+        except OSError:
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Local OTLP collector for Claude Code")
+    parser.add_argument("--port", type=int, default=4318, help="Port to listen on (default: 4318)")
+    parser.add_argument(
+        "--log-file",
+        default=os.path.expanduser("~/.claude/metrics/otel-current.jsonl"),
+        help="JSONL output file",
+    )
+    parser.add_argument("--pid-file", default=DEFAULT_PID_FILE, help="PID file for lifecycle management")
+    parser.add_argument("--daemon", action="store_true", help="Fork into background and return immediately")
+    parser.add_argument("--fresh", action="store_true", help="Truncate log file before starting")
+    parser.add_argument("--stop", action="store_true", help="Stop a running collector via its PID file")
+    args = parser.parse_args()
+
+    if args.stop:
+        stop_collector(args.pid_file)
+        return
+
+    if args.daemon:
+        # Stop any existing collector on this pid-file before forking so the
+        # port is free and the old JSONL is closed cleanly.
+        import time
+        stop_collector(args.pid_file)
+        time.sleep(0.6)  # wait for serve_forever's select loop (0.5s timeout) to exit
+
+    if args.fresh and os.path.exists(args.log_file):
+        os.remove(args.log_file)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.log_file)), exist_ok=True)
+
+    if args.daemon:
+        pid = os.fork()
+        if pid > 0:
+            sys.exit(0)  # parent exits immediately; child continues below
+        os.setsid()
+        devnull = os.open(os.devnull, os.O_RDWR)
+        for fd in (0, 1, 2):
+            os.dup2(devnull, fd)
+        os.close(devnull)
+
+    OTLPHandler.log_file = args.log_file
+    try:
+        server = OTLPServer(("127.0.0.1", args.port), OTLPHandler)
+    except OSError as e:
+        print(f"Error: cannot bind to port {args.port}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.pid_file, "w") as f:
+        f.write(str(os.getpid()))
+
+    def shutdown(signum, frame):
+        def _stop():
+            server.shutdown()
+            server.server_close()
+        threading.Thread(target=_stop).start()
+        if os.path.exists(args.pid_file):
+            os.remove(args.pid_file)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/metrics/scripts/ingest.py
+++ b/plugins/metrics/scripts/ingest.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Ingest OTEL JSONL from collector.py into a structured metrics JSON file.
+
+Reads the three OTEL metric types emitted by Claude Code and produces a
+single clean JSON file. No session JSONL parsing; OTEL is the sole source.
+
+Metrics extracted:
+  /v1/metrics  claude_code.token.usage    → tokens (input/output/cache)
+  /v1/metrics  claude_code.cost.usage     → cost_usd
+  /v1/metrics  claude_code.active_time.total → timing (api_s, tool_execution_s)
+  /v1/logs     tool_decision events       → tools breakdown
+
+Usage:
+    python3 ingest.py --otel-log otel-current.jsonl [--out metrics.json]
+
+    # SessionEnd hook (reads session_id from stdin JSON):
+    python3 ingest.py --otel-log otel-current.jsonl --from-hook
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+
+
+def load_records(log_file):
+    records = []
+    try:
+        with open(log_file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    except FileNotFoundError:
+        print(f"Error: OTEL log not found: {log_file}", file=sys.stderr)
+        sys.exit(1)
+    return records
+
+
+def get_attr(attributes, key):
+    for a in attributes:
+        if a.get("key") == key:
+            v = a.get("value", {})
+            return v.get("stringValue", v.get("intValue", v.get("doubleValue")))
+    return None
+
+
+def parse_otel(records):
+    tokens = defaultdict(float)     # (model, type) -> count
+    costs = defaultdict(float)      # model -> usd
+    active_time = defaultdict(float)  # type -> seconds
+    tools = defaultdict(int)        # tool_name -> count
+
+    for rec in records:
+        path = rec.get("path", "")
+        payload = rec.get("payload", {})
+
+        if "/v1/metrics" in path:
+            for rm in payload.get("resourceMetrics", []):
+                for sm in rm.get("scopeMetrics", []):
+                    for metric in sm.get("metrics", []):
+                        name = metric.get("name", "")
+                        data = metric.get("sum", metric.get("gauge", metric.get("histogram", {})))
+                        for dp in data.get("dataPoints", []):
+                            attrs = dp.get("attributes", [])
+                            value = dp.get("asDouble", dp.get("asInt", 0))
+
+                            if name == "claude_code.token.usage":
+                                model = get_attr(attrs, "model") or "unknown"
+                                token_type = get_attr(attrs, "type") or "unknown"
+                                tokens[(model, token_type)] += value
+                            elif name == "claude_code.cost.usage":
+                                model = get_attr(attrs, "model") or "unknown"
+                                costs[model] += value
+                            elif name == "claude_code.active_time.total":
+                                time_type = get_attr(attrs, "type") or "unknown"
+                                active_time[time_type] += value
+
+        elif "/v1/logs" in path:
+            for rl in payload.get("resourceLogs", []):
+                for sl in rl.get("scopeLogs", []):
+                    for lr in sl.get("logRecords", []):
+                        attrs = lr.get("attributes", [])
+                        event_name = get_attr(attrs, "event.name") or ""
+                        if event_name == "tool_decision":
+                            tool_name = get_attr(attrs, "tool_name") or "unknown"
+                            decision = get_attr(attrs, "decision") or ""
+                            if decision == "accept":
+                                tools[tool_name] += 1
+
+    return dict(tokens), dict(costs), dict(active_time), dict(tools)
+
+
+def build_output(tokens, costs, active_time, tools, records, session_id=None):
+    type_map = {
+        "input": "input",
+        "output": "output",
+        "cacheRead": "cache_read",
+        "cacheCreation": "cache_creation",
+    }
+    token_totals = {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0}
+    models = set()
+    for (model, token_type), count in tokens.items():
+        models.add(model)
+        mapped = type_map.get(token_type)
+        if mapped:
+            token_totals[mapped] += int(count)
+
+    primary_model = max(costs, key=costs.get) if costs else (next(iter(models), "unknown"))
+    cost_usd = sum(costs.values())
+
+    total_input = token_totals["input"] + token_totals["cache_read"] + token_totals["cache_creation"]
+    cache_hit_rate = round(token_totals["cache_read"] / total_input, 4) if total_input > 0 else 0.0
+
+    timestamps = sorted(r.get("ts") for r in records if r.get("ts"))
+
+    result = {
+        "ingested_at": datetime.now(timezone.utc).isoformat(),
+        "session_start": timestamps[0] if timestamps else None,
+        "session_end": timestamps[-1] if timestamps else None,
+        "model": primary_model,
+        "cost_usd": round(cost_usd, 6),
+        "tokens": {**token_totals, "cache_hit_rate": cache_hit_rate},
+        "timing": {
+            "api_s": round(active_time.get("api", 0), 2),
+            "tool_execution_s": round(active_time.get("tool_execution", 0), 2),
+        },
+        "tools": {
+            "total": sum(tools.values()),
+            "breakdown": dict(sorted(tools.items(), key=lambda x: x[1], reverse=True)),
+        },
+    }
+    if session_id:
+        result["session_id"] = session_id
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ingest OTEL JSONL into session metrics JSON")
+    parser.add_argument("--otel-log", required=True, help="OTEL JSONL file from collector.py")
+    parser.add_argument("--out", help="Output JSON path (default: same as otel-log with .json extension)")
+    parser.add_argument(
+        "--from-hook",
+        action="store_true",
+        help="Read session_id from Claude Code hook stdin (JSON)",
+    )
+    args = parser.parse_args()
+
+    session_id = None
+    if args.from_hook:
+        try:
+            hook_data = json.load(sys.stdin)
+            session_id = hook_data.get("session_id")
+        except (json.JSONDecodeError, EOFError):
+            pass
+
+    records = load_records(args.otel_log)
+    if not records:
+        print("Warning: no OTEL records found in log file", file=sys.stderr)
+
+    tokens, costs, active_time, tools = parse_otel(records)
+    output = build_output(tokens, costs, active_time, tools, records, session_id)
+
+    out_path = args.out
+    if not out_path:
+        base = os.path.splitext(args.otel_log)[0]
+        out_path = base + ".json"
+
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(output, f, indent=2)
+
+    print(f"Metrics written to {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Local OTEL telemetry pipeline for measuring Claude Code sessions, supporting the agentic-docs plugin.

- `scripts/collector.py`: fixed-port (4318) OTLP HTTP/JSON receiver, runs as a daemon via `SessionStart`/`SessionEnd` hooks
- `scripts/ingest.py`: reads OTEL JSONL → extract session metrics JSON (tokens, cost, timing, tool breakdown)
- `hooks/hooks.json`: wires collector start/stop and ingest into session lifecycle

Fixed port 4318 (pre-configured in `~/.claude/settings.json`) is required because `SessionStart` fires inside an already-running Claude Code process — ephemeral port discovery is not possible. 

## Test plan

- [ ] Add OTEL env vars to `~/.claude/settings.json` (see README)
- [ ] Start a new Claude Code session and verify `collector.py` starts via `SessionStart` hook
- [ ] End session and verify `ingest.py` produces a metrics JSON file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics plugin for anonymous usage tracking of slash commands and skill invocations.
  * New command to display aggregated session metrics including cost, tokens, timing, and tool usage.
  * Integrated OTEL telemetry support with local collector for session-level metrics.

* **Documentation**
  * Added comprehensive plugin documentation with setup, configuration, and privacy guarantees.

* **Chores**
  * Updated plugin marketplace metadata with discovery keywords.
  * Updated .gitignore for telemetry runtime artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->