### PR TITLE
Add github plugin with screenshot upload, PR comment, and CI status skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,6 +40,19 @@
       ]
     },
     {
+      "name": "github",
+      "source": "./plugins/github",
+      "description": "GitHub utilities for image uploads, asset management, and PR automation",
+      "version": "0.1.0",
+      "category": "tooling",
+      "keywords": [
+        "github",
+        "screenshots",
+        "images",
+        "uploads"
+      ]
+    },
+    {
       "name": "hello-world",
       "source": "./plugins/hello-world",
       "description": "Hello World Plugin",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1247,6 +1247,47 @@ footer a { color: var(--primary); }
       }
     },
     {
+      "name": "github",
+      "description": "GitHub utilities for image uploads, asset management, and PR automation",
+      "version": "0.1.0",
+      "has_readme": true,
+      "commands": [],
+      "skills": [
+        {
+          "name": "check-pr-ci-status",
+          "description": "Check CI status on a GitHub PR and detect new failures. Use when monitoring a PR for CI regressions, deciding if CI failures need attention, or building a review-response loop.",
+          "description_html": "Check CI status on a GitHub PR and detect new failures. Use when monitoring a PR for CI regressions, deciding if CI failures need attention, or building a review-response loop.",
+          "meta": ""
+        },
+        {
+          "name": "fetch-pr-comments",
+          "description": "Fetch new review comments from a GitHub PR, filtered to trusted users (org members + allowed bots). Use when monitoring a PR for feedback, checking for new review comments, or building a review-response workflow.",
+          "description_html": "Fetch new review comments from a GitHub PR, filtered to trusted users (org members + allowed bots). Use when monitoring a PR for feedback, checking for new review comments, or building a review-response workflow.",
+          "meta": ""
+        },
+        {
+          "name": "upload-screenshot",
+          "description": "Upload screenshots or images to GitHub and get back embeddable URLs for PR comments and issues. Use this when you have taken a screenshot, captured a UI change, or have any image file that needs to be shared in a GitHub PR or issue.",
+          "description_html": "Upload screenshots or images to GitHub and get back embeddable URLs for PR comments and issues. Use this when you have taken a screenshot, captured a UI change, or have any image file that needs to be shared in a GitHub PR or issue.",
+          "meta": ""
+        }
+      ],
+      "agents": [],
+      "hooks": [],
+      "mcp_servers": [],
+      "rules": [],
+      "category": "tooling",
+      "keywords": [
+        "github",
+        "screenshots",
+        "images",
+        "uploads"
+      ],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
+    },
+    {
       "name": "golang",
       "description": "Go development tools: gopls MCP server, LSP integration, automatic gofmt formatting, golangci-lint linting, and CVE dependency patching",
       "version": "0.3.1",

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "github",
+  "description": "GitHub utilities for image uploads, asset management, and PR automation",
+  "version": "0.1.0",
+  "author": {
+    "name": "github.com/openshift-eng"
+  }
+}

--- a/plugins/github/OWNERS
+++ b/plugins/github/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ai-helpers-admins
+- smg247
+reviewers:
+- ai-helpers-admins
+- smg247

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,0 +1,19 @@
+# github
+
+GitHub utilities for image uploads, asset management, and PR automation.
+
+## Skills
+
+### upload-screenshot
+
+Upload screenshots and images to GitHub via release assets, returning stable URLs that can be embedded in PR comments, issue descriptions, and markdown.
+
+Uses the official `gh` CLI release asset API — no browser sessions, cookies, or third-party dependencies required.
+
+### fetch-pr-comments
+
+Fetch all comments from a GitHub PR, filtered to trusted users only (org members + allowed bots). Returns structured JSON with comments from all three GitHub endpoints (inline review, review summaries, PR conversation) plus pre-formatted text ready for Claude prompts. Supports stateful polling via exclude-ids tracking.
+
+### check-pr-ci-status
+
+Check CI status on a GitHub PR and detect new failures since the last check. Returns failing check details and a `has_new_failures` flag for efficient polling loops. Designed to be called repeatedly with the previous iteration's failure list.

