### PR TITLE
Add nested podman Dockerfile variant

### DIFF
--- a/images/Dockerfile.nested-podman
+++ b/images/Dockerfile.nested-podman
@@ -1,0 +1,95 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS claude-latest
+ENV ART_DNF_WRAPPER_POLICY=append
+COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
+COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
+RUN rm /etc/yum.repos.d/ubi.repo && \
+    dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
+    dnf clean all
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+
+# Copy external rpm repos into the image, and tell the ART wrapper to append them
+ENV ART_DNF_WRAPPER_POLICY=append
+RUN rm /etc/yum.repos.d/ubi.repo
+COPY images/repos/*.repo /etc/yum.repos.d/
+COPY images/repos/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
+
+# Install all system packages in a single dnf transaction to avoid repeated
+# metadata fetches (~800MB each). Disable foreign-arch repos to prevent
+# cross-architecture dependency resolution failures in CI.
+RUN dnf install -y \
+    --disablerepo='*-ppc64le' --disablerepo='*-s390x' \
+    python3.11 \
+    python3.11-pip \
+    python3.11-devel \
+    gh \
+    claude-code \
+    pcp \
+    pcp-devel \
+    pcp-export-pcp2json \
+    podman \
+    shadow-utils \
+    fuse-overlayfs \
+    && dnf clean all \
+    && alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && alternatives --set python3 /usr/bin/python3.11
+
+# The "latest" channel binary lets users try newer features not yet in stable,
+# or compare behavior between versions, without disrupting the default entrypoint.
+COPY --from=claude-latest /usr/bin/claude /usr/local/bin/claude-latest
+
+# Install Python tools and PCP bindings
+RUN python3 -m pip install --no-cache-dir \
+    agentic-ci \
+    pytest \
+    requests \
+    pyyaml \
+    && python3 -m pip install --no-cache-dir --use-pep517 pcp
+
+# Create claude user with root group for OpenShift compatibility
+RUN useradd -m -u 1000 -g 0 -s /bin/bash claude
+
+# Copy ai-helpers repository to /opt/ai-helpers
+COPY . /opt/ai-helpers
+RUN chown -R claude:root /opt/ai-helpers
+
+# Create Claude configuration directory and copy settings
+#   Note: We pre-configure known_marketplaces.json because extraKnownMarketplaces doesn't seem to work in non-interactive mode.
+RUN mkdir -p /home/claude/.claude/plugins
+COPY images/claude-settings.json /home/claude/.claude/settings.json
+COPY images/known_marketplaces.json /home/claude/.claude/plugins/known_marketplaces.json
+RUN chown -R claude:root /home/claude
+
+# Create workspace directory
+RUN mkdir -p /workspace && chown -R claude:root /workspace
+WORKDIR /workspace
+
+# Set up nested podman support
+COPY images/nested-podman-entrypoint.sh /nested-podman-entrypoint.sh
+ENV BUILDAH_ISOLATION=chroot
+RUN chmod +rx /nested-podman-entrypoint.sh && \
+    chown 0:0 /etc/passwd /etc/group && \
+    chmod g=u /etc/passwd /etc/group && \
+    setcap cap_setuid+ep /usr/bin/newuidmap && \
+    setcap cap_setgid+ep /usr/bin/newgidmap && \
+    touch /etc/subgid /etc/subuid && \
+    chown 0:0 /etc/subgid /etc/subuid && \
+    chmod -R g=u /etc/subuid /etc/subgid
+
+# Switch to claude user
+USER claude
+
+# In CI, OpenShift uses a random UID, but in the root group
+RUN chmod -R g+rwx /home/claude && \
+  chmod -R g+rwx /opt/ai-helpers && \
+  chmod -R g+rwx /workspace
+
+ENV HOME="/home/claude" \
+    CLAUDE_CONFIG_DIR="/home/claude/.claude"
+
+# Use catatonit as init process, chaining through the entrypoint script
+# that configures rootless podman before executing the actual command.
+ENTRYPOINT ["/usr/libexec/podman/catatonit", "--", "/nested-podman-entrypoint.sh"]
+
+# Default to showing help
+CMD ["claude", "--help"]

--- a/images/nested-podman-entrypoint.sh
+++ b/images/nested-podman-entrypoint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Create Home directory
+if [ ! -d "${HOME}" ]; then
+  mkdir -p "${HOME}"
+fi
+
+# Create Podman configuration
+mkdir -p "${HOME}/.config/containers"
+
+if [ ! -f "${HOME}/.config/containers/registries.conf" ]; then
+  cat > "${HOME}/.config/containers/registries.conf" <<'REGISTRIES'
+unqualified-search-registries = [
+  "registry.access.redhat.com",
+  "registry.redhat.io",
+  "docker.io"
+]
+short-name-mode = "permissive"
+REGISTRIES
+fi
+
+if [ ! -f "${HOME}/.config/containers/storage.conf" ]; then
+  if [ -c "/dev/fuse" ] && [ -f "/usr/bin/fuse-overlayfs" ]; then
+    cat > "${HOME}/.config/containers/storage.conf" <<'STORAGE'
+[storage]
+driver = "overlay"
+graphroot = "/tmp/graphroot"
+[storage.options.overlay]
+mount_program = "/usr/bin/fuse-overlayfs"
+STORAGE
+  else
+    cat > "${HOME}/.config/containers/storage.conf" <<'STORAGE'
+[storage]
+driver = "vfs"
+STORAGE
+  fi
+fi
+
+# Create User ID entry if running as an unmapped UID (common in OpenShift)
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
+# Create subuid/gid entries for rootless podman
+USER_NAME="$(whoami)"
+SUBID_START="${SUBID_START:-100000}"
+SUBID_COUNT="${SUBID_COUNT:-65536}"
+echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subuid
+echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subgid
+
+exec "$@"


### PR DESCRIPTION
Adds a separate Dockerfile (`images/Dockerfile.nested-podman`) and entrypoint
script that enable running podman commands inside CI containers. The setup
mirrors the upstream `ci/nested-podman` image configuration from
openshift/release: installs podman, shadow-utils, and fuse-overlayfs, sets up
rootless podman permissions (setcap, subuid/subgid), and uses catatonit as
init process chaining through an entrypoint script that configures podman
storage and user namespaces at container startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new container image tailored for running Podman in nested, rootless environments.
  * Introduced a containerized Claude CLI experience with a non-root default user and safer startup configuration.
  * Added an entrypoint that auto-initializes container registry and storage settings, and sets up user/subuid mappings needed for rootless compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->