### PR TITLE
[wip] Fix payload analysis to detect merged reverts not yet in payload

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -512,7 +512,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.54",
+      "version": "0.0.55",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -348,18 +348,22 @@ For each revert candidate, record: PR URL, description, component, confidence sc
 
 **Do NOT propose reverts for**: Infrastructure failures, flaky tests that also fail on accepted payloads, jobs where analysis is inconclusive.
 
-#### 6.3: Check if Revert Candidates Were Already Reverted
+#### 6.3: Check if Candidate PRs Were Already Reverted
 
-For each revert candidate:
+For **every scored candidate PR** (not just revert candidates with score >= 85), check whether a revert PR already exists:
 
 ```bash
 gh pr list --repo <org>/<repo> --search "revert <pr_number>" --json number,title,url,state,mergedAt --limit 5
 ```
 
 If a revert PR is found:
-- **Merged**: Note when it merged relative to the payload. If after the payload was cut, the fix is expected in the next payload. Do not recommend reverting again.
-- **Open**: Mention the existing revert PR and link to it.
+- **Open**: Record the existing revert PR URL and link to it. For revert candidates (score >= 85), do not open a duplicate revert.
 - **Closed (not merged)**: Ignore.
+- **Merged**: Determine whether the merged revert has been **included in the current payload**. Check the target payload's PR list in `summary.json` → `payloads[0].prs[]` for a matching PR number and repository. Also check subsequent payloads in the chain (`payloads[1]`, `payloads[2]`, etc.) in case the revert landed in a later payload that was also rejected.
+  - **Revert in payload** (`revert_in_payload: true`): The revert is already included in this payload. The failure must have a different root cause, or the revert was insufficient. Note this and continue scoring — the revert did not fix the problem.
+  - **Revert NOT in payload** (`revert_in_payload: false`): The revert was merged after the payload was cut (or has not yet been picked up by the build system). Record this as `status: "merged_not_in_payload"`. Do **not** recommend opening a new revert for this candidate. Instead, surface this prominently in the report: the fix exists and is expected in the next payload build.
+
+This check is critical for avoiding redundant work: when a revert has already been merged but simply hasn't been included in the current payload yet, the analysis should clearly communicate that the fix is pending rather than recommending a duplicate revert.
 
 #### 6.4: Determine Force-Accept Recommendation
 
@@ -396,8 +400,12 @@ The report must include the following sections:
   <p>{total_blocking} blocking jobs: {succeeded} passed, {failed} failed</p>
   <p>{new_failures} new failure(s), {persistent_failures} persistent failure(s)</p>
   <p>Chain: {chain_length} payloads, {hours_since_baseline}h since baseline</p>
+  <!-- Include when merged reverts are pending inclusion in the next payload -->
+  <p class="revert-pending">{N} merged revert(s) pending inclusion in the next payload</p>
 </div>
 ```
+
+The `revert-pending` line should only appear when one or more candidates have `status: "merged_not_in_payload"` from Step 6.3. This is the most important signal for operators monitoring payload health — it tells them the fix exists and a new payload build should resolve the issue.
 
 #### 7.2: Blocking Jobs Summary Table
 
@@ -517,6 +525,34 @@ If no revert candidates:
   <strong>No Recommended Reverts</strong>
   <p>No PRs were identified with sufficient confidence for revert recommendation.</p>
 </div>
+```
+
+#### 7.4b: Merged Reverts Pending Inclusion
+
+Include this section immediately after the Recommended Reverts section when any candidate has `status: "merged_not_in_payload"` from Step 6.3. This section appears regardless of whether there are also new revert recommendations — a payload can have both new revert candidates and already-merged reverts awaiting inclusion.
+
+```html
+<div class="verdict verdict-pending-revert">
+  <h2>Merged Reverts Pending Inclusion</h2>
+  <p>The following revert PRs have been merged but are <strong>not yet included</strong> in this payload.
+     The next payload build is expected to include these fixes.</p>
+  <table>
+    <tr><th>Revert PR</th><th>Reverts</th><th>Component</th><th>Merged At</th><th>Affected Jobs</th></tr>
+    <tr>
+      <td><a href="{revert_pr_url}" target="_blank">#{revert_pr_number}</a></td>
+      <td><a href="{original_pr_url}" target="_blank">#{original_pr_number}</a></td>
+      <td>{component}</td>
+      <td>{merged_at}</td>
+      <td>{comma-separated failing job names}</td>
+    </tr>
+  </table>
+</div>
+```
+
+Add this CSS for the pending revert styling:
+```css
+.verdict-pending-revert { background: rgba(88,166,255,0.1); border-left: 4px solid var(--blue); padding: 0.75rem 1rem; border-radius: 0 0.3rem 0.3rem 0; margin: 0.75rem 0; }
+.revert-pending { color: var(--blue); font-weight: 600; }
 ```
 
 #### 7.5: Force-Accept Recommendation

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -71,6 +71,7 @@ candidates:
         status: "staged"
         revert_pr_url: "https://github.com/openshift/cno/pull/2038"
         revert_pr_state: "open"
+        revert_in_payload: false
         result_summary: "Revert PR opened and payload jobs triggered"
         jira_key: "TRT-1234"
         jira_url: "https://redhat.atlassian.net/browse/TRT-1234"
