### PR TITLE
`ci:payload-analysis`: surface RHCOS RPM changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,7 +49,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -512,7 +512,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -169,6 +169,21 @@ If this finds nothing, also check steps that run earlier in the workflow and set
 
 This step catches failures caused by CI tooling changes (mirror URL migrations, proxy configuration updates, script refactors) that are invisible to the snapshot's PR tracking.
 
+#### 3.7: RHCOS RPM Changes
+
+For each failed job's `streak.originating_payload`, find the matching entry in `summary.json` → `payloads[]` and check for `rhcos_changes[]`. This array (when present) contains per-RHCOS-variant RPM diffs showing which packages changed in the underlying RHCOS image for that payload:
+
+- `name`: Human-readable version (e.g., "Red Hat Enterprise Linux CoreOS 10.2")
+- `tag`: Image stream tag — maps to job RHCOS variants:
+  - `rhel-coreos` → applies to jobs with `rhcos_version` of `rhcos9` or `rhcos9-default`
+  - `rhel-coreos-10` → applies to jobs with `rhcos_version` of `rhcos10` or `rhcos10-default`
+  - Both apply to `rhcos9_10` (heterogeneous) jobs
+- `changed`: `{package_name: {"old": old_version, "new": new_version}}`
+- `added`: newly added packages (when present)
+- `removed`: removed packages (when present)
+
+For each failed job, identify the matching RHCOS variant's RPM changes (if any) based on the job's `rhcos_version` field and the RHCOS tag mapping above. These changes are used as additional context in Step 4 and as potential suspects in Step 6.
+
 ### Step 4: Investigate Each Failed Job in Parallel
 
 For each failed blocking job in the **target payload**, launch a **parallel subagent** to investigate the failure. Pass the subagent the Prow URL and all previous attempt URLs from Step 3.2.
@@ -185,6 +200,8 @@ You MUST use the following prompt verbatim (substituting the placeholder values)
 >
 > **RHCOS version**: This job's cluster runs on **<rhcos_version>**. <rhcos_context>
 >
+> **RHCOS RPM changes**: Read `<summary_json_path>` and find the entry in `payloads[]` whose `tag` equals `<originating_payload_tag>`. If that entry has an `rhcos_changes[]` array, look up the RHCOS variant matching this job's `rhcos_version` using the tag mapping: `rhel-coreos` → `rhcos9`/`rhcos9-default`, `rhel-coreos-10` → `rhcos10`/`rhcos10-default`, both apply to `rhcos9_10`. Check whether any changed, added, or removed RPM packages overlap with the failure's root cause. If the failure involves OS-level components (kernel, bootloader, systemd, SELinux, rpm-ostree, cri-o, crun, runc, networking) and matching packages changed, note the potential correlation in your ANALYSIS_RESULT.
+>
 > First, check the JUnit results or build log to determine whether this is an install failure (look for `install should succeed: overall` or similar install-related test failures) or a test failure (install passed, specific tests failed).
 >
 > Based on the failure type, use the appropriate skill:
@@ -199,10 +216,12 @@ You MUST use the following prompt verbatim (substituting the placeholder values)
 >
 > If the job is an aggregated job (has `aggregated-` prefix in the name or an `aggregator` container/step), also return the **underlying job name** (e.g., `periodic-ci-openshift-release-main-ci-4.22-e2e-aws-upgrade-ovn-single-node`). This is found in the junit-aggregated.xml artifacts — each `<testcase>` has `<system-out>` YAML data with a `humanurl` field linking to individual runs whose URL path contains the underlying job name. The underlying job name cannot be derived from the aggregated job name — it must be extracted from the artifacts.
 
-Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed job entry, and `<rhcos_context>` is one of:
+Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed job entry, `<rhcos_context>` is one of:
 - For **`rhcos9`** or **`rhcos9-default`**: "RHCOS 9 is based on RHEL 9 — the standard CoreOS variant for this OCP version."
 - For **`rhcos10`** or **`rhcos10-default`**: "RHCOS 10 is based on RHEL 10 with a different kernel, systemd, SELinux policy, and package versions than RHCOS 9. If the failure involves OS-level components (kernel, bootloader, rpm-ostree, MCO, Ignition), consider whether RHEL 10 differences could be the root cause."
 - For **`rhcos9_10`** (heterogeneous): "This is a heterogeneous cluster with both RHCOS 9 and RHCOS 10 nodes. Failures may be specific to one node variant — check whether failing nodes are RHCOS 9 or RHCOS 10 when node-level logs are available."
