### PR TITLE
Add --token-file to upload-screenshot for CI environments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,7 @@
       "name": "github",
       "source": "./plugins/github",
       "description": "GitHub utilities for image uploads, asset management, and PR automation",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "tooling",
       "keywords": [
         "github",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1249,7 +1249,7 @@ footer a { color: var(--primary); }
     {
       "name": "github",
       "description": "GitHub utilities for image uploads, asset management, and PR automation",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "GitHub utilities for image uploads, asset management, and PR automation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/github/skills/upload-screenshot/SKILL.md
+++ b/plugins/github/skills/upload-screenshot/SKILL.md
@@ -7,6 +7,8 @@ description: Upload screenshots or images to GitHub and get back embeddable URLs
 
 Upload images to GitHub via release assets and get back stable, embeddable URLs. This is the recommended way to share screenshots of frontend changes, UI diffs, or any visual artifacts in PR comments and issue descriptions.
 
+**Important:** Always upload to the **fork** repo, not upstream, to avoid polluting upstream releases.
+
 ## When to Use This Skill
 
 Use this skill when you:
@@ -28,7 +30,7 @@ Use this skill when you:
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
   --file /path/to/screenshot.png \
-  --repo owner/repo
+  --repo owner/fork-repo
 ```
 
 ### Upload with a custom title
@@ -36,7 +38,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
   --file /path/to/screenshot.png \
-  --repo owner/repo \
+  --repo owner/fork-repo \
   --title "Login page after dark mode changes"
 ```
 
@@ -44,9 +46,12 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--file`  | Yes      | Path to the image file (png, jpg, gif, svg, webp) |
-| `--repo`  | Yes      | Target GitHub repository in `owner/repo` format |
-| `--title` | No       | Alt text for the image (defaults to filename) |
+| `--file`       | Yes      | Path to the image file (png, jpg, gif, svg, webp) |
+| `--repo`       | Yes      | Target GitHub repository in `owner/repo` format |
+| `--title`      | No       | Alt text for the image (defaults to filename) |
+| `--token-file` | No       | Path to a file containing a GitHub token to use for auth |
+
+When `--token-file` is provided, the token is loaded into `GITHUB_TOKEN` for the duration of the script. This is useful in CI where the default `GITHUB_TOKEN` may not have write access to the target repo.
 
 ### Output
 
@@ -54,10 +59,10 @@ JSON on stdout:
 
 ```json
 {
-  "url": "https://github.com/owner/repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png",
-  "markdown": "![Login page](https://github.com/owner/repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png)",
+  "url": "https://github.com/owner/fork-repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png",
+  "markdown": "![Login page](https://github.com/owner/fork-repo/releases/download/screenshot-1719100000-a1b2c3d4/screenshot.png)",
   "tag": "screenshot-1719100000-a1b2c3d4",
-  "repo": "owner/repo"
+  "repo": "owner/fork-repo"
 }
 ```
 
@@ -67,10 +72,10 @@ After uploading, use the `markdown` field directly in a `gh pr comment`:
 
 ```bash
 result=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
-  --file /tmp/screenshot.png --repo owner/repo --title "UI change")
+  --file /tmp/screenshot.png --repo owner/fork-repo --title "UI change")
 
 markdown=$(echo "$result" | jq -r '.markdown')
-gh pr comment 123 --repo owner/repo --body "## Screenshot
+gh pr comment 123 --repo owner/upstream-repo --body "## Screenshot
 
 $markdown"
 ```
@@ -90,13 +95,13 @@ Screenshot releases accumulate over time. To clean up old uploads:
 
 ```bash
 # Delete a specific screenshot release
-gh release delete screenshot-1719100000-a1b2c3d4 --yes --cleanup-tag --repo owner/repo
+gh release delete screenshot-1719100000-a1b2c3d4 --yes --cleanup-tag --repo owner/fork-repo
 
 # Delete all screenshot releases older than 30 days
-gh api "repos/owner/repo/releases" --paginate --jq \
+gh api "repos/owner/fork-repo/releases" --paginate --jq \
   '.[] | select(.tag_name | startswith("screenshot-")) | select(.prerelease) | .tag_name' | \
   while read -r tag; do
-    gh release delete "$tag" --yes --cleanup-tag --repo owner/repo
+    gh release delete "$tag" --yes --cleanup-tag --repo owner/fork-repo
   done
 ```
 

--- a/plugins/github/skills/upload-screenshot/upload_screenshot.sh
+++ b/plugins/github/skills/upload-screenshot/upload_screenshot.sh
@@ -2,26 +2,29 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 --file <path> --repo <owner/repo> [--title <title>]" >&2
+  echo "Usage: $0 --file <path> --repo <owner/repo> [--title <title>] [--token-file <path>]" >&2
   echo "" >&2
   echo "Upload an image to GitHub as a release asset and return the URL." >&2
   echo "" >&2
   echo "Options:" >&2
-  echo "  --file   Path to the image file (required)" >&2
-  echo "  --repo   GitHub repository in owner/repo format (required)" >&2
-  echo "  --title  Alt text / title for the image (default: filename)" >&2
+  echo "  --file        Path to the image file (required)" >&2
+  echo "  --repo        GitHub repository in owner/repo format (required)" >&2
+  echo "  --title       Alt text / title for the image (default: filename)" >&2
+  echo "  --token-file  Path to a file containing a GitHub token to use for auth" >&2
   exit 1
 }
 
 FILE=""
 REPO=""
 TITLE=""
+TOKEN_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --file)  FILE="$2"; shift 2 ;;
-    --repo)  REPO="$2"; shift 2 ;;
-    --title) TITLE="$2"; shift 2 ;;
+    --file)       FILE="$2"; shift 2 ;;
+    --repo)       REPO="$2"; shift 2 ;;
+    --title)      TITLE="$2"; shift 2 ;;
+    --token-file) TOKEN_FILE="$2"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "Unknown option: $1" >&2; usage ;;
   esac
@@ -40,6 +43,15 @@ fi
 FILENAME=$(basename "$FILE")
 if [[ -z "$TITLE" ]]; then
   TITLE="$FILENAME"
+fi
+
+if [[ -n "$TOKEN_FILE" ]]; then
+  if [[ ! -f "$TOKEN_FILE" ]]; then
+    echo "{\"error\": \"Token file not found: $TOKEN_FILE\"}" >&2
+    exit 1
+  fi
+  export GITHUB_TOKEN
+  GITHUB_TOKEN=$(cat "$TOKEN_FILE")
 fi
 
 TAG="screenshot-$(date +%s)-$(head -c 4 /dev/urandom | xxd -p)"


### PR DESCRIPTION
The script previously relied on whatever GITHUB_TOKEN was set, which in CI pointed at the upstream repo and created releases there. Add --token-file so callers can pass the appropriate token for the target repo. Also update docs to recommend uploading to the fork.

We cannot use gists for this because:
- Gists are a user/account permission, not a repository permission
  - The POST /gists endpoint only supports user access tokens (UAT), not installation access tokens
  - The gist setting exists in the app configuration because GitHub Apps can also generate user access tokens (via the OAuth authorization flow), and that's when the gist permission would apply

  The TRT workflow generates installation access tokens (via POST /app/installations/{id}/access_tokens), so those tokens can't create gists regardless of the app's gist permission setting. You'd need a
  user to authorize the app and use the resulting user access token, which doesn't fit the CI flow.