@@ -78,6 +79,21 @@ candidates:
           - command: "/payload-job periodic-ci-...-e2e-aws-ovn"
             test_url: "https://pr-payload-tests.ci.openshift.org/runs/ci/..."
             test_prow_url: "https://prow.ci.openshift.org/view/gs/..."
+  - pr_url: "https://github.com/openshift/mco/pull/4100"
+    pr_number: 4100
+    component: "machine-config-operator"
+    title: "Update MCO rollout strategy"
+    confidence_score: 90
+    rationale: "new failure mode + sole modifier of affected component"
+    failing_jobs:
+      - "periodic-ci-...-e2e-aws-ovn-upgrade"
+    actions:
+      - type: "revert"
+        status: "merged_not_in_payload"
+        revert_pr_url: "https://github.com/openshift/mco/pull/4105"
+        revert_pr_state: "merged"
+        revert_in_payload: false
+        result_summary: "Revert PR #4105 merged 2h after payload was cut — fix pending in next payload"
 
 rhcos_suspects:
   - rhcos_tag: "rhel-coreos-10"
@@ -147,6 +163,7 @@ Actions taken on a candidate. New entries are **appended** by downstream skills.
 | `status` | string | See status values below |
 | `revert_pr_url` | string | URL of the revert PR (draft or real) |
 | `revert_pr_state` | string | `"draft"`, `"open"`, `"merged"`, `"closed"` |
+| `revert_in_payload` | bool | `true` if the revert PR is included in the current payload's PR list, `false` if merged but not yet picked up. Only set when `revert_pr_state` is `"merged"`. |
 | `result_summary` | string | Brief description of the outcome |
 | `jira_key` | string | TRT JIRA key (e.g., `"TRT-1234"`), or `""` |
 | `jira_url` | string | TRT JIRA URL, or `""` |
@@ -157,7 +174,8 @@ Actions taken on a candidate. New entries are **appended** by downstream skills.
 | Status | Meaning |
 |--------|---------|
 | `"open"` | Pre-existing revert PR found open during analysis |
-| `"merged"` | Pre-existing revert PR already merged |
+| `"merged"` | Pre-existing revert PR already merged and included in the current payload |
+| `"merged_not_in_payload"` | Pre-existing revert PR merged but not yet included in the current payload — fix is pending inclusion in the next payload build |
 | `"staged"` | Revert PR and JIRA created, payload jobs triggered (used by `type: "revert"`) |
 | `"pending"` | Experiment dispatched, payload jobs running, results not yet collected |
 | `"passed"` | Payload jobs passed with the revert — candidate confirmed as cause |
@@ -196,11 +214,11 @@ An empty array or absent key means no RHCOS RPM changes were suspected.
 
 ### Create (used by `payload-analysis`)
 
-Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, `candidates`, and optionally `rhcos_suspects` populated. All failed blocking jobs are recorded in `failing_jobs`. Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis, append an action with `type: "revert"` and `status: "open"` or `"merged"`. If RHCOS RPM suspects were identified, include them in `rhcos_suspects[]`.
+Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, `candidates`, and optionally `rhcos_suspects` populated. All failed blocking jobs are recorded in `failing_jobs`. Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis, append an action with `type: "revert"` and the appropriate status: `"open"` (revert PR is open), `"merged"` (revert PR merged and included in the current payload), or `"merged_not_in_payload"` (revert PR merged but not yet included in the current payload). When the status is `"merged"` or `"merged_not_in_payload"`, set `revert_in_payload` to `true` or `false` respectively. If RHCOS RPM suspects were identified, include them in `rhcos_suspects[]`.
 
 ### Read Candidates (used by `payload-revert`, `payload-experiment`)
 
-Read the file. Filter candidates by `confidence_score` range. Exclude candidates that already have an action with `status` of `"open"` or `"merged"` (pre-existing revert). Return matching candidates. Use the top-level `failing_jobs[]` to look up full job details for each candidate's `failing_jobs` references.
+Read the file. Filter candidates by `confidence_score` range. Exclude candidates that already have an action with `status` of `"open"`, `"merged"`, or `"merged_not_in_payload"` (pre-existing revert). Return matching candidates. Use the top-level `failing_jobs[]` to look up full job details for each candidate's `failing_jobs` references.
 
 ### Append Action (used by `stage-payload-reverts`, `payload-experimental-reverts`)
 


### PR DESCRIPTION
The payload analysis skill's Step 6.3 previously only checked revert candidates (score >= 85) for existing revert PRs. This missed a critical scenario: when a breaking PR has already been reverted and the revert is merged, but hasn't been included in the current payload yet.

Changes:
- Expand Step 6.3 to check ALL scored candidate PRs for existing reverts
- Add logic to verify whether a merged revert appears in the current payload's PR list (summary.json → payloads[].prs[])
- Add new "merged_not_in_payload" status and revert_in_payload field to the payload-results-yaml schema
- Add "Merged Reverts Pending Inclusion" report section (Step 7.4b)
- Add revert-pending line to executive summary
- Update Read Candidates operation to exclude merged_not_in_payload
- Bump CI plugin version to 0.0.55

<!--

** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated payload analysis guidance to better handle merged revert PRs that are not yet included in the current payload.
  * Added clearer reporting for pending reverts, including a new summary line and a dedicated report section.
  * Refreshed plugin documentation to reflect the latest version number.

* **Chores**
  * Bumped the `ci` plugin version to `0.0.55`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->