+
+`<summary_json_path>` is the absolute path to the snapshot's `summary.json` file, and `<originating_payload_tag>` is the `streak.originating_payload` value from the failed job entry.
 
 **Structured Return Format**: Instruct each subagent to include an `ANALYSIS_RESULT` block at the end of its response:
 
@@ -217,7 +236,14 @@ ANALYSIS_RESULT:
 - retries_consistent: yes|no|no_retries|only_final_examined
 - retry_summary: <brief comparison of failure modes across attempts, e.g. "all 3 attempts failed with same KAS crashloop" or "attempt 1 infra timeout, attempts 2-3 test failure", or "no retries" when there was only a single attempt>
 - rhcos_version: rhcos9|rhcos10|rhcos9_10|rhcos9-default|rhcos10-default
+- rhcos_rpm_correlation: none|possible|likely
+- rhcos_rpm_suspect_packages: <comma-separated package names if correlation is possible or likely, or "none">
 ```
+
+The `rhcos_rpm_correlation` field indicates whether the failure may be related to RHCOS RPM changes found in `summary.json`:
+- `none` — no correlation found, or no RHCOS RPM changes exist for this job's variant
+- `possible` — the failure involves OS-level components that overlap with changed packages, but the link is not definitive
+- `likely` — error messages or failure behavior directly point to functionality provided by a changed RPM package
 
 **Note for aggregated jobs**: Since only the final attempt is examined (retries re-run aggregation only), set `retries_consistent: only_final_examined` and `retry_summary: "Aggregated job — only final attempt examined (retries re-run aggregation only)"`.
 
@@ -287,6 +313,27 @@ Maximum possible score is 130, capped at 100. Record the numeric score alongside
 
 **Apply the rubric mechanically.** Calculate the score by summing the weights for each signal that fires based on concrete evidence. Do NOT adjust the score downward based on speculative counter-arguments like "if this were the sole cause, other jobs would also fail" or "this could be a coincidence." If the error messages reference the PR's changes, that's +40 — the fact that some other jobs didn't fail doesn't negate the match. If the failure is new (streak=1) and the PR is the only one touching the component, those signals fire regardless of theoretical alternatives. Trust the rubric — it exists to prevent both over- and under-attribution.
 
+#### 6.1b: RHCOS RPM Change Correlation
+
+After scoring PR candidates, check for RHCOS RPM change correlation. A failure correlates with RHCOS RPM changes when ANY of the following hold:
+
+1. The subagent's `rhcos_rpm_correlation` is `possible` or `likely`
+2. The failure is variant-isolated (e.g., appears only in RHCOS 10 jobs) AND the matching RHCOS variant has RPM changes in the originating payload
+3. The root cause involves OS-level components (kernel, systemd, SELinux, cri-o, crun, runc, networking, bootloader, rpm-ostree, MCO, Ignition) AND matching RHCOS RPM changes exist in the originating payload
+4. No high-confidence PR candidates exist (all scores < 50) AND RHCOS RPM changes exist in the originating payload — in this case, the RPM changes are the most plausible explanation
+
+**RHCOS RPM changes are NOT revert candidates.** They cannot be easily reverted from the payload. Do NOT propose reverts for RHCOS changes. Instead, surface them as **"RHCOS RPM suspects"** — informational entries for manual investigation by the RHCOS or platform team.
+
+When both PR candidates AND RHCOS RPM changes are plausible causes, include both. The PR candidate scoring is unchanged; RHCOS suspects are additive context, not alternatives. It is possible for a failure to be caused by an interaction between a PR change and an RHCOS change.
+
+For each RHCOS RPM suspect, record:
+- `rhcos_tag`: the RHCOS image stream tag (e.g., `rhel-coreos-10`)
+- `rhcos_name`: human-readable name (e.g., "Red Hat Enterprise Linux CoreOS 10.2")
+- `package`: the RPM package name
+- `old_version`, `new_version`: the version change
+- `failing_jobs`: list of job names where this package change may be relevant
+- `rationale`: why this package is suspected (e.g., "systemd update correlates with variant-isolated boot timeout in RHCOS 10 jobs")
+
 #### 6.2: Propose Revert Candidates
 
 For each candidate PR with a rubric score of **>= 85**, mark it as a **revert candidate**. A PR qualifies when:
@@ -326,7 +373,7 @@ Recommend force-accepting when **all** of the following are true:
 
 Use the `payload-results-yaml` skill to create: `payload-results-{tag}.yaml`
 
-This file contains ALL scored candidates across all confidence tiers (HIGH, MEDIUM, LOW), enabling downstream commands to filter by their own criteria.
+This file contains ALL scored candidates across all confidence tiers (HIGH, MEDIUM, LOW), enabling downstream commands to filter by their own criteria. If RHCOS RPM suspects were identified in Step 6.1b, include them in the `rhcos_suspects[]` array (see the `payload-results-yaml` skill for the schema).
 
 ### Step 7: Generate HTML Report
 
@@ -399,6 +446,47 @@ For each failed job, a collapsible section containing:
     </table>
   </div>
 </details>
+```
+
+#### 7.3b: RHCOS Changes
+
+Include this section after the failed job details when any payload in the chain has RHCOS RPM changes. If RHCOS RPM suspects were identified (Step 6.1b), show them prominently first, then include the full RPM diff in a collapsible section.
+
+```html
+<div class="card">
+  <h2>RHCOS Changes</h2>
+
+  <!-- Only when RHCOS RPM suspects exist -->
+  <div class="rhcos-suspect">
+    <h3>Suspected RHCOS RPM Changes</h3>
+    <p>The following RHCOS package updates may be contributing to failures. These cannot be reverted
+       through the normal PR revert process — escalate to the RHCOS or platform team if confirmed.</p>
+    <table>
+      <tr><th>Package</th><th>Old Version</th><th>New Version</th><th>Variant</th><th>Affected Jobs</th><th>Rationale</th></tr>
+      <tr>
+        <td>{package}</td><td>{old_version}</td><td>{new_version}</td>
+        <td><span class="badge badge-{rhcos9|rhcos10}">{variant}</span></td>
+        <td>{comma-separated job names}</td><td>{rationale}</td>
+      </tr>
+    </table>
+  </div>
+
+  <!-- Always include full RPM diffs when RHCOS changes exist in any originating payload -->
+  <details>
+    <summary>Full RHCOS RPM Diffs ({originating_payload_tag})</summary>
+    <h4>{rhcos_name} ({rhcos_tag})</h4>
+    <table>
+      <tr><th>Package</th><th>Old Version</th><th>New Version</th></tr>
+      <!-- List all changed packages -->
+    </table>
+    <!-- Repeat for each RHCOS variant with changes -->
+  </details>
+</div>
+```
+
+Add this CSS for RHCOS suspect styling:
+```css
+.rhcos-suspect { background: rgba(188,140,255,0.1); border-left: 4px solid var(--purple); padding: 0.75rem 1rem; border-radius: 0 0.3rem 0.3rem 0; margin: 0.75rem 0; }
 ```
 
 #### 7.4: Recommended Reverts