--- a/plugins/github/skills/check-pr-ci-status/SKILL.md
+++ b/plugins/github/skills/check-pr-ci-status/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: check-pr-ci-status
+description: Check CI status on a GitHub PR and detect new failures. Use when monitoring a PR for CI regressions, deciding if CI failures need attention, or building a review-response loop.
+---
+
+# Check PR CI Status
+
+Check the CI check status on a GitHub pull request and detect whether any failures are new since the last check. This enables efficient CI monitoring — only act on new failures, not stale ones that were already addressed.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Check if a PR has any failing CI checks
+- Detect new CI failures that appeared since your last check
+- Decide whether CI failures need attention in an agentic workflow
+- Build a polling loop that reacts to CI status changes
+
+## Prerequisites
+
+1. **`gh` CLI**: Authenticated with `gh auth login`
+2. **Repository read access**: The token must have permission to view PR check status
+
+## Implementation
+
+### Basic usage
+
+```bash
+result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/check-pr-ci-status/check_pr_ci_status.sh" \
+  --repo owner/repo \
+  --pr 123)
+```
+
+### With previous failure tracking
+
+```bash
+result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/check-pr-ci-status/check_pr_ci_status.sh" \
+  --repo owner/repo \
+  --pr 123 \
+  --previous-failures "ci/prow/e2e-aws ci/prow/unit")
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--repo` | Yes | GitHub repository in `owner/repo` format |
+| `--pr` | Yes | Pull request number |
+| `--previous-failures` | No | Space-separated check names that were failing on the last check |
+
+### Output
+
+JSON on stdout:
+
+```json
+{
+  "failing_checks": [
+    {"name": "ci/prow/e2e-aws", "state": "FAILURE"},
+    {"name": "ci/prow/unit", "state": "FAILURE"}
+  ],
+  "failing_count": 2,
+  "failing_names": "ci/prow/e2e-aws ci/prow/unit",
+  "has_new_failures": true,
+  "formatted": "- ci/prow/e2e-aws (FAILURE)\n- ci/prow/unit (FAILURE)"
+}
+```
+
+### Using in a polling loop
+
+The `failing_names` field is designed to be passed back as `--previous-failures` on the next call:
+
+```bash
+LAST_FAILURES=""
+
+while true; do
+  sleep 300
+
+  result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/check-pr-ci-status/check_pr_ci_status.sh" \
+    --repo owner/repo --pr 123 --previous-failures "$LAST_FAILURES")
+
+  has_new=$(echo "$result" | jq -r '.has_new_failures')
+  if [[ "$has_new" == "true" ]]; then
+    formatted=$(echo "$result" | jq -r '.formatted')
+    echo "New CI failures detected:"
+    echo "$formatted"
+    # Address failures...
+  fi
+
+  LAST_FAILURES=$(echo "$result" | jq -r '.failing_names')
+done
+```
+
+## How It Works
+
+1. Runs `gh pr checks` to get all check statuses
+2. Filters to checks with state FAIL or FAILURE
+3. Compares current failing check names against `--previous-failures`
+4. Reports `has_new_failures: true` if the set of failing checks has changed
+5. Returns both structured data and pre-formatted text
+
+## New Failure Detection
+
+A failure is considered "new" when the set of failing check names differs from `--previous-failures`. This means:
+- A check that was passing and is now failing triggers `has_new_failures`
+- A check that was already failing stays in the list but doesn't trigger by itself
+- A check that was failing and is now passing changes the set and triggers too
+
+If `--previous-failures` is not provided, any failing check is considered new.
+
+## See Also
+
+- Related Skill: `fetch-pr-comments` — Fetch trusted PR review comments
+- Related Skill: `upload-screenshot` — Upload images to GitHub for PR comments

