### PR TITLE
Snowflake plugin gcloud auth options

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
       "name": "snowflake",
       "source": "./plugins/snowflake",
       "description": "Snowflake data analysis commands for engineering metrics and reports",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "data",
       "keywords": [
         "snowflake",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2422,7 +2422,7 @@ footer a { color: var(--primary); }
     {
       "name": "snowflake",
       "description": "Snowflake data analysis commands for engineering metrics and reports",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/snowflake/.claude-plugin/plugin.json
+++ b/plugins/snowflake/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "snowflake",
   "description": "Snowflake data analysis commands for engineering metrics and reports",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/snowflake/README.md
+++ b/plugins/snowflake/README.md
@@ -133,7 +133,10 @@ Classify Jira issues into activity types and generate an interactive sankey repo
 4. Results are merged and `generate_sankey.py` produces the HTML report
 
 **Requirements:** The classification script calls Claude via Vertex AI and requires:
-- `gcloud` CLI authenticated (`gcloud auth login`)
+- `gcloud` CLI authenticated via one of:
+  - `gcloud auth login` (traditional user authentication)
+  - `gcloud auth application-default login` (application default credentials)
+  - Workload identity environment (automatic in some GCP services)
 - Environment variables: `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID` (already set in the org's devcontainer)
 - Optional: `ANTHROPIC_SMALL_FAST_MODEL` to override the model (default: `claude-sonnet-4-6`)
 
@@ -166,7 +169,7 @@ This plugin runs Python scripts via shell commands during report generation. You
 - `python3 .../classify_issues.py` -- Classifies issues by calling Claude via Vertex AI
 - `python3 .../generate_sankey.py` -- Generates the interactive HTML report
 - `python3 .../open_report.py` -- Starts a temporary HTTP server (auto-shuts down after 30s) and opens the report in your browser via VS Code port forwarding
-- `gcloud auth print-access-token` -- Called by the classification script for Vertex AI authentication
+- `gcloud auth print-access-token` or `gcloud auth application-default print-access-token` -- Called by the classification script for Vertex AI authentication (tries both methods)
 
 These scripts are located in the plugin's `scripts/` directory and only read/write local files.
 

--- a/plugins/snowflake/README.md
+++ b/plugins/snowflake/README.md
@@ -133,12 +133,13 @@ Classify Jira issues into activity types and generate an interactive sankey repo
 4. Results are merged and `generate_sankey.py` produces the HTML report
 
 **Requirements:** The classification script calls Claude via Vertex AI and requires:
-- `gcloud` CLI authenticated via one of:
-  - `gcloud auth login` (traditional user authentication)
-  - `gcloud auth application-default login` (application default credentials)
-  - Workload identity environment (automatic in some GCP services)
-- Environment variables: `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID` (already set in the org's devcontainer)
-- Optional: `ANTHROPIC_SMALL_FAST_MODEL` to override the model (default: `claude-sonnet-4-6`)
+- **Authentication** via one of (automatically detected):
+  - Application Default Credentials: `gcloud auth application-default login`
+  - Workload identity: automatic in GCP environments (GCE, Cloud Run, GKE)
+  - Service account key: set `GOOGLE_APPLICATION_CREDENTIALS` env var
+  - User credentials: `gcloud auth login` (fallback if google-auth not installed)
+- **Environment variables**: `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_PROJECT_ID` (already set in the org's devcontainer)
+- **Optional**: `ANTHROPIC_SMALL_FAST_MODEL` to override the model (default: `claude-sonnet-4-6`)
 
 The AI considers each issue's summary, description, type, status, components, and project context when classifying. Categories are:
 
@@ -166,10 +167,11 @@ Classification calls Vertex AI directly (no sub-agents), processing ~15 issues p
 
 This plugin runs Python scripts via shell commands during report generation. You will be prompted to approve these commands:
 
-- `python3 .../classify_issues.py` -- Classifies issues by calling Claude via Vertex AI
+- `python3 .../classify_issues.py` -- Classifies issues by calling Claude via Vertex AI (uses google.auth.default() for authentication)
 - `python3 .../generate_sankey.py` -- Generates the interactive HTML report
 - `python3 .../open_report.py` -- Starts a temporary HTTP server (auto-shuts down after 30s) and opens the report in your browser via VS Code port forwarding
-- `gcloud auth print-access-token` or `gcloud auth application-default print-access-token` -- Called by the classification script for Vertex AI authentication (tries both methods)
+
+The classification script uses the `google-auth` library which automatically discovers credentials via Application Default Credentials (ADC), workload identity, service account keys, or user credentials.
 
 These scripts are located in the plugin's `scripts/` directory and only read/write local files.
 

--- a/plugins/snowflake/scripts/classify_issues.py
+++ b/plugins/snowflake/scripts/classify_issues.py
@@ -5,10 +5,11 @@ Reads a JSON array of issues, sends them in batches to Claude for
 classification, and writes the results back with an activity_type field.
 
 Requires:
-  - gcloud CLI authenticated via one of:
-    - gcloud auth login (traditional user auth)
-    - gcloud auth application-default login (workload identity/ADC)
-    - Workload identity environment (automatic in some GCP services)
+  - Authentication via one of:
+    - google-auth library (recommended): uses Application Default Credentials
+    - gcloud CLI: gcloud auth application-default login or gcloud auth login
+    - Workload identity: automatic in GCP environments (GCE, Cloud Run, GKE)
+    - Service account: set GOOGLE_APPLICATION_CREDENTIALS env var
   - Environment variables: CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID
   - Optional: ANTHROPIC_SMALL_FAST_MODEL (default: claude-sonnet-4-6)
 """
@@ -17,12 +18,19 @@ import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 import time
 import urllib.request
 import urllib.error
 from collections import Counter
+
+try:
+    from google.auth.transport.requests import Request
+    import google.auth
+    USE_GOOGLE_AUTH = True
+except ImportError:
+    import subprocess
+    USE_GOOGLE_AUTH = False
 
 ACTIVITY_TYPE_DEFINITIONS = {
     "Associate Wellness & Development": (
@@ -116,45 +124,67 @@ def build_prompt(batch):
 
 
 def get_gcloud_token():
-    """Get OAuth token via gcloud CLI or workload identity.
+    """Get OAuth token via google.auth or gcloud CLI.
 
-    First tries 'gcloud auth print-access-token' (traditional auth).
-    If that fails, tries 'gcloud auth application-default print-access-token'
-    (workload identity, ADC).
+    Prefers google.auth.default() which automatically supports:
+    - Application Default Credentials (ADC)
+    - Workload identity
+    - Service account keys
+    - User credentials via gcloud auth application-default login
+
+    Falls back to gcloud CLI if google-auth library is not available.
     """
-    try:
-        # Try traditional user authentication first
-        result = subprocess.run(
-            ["gcloud", "auth", "print-access-token"],
-            capture_output=True, text=True, check=True, timeout=30,
-        )
-        token = result.stdout.strip()
-        if not token:
-            raise RuntimeError("gcloud auth print-access-token returned empty")
-        return token
-    except (subprocess.CalledProcessError, RuntimeError):
-        # Fall back to application default credentials (workload identity)
+    if USE_GOOGLE_AUTH:
         try:
+            credentials, project = google.auth.default()
+            # Refresh credentials if needed
+            if not credentials.valid:
+                credentials.refresh(Request())
+            return credentials.token
+        except google.auth.exceptions.DefaultCredentialsError as e:
+            print(f"Error: Failed to get credentials via google.auth.default(): {e}", file=sys.stderr)
+            print("\nTry one of:", file=sys.stderr)
+            print("  - gcloud auth application-default login (for ADC)", file=sys.stderr)
+            print("  - gcloud auth login (for user authentication)", file=sys.stderr)
+            print("  - Set GOOGLE_APPLICATION_CREDENTIALS to point to a service account key", file=sys.stderr)
+            print("  - Ensure workload identity is properly configured", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Fallback to gcloud CLI if google-auth is not installed
+        try:
+            # Try traditional user authentication first
             result = subprocess.run(
-                ["gcloud", "auth", "application-default", "print-access-token"],
+                ["gcloud", "auth", "print-access-token"],
                 capture_output=True, text=True, check=True, timeout=30,
             )
             token = result.stdout.strip()
             if not token:
-                raise RuntimeError("gcloud auth application-default print-access-token returned empty")
+                raise RuntimeError("gcloud auth print-access-token returned empty")
             return token
-        except subprocess.CalledProcessError as e:
-            print("Error: Both gcloud auth methods failed:", file=sys.stderr)
-            print(f"  1. User auth: Not authenticated", file=sys.stderr)
-            print(f"  2. Application default auth (workload identity): {e.stderr}", file=sys.stderr)
-            print("\nTry one of:", file=sys.stderr)
-            print("  - gcloud auth login (for user authentication)", file=sys.stderr)
-            print("  - gcloud auth application-default login (for ADC)", file=sys.stderr)
-            print("  - Or ensure workload identity is properly configured", file=sys.stderr)
+        except (subprocess.CalledProcessError, RuntimeError):
+            # Fall back to application default credentials
+            try:
+                result = subprocess.run(
+                    ["gcloud", "auth", "application-default", "print-access-token"],
+                    capture_output=True, text=True, check=True, timeout=30,
+                )
+                token = result.stdout.strip()
+                if not token:
+                    raise RuntimeError("gcloud auth application-default print-access-token returned empty")
+                return token
+            except subprocess.CalledProcessError as e:
+                print("Error: Both gcloud auth methods failed:", file=sys.stderr)
+                print(f"  1. User auth: Not authenticated", file=sys.stderr)
+                print(f"  2. Application default auth: {e.stderr}", file=sys.stderr)
+                print("\nTry: gcloud auth application-default login", file=sys.stderr)
+                print("Or install google-auth: pip install google-auth", file=sys.stderr)
+                sys.exit(1)
+        except FileNotFoundError:
+            print("Error: gcloud CLI not found and google-auth not installed.", file=sys.stderr)
+            print("Install one of:", file=sys.stderr)
+            print("  - gcloud CLI: https://cloud.google.com/sdk", file=sys.stderr)
+            print("  - google-auth: pip install google-auth", file=sys.stderr)
             sys.exit(1)
-    except FileNotFoundError:
-        print("Error: gcloud CLI not found. Install it from https://cloud.google.com/sdk", file=sys.stderr)
-        sys.exit(1)
 
 
 def classify_batch(batch, token, endpoint, model):

--- a/plugins/snowflake/scripts/classify_issues.py
+++ b/plugins/snowflake/scripts/classify_issues.py
@@ -5,7 +5,10 @@ Reads a JSON array of issues, sends them in batches to Claude for
 classification, and writes the results back with an activity_type field.
 
 Requires:
-  - gcloud CLI authenticated (gcloud auth login)
+  - gcloud CLI authenticated via one of:
+    - gcloud auth login (traditional user auth)
+    - gcloud auth application-default login (workload identity/ADC)
+    - Workload identity environment (automatic in some GCP services)
   - Environment variables: CLOUD_ML_REGION, ANTHROPIC_VERTEX_PROJECT_ID
   - Optional: ANTHROPIC_SMALL_FAST_MODEL (default: claude-sonnet-4-6)
 """
@@ -113,8 +116,14 @@ def build_prompt(batch):
 
 
 def get_gcloud_token():
-    """Get OAuth token via gcloud CLI."""
+    """Get OAuth token via gcloud CLI or workload identity.
+
+    First tries 'gcloud auth print-access-token' (traditional auth).
+    If that fails, tries 'gcloud auth application-default print-access-token'
+    (workload identity, ADC).
+    """
     try:
+        # Try traditional user authentication first
         result = subprocess.run(
             ["gcloud", "auth", "print-access-token"],
             capture_output=True, text=True, check=True, timeout=30,
@@ -123,12 +132,28 @@ def get_gcloud_token():
         if not token:
             raise RuntimeError("gcloud auth print-access-token returned empty")
         return token
+    except (subprocess.CalledProcessError, RuntimeError):
+        # Fall back to application default credentials (workload identity)
+        try:
+            result = subprocess.run(
+                ["gcloud", "auth", "application-default", "print-access-token"],
+                capture_output=True, text=True, check=True, timeout=30,
+            )
+            token = result.stdout.strip()
+            if not token:
+                raise RuntimeError("gcloud auth application-default print-access-token returned empty")
+            return token
+        except subprocess.CalledProcessError as e:
+            print("Error: Both gcloud auth methods failed:", file=sys.stderr)
+            print(f"  1. User auth: Not authenticated", file=sys.stderr)
+            print(f"  2. Application default auth (workload identity): {e.stderr}", file=sys.stderr)
+            print("\nTry one of:", file=sys.stderr)
+            print("  - gcloud auth login (for user authentication)", file=sys.stderr)
+            print("  - gcloud auth application-default login (for ADC)", file=sys.stderr)
+            print("  - Or ensure workload identity is properly configured", file=sys.stderr)
+            sys.exit(1)
     except FileNotFoundError:
         print("Error: gcloud CLI not found. Install it from https://cloud.google.com/sdk", file=sys.stderr)
-        sys.exit(1)
-    except subprocess.CalledProcessError as e:
-        print(f"Error: gcloud auth failed: {e.stderr}", file=sys.stderr)
-        print("Run: gcloud auth login", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## What this PR does / why we need it:
Snowflake plugin assumes gcloud print-access-token can run, which is not true for workload identity based auth in chai-bot.

## Which issue(s) this PR fixes:
Several modes of auth are attempted in addition to capturing the printed token. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the classification script authentication requirements to list supported credential sources and clarify how credentials are discovered.

* **New Features**
  * Improved classification authentication by using automatic credential discovery when the Google authentication library is available.
  * Added a fallback flow to obtain access tokens when the library-based approach isn’t available.

* **Chores**
  * Bumped the Snowflake plugin version to **0.5.1** in the plugin and website metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->