@@ -497,10 +585,11 @@ After generating the initial report and output files, launch a **dedicated subag
 
 The reviewer should receive **only** the following (NOT the full conversation history):
 
-1. The `summary.json` snapshot data (payload metadata, failed jobs, streaks, test regressions)
+1. The `summary.json` snapshot data (payload metadata, failed jobs, streaks, test regressions, RHCOS changes)
 2. The scored candidate list with per-component rubric breakdowns from Step 6
 3. The `ANALYSIS_RESULT` blocks from all subagents in Step 4
 4. The revert recommendations (if any)
+5. The RHCOS RPM suspects (if any)
 
 Use this prompt for the reviewer:
 
@@ -523,6 +612,8 @@ Use this prompt for the reviewer:
 > 3. **Incomplete coverage**: Are there failed jobs with no subagent analysis or with only a one-line summary? Every failed blocking job deserves a thorough investigation.
 >
 > 4. **Wrong skill for failure type**: Was an install failure analyzed with the test failure skill or vice versa?
+>
+> 5. **Missing RHCOS RPM correlation**: If RHCOS RPM changes exist in the originating payload and failures are variant-isolated or involve OS-level components, was the correlation checked? Were relevant packages surfaced as suspects?
 >
 > **Rules**:
 > - Do NOT suggest lowering confidence scores. If the rubric signals fired (error message match, new failure, component exclusivity), the score is correct. Period.