--- a/plugins/github/skills/check-pr-ci-status/check_pr_ci_status.sh
+++ b/plugins/github/skills/check-pr-ci-status/check_pr_ci_status.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --repo <owner/repo> --pr <number> [--previous-failures <\"name1 name2\">]" >&2
+  echo "" >&2
+  echo "Check CI status on a GitHub PR and detect new failures." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  --repo                GitHub repository in owner/repo format (required)" >&2
+  echo "  --pr                  Pull request number (required)" >&2
+  echo "  --previous-failures   Space-separated check names from last check (optional)" >&2
+  exit 1
+}
+
+REPO=""
+PR=""
+PREVIOUS_FAILURES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)               REPO="$2"; shift 2 ;;
+    --pr)                 PR="$2"; shift 2 ;;
+    --previous-failures)  PREVIOUS_FAILURES="$2"; shift 2 ;;
+    -h|--help)            usage ;;
+    *)                    echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$PR" ]]; then
+  echo '{"error": "Missing required arguments. Use --repo and --pr."}' >&2
+  exit 1
+fi
+
+# --- Fetch CI checks ---
+checks_json=$(gh pr checks "${PR}" --repo "${REPO}" --json name,state 2>/dev/null || echo "[]")
+
+failing_checks=$(echo "${checks_json}" | jq '[.[] | select(.state == "FAIL" or .state == "FAILURE" or .state == "fail" or .state == "failure")]')
+failing_count=$(echo "${failing_checks}" | jq 'length')
+current_failing_names=$(echo "${failing_checks}" | jq -r '.[].name' 2>/dev/null | sort | tr '\n' ' ' | xargs)
+
+# --- Detect new failures ---
+has_new_failures=false
+if [[ "${failing_count}" -gt 0 && "${current_failing_names}" != "${PREVIOUS_FAILURES}" ]]; then
+  has_new_failures=true
+fi
+
+# --- Formatted output ---
+formatted=$(echo "${failing_checks}" | jq -r '.[] | "- \(.name) (\(.state))"' 2>/dev/null || echo "")
+
+# --- Output ---
+jq -n \
+  --argjson failing_checks "${failing_checks}" \
+  --arg failing_count "${failing_count}" \
+  --arg failing_names "${current_failing_names}" \
+  --arg has_new_failures "${has_new_failures}" \
+  --arg formatted "${formatted}" \
+  '{
+    failing_checks: $failing_checks,
+    failing_count: ($failing_count | tonumber),
+    failing_names: $failing_names,
+    has_new_failures: ($has_new_failures == "true"),
+    formatted: $formatted
+  }'

