### PR TITLE
fix: bump openshift-developer ci dependency to ^0.0.52

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -396,7 +396,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2323,7 +2323,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
     { "name": "jira", "version": "^0.7.0" },
-    { "name": "ci", "version": "^0.0.42" },
+    { "name": "ci", "version": "^0.0.52" },
     { "name": "golang", "version": "^0.3.0" },
     { "name": "prodsec-skills", "marketplace": "prodsec-skills" },
     { "name": "git", "version": "^0.0.6" }


### PR DESCRIPTION
## Summary
- The `ci` plugin is at `0.0.52` but `openshift-developer` required `^0.0.42`, which in semver `0.x` means `>=0.0.42 <0.0.43`. This prevents the plugin from loading with: `Requires "ci@ai-helpers" ^0.0.42, installed 0.0.52`

## Test plan
- [ ] `claude plugin install openshift-developer@ai-helpers` succeeds without version conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the OpenShift Developer plugin version to **1.1.1** in the published plugin metadata.
  * Updated the marketplace listing to reflect the new **1.1.1** release.
  * Refreshed the CI dependency compatibility range to align with the updated release.
  * Updated the documentation bundle so the embedded plugin entry matches **1.1.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->