### PR TITLE
CNTRLPLANE-3677: openshift-developer: add create-pr skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,11 @@
       "description": "Go language server for code intelligence and refactoring",
       "version": "1.0.0",
       "category": "development",
-      "keywords": ["go", "gopls", "lsp"]
+      "keywords": [
+        "go",
+        "gopls",
+        "lsp"
+      ]
     },
     {
       "name": "prodsec-skills",
@@ -25,7 +29,10 @@
       "description": "Security guidance skills for AI coding assistants",
       "version": "1.0.0",
       "category": "security",
-      "keywords": ["security", "prodsec"]
+      "keywords": [
+        "security",
+        "prodsec"
+      ]
     },
     {
       "name": "git",
@@ -428,7 +435,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2364,7 +2364,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "has_readme": true,
       "commands": [],
       "skills": [
@@ -2378,6 +2378,12 @@ footer a { color: var(--primary); }
           "name": "address-review-precommit",
           "description": "Fix code review findings before committing. Use when the user wants to address pre-commit review feedback, fix review findings in the current branch, or apply code review fixes and push.",
           "description_html": "Fix code review findings before committing. Use when the user wants to address pre-commit review feedback, fix review findings in the current branch, or apply code review fixes and push.",
+          "meta": ""
+        },
+        {
+          "name": "create-pr",
+          "description": "Create a pull request from the current branch for a Jira issue. Use when changes are committed and pushed and the user wants to open a PR linking back to a Jira issue.",
+          "description_html": "Create a pull request from the current branch for a Jira issue. Use when changes are committed and pushed and the user wants to open a PR linking back to a Jira issue.",
           "meta": ""
         }
       ],

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/skills/create-pr/SKILL.md
+++ b/plugins/openshift-developer/skills/create-pr/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: create-pr
+description: Create a pull request from the current branch for a Jira issue. Use when changes are committed and pushed and the user wants to open a PR linking back to a Jira issue.
+---
+
+## Name
+openshift-developer:create-pr
+
+## Synopsis
+```text
+/openshift-developer:create-pr <ISSUE_KEY> [--upstream <owner/repo>] [--head <fork-owner>:<branch>]
+```
+
+## Description
+Creates a pull request from the current feature branch, linking it to a Jira issue. Reads the repo's PR template, inspects the commit log, and generates a well-structured PR title and body. Designed as the final step of the solve pipeline, after `/jira:solve`, `code-review:pre-commit-review` and `address-review-precommit`.
+
+## Implementation
+
+### Step 1: Gather context
+
+1. Parse arguments:
+   - `$1` — Jira issue key (required, e.g. `OCPBUGS-1234`)
+   - `--upstream` — target repository (default: infer from `gh repo view --json nameWithOwner`)
+   - `--head` — PR head ref in `fork-owner:branch` format (default: current branch)
+
+2. Determine the current branch:
+   ```bash
+   BRANCH=$(git branch --show-current)
+   ```
+
+3. Discover remotes, then determine the base branch:
+   ```bash
+   REMOTE=$(git remote | head -1)
+   BASE_BRANCH=$(git remote show "$REMOTE" | sed -n 's/.*HEAD branch: //p')
+   ```
+   Fall back to `main` if detection fails.
+
+4. Read the commit history for the PR:
+   ```bash
+   git log "${BASE_BRANCH}..HEAD" --format="%h %s%n%n%b" --reverse
+   ```
+
+5. Read the PR template if it exists:
+   ```bash
+   cat .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null || true
+   ```
+
+### Step 2: Compose the PR
+
+1. **Title**: Must start with `<ISSUE_KEY>: ` followed by a concise summary derived from the commits.
+
+2. **Body**: Structure using the PR template if one exists. Include:
+   - A description of the changes based on the commit log
+   - A link to the Jira issue: `https://redhat.atlassian.net/browse/<ISSUE_KEY>`
+   - The following footer at the very end:
+     ```text
+     Always review AI generated responses prior to use.
+     Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin
+     ```
+
+### Step 3: Create the PR
+
+Build and run the `gh pr create` command:
+
+```bash
+gh pr create \
+  --repo <UPSTREAM> \
+  --head <HEAD_REF> \
+  --no-maintainer-edit \
+  --title '<ISSUE_KEY>: <summary>' \
+  --body '<body>'
+```
+
+- If `--upstream` was provided, use it as `--repo`.
+- If `--head` was provided, use it directly.
+- If neither was provided, omit `--repo` and `--head` (defaults to current repo context and current branch).
+
+### Step 4: Report
+
+Print the PR URL returned by `gh pr create`.
+
+## Return Value
+- **PR URL**: the URL of the newly created pull request
+
+## Examples
+
+1. **Create a PR for a Jira issue (simple)**:
+   ```text
+   /openshift-developer:create-pr CNTRLPLANE-1234
+   ```
+
+2. **Create a PR targeting a specific upstream from a fork**:
+   ```text
+   /openshift-developer:create-pr OCPBUGS-5678 --upstream openshift/hypershift --head hypershift-community:fix/OCPBUGS-5678
+   ```
+
+## Arguments
+- `$1` — Jira issue key (required)
+- `--upstream` — target repository in `owner/repo` format (optional)
+- `--head` — PR head ref in `fork-owner:branch` format (optional)
+
+## Guidelines
+
+- Discover remotes first (e.g. `git remote` or `git branch -vv`) before selecting one
+- Always include the Jira issue key prefix in the PR title
+- Always include the AI-generated footer at the end of the PR body
+- Use the repo's PR template when available
+- Derive the PR description from the actual commit log, not from assumptions


### PR DESCRIPTION
## Summary
- Add `create-pr` skill to the openshift-developer plugin — creates a PR from the current branch for a Jira issue, completing the pre-PR author loop after `jira:solve`, `code-review:pre-commit-review`, and `address-review-precommit`.
- Bump plugin version to 1.1.3.
- This skill replaces the hardcoded PR creation prompts in the [jira-agent Prow job](https://github.com/openshift/release/tree/main/ci-operator/step-registry/hypershift/jira-agent), allowing the process script to invoke `/openshift-developer:create-pr` instead of constructing custom prompts inline.

## Test plan
- [ ] Install the plugin and verify `/openshift-developer:create-pr` is listed as an available skill
- [ ] Test invocation: `/openshift-developer:create-pr <ISSUE_KEY> --upstream <repo> --head <fork>:<branch>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new OpenShift Developer skill guide for creating a Jira-linked GitHub pull request from the current branch, including argument options, automatic base-branch inference, PR title/body generation from commit history, and PR creation via `gh`.
* **Chores**
  * Bumped the OpenShift Developer plugin version to the latest patch release.
  * Reformatted marketplace keywords for related plugins (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->