--- a/plugins/github/skills/fetch-pr-comments/SKILL.md
+++ b/plugins/github/skills/fetch-pr-comments/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: fetch-pr-comments
+description: Fetch new review comments from a GitHub PR, filtered to trusted users (org members + allowed bots). Use when monitoring a PR for feedback, checking for new review comments, or building a review-response workflow.
+---
+
+# Fetch PR Comments
+
+Fetch all comments from a GitHub pull request, filtered to trusted users only. Trusted users are GitHub org members and explicitly allowed bots. Untrusted comments are silently excluded.
+
+This skill fetches from all three GitHub comment endpoints (inline review comments, review summaries, and PR conversation comments), providing a complete picture of PR feedback.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Check a PR for new review comments that need attention
+- Monitor a PR for feedback during an agentic workflow
+- Build a review-response loop that only processes trusted feedback
+- Fetch all actionable PR comments in a single call
+
+## Prerequisites
+
+1. **`gh` CLI**: Authenticated with `gh auth login`
+2. **Repository read access**: The token must have permission to read PR comments and check org membership
+
+## Implementation
+
+### Basic usage
+
+```bash
+result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/fetch-pr-comments/fetch_pr_comments.sh" \
+  --repo owner/repo \
+  --pr 123)
+```
+
+### With custom trusted bots and exclusions
+
+```bash
+result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/fetch-pr-comments/fetch_pr_comments.sh" \
+  --repo owner/repo \
+  --pr 123 \
+  --trusted-bots "coderabbitai,dependabot" \
+  --exclude-ids "12345,67890")
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--repo` | Yes | GitHub repository in `owner/repo` format |
+| `--pr` | Yes | Pull request number |
+| `--trusted-bots` | No | Comma-separated bot logins to trust (default: `coderabbitai`) |
+| `--exclude-ids` | No | Comma-separated comment IDs to skip (already processed) |
+
+### Output
+
+JSON on stdout:
+
+```json
+{
+  "inline_comments": [
+    {"id": "123", "user": "reviewer", "path": "pkg/server.go", "body": "This needs a nil check"}
+  ],
+  "reviews": [
+    {"id": "456", "user": "reviewer", "state": "CHANGES_REQUESTED", "body": "See inline comments"}
+  ],
+  "issue_comments": [
+    {"id": "789", "user": "coderabbitai[bot]", "body": "Static analysis found..."}
+  ],
+  "all_ids": ["123", "456", "789"],
+  "total": 3,
+  "formatted": {
+    "inline": "**reviewer** on `pkg/server.go`:\nThis needs a nil check\n---",
+    "reviews": "**reviewer** (CHANGES_REQUESTED):\nSee inline comments\n---",
+    "issue_comments": "**coderabbitai[bot]**:\nStatic analysis found...\n---"
+  }
+}
+```
+
+### Using in a polling loop
+
+The `all_ids` and `--exclude-ids` fields enable stateful polling across iterations:
+
+```bash
+PROCESSED_IDS=""
+
+while true; do
+  sleep 300
+
+  result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/fetch-pr-comments/fetch_pr_comments.sh" \
+    --repo owner/repo --pr 123 --exclude-ids "$PROCESSED_IDS")
+
+  total=$(echo "$result" | jq -r '.total')
+  if [[ "$total" -gt 0 ]]; then
+    # Process comments...
+    new_ids=$(echo "$result" | jq -r '.all_ids | join(",")')
+    PROCESSED_IDS="${PROCESSED_IDS:+$PROCESSED_IDS,}$new_ids"
+  fi
+done
+```
+
+### Using formatted output for Claude prompts
+
+The `formatted` fields provide ready-to-use text:
+
+```bash
+inline=$(echo "$result" | jq -r '.formatted.inline')
+reviews=$(echo "$result" | jq -r '.formatted.reviews')
+issue_comments=$(echo "$result" | jq -r '.formatted.issue_comments')
+```
+
+## How It Works
+
+1. Fetches from three GitHub API endpoints:
+   - `repos/{repo}/pulls/{pr}/comments` — inline code review comments
+   - `repos/{repo}/pulls/{pr}/reviews` — review summaries (CHANGES_REQUESTED, etc.)
+   - `repos/{repo}/issues/{pr}/comments` — PR conversation thread
+2. Identifies all unique comment authors
+3. Checks each author against the trusted bots list and org membership (`gh api orgs/{org}/members/{login}`)
+4. Filters comments to trusted authors only
+5. Excludes already-processed comment IDs
+6. Filters out APPROVED and PENDING reviews (no actionable content)
+7. Returns structured JSON with both raw data and pre-formatted text
+
+## Trust Model
+
+A user is trusted if they match ANY of:
+- Their login matches a `--trusted-bots` entry (with or without `[bot]` suffix)
+- They are a member of the repository's GitHub organization
+
+All other commenters are silently excluded.
+
+## See Also
+
+- Related Skill: `check-pr-ci-status` — Check CI status and detect new failures
+- Related Skill: `upload-screenshot` — Upload images to GitHub for PR comments
+- Related Command: `/utils:address-reviews` — Full review-addressing workflow

