### PR TITLE
fix: bundle external deps into ai-helpers marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,11 +3,30 @@
   "owner": {
     "name": "openshift-eng"
   },
-  "allowCrossMarketplaceDependenciesOn": [
-    "claude-plugins-official",
-    "prodsec-skills"
-  ],
   "plugins": [
+    {
+      "name": "gopls-lsp",
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official",
+        "path": "plugins/gopls-lsp"
+      },
+      "description": "Go language server for code intelligence and refactoring",
+      "version": "1.0.0",
+      "category": "development",
+      "keywords": ["go", "gopls", "lsp"]
+    },
+    {
+      "name": "prodsec-skills",
+      "source": {
+        "source": "github",
+        "repo": "RedHatProductSecurity/prodsec-skills"
+      },
+      "description": "Security guidance skills for AI coding assistants",
+      "version": "1.0.0",
+      "category": "security",
+      "keywords": ["security", "prodsec"]
+    },
     {
       "name": "git",
       "source": "./plugins/git",
@@ -322,7 +341,7 @@
       "name": "golang",
       "source": "./plugins/golang",
       "description": "Go development tools: gopls MCP server, LSP integration, automatic gofmt formatting, golangci-lint linting, and CVE dependency patching",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "development",
       "keywords": [
         "go",
@@ -396,7 +415,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1249,7 +1249,7 @@ footer a { color: var(--primary); }
     {
       "name": "golang",
       "description": "Go development tools: gopls MCP server, LSP integration, automatic gofmt formatting, golangci-lint linting, and CVE dependency patching",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "has_readme": true,
       "commands": [],
       "skills": [
@@ -2323,7 +2323,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/golang/.claude-plugin/plugin.json
+++ b/plugins/golang/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "golang",
   "description": "Go development tools: gopls MCP server, LSP integration, automatic gofmt formatting, golangci-lint linting, and CVE dependency patching",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
-    { "name": "gopls-lsp", "marketplace": "claude-plugins-official" }
+    { "name": "gopls-lsp" }
   ]
 }

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "github.com/openshift-eng"
   },
@@ -9,7 +9,7 @@
     { "name": "jira", "version": "^0.7.0" },
     { "name": "ci", "version": "^0.0.52" },
     { "name": "golang", "version": "^0.3.0" },
-    { "name": "prodsec-skills", "marketplace": "prodsec-skills" },
-    { "name": "git", "version": "^0.0.6" }
+    { "name": "prodsec-skills" },
+    { "name": "git", "version": "^0.0.7" }
   ]
 }


### PR DESCRIPTION
## Problem

The `openshift-developer` bundle failed to load in GHA because its transitive
dependencies (`gopls-lsp` from `claude-plugins-official`, `prodsec-skills` from
`RedHatProductSecurity/prodsec-skills`) live in external marketplaces that
consumers don't have added. The `allowCrossMarketplaceDependenciesOn` field only
*permits* cross-marketplace deps — it does NOT auto-add those marketplaces for
consumers.

Additionally, the `git` plugin is at `0.0.7` but `openshift-developer` required
`^0.0.6`. Under semver `0.x` rules, `^0.0.6` means `>=0.0.6 <0.0.7`, so
`0.0.7` is excluded and the bundle fails with:

```
Error: Requires "git@ai-helpers" ^0.0.6, installed 0.0.7
```

## Fix

1. **Bundle external deps into ai-helpers marketplace** — add `gopls-lsp` and
   `prodsec-skills` as marketplace entries with `source` pointers to their
   upstream repos. Consumers now only need the `ai-helpers` marketplace.

2. **Remove cross-marketplace references** — `golang` plugin's `gopls-lsp` dep
   and `openshift-developer`'s `prodsec-skills` dep no longer specify
   `"marketplace"` since they resolve within ai-helpers now.

3. **Fix git dep constraint** — update `openshift-developer`'s git dep from
   `^0.0.6` to `^0.0.7`.

4. **Version bumps** — `openshift-developer` `1.1.1` → `1.1.2`, `golang`
   `0.3.0` → `0.3.1`.

## Evidence

GHA failure from hypershift PR #8809 (merged):
```
Error: dependency-unsatisfied for openshift-developer@ai-helpers
```

Local verification after fix:
```
$ claude plugin install openshift-developer@ai-helpers
✓ openshift-developer 1.1.2 installed (with gopls-lsp, prodsec-skills resolved)
$ claude -p "/openshift-developer:address-review-pr 8809"
✓ Skill recognized and executed
```