### PR TITLE
fix(openshift-developer): paginate GitHub API calls in address-review-pr

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -435,7 +435,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2364,7 +2364,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/skills/address-review-pr/SKILL.md
+++ b/plugins/openshift-developer/skills/address-review-pr/SKILL.md
@@ -39,7 +39,9 @@ Automates addressing PR review comments by fetching all comments from a pull req
    })'
 
    # Get reviews (need REST API for numeric IDs)
-   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews --jq 'map({
+   # IMPORTANT: Use --paginate to fetch ALL pages (default page size is 30;
+   # PRs with many bot/CI reviews easily exceed this, silently dropping recent human reviews)
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews --paginate --jq 'map({
      id,
      author: .user.login,
      length: (.body | length),
@@ -49,7 +51,8 @@ Automates addressing PR review comments by fetching all comments from a pull req
    })'
 
    # Get review comments (inline code comments)
-   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments --jq 'map({
+   # IMPORTANT: Use --paginate — same pagination issue as reviews above
+   gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments --paginate --jq 'map({
      id,
      author: .user.login,
      length: (.body | length),


### PR DESCRIPTION
## Summary

- Adds `--paginate` to the `gh api` calls for reviews and review comments in the `address-review-pr` skill
- The GitHub REST API returns only 30 items per page by default — on PRs with many bot/CI reviews (coderabbitai, hypershift-jira-solve-ci, etc.), recent human reviews silently fell off the first page and were never fetched
- Observed on [PR #8280](https://github.com/openshift/hypershift/pull/8280) which had 36 reviews: review `4562799027` (comments "This still needs addressed" and "Why is this here?") was review #31+ and was completely missed by the [workflow run](https://github.com/openshift/hypershift/actions/runs/28103634578)

## Test plan

- [ ] Verify `gh api repos/{owner}/{repo}/pulls/{pr}/reviews --paginate` returns all reviews (confirmed locally: 30 without paginate vs 36 with paginate on PR #8280)
- [ ] Run `make lint` — passes with A+ grade
- [ ] Re-run `/address-review-pr` on a PR with >30 reviews and confirm all reviews are discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the OpenShift Developer plugin to version **1.1.4**.
* **Bug Fixes**
  * Improved PR review data collection so all review and inline comment pages are included, helping prevent missing feedback in large or highly active pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->