--- a/plugins/github/skills/fetch-pr-comments/fetch_pr_comments.sh
+++ b/plugins/github/skills/fetch-pr-comments/fetch_pr_comments.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --repo <owner/repo> --pr <number> [--trusted-bots <bot1,bot2>] [--exclude-ids <id1,id2>]" >&2
+  echo "" >&2
+  echo "Fetch PR comments filtered to trusted users (org members + allowed bots)." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  --repo          GitHub repository in owner/repo format (required)" >&2
+  echo "  --pr            Pull request number (required)" >&2
+  echo "  --trusted-bots  Comma-separated list of trusted bot logins (default: coderabbitai)" >&2
+  echo "  --exclude-ids   Comma-separated list of comment IDs to exclude" >&2
+  exit 1
+}
+
+REPO=""
+PR=""
+TRUSTED_BOTS="coderabbitai"
+EXCLUDE_IDS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)         REPO="$2"; shift 2 ;;
+    --pr)           PR="$2"; shift 2 ;;
+    --trusted-bots) TRUSTED_BOTS="$2"; shift 2 ;;
+    --exclude-ids)  EXCLUDE_IDS="$2"; shift 2 ;;
+    -h|--help)      usage ;;
+    *)              echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$PR" ]]; then
+  echo '{"error": "Missing required arguments. Use --repo and --pr."}' >&2
+  exit 1
+fi
+
+ORG="${REPO%%/*}"
+
+# --- Fetch from all three endpoints ---
+raw_inline=$(gh api "repos/${REPO}/pulls/${PR}/comments" --paginate 2>/dev/null || echo "[]")
+raw_reviews=$(gh api "repos/${REPO}/pulls/${PR}/reviews" --paginate 2>/dev/null || echo "[]")
+raw_issue_comments=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate 2>/dev/null || echo "[]")
+
+# --- Build trusted user list ---
+all_users=$(echo "${raw_inline}" "${raw_reviews}" "${raw_issue_comments}" \
+  | jq -r '.[].user.login' 2>/dev/null | sort -u)
+
+trusted_users=""
+IFS=',' read -ra BOT_ARRAY <<< "$TRUSTED_BOTS"
+
+for user in ${all_users}; do
+  is_trusted=false
+
+  for bot in "${BOT_ARRAY[@]}"; do
+    if [[ "${user}" == "${bot}" || "${user}" == "${bot}[bot]" ]]; then
+      is_trusted=true
+      break
+    fi
+  done
+
+  if [[ "$is_trusted" == "false" ]]; then
+    if gh api "orgs/${ORG}/members/${user}" --silent 2>/dev/null; then
+      is_trusted=true
+    fi
+  fi
+
+  if [[ "$is_trusted" == "true" ]]; then
+    trusted_users="${trusted_users} ${user}"
+  fi
+done
+
+# --- Filter to trusted users ---
+trusted_jq_filter=$(echo "${trusted_users}" | xargs -n1 2>/dev/null | jq -R . | jq -s '.' 2>/dev/null || echo '[]')
+
+inline_filtered=$(echo "${raw_inline}" | jq --argjson trusted "${trusted_jq_filter}" \
+  '[.[] | select(.user.login as $u | $trusted | index($u))]')
+reviews_filtered=$(echo "${raw_reviews}" | jq --argjson trusted "${trusted_jq_filter}" \
+  '[.[] | select(.user.login as $u | $trusted | index($u))]')
+issue_comments_filtered=$(echo "${raw_issue_comments}" | jq --argjson trusted "${trusted_jq_filter}" \
+  '[.[] | select(.user.login as $u | $trusted | index($u))]')
+
+# --- Exclude already-processed IDs ---
+if [[ -n "${EXCLUDE_IDS}" ]]; then
+  exclude_jq_filter=$(echo "${EXCLUDE_IDS}" | tr ',' '\n' | jq -R . | jq -s '.')
+  inline_filtered=$(echo "${inline_filtered}" | jq --argjson seen "${exclude_jq_filter}" \
+    '[.[] | select((.id | tostring) as $id | $seen | index($id) | not)]')
+  reviews_filtered=$(echo "${reviews_filtered}" | jq --argjson seen "${exclude_jq_filter}" \
+    '[.[] | select((.id | tostring) as $id | $seen | index($id) | not)]')
+  issue_comments_filtered=$(echo "${issue_comments_filtered}" | jq --argjson seen "${exclude_jq_filter}" \
+    '[.[] | select((.id | tostring) as $id | $seen | index($id) | not)]')
+fi
+
+# --- Filter out APPROVED/PENDING reviews ---
+reviews_filtered=$(echo "${reviews_filtered}" | jq '[.[] | select(.state != "APPROVED" and .state != "PENDING")]')
+
+# --- Extract slim comment objects ---
+inline_slim=$(echo "${inline_filtered}" | jq '[.[] | {id: (.id | tostring), user: .user.login, path: (.path // "general"), body: .body}]')
+reviews_slim=$(echo "${reviews_filtered}" | jq '[.[] | {id: (.id | tostring), user: .user.login, state: .state, body: .body}]')
+issue_comments_slim=$(echo "${issue_comments_filtered}" | jq '[.[] | {id: (.id | tostring), user: .user.login, body: .body}]')
+
+# --- Collect all IDs ---
+all_ids=$(echo "${inline_slim} ${reviews_slim} ${issue_comments_slim}" | jq -s 'map(.[].id) | unique')
+
+# --- Counts ---
+inline_count=$(echo "${inline_slim}" | jq 'length')
+review_count=$(echo "${reviews_slim}" | jq 'length')
+issue_comment_count=$(echo "${issue_comments_slim}" | jq 'length')
+total=$(( inline_count + review_count + issue_comment_count ))
+
+# --- Formatted text for prompts ---
+fmt_inline=$(echo "${inline_slim}" | jq -r '.[] | "**\(.user)** on `\(.path)`:\n\(.body)\n---"' 2>/dev/null || echo "")
+fmt_reviews=$(echo "${reviews_slim}" | jq -r '.[] | "**\(.user)** (\(.state)):\n\(.body)\n---"' 2>/dev/null || echo "")
+fmt_issue_comments=$(echo "${issue_comments_slim}" | jq -r '.[] | "**\(.user)**:\n\(.body)\n---"' 2>/dev/null || echo "")
+
+# --- Output ---
+jq -n \
+  --argjson inline_comments "${inline_slim}" \
+  --argjson reviews "${reviews_slim}" \
+  --argjson issue_comments "${issue_comments_slim}" \
+  --argjson all_ids "${all_ids}" \
+  --arg total "${total}" \
+  --arg fmt_inline "${fmt_inline}" \
+  --arg fmt_reviews "${fmt_reviews}" \
+  --arg fmt_issue_comments "${fmt_issue_comments}" \
+  '{
+    inline_comments: $inline_comments,
+    reviews: $reviews,
+    issue_comments: $issue_comments,
+    all_ids: $all_ids,
+    total: ($total | tonumber),
+    formatted: {
+      inline: $fmt_inline,
+      reviews: $fmt_reviews,
+      issue_comments: $fmt_issue_comments
+    }
+  }'