--- a/plugins/ci/skills/payload-autodl-json/SKILL.md
+++ b/plugins/ci/skills/payload-autodl-json/SKILL.md
@@ -51,7 +51,9 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
         "candidate_confidence_score": "int64",
         "candidate_rationale": "string",
         "revert_pr_url": "string",
-        "revert_pr_status": "string"
+        "revert_pr_status": "string",
+        "rhcos_change_suspected": "int64",
+        "rhcos_suspect_packages": "string"
     },
     "schema_mapping": null,
     "rows": [
@@ -80,7 +82,9 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
             "candidate_confidence_score": "95",
             "candidate_rationale": "Error references code changed by this PR",
             "revert_pr_url": "https://github.com/openshift/cno/pull/2038",
-            "revert_pr_status": "open"
+            "revert_pr_status": "open",
+            "rhcos_change_suspected": "0",
+            "rhcos_suspect_packages": ""
         },
         {
             "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
@@ -107,7 +111,9 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
             "candidate_confidence_score": "0",
             "candidate_rationale": "",
             "revert_pr_url": "",
-            "revert_pr_status": ""
+            "revert_pr_status": "",
+            "rhcos_change_suspected": "1",
+            "rhcos_suspect_packages": "systemd,glibc"
         }
     ],
     "chunk_size": 0,
@@ -177,6 +183,13 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
 | `candidate_rationale` | string | Explanation of why this PR is a candidate, or `""` |
 | `revert_pr_url` | string | URL of a revert PR if one exists, or `""` |
 | `revert_pr_status` | string | `"open"`, `"merged"`, `"draft"`, `"closed"`, or `""` |
+
+### RHCOS suspect fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rhcos_change_suspected` | int64 | `"1"` if RHCOS RPM changes are suspected to contribute to this job's failure, `"0"` otherwise |
+| `rhcos_suspect_packages` | string | Comma-separated RPM package names suspected as causes (e.g., `"kernel,systemd"`), or `""` when not suspected |
 
 ## Operations
 

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -78,6 +78,16 @@ candidates:
           - command: "/payload-job periodic-ci-...-e2e-aws-ovn"
             test_url: "https://pr-payload-tests.ci.openshift.org/runs/ci/..."
             test_prow_url: "https://prow.ci.openshift.org/view/gs/..."
+
+rhcos_suspects:
+  - rhcos_tag: "rhel-coreos-10"
+    rhcos_name: "Red Hat Enterprise Linux CoreOS 10.2"
+    package: "systemd"
+    old_version: "257-23.el10"
+    new_version: "257-23.el10_2.2"
+    failing_jobs:
+      - "periodic-ci-...-e2e-metal-ipi-ovn-ipv4"
+    rationale: "systemd update correlates with variant-isolated boot timeout in RHCOS 10 jobs"
 ```
 
 ### `metadata`
@@ -166,11 +176,27 @@ Payload validation jobs triggered against the revert PR.
 | `test_url` | string | pr-payload-tests URL for the run |
 | `test_prow_url` | string | Prow URL for the resulting test run |
 
+### `rhcos_suspects[]` (optional)
+
+RHCOS RPM package updates suspected of contributing to failures. Written once by `payload-analysis` when RHCOS RPM changes correlate with job failures (see Step 6.1b of the payload-analysis skill). This array is separate from `candidates[]` because RHCOS changes cannot be reverted through the PR revert mechanism — they are informational for manual investigation.
+
+An empty array or absent key means no RHCOS RPM changes were suspected.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rhcos_tag` | string | RHCOS image stream tag (`rhel-coreos` or `rhel-coreos-10`) |
+| `rhcos_name` | string | Human-readable RHCOS version name |
+| `package` | string | RPM package name |
+| `old_version` | string | Previous RPM version |
+| `new_version` | string | New RPM version |
+| `failing_jobs` | array of strings | Job names from `failing_jobs[]` where this package change may be relevant |
+| `rationale` | string | Why this package is suspected |
+
 ## Operations
 
 ### Create (used by `payload-analysis`)
 
-Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, and `candidates` populated. All failed blocking jobs are recorded in `failing_jobs`. Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis, append an action with `type: "revert"` and `status: "open"` or `"merged"`.
+Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, `candidates`, and optionally `rhcos_suspects` populated. All failed blocking jobs are recorded in `failing_jobs`. Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis, append an action with `type: "revert"` and `status: "open"` or `"merged"`. If RHCOS RPM suspects were identified, include them in `rhcos_suspects[]`.
 
 ### Read Candidates (used by `payload-revert`, `payload-experiment`)
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
@@ -28,9 +28,11 @@ if __name__ == "__main__":
     cases = [
         ("valid full schema", f"{TESTDATA}/valid.yaml", 0),
         ("valid no candidates", f"{TESTDATA}/valid_no_candidates.yaml", 0),
+        ("valid with rhcos suspects", f"{TESTDATA}/valid_with_rhcos_suspects.yaml", 0),
         ("invalid flat schema (no metadata wrapper)", f"{TESTDATA}/invalid_flat_schema.yaml", 1),
         ("invalid metadata is string", f"{TESTDATA}/invalid_metadata_string.yaml", 1),
         ("invalid missing job/candidate fields", f"{TESTDATA}/invalid_missing_job_fields.yaml", 1),
+        ("invalid rhcos suspects missing fields", f"{TESTDATA}/invalid_rhcos_suspects.yaml", 1),
         ("file not found", f"{TESTDATA}/nonexistent.yaml", 1),
     ]
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_rhcos_suspects.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_rhcos_suspects.yaml
@@ -1,0 +1,17 @@
+metadata:
+  payload_tag: "5.0.0-0.nightly-2026-06-17-095118"
+  version: "5.0"
+  stream: "nightly"
+  architecture: "amd64"
+
+failing_jobs:
+  - job_name: "test-job"
+    failure_type: "test"
+    root_cause_summary: "test failure"
+
+candidates: []
+
+rhcos_suspects:
+  - rhcos_name: "Missing required fields"
+    old_version: "1.0"
+    new_version: "2.0"

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid_with_rhcos_suspects.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid_with_rhcos_suspects.yaml
@@ -1,0 +1,28 @@
+metadata:
+  payload_tag: "5.0.0-0.nightly-2026-06-17-095118"
+  version: "5.0"
+  stream: "nightly"
+  architecture: "amd64"
+  release_controller_url: "https://amd64.ocp.releases.ci.openshift.org/..."
+  analyzed_at: "2026-06-17T12:00:00Z"
+  force_accept_recommended: false
+
+failing_jobs:
+  - job_name: "periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-ipv4"
+    prow_url: "https://prow.ci.openshift.org/view/gs/..."
+    failure_type: "install"
+    root_cause_summary: "Boot timeout during RHCOS 10 node provisioning"
+    streak_length: 2
+    originating_payload_tag: "5.0.0-0.nightly-2026-06-17-022519"
+
+candidates: []
+
+rhcos_suspects:
+  - rhcos_tag: "rhel-coreos-10"
+    rhcos_name: "Red Hat Enterprise Linux CoreOS 10.2"
+    package: "systemd"
+    old_version: "257-23.el10"
+    new_version: "257-23.el10_2.2"
+    failing_jobs:
+      - "periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-ipv4"
+    rationale: "systemd update correlates with variant-isolated boot timeout in RHCOS 10 jobs"