--- a/plugins/github/skills/upload-screenshot/SKILL.md
+++ b/plugins/github/skills/upload-screenshot/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: upload-screenshot
+description: Upload screenshots or images to GitHub and get back embeddable URLs for PR comments and issues. Use this when you have taken a screenshot, captured a UI change, or have any image file that needs to be shared in a GitHub PR or issue.
+---
+
+# Upload Screenshot
+
+Upload images to GitHub via release assets and get back stable, embeddable URLs. This is the recommended way to share screenshots of frontend changes, UI diffs, or any visual artifacts in PR comments and issue descriptions.
+
+## When to Use This Skill
+
+Use this skill when you:
+
+- Have taken a screenshot of a frontend/UI change and need to show it in a PR
+- Need to attach visual evidence (error screenshots, UI comparisons) to a GitHub issue or PR comment
+- Want to embed an image in any GitHub markdown context (PR description, comment, issue)
+- Are working in an agentic workflow and need to share visual output
+
+## Prerequisites
+
+1. **`gh` CLI**: Authenticated with `gh auth login`
+2. **Repository write access**: The `gh` token must have permission to create releases on the target repo
+
+## Implementation
+
+### Upload a screenshot
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
+  --file /path/to/screenshot.png \
+  --repo owner/repo
+```
+
+### Upload with a custom title
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
+  --file /path/to/screenshot.png \
+  --repo owner/repo \
+  --title "Login page after dark mode changes"
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--file`  | Yes      | Path to the image file (png, jpg, gif, svg, webp) |
+| `--repo`  | Yes      | Target GitHub repository in `owner/repo` format |
+| `--title` | No       | Alt text for the image (defaults to filename) |
+
+### Output
+
+JSON on stdout:
+
+```json
+{
+  "url": "https://github.com/owner/repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png",
+  "markdown": "![Login page](https://github.com/owner/repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png)",
+  "tag": "screenshot-1719100000-a1b2c3d4",
+  "repo": "owner/repo"
+}
+```
+
+### Embedding in a PR comment
+
+After uploading, use the `markdown` field directly in a `gh pr comment`:
+
+```bash
+result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
+  --file /tmp/screenshot.png --repo owner/repo --title "UI change")
+
+markdown=$(echo "$result" | jq -r '.markdown')
+gh pr comment 123 --repo owner/repo --body "## Screenshot
+
+$markdown"
+```
+
+## How It Works
+
+1. Creates a GitHub prerelease with a unique tag (`screenshot-<timestamp>-<random>`)
+2. Attaches the image file as a release asset
+3. Extracts the `browser_download_url` from the GitHub API
+4. Returns the URL in both raw and markdown-formatted forms
+
+The release is marked as a prerelease and tagged with a `screenshot-` prefix for easy identification and cleanup.
+
+## Cleanup
+
+Screenshot releases accumulate over time. To clean up old uploads:
+
+```bash
+# Delete a specific screenshot release
+gh release delete screenshot-1719100000-a1b2c3d4 --yes --cleanup-tag --repo owner/repo
+
+# Delete all screenshot releases older than 30 days
+gh api "repos/owner/repo/releases" --paginate --jq \
+  '.[] | select(.tag_name | startswith("screenshot-")) | select(.prerelease) | .tag_name' | \
+  while read -r tag; do
+    gh release delete "$tag" --yes --cleanup-tag --repo owner/repo
+  done
+```
+
+## Limitations
+
+- URLs are only accessible as long as the release exists
+- For private repos, viewers must have repo access to see the images
+- GitHub release asset size limit is 2 GB per file
+- Creates one release per upload (use cleanup to manage volume)
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Missing required arguments` | `--file` or `--repo` not provided | Provide both required arguments |
+| `File not found` | Image path doesn't exist | Check the file path |
+| `Failed to create release` | Auth or permission issue | Run `gh auth login` or check repo access |
+| `Failed to retrieve asset URL` | Release created but asset missing | Retry; the release is auto-cleaned on failure |
+
+## See Also
+
+- GitHub Releases API: https://docs.github.com/en/rest/releases
+- `gh release create` docs: https://cli.github.com/manual/gh_release_create

--- a/plugins/github/skills/upload-screenshot/upload_screenshot.sh
+++ b/plugins/github/skills/upload-screenshot/upload_screenshot.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --file <path> --repo <owner/repo> [--title <title>]" >&2
+  echo "" >&2
+  echo "Upload an image to GitHub as a release asset and return the URL." >&2
+  echo "" >&2
+  echo "Options:" >&2
+  echo "  --file   Path to the image file (required)" >&2
+  echo "  --repo   GitHub repository in owner/repo format (required)" >&2
+  echo "  --title  Alt text / title for the image (default: filename)" >&2
+  exit 1
+}
+
+FILE=""
+REPO=""
+TITLE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)  FILE="$2"; shift 2 ;;
+    --repo)  REPO="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$FILE" || -z "$REPO" ]]; then
+  echo '{"error": "Missing required arguments. Use --file and --repo."}' >&2
+  exit 1
+fi
+
+if [[ ! -f "$FILE" ]]; then
+  echo "{\"error\": \"File not found: $FILE\"}" >&2
+  exit 1
+fi
+
+FILENAME=$(basename "$FILE")
+if [[ -z "$TITLE" ]]; then
+  TITLE="$FILENAME"
+fi
+
+TAG="screenshot-$(date +%s)-$(head -c 4 /dev/urandom | xxd -p)"
+
+if ! gh release create "$TAG" "$FILE" \
+  --repo "$REPO" \
+  --title "Screenshot: $TITLE" \
+  --notes "Automated screenshot upload. Safe to delete." \
+  --prerelease > /dev/null 2>&1; then
+  echo '{"error": "Failed to create release. Check gh auth and repo permissions."}' >&2
+  exit 1
+fi
+
+URL=$(gh api "repos/$REPO/releases/tags/$TAG" --jq '.assets[0].browser_download_url' 2>/dev/null)
+
+if [[ -z "$URL" || "$URL" == "null" ]]; then
+  gh release delete "$TAG" --yes --cleanup-tag --repo "$REPO" > /dev/null 2>&1 || true
+  echo '{"error": "Release created but failed to retrieve asset URL."}' >&2
+  exit 1
+fi
+
+cat <<EOF
+{"url": "$URL", "markdown": "![${TITLE}](${URL})", "tag": "$TAG", "repo": "$REPO"}
+EOF


### PR DESCRIPTION
New plugin providing three reusable skills for agentic workflows:
- upload-screenshot: Upload images to GitHub via release assets for PR comments
- fetch-pr-comments: Fetch PR comments filtered to trusted users (org members + allowed bots)
- check-pr-ci-status: Check CI status and detect new failures since last check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new GitHub plugin with three skills:
    * Upload screenshots to GitHub releases and retrieve shareable URLs
    * Fetch PR comments with trusted user filtering
    * Check PR CI status and detect new failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->