--- a/plugins/ci/skills/payload-results-yaml/scripts/validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/validate.py
@@ -7,6 +7,7 @@ import yaml
 REQUIRED_METADATA = ["payload_tag", "version", "stream", "architecture"]
 REQUIRED_JOB_FIELDS = ["job_name", "failure_type", "root_cause_summary"]
 REQUIRED_CANDIDATE_FIELDS = ["pr_url", "confidence_score", "failing_jobs"]
+REQUIRED_RHCOS_SUSPECT_FIELDS = ["rhcos_tag", "package", "failing_jobs"]
 
 
 def validate(path):
@@ -60,6 +61,21 @@ def validate(path):
                 if field not in cand:
                     errors.append(f"candidates[{i}] missing '{field}'")
 
+    rhcos_suspects = data.get("rhcos_suspects")
+    if rhcos_suspects is not None:
+        if not isinstance(rhcos_suspects, list):
+            errors.append("'rhcos_suspects' is not a list")
+        else:
+            for i, suspect in enumerate(rhcos_suspects):
+                if not isinstance(suspect, dict):
+                    errors.append(f"rhcos_suspects[{i}] is not an object")
+                    continue
+                for field in REQUIRED_RHCOS_SUSPECT_FIELDS:
+                    if field not in suspect:
+                        errors.append(
+                            f"rhcos_suspects[{i}] missing '{field}'"
+                        )
+
     if errors:
         print(f"FAIL: {len(errors)} error(s)")
         for e in errors:
@@ -68,7 +84,11 @@ def validate(path):
 
     jobs = len(data.get("failing_jobs", []))
     cands = len(data.get("candidates", []))
-    print(f"OK: {jobs} failing jobs, {cands} candidates")
+    suspects = len(data.get("rhcos_suspects", []))
+    parts = [f"{jobs} failing jobs", f"{cands} candidates"]
+    if suspects:
+        parts.append(f"{suspects} RHCOS suspects")
+    print(f"OK: {', '.join(parts)}")
     return 0
 
 

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -161,7 +161,7 @@ Comprehensive stream-level triage data — start here. Contains:
 - `blocking_jobs.failed_jobs[]` — detailed objects with `name`, `state`, `prow_url`, `gcs_url`, and relative path `job_json`. May include: `rhcos_version`, `streak` (with `streak_length`, `originating_payload`, `is_new_failure`, `failure_pattern`), `build_log_errors`, `test_failure_count`, and relative paths `junit_results`, `build_log`
 - `informing_jobs.failed_jobs[]` — job name strings
 - `test_failures.blocking[]` — `test_name`, `jobs`, `first_failed_in`, `payloads_failing`, `failure_message`, `failure_text` (full, not truncated)
-- `payloads[]` — per-payload entries with `tag`, `phase`, relative file paths, and `prs[]` with component/diff/comments paths
+- `payloads[]` — per-payload entries with `tag`, `phase`, relative file paths, `prs[]` with component/diff/comments paths, and `rhcos_changes[]` with RPM diffs per RHCOS variant (name, tag, changed/added/removed package versions)
 
 ### `AGENTS.md` / `CLAUDE.md`
 
@@ -173,7 +173,18 @@ Full release controller response including `blockingJobs`, `informingJobs`, and 
 
 ### `changelog.json`
 
-Release controller diff response with `changeLogJson.updatedImages` listing every PR that changed between this payload and its predecessor.
+Release controller diff response with `changeLogJson.updatedImages` listing every PR that changed between this payload and its predecessor. Also contains `nodeImageStreams` at the top level — RPM diffs for each RHCOS variant showing which packages changed between payloads.
+
+### `rhcos_changes[]` (in payloads[] within summary.json)
+
+Per-payload RHCOS RPM diff data extracted from the changelog's `nodeImageStreams`. Each entry contains:
+- `name`: Human-readable RHCOS version name (e.g., "Red Hat Enterprise Linux CoreOS 10.2")
+- `tag`: RHCOS image stream tag (`rhel-coreos` for RHCOS 9, `rhel-coreos-10` for RHCOS 10)
+- `changed`: Dict of `{package_name: {"old": old_version, "new": new_version}}`
+- `added`: Dict of newly added packages `{package_name: new_version}` (when present)
+- `removed`: Dict of removed packages `{package_name: old_version}` (when present)
+
+Only variants with non-empty `rpmDiff` are included. When the snapshot is created from Sippy-based changelogs (which lack `nodeImageStreams`), this field is absent.
 
 ### `regressions.json`
 

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -1215,7 +1215,8 @@ class SummaryGenerator:
             "  `first_failed_in`, `payloads_failing`, `failure_message`,",
             "  `failure_text`",
             "- `payloads[]` — per-payload entries with `tag`, `phase`,",
-            "  relative paths, and `prs[]` with component/diff/comments paths",
+            "  relative paths, `prs[]` with component/diff/comments paths,",
+            "  and `rhcos_changes[]` with RPM diffs per RHCOS variant",
             "",
         ])
 
@@ -1340,6 +1341,9 @@ class SummaryGenerator:
                         }
                         for p in prs
                     ]
+                rhcos_changes = _extract_rhcos_changes(changelog)
+                if rhcos_changes:
+                    entry["rhcos_changes"] = rhcos_changes
             regressions_path = os.path.join(
                 self.base_dir, tag_name, "regressions.json"
             )
@@ -1857,6 +1861,26 @@ def _extract_prs(changelog: dict) -> list[dict]:
                     "url": pull_url,
                 })
     return prs
+
+
+def _extract_rhcos_changes(changelog: dict) -> list[dict]:
+    """Extract RHCOS RPM diff data from the changelog's nodeImageStreams."""
+    if not changelog:
+        return []
+
+    results = []
+    for stream in changelog.get("nodeImageStreams") or []:
+        rpm_diff = stream.get("rpmDiff") or {}
+        if not any(rpm_diff.get(k) for k in ("changed", "added", "removed")):
+            continue
+        results.append({
+            "name": stream.get("name", ""),
+            "tag": stream.get("tag", ""),
+            "changed": rpm_diff.get("changed", {}),
+            "added": rpm_diff.get("added", {}),
+            "removed": rpm_diff.get("removed", {}),
+        })
+    return results
 
 
 def _parse_pr_url(url: str) -> Optional[tuple[str, str, int]]:


### PR DESCRIPTION
The release controller API returns `nodeImageStreams` in changelog responses with RPM diffs showing which packages changed in RHCOS images between payloads. This data was already preserved in `changelog.json` but invisible to the analysis pipeline — `summary.json` didn't extract it, the payload-analysis skill didn't consider it, and reports didn't surface it.

RHCOS RPM changes (systemd, kernel, glibc, SELinux, etc.) can cause failures, especially on variant-isolated jobs (rhcos10-only or rhcos9-only). When no PR candidate explains a failure, RHCOS changes are a likely culprit. Unlike PRs, they can't be reverted through the normal mechanism, so they're surfaced as informational suspects rather than revert candidates.

Changes:
- `payload_snapshot.py`: extract `nodeImageStreams` RPM diffs into `summary.json` per-payload `rhcos_changes[]` entries
- `payload-analysis/SKILL.md`: pass RHCOS RPM changes to subagents as failure context, add RHCOS RPM correlation step (6.1b), add RHCOS changes section to HTML report (7.3b), extend completeness review
- `payload-results-yaml/SKILL.md`: add optional `rhcos_suspects[]` array separate from PR `candidates[]`
- `payload-autodl-json/SKILL.md`: add `rhcos_change_suspected` and `rhcos_suspect_packages` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extraction of per-payload RHCOS RPM diffs and enhanced failure analysis to correlate those changes with failing jobs
  * Extended CI payload artifacts to record RHCOS correlation status and suspected RHCOS RPM packages (YAML/JSON outputs)
  * Added an “RHCOS Changes” section to HTML reports for suspected RHCOS RPM updates
* **Documentation**
  * Updated skill and snapshot documentation for `rhcos_changes[]` and new RHCOS suspect fields/sections
* **Tests**
  * Added fixtures and validation coverage for `rhcos_suspects`, including missing-field failure cases
* **Chores**
  * Bumped the CI plugin version to **0.0.53**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->