### PR TITLE
agentic-docs: add review-docs skill, harden component-docs against hallucinations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -495,7 +495,7 @@
       "name": "agentic-docs",
       "source": "./plugins/agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.0.0"
+      "version": "1.2.2"
     },
     {
       "name": "metrics",

--- a/docs/index.html
+++ b/docs/index.html
@@ -415,7 +415,7 @@ footer a { color: var(--primary); }
     {
       "name": "agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.0.0",
+      "version": "1.2.2",
       "has_readme": true,
       "commands": [],
       "skills": [
@@ -423,6 +423,12 @@ footer a { color: var(--primary); }
           "name": "component-docs",
           "description": "Create lean component documentation for OpenShift repositories",
           "description_html": "Create lean component documentation for OpenShift repositories",
+          "meta": ""
+        },
+        {
+          "name": "review-docs",
+          "description": "Review agentic documentation — verify claims locally against source code first, then use chai-bot for cross-repo and cross-functional verification",
+          "description_html": "Review agentic documentation — verify claims locally against source code first, then use chai-bot for cross-repo and cross-functional verification",
           "meta": ""
         },
         {

--- a/plugins/agentic-docs/.claude-plugin/plugin.json
+++ b/plugins/agentic-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-docs",
   "description": "Create and maintain AI-optimized documentation for OpenShift",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/agentic-docs/.mcp.json.sample
+++ b/plugins/agentic-docs/.mcp.json.sample
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chai-bot": {
+      "comment": "OpenShift AI helpdesk persona (ocp_ai_helpdesk) - VPN required",
+      "type": "http",
+      "url": "https://ship-help-mcp-continuous-release-tooling--ship-help-bot.apps.gpc.ocp-hub.prod.psi.redhat.com/personas/ocp_ai_helpdesk/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}

--- a/plugins/agentic-docs/README.md
+++ b/plugins/agentic-docs/README.md
@@ -32,8 +32,74 @@ cd /path/to/component-repository
 
 Creates AGENTS.md + ai-docs/ with: component CRDs only, architecture, component ADRs, exec-plans, ecosystem links to platform docs, development/testing guides. Excludes generic patterns (lives in platform docs). Example: [machine-config-operator/ai-docs](https://github.com/openshift/machine-config-operator/tree/master/ai-docs).
 
+### `/review-docs`
+Review agentic documentation for hallucinations and verify claims against authoritative sources.
+
+```bash
+cd /path/to/component-repository
+/review-docs
+```
+
+Uses the **chai-bot MCP server** to verify documentation claims against verified OpenShift knowledge, GitHub source code, Slack history, Jira, and official docs. Detects hallucinations, outdated conventions, and missing references.
+
+**Prerequisites**: Requires chai-bot MCP server configuration (see Setup below).
+
+## Setup
+
+### chai-bot MCP Server (for `/review-docs`)
+
+The `/review-docs` skill requires access to the **chai-bot MCP server** configured with the **"OpenShift AI helpdesk"** persona — an AI agent with verified OpenShift knowledge.
+
+**Prerequisites:**
+1. **Red Hat VPN** - Must be connected to Red Hat VPN
+2. **Bearer Token** - Obtain from the chai-bot Slack app
+3. **Persona** - This plugin uses the `ocp_ai_helpdesk` persona (OpenShift AI helpdesk)
+
+**Configuration:**
+
+Add to `~/.claude.json` under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "chai-bot": {
+      "type": "http",
+      "url": "https://ship-help-mcp-continuous-release-tooling--ship-help-bot.apps.gpc.ocp-hub.prod.psi.redhat.com/personas/ocp_ai_helpdesk/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+**Important:** 
+- The URL includes `/personas/ocp_ai_helpdesk` — this is the **OpenShift AI helpdesk** persona
+- Replace `YOUR_TOKEN_HERE` with your bearer token from the chai-bot Slack app
+- Restart Claude Code after configuration
+
+**Alternative:** Merge `plugins/agentic-docs/.mcp.json.sample` into your existing `~/.mcp.json` (or create it if it doesn't exist):
+```bash
+# Merge without overwriting existing entries
+jq -s '.[0] * .[1]' ~/.mcp.json plugins/agentic-docs/.mcp.json.sample > ~/.mcp.json.tmp \
+  && mv ~/.mcp.json.tmp ~/.mcp.json \
+  || cp plugins/agentic-docs/.mcp.json.sample ~/.mcp.json
+```
+Then edit `~/.mcp.json` and replace the `YOUR_TOKEN_HERE` placeholder with your actual bearer token from the chai-bot Slack app.
+
+**Verification:**
+```bash
+# Must be on VPN
+ping -c 1 ship-help-mcp-continuous-release-tooling--ship-help-bot.apps.gpc.ocp-hub.prod.psi.redhat.com
+
+# Check config
+jq '.mcpServers."chai-bot"' ~/.mcp.json
+```
+
+After configuration, restart Claude Code to load the MCP server.
+
 ## Development
 
-Skills live under `skills/{update-platform-docs,component-docs}/` with SKILL.md, scripts, and templates.
+Skills live under `skills/{update-platform-docs,component-docs,review-docs}/` with SKILL.md, scripts, and templates.
 
 **License:** Apache 2.0

--- a/plugins/agentic-docs/skills/component-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/component-docs/SKILL.md
@@ -2,7 +2,6 @@
 name: component-docs
 description: Create lean component documentation for OpenShift repositories
 trigger: explicit
-model: sonnet
 ---
 
 # Component Documentation Creator
@@ -17,7 +16,7 @@ Creates lean component agentic documentation for OpenShift component repositorie
 **Contains**: Operator patterns, testing practices, security guidelines, Kubernetes/OpenShift fundamentals, cross-repo ADRs
 
 ### Component: Component Repos (LEAN)
-**Contains**: Component-specific CRDs, component architecture, component ADRs, exec-plans
+**Contains**: Component-specific APIs/types, component architecture, component ADRs, exec-plans
 
 **Decision Rule**: "Would another repo need to duplicate this?"
 - YES → Platform (platform)
@@ -29,7 +28,7 @@ Creates lean component agentic documentation for OpenShift component repositorie
 component-repo/
 ├── AGENTS.md                      # Master entry point (80-100 lines)
 └── ai-docs/
-    ├── domain/                    # Component CRDs ONLY
+    ├── domain/                    # Component APIs/types
     ├── architecture/              # Component internals
     │   └── components.md
     ├── decisions/                 # Component ADRs ONLY
@@ -43,15 +42,15 @@ component-repo/
     │   └── enhancements.md        # Enhancement proposals & design docs
     ├── [COMPONENT]_DEVELOPMENT.md
     └── [COMPONENT]_TESTING.md
-```text
+```
 
 ## What NOT to Include (lives in Platform)
 
-❌ Generic operator patterns (controller-runtime, status conditions)  
-❌ Testing practices (test pyramid, E2E framework)  
-❌ Security practices (STRIDE, RBAC guidelines)  
-❌ Reliability practices (SLO framework)  
-❌ Kubernetes fundamentals (Pod, Node, Service)  
+❌ Generic framework patterns (controller-runtime, status conditions, common libraries)
+❌ Testing practices (test pyramid, E2E framework)
+❌ Security practices (STRIDE, RBAC guidelines)
+❌ Reliability practices (SLO framework)
+❌ Kubernetes fundamentals (Pod, Node, Service)
 ❌ Cross-repo ADRs (etcd, CVO orchestration, immutable nodes)
 
 ## Execution Workflow
@@ -63,17 +62,31 @@ component-repo/
 - [ ] Run `bash "$SKILL_DIR/scripts/create-structure.sh" "$REPO_PATH"`
 
 ### Phase 2: Create AGENTS.md (80-100 lines)
-- [ ] Create master entry point at repo root
+- [ ] Create initial AGENTS.md at repo root using `templates/AGENTS-template.md`
 - [ ] Include compressed index of component docs
-- [ ] Add retrieval-first instruction
 - [ ] Add Platform ecosystem hub links
-- [ ] Add component quick navigation
+- [ ] **Revisit after Phase 5**: Fill in the Critical Patterns section with 2-3 "never do X" rules discovered during architecture exploration
 - [ ] Validate line count: `wc -l AGENTS.md` (target: 80-100)
 
 ### Phase 3: Component Domain Concepts
-- [ ] Identify component-specific CRDs (via `oc api-resources`)
-- [ ] Create domain/*.md for each CRD
-- [ ] Document CRD purpose, key fields, lifecycle
+
+- [ ] Identify component-specific APIs, types, or CRDs:
+  - For operators: check CRD definitions, `oc api-resources`, or `config/crd/`
+  - For libraries: identify primary exported types and interfaces
+  - For CLIs: identify core commands and configuration types
+- [ ] **VERIFY BEFORE DOCUMENTING**: For each type you plan to document, find its definition and verify fields/values from source:
+  ```bash
+  # Replace <TypeName> with the actual type (e.g., MachineSet, Build, Route)
+
+  # If types live in openshift/api
+  [ ! -d "/tmp/openshift-api" ] && git clone --depth 1 https://github.com/openshift/api.git /tmp/openshift-api
+  find /tmp/openshift-api -name "types*.go" | xargs grep -A30 "type <TypeName>"
+
+  # OR in component repo
+  find . -name "types*.go" -o -name "types.go" | xargs grep -A30 "type <TypeName>"
+  ```
+  Read actual source, document ONLY existing fields with correct types
+- [ ] Create domain/*.md for each key type with links to source definitions (100-200 lines per concept)
 - [ ] Use `templates/domain-concept-template.md` for structure
 - [ ] Focus on component-specific behavior, link to Platform for generic patterns
 
@@ -81,69 +94,137 @@ component-repo/
 - [ ] Create references/enhancements.md to catalog all design documentation
 - [ ] Search openshift/enhancements repo for component-specific proposals:
   - Check `https://github.com/openshift/enhancements/tree/master/enhancements/{component-area}/`
-  - Example: MCO → `enhancements/machine-config/*.md`
-  - List all enhancement proposals with links to GitHub
 - [ ] Search component repo for local design docs:
   - Check docs/, design/, enhancements/ directories
   - Check for files with "design", "proposal", "enhancement" in name
-  - Include links to local design docs
-- [ ] Categorize by status: implemented/provisional/rejected (from enhancement metadata)
-- [ ] Use `templates/enhancements-template.md` for structure
-- [ ] Keep concise: Just title, status, link (no summaries - enhancement is the source of truth)
+- [ ] Categorize by status: implemented/provisional/rejected
+- [ ] Keep concise: title, status, link only (enhancement is the source of truth)
+- [ ] **Note**: Enhancement proposals are feature designs (often cross-component). ADRs are component architectural decisions. Don't conflate them.
 
 ### Phase 5: Component Architecture
-- [ ] Create architecture/components.md
-- [ ] Document component structure (pkg/, cmd/, controllers/)
+
+- [ ] **Read one complete implementation first**: Pick one controller/component package (preferably the most recently added). Read ALL files in it — not just controller.go, but constants, utils, every reconciler file, install sequence, and tests. This is your reference implementation. Document every pattern you observe: how it applies resources, what shared utilities it calls, what predicates it uses, what constants it defines, what env vars it reads. If the repo has 2+ similar components, compare them — divergences in approach are the most valuable thing to document ("use X pattern from component A, not Y pattern from component B").
+- [ ] **Detect repo type**: Check for operator signals (`controller-runtime`, `library-go`, `operator-sdk`, OLM bundle in `bundle/`, CRDs in `config/crd/`). If operator detected, follow the **Operator-Specific Discovery** checklist below in addition to the generic checklist.
+- [ ] **Explore remaining codebase**: Read entrypoints, key packages, dependencies. Follow the **Implementation Pattern Discovery** checklist below. The architecture doc should contain enough detail that an agent reading it produces correct code on the first try.
+- [ ] Create architecture/components.md with **repo layout as single source of truth** (add actionable annotations like "DO NOT use X for Y")
+- [ ] Document discovered patterns using the discovery checklist results
 - [ ] Explain component relationships and data flow
-- [ ] Keep lean (100-200 lines)
+- [ ] Keep lean but dense (100-200 lines, high information per line)
 
 ### Phase 6: Component ADRs
 - [ ] Create decisions/adr-template.md (copy from templates)
 - [ ] Create 2-3 component-specific ADRs
-- [ ] Example: rpm-ostree choice, Ignition format, config drift detection
 - [ ] NO cross-repo ADRs (those go in Platform)
 
 ### Phase 7: Exec-Plans
-- [ ] Create exec-plans/active/ directory (for component-specific exec-plans)
+- [ ] Create exec-plans/active/ directory
 - [ ] Create exec-plans/README.md with pointer to Platform guidance
-- [ ] Link to Platform exec-plans guidance
-- [ ] NO templates or detailed guidance (lives in Platform)
 
 ### Phase 8: Ecosystem References
-- [ ] Create references/ecosystem.md
-- [ ] Link to Platform operator patterns
-- [ ] Link to Platform testing practices
-- [ ] Link to Platform security practices
-- [ ] Link to Platform Kubernetes/OpenShift fundamentals
-- [ ] Link to Platform cross-repo ADRs
+- [ ] Create references/ecosystem.md using `templates/ecosystem-template.md`
+- [ ] Link to Platform: operator patterns, testing, security, Kubernetes/OpenShift fundamentals, cross-repo ADRs
 
 ### Phase 9: Development & Testing Docs
-- [ ] Create [COMPONENT]_DEVELOPMENT.md using `templates/DEVELOPMENT-template.md`
-- [ ] Create [COMPONENT]_TESTING.md using `templates/TESTING-template.md`
-- [ ] Link to Platform for generic practices
-- [ ] Document ONLY component-specific details:
-  - Build instructions (make targets, go commands)
-  - Repository structure (cmd/, pkg/ organization)
-  - Development workflow (local dev, on-cluster testing)
-  - Test suites (unit, integration, E2E locations and commands)
-  - Component-specific test patterns
-  - Common development tasks (add CRD, add controller, update deps)
 
-### Phase 10: Validation
+- [ ] **VERIFY FIRST**:
+  ```bash
+  # Go version
+  grep "^go " "$REPO_PATH/go.mod"
+
+  # Branch name (no clone needed) — uses first remote found
+  _remote=$(git remote | head -1)
+  git ls-remote --symref "$(git remote get-url "$_remote")" HEAD | grep 'ref:' | awk '{print $2}' | cut -d/ -f3
+
+  # Makefile targets
+  grep "^[a-zA-Z-]*:" Makefile | cut -d: -f1
+
+  # Directory structure
+  ls -d cmd pkg test manifests 2>/dev/null
+  ```
+- [ ] Create [COMPONENT]_DEVELOPMENT.md from template:
+  - **Remove** "Repository Structure" section (already in components.md)
+  - **Replace** generic template placeholders with actual repo patterns discovered in Phase 5
+  - Fill "Common Tasks" with repo-specific tasks, not generic placeholders
+  - Fill "Common Mistakes" from anti-patterns discovered in Phase 5
+  - If common tasks vary in complexity, document tiers with specific file modification lists
+- [ ] Create [COMPONENT]_TESTING.md from template:
+  - **Replace** generic code examples with actual test patterns from this repo
+  - Fill "Component-Specific" sections with real test scenarios
+- [ ] Link to Platform for generic practices
+- [ ] Document ONLY verified component-specific details (target: 100-200 lines each)
+
+### Phase 10: Validation & Verification
+
 - [ ] Run `bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH"` (includes link validation)
-- [ ] Verify AGENTS.md ≤100 lines
-- [ ] Verify no generic duplication
-- [ ] Verify ecosystem.md exists with Platform links
-- [ ] Verify all external links (HTTP/HTTPS) are valid
-- [ ] Verify all internal links (relative paths) are valid
-- [ ] Fix any broken links found
+- [ ] Verify AGENTS.md ≤100 lines, no generic duplication, ecosystem.md exists
+- [ ] **Verify specificity**: Repo structure only in components.md (not duplicated in DEVELOPMENT.md), pattern claims backed by code evidence
+- [ ] **Anti-hallucination checks**: Spot-check type fields if applicable, verify branch names in examples match repo, confirm pattern claims reference actual code
+- [ ] **Operator-specific checks** (if operator repo): Verify apply method claims per-controller (`grep -r "client.Apply\|r.Update\|resourceapply" pkg/controller/<name>/`). Verify feature gate claims trace to actual runtime code. Verify image env var names match Makefile/CSV.
+- [ ] Verify all domain/*.md files link to actual type definitions
+- [ ] Cross-check with openshift-docs if time permits
+- [ ] **Flag discovery gaps**: At the end of components.md and DEVELOPMENT.md, add a brief "SME Review Recommended" note listing areas where automated discovery may be incomplete — typically: implementation recipes for adding new components, anti-patterns from institutional knowledge, and rationale behind pattern choices. This sets expectations that the docs are a verified foundation, not a complete implementation guide
 
 **Link Validation**:
+- Link validation always runs — broken links (wrong relative paths, 404 URLs) are a common source of documentation errors
 - Automatically checks all HTTP/HTTPS links (with timeout and user agent)
 - Validates internal/relative links (file existence)
 - Flags known Platform planned links as "KNOWN BROKEN"
-- Use `VERBOSE=true bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH"` to see all links
-- Use `bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH" false` to skip link validation
+- Use `VERBOSE=true bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH"` to see all links including successful ones
+
+### Phase 11: Verification (Recommended)
+
+- [ ] **Ask user**: "Run `/review-docs` to verify claims?"
+  - If **YES**: Run `/review-docs --path "$REPO_PATH"`
+  - If **NO**: Warn user:
+    ```
+    Skipping verification. Documentation may contain:
+    - Incorrect API field claims
+    - Wrong branch/version references
+    - Unverified pattern claims (SSA vs strategic merge, etc.)
+
+    Recommend running `/review-docs` before creating PRs to catch hallucinations.
+    ```
+
+**Note**: `/review-docs` verifies claims locally against the repo's source code (including vendored dependencies) first, then uses chai-bot MCP for cross-repo verification (enhancements, platform terminology, convention compliance). Local verification works without any setup. Chai-bot is needed for cross-functional checks and requires VPN + MCP configuration — see [review-docs skill](../review-docs/SKILL.md).
+
+## Implementation Pattern Discovery
+
+Use this checklist during Phase 5 when exploring the codebase. These patterns produce the most valuable documentation — the kind that prevents an agent from writing subtly incorrect code.
+
+### What to Look For
+
+| Pattern | How to Discover | What to Document |
+|---------|----------------|------------------|
+| **Multiple paradigms** | Do different packages use different frameworks or approaches for similar tasks? | Comparison table with "use X for Y, never Z for Y" guidance |
+| **Shared utilities** | Is there a `common/`, `shared/`, `utils/`, or `internal/` package used across components? | Exact exported symbols with one-line usage contract |
+| **Wiring/registration** | How do new components get registered and started? How does work get dispatched to them? | Startup sequence, event/trigger flow, where to hook in new components |
+| **Resource management** | How does code create/update external resources? (SSA, strategic merge, REST calls, etc.) | Actual method with code reference — verify in code, don't assume |
+| **Naming conventions** | Grep for patterns in env vars, labels, file names, package names | Exact format with examples |
+| **Feature toggles** | Are there feature gates, flags, or config-driven enablement? | Definition → runtime check → wiring chain |
+| **Anti-patterns** | Search for "DO NOT", "NEVER", "MUST", "HACK" in code comments. Study 2-3 existing implementations to identify shared patterns and things they avoid | Numbered "DO NOT" list with brief explanation |
+
+### Operator-Specific Discovery
+
+When the repo is a Kubernetes/OpenShift operator (detected via controller-runtime, library-go, OLM bundle, CRDs), also investigate these patterns. Skipping them produces docs that look correct but cause agents to write subtly wrong code.
+
+| Pattern | How to Discover | What to Document |
+|---------|----------------|------------------|
+| **Controller framework split** | Check imports in EACH controller package for `library-go` vs `controller-runtime`. Don't assume uniformity. | Per-controller table: framework, apply method (`client.Apply` vs `resourceapply` vs Create+Update), code ref. |
+| **Reconciliation apply method** | For EACH controller: `grep -r "client.Apply\|r.Update\|r.Create\|resourceapply" pkg/controller/<name>/` | Actual method per controller. This is the #1 source of hallucinations — the cert-manager-operator review found docs claiming "all controllers use SSA" when only one of three did. |
+| **Feature gate runtime behavior** | Read `features.go` end-to-end. Trace from definition → runtime check → startup wiring. | Full chain. For TechPreview: cluster-side gating (FeatureSet discovery, fail-closed). Don't just list gate names. |
+| **Image resolution & OLM bundle** | `grep -r RELATED_IMAGE Makefile bundle/`. Check Makefile for `*_VERSION` vars. Check `bundle/manifests/` for CSV. | Env var naming convention, version variables, how OLM injects images. CSV update checklist (env vars, RBAC, relatedImages). |
+| **Error classification** | Check common/ for error wrapper types (`IrrecoverableError`, `RetryRequiredError`). | Which types exist, effect on requeue behavior. |
+| **Generated code & bindata pipeline** | `find . -name "zz_generated*" -o -name "bindata.go" -o -path "*/clientset/*"`. Check Makefile for generation targets. | Generated files/dirs with "NEVER hand-edit" + make target. For bindata: version var → hack script → output dir → Go loading. |
+| **Status conditions & OpenShift integrations** | Check for library-go `OperatorStatus` vs custom conditions. Grep for proxy, trusted-CA, TLS profile, CCO references. | Which condition system, which integrations exist — only document what's present. |
+
+### Information Density
+
+- Exact symbol names over generic descriptions
+- Comparison tables for contrasting patterns
+- "Never" / "DO NOT" warnings for common confusion points
+- One table with symbols beats three paragraphs of prose
+- Every line should tell the reader something they can't infer from file names alone
+- Every pattern claim must include a file:line reference (e.g., `pkg/controller/foo/deployments.go:40`). If you can't point to source, you're inferring — flag it as unverified instead of stating it as fact
 
 ## AGENTS.md Requirements
 
@@ -152,406 +233,95 @@ component-repo/
 **Required Sections**:
 1. Component metadata (name, repository)
 2. Platform reference (link to ecosystem hub)
-3. Component purpose (what is it?)
+3. Component purpose (1-2 sentences)
 4. Core components (brief)
-5. Documentation structure (compressed)
-6. Knowledge graph (visual)
-7. Platform ecosystem links (operator patterns, testing, security, etc.)
-
-**Format**: Compressed, table-based, links not prose
-
-**Example**:
-```markdown
-# Component Name - Agentic Documentation
-
-**Component**: Machine Config Operator  
-**Repository**: openshift/machine-config-operator  
-
-> **Generic Platform Patterns**: See Platform documentation (openshift/enhancements/ai-docs/)
-
-## What is MCO?
-
-Manages OS configuration for OpenShift nodes. Controls everything between kernel and kubelet.
-
-## Core Components
-
-- **MCD**: DaemonSet applying configs | **MCC**: Coordinates upgrades | **MCS**: Serves Ignition
-
-## Documentation Structure
-
-```text
-ai-docs/
-├── domain/          # CRDs: MachineConfig, MachineConfigPool
-├── architecture/    # Component internals
-├── decisions/       # Component ADRs
-└── exec-plans/      # Feature planning
-```text
-
-## Platform Links
-
-**Patterns**: Operator | Testing | Security (see Platform docs)
-
-## Component-Specific Domain Concepts
-
-**Template**: `templates/domain-concept-template.md`
-
-**Structure**:
-- API Group / Kind / Scope
-- Purpose (component-specific behavior)
-- Key fields (most important only)
-- Lifecycle
-- Examples (component-specific usage)
-
-**Length**: 100-200 lines per concept
-
-**Example**: MachineConfig (MCO-specific)
-- Ignition config structure
-- Rendered config merging
-- OS update mechanism
-- Ownership model (system vs user)
-
-## Component Architecture
-
-**File**: `architecture/components.md`
-
-**Contents**:
-- Component structure (pkg/, cmd/, controllers/)
-- Component relationships
-- Data flow
-- Key responsibilities
-
-**Length**: 100-200 lines
-
-## Component ADRs
-
-**Format**: `decisions/adr-NNNN-title.md`
-
-**Example Component ADRs**:
-- Why rpm-ostree for OS updates (MCO)
-- Why Ignition format for config (MCO)
-- Why etcd for platform state (Platform, NOT component)
-
-**Template**: `decisions/adr-template.md`
-
-## Exec-Plans
-
-**Purpose**: Track active feature implementation (bridges enhancements and PRs)
-
-**Location**: Component repo (`ai-docs/exec-plans/active/`)
-
-**Guidance**: See Platform documentation for exec-plans templates and workflows
-
-**Component repo structure**:
-```text
-ai-docs/exec-plans/
-├── active/           # Component-specific exec-plans go here
-└── README.md         # Pointer to Platform guidance
-```text
-
-**What component-docs creates**:
-- `active/` directory (empty, ready for exec-plans)
-- `README.md` with pointer to Platform exec-plans guidance
-
-**Note**: Exec-plans are deleted after completion; knowledge is extracted into ADRs or architecture docs
-
-## Enhancement Proposals & Design Docs
-
-**File**: `references/enhancements.md`
-
-**Purpose**: Index all design documentation for this component
-
-**Sources to search**:
-1. openshift/enhancements repo: `https://github.com/openshift/enhancements/tree/master/enhancements/{component-area}/`
-2. Component repo: docs/, design/, enhancements/ directories
-
-**Format**: Simple catalog with title, status, and link (no summaries - the enhancement is the source of truth)
-
-**Example**:
-```markdown
-# Enhancement Proposals & Design Docs
-
-## openshift/enhancements
-- [On-Cluster Layering](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/on-cluster-layering.md) - Implemented
-- [Admin Node Disruption Policy](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/admin-defined-node-disruption-policy.md) - Implemented
-
-## Local Design Docs
-- [Config Drift Detection](../docs/design/config-drift.md)
-```
-
-**Distinction from ADRs**: Enhancement proposals are feature designs (often cross-component), ADRs are component architectural decisions
-
-## Ecosystem References
-
-**File**: `references/ecosystem.md`
-
-**Links to Platform**:
-- Operator patterns (controller-runtime, status conditions, webhooks, finalizers, RBAC)
-- Testing practices (pyramid, E2E framework)
-- Security practices (STRIDE, RBAC, secrets)
-- Reliability practices (SLO, observability, degraded states)
-- Kubernetes fundamentals (Pod, Node, DaemonSet)
-- OpenShift fundamentals (ClusterOperator, release image)
-- Cross-repo ADRs (etcd, CVO orchestration, immutable nodes)
-
-**Purpose**: Single source of truth for Platform links
-
-## Development & Testing Docs
-
-**Files**: `[COMPONENT]_DEVELOPMENT.md`, `[COMPONENT]_TESTING.md`
-
-**Templates**: Use `templates/DEVELOPMENT-template.md` and `templates/TESTING-template.md`
-
-### DEVELOPMENT.md Contents
-
-**Required sections** (component-specific ONLY):
-
-1. **Quick Start**
-   - Prerequisites (Go version, cluster access, tools)
-   - Build commands (`make [target]`, `go build`)
-   - Output locations
-
-2. **Repository Structure**
-   - cmd/ organization
-   - pkg/ organization
-   - manifests/ structure
-   - test/ organization
-
-3. **Development Workflow**
-   - Local development (build binaries, run tests)
-   - On-cluster testing (replace pod, run locally against cluster)
-   - Debugging (logs, exec, delve)
-
-4. **Code Organization**
-   - Where controllers live
-   - Where domain logic lives
-   - Package structure
-
-5. **Common Tasks**
-   - Add new CRD
-   - Add new controller
-   - Update dependencies
-   - Build & release process
-
-6. **Component-Specific Notes**
-   - Special build flags
-   - Environment variables
-   - Local development quirks
-
-**Link to Platform for**: Generic Go standards, controller-runtime patterns, CI/CD workflows
-
-### TESTING.md Contents
-
-**Required sections** (component-specific ONLY):
-
-1. **Test Organization**
-   - Test pyramid visualization
-   - Where tests live (unit, integration, E2E)
-
-2. **Unit Tests**
-   - Location (pkg/*/\*_test.go)
-   - Running commands (`make test-unit`, `go test`)
-   - Component-specific test patterns
-   - Coverage commands
-
-3. **Integration Tests**
-   - Location (test/integration/ or with build tags)
-   - Running commands
-   - Component-specific integration scenarios
-
-4. **E2E Tests**
-   - Location (test/e2e/)
-   - Running commands
-   - Component-specific E2E scenarios
-   - Test organization
-
-5. **Test Coverage**
-   - Current coverage
-   - Coverage targets
-   - Known gaps
-
-6. **Debugging Tests**
-   - Unit test failures
-   - E2E test failures
-   - Must-gather commands
-
-7. **Component-Specific Test Notes**
-   - Special test setup
-   - Known flaky tests
-   - Test environment requirements
-
-**Link to Platform for**: Test pyramid philosophy (60/30/10), E2E framework patterns, mock vs real strategies
-
-### Example from MCO
-
-**DEVELOPMENT.md** includes:
-- Build commands: `make machine-config-daemon`, `make machine-config-controller`
-- Repository structure: cmd/, pkg/, templates/, manifests/
-- Development workflow: Local build, on-cluster testing
-- Common tasks: Add CRD, update deps
-
-**TESTING.md** includes:
-- Unit test patterns: Controller tests, Ignition tests
-- Integration tests: Node update scenarios
-- E2E tests: OS update tests, config drift tests
-- Test commands: `make test-unit`, `make test-e2e`
-
-**Both files** are ~100-200 lines, lean, component-specific only
+5. Critical patterns (2-3 "never do X" rules — the most important architectural warnings)
+6. Documentation structure (compressed)
+7. Platform ecosystem links
+
+**Format**: Compressed, table-based, links not prose. Use `templates/AGENTS-template.md`.
 
 ## Validation Criteria
 
-✅ **AGENTS.md**:
-- At repo root (not in ai-docs/)
-- 80-100 lines
-- Compressed index format
-- Retrieval-first instruction
-- Platform ecosystem links section
+✅ **AGENTS.md**: At repo root, 80-100 lines, compressed index, retrieval-first instruction, Platform links, critical pattern warnings
 
-✅ **No duplication**:
-- No testing pyramid explanations
-- No controller-runtime patterns
-- No status condition semantics
-- No STRIDE threat model
-- No SLO framework
+✅ **No duplication**: No generic framework explanations, no testing pyramid, no security frameworks
 
-✅ **References**:
-- references/ecosystem.md exists with Platform links
-- references/enhancements.md exists with design docs catalog
-- Enhancement proposals from openshift/enhancements discovered
-- Local design docs discovered and linked
+✅ **References**: ecosystem.md with Platform links, enhancements.md with design docs catalog
 
-✅ **Component-specific only**:
-- Domain concepts are component CRDs
-- ADRs are component-specific
-- Architecture is component internals
+✅ **Component-specific only**: Domain concepts are component-specific, ADRs are component-specific, architecture is component internals
 
-✅ **Link validation**:
-- All external links (HTTP/HTTPS) return 200 OK
-- All internal links (relative paths) resolve to existing files/directories
-- No broken links except known Platform planned links
-- Links to upstream documentation are valid and current
+✅ **Link validation**: All external links return 200 OK, all internal links resolve
+
+✅ **Implementation patterns**: Architecture doc has discovery checklist results, shared utilities listed with exact symbols, anti-patterns documented
+
+✅ **Operator accuracy** (if operator repo): Apply method documented per-controller (not assumed uniform), feature gate runtime behavior traced, generated code inventory listed, image resolution mechanism documented
 
 ## Anti-Patterns
 
 ### ❌ DON'T duplicate Platform content
 
-**Wrong**:
-```markdown
-# TESTING.md (187 lines, 60% generic)
+**Wrong**: 187-line TESTING.md where 60% is generic test pyramid explanation
+**Right**: 90-line COMPONENT_TESTING.md that's 100% component-specific, links to Platform
 
-## Testing Pyramid
-[100 lines explaining pyramid]
+### ❌ DON'T explain generic framework patterns
 
-## Component Tests
-[37 lines component-specific]
-```text
-
-**Right**:
-```markdown
-# COMPONENT_TESTING.md (90 lines, 100% component-specific)
-
-> Testing practices: See Platform docs
-
-## Component Test Suites
-[90 lines component-specific]
-```text
-
-### ❌ DON'T explain generic patterns
-
-**Wrong**: Explaining controller-runtime in component docs  
-**Right**: Link to Platform, document component-specific usage
+**Wrong**: Explaining framework internals in component docs
+**Right**: Link to Platform, document component-specific usage only
 
 ### ❌ DON'T create cross-repo ADRs
 
-**Wrong**: ADR about etcd in component repo  
-**Right**: ADR about etcd in Platform
+**Wrong**: ADR about shared infrastructure in component repo
+**Right**: That ADR belongs in Platform
 
-## Metrics
+### ❌ DON'T document without verification
 
-**Expected structure**:
-- AGENTS.md: 80-100 lines (vs 150+ for single-tier)
-- Total docs: ~2,500 lines (vs ~6,000 single-tier)
-- Generic duplication: 0 lines (vs ~2,400 single-tier)
+**Wrong**: Type fields from memory, outdated conventions, pattern claims without code evidence
+**Right**: Verify in source code, check actual branch names, confirm patterns exist, link to sources
 
-**Benefits**:
-- 58% smaller than single-tier
-- Zero duplication across ecosystem
-- Pattern updates: 1 Platform PR (not 60+ component PRs)
+### ❌ DON'T write generic placeholders
+
+**Wrong**: "Add new controller: 1. Create controller.go 2. Implement Reconcile() 3. Register"
+**Right**: Repo-specific steps with exact file paths, shared utilities to use, registration wiring, and naming conventions
 
 ## Prerequisites
 
-**Before running**:
-1. ✅ Platform exists at openshift/enhancements/ai-docs/
-2. ✅ Repository is OpenShift component
-3. ✅ You understand two-tier architecture
-4. ✅ Platform documentation exists at openshift/enhancements/ai-docs/
+1. ✅ Platform documentation exists at openshift/enhancements/ai-docs/
+2. ✅ Repository is an OpenShift component
 
 ## Arguments
 
 ```bash
 /component-docs [--path <repository-path>]
-```text
+```
 
-**Arguments**:
 - `--path <repository-path>`: Path to component repository (default: current directory)
-- No args: Create documentation in current directory
 
 ## Success Output
 
 ```text
 ✅ Component Documentation Created
 
-Component: machine-config-operator
-Repository: /path/to/repo
+Component: [component-name]
+Repository: [path]
 
 Structure:
-  ✅ AGENTS.md (root): 87 lines (target: 80-100)
-  ✅ Domain concepts: 4 files (component CRDs only)
-  ✅ Architecture: 1 file (components.md)
-  ✅ Component ADRs: 3 files
-  ✅ Exec-plans: README.md, active/
+  ✅ AGENTS.md (root): XX lines (target: 80-100)
+  ✅ Domain concepts: N files
+  ✅ Architecture: components.md
+  ✅ Component ADRs: N files
   ✅ References: ecosystem.md, enhancements.md
   ✅ Development: COMPONENT_DEVELOPMENT.md
   ✅ Testing: COMPONENT_TESTING.md
 
-Validation:
-  ✅ AGENTS.md at root (80-100 lines)
-  ✅ No generic duplication
-  ✅ Platform links present
-  ✅ Component-specific content only
-
-References:
-  - Ecosystem hub: openshift/enhancements/ai-docs
-  - Enhancement proposals: Catalogued from openshift/enhancements + local docs
-  - Platform links: Operator patterns, testing, security, Kubernetes/OpenShift fundamentals
-
 Next Steps:
-  1. Populate domain/*.md with component CRDs
-  2. Document architecture in components.md
-  3. Create component-specific ADRs
-  4. Use exec-plans/ for active features
-```text
-
-## Example: Machine Config Operator
-
-**Created files**:
-- AGENTS.md (87 lines)
-- ai-docs/domain/machineconfig.md
-- ai-docs/domain/machineconfigpool.md
-- ai-docs/domain/kubeletconfig.md
-- ai-docs/domain/containerruntimeconfig.md
-- ai-docs/architecture/components.md
-- ai-docs/decisions/adr-0001-rpm-ostree-updates.md
-- ai-docs/decisions/adr-0002-ignition-format.md
-- ai-docs/decisions/adr-0003-config-drift-detection.md
-- ai-docs/references/ecosystem.md
-- ai-docs/exec-plans/README.md
-- ai-docs/MCO_DEVELOPMENT.md
-- ai-docs/MCO_TESTING.md
-
-**Total**: ~2,500 lines (component-specific only)
+  1. Run `/review-docs` to verify claims locally + cross-repo via chai-bot (recommended)
+  2. Review generated documentation for accuracy
+  3. Create PR with documentation changes
+```
 
 ## See Also
 
+- `/review-docs` - Verify documentation claims locally and cross-repo via chai-bot (recommended after creation)
 - `/update-platform-docs` - Update Platform documentation
 - Platform Documentation (openshift/enhancements/ai-docs/)
-- [MCO Example](https://github.com/openshift/machine-config-operator/tree/master/ai-docs)

--- a/plugins/agentic-docs/skills/component-docs/scripts/create-structure.sh
+++ b/plugins/agentic-docs/skills/component-docs/scripts/create-structure.sh
@@ -10,7 +10,6 @@ mkdir -p "$REPO_PATH/ai-docs/domain"
 mkdir -p "$REPO_PATH/ai-docs/architecture"
 mkdir -p "$REPO_PATH/ai-docs/decisions"
 mkdir -p "$REPO_PATH/ai-docs/exec-plans/active"
-mkdir -p "$REPO_PATH/ai-docs/exec-plans/completed"
 mkdir -p "$REPO_PATH/ai-docs/references"
 
 echo "✅ Directory structure created:"

--- a/plugins/agentic-docs/skills/component-docs/scripts/validate.sh
+++ b/plugins/agentic-docs/skills/component-docs/scripts/validate.sh
@@ -5,24 +5,22 @@
 # Validates component-level documentation structure and links.
 #
 # Usage:
-#   ./validate.sh [REPO_PATH] [VALIDATE_LINKS]
+#   ./validate.sh [REPO_PATH]
 #
 # Arguments:
 #   REPO_PATH        Path to repository (default: current directory)
-#   VALIDATE_LINKS   true/false to enable/disable link validation (default: true)
 #
 # Environment:
 #   VERBOSE=true     Show all successful links (default: false, only shows broken links)
 #
 # Examples:
 #   ./validate.sh                          # Validate current directory with link checking
-#   ./validate.sh /path/to/repo false      # Validate without link checking
+#   ./validate.sh /path/to/repo            # Validate specific repo
 #   VERBOSE=true ./validate.sh             # Show all links, including successful ones
 #
 set -euo pipefail
 
 REPO_PATH="${1:-.}"
-VALIDATE_LINKS="${2:-true}"  # Default: validate links
 VERBOSE="${VERBOSE:-false}"   # Set VERBOSE=true to see all successful links
 
 echo "✅ Validating component documentation in: $REPO_PATH"
@@ -300,52 +298,46 @@ fi
 
 echo ""
 
-# Validate links (if enabled)
-if [ "$VALIDATE_LINKS" = "true" ]; then
-    echo "Validating links..."
+# Validate links
+echo "Validating links..."
+echo ""
+
+LINK_VALIDATION_FAILED=false
+
+# Check links in AGENTS.md
+if [ -f "$REPO_PATH/AGENTS.md" ]; then
+    echo "📄 Checking AGENTS.md:"
+    echo "  🔗 External links:"
+    if ! validate_links "$REPO_PATH/AGENTS.md"; then
+        LINK_VALIDATION_FAILED=true
+    fi
+    echo "  🔗 Internal links:"
+    if ! validate_internal_links "$REPO_PATH/AGENTS.md"; then
+        LINK_VALIDATION_FAILED=true
+    fi
     echo ""
+fi
 
-    LINK_VALIDATION_FAILED=false
-
-    # Check links in AGENTS.md
-    if [ -f "$REPO_PATH/AGENTS.md" ]; then
-        echo "📄 Checking AGENTS.md:"
+# Check links in all ai-docs markdown files
+if [ -d "$REPO_PATH/ai-docs" ]; then
+    while IFS= read -r -d '' file; do
+        echo "📄 Checking $(basename "$file"):"
         echo "  🔗 External links:"
-        if ! validate_links "$REPO_PATH/AGENTS.md"; then
+        if ! validate_links "$file"; then
             LINK_VALIDATION_FAILED=true
         fi
         echo "  🔗 Internal links:"
-        if ! validate_internal_links "$REPO_PATH/AGENTS.md"; then
+        if ! validate_internal_links "$file"; then
             LINK_VALIDATION_FAILED=true
         fi
         echo ""
-    fi
+    done < <(find "$REPO_PATH/ai-docs" -name "*.md" -type f -print0)
+fi
 
-    # Check links in all ai-docs markdown files
-    if [ -d "$REPO_PATH/ai-docs" ]; then
-        while IFS= read -r -d '' file; do
-            echo "📄 Checking $(basename "$file"):"
-            echo "  🔗 External links:"
-            if ! validate_links "$file"; then
-                LINK_VALIDATION_FAILED=true
-            fi
-            echo "  🔗 Internal links:"
-            if ! validate_internal_links "$file"; then
-                LINK_VALIDATION_FAILED=true
-            fi
-            echo ""
-        done < <(find "$REPO_PATH/ai-docs" -name "*.md" -type f -print0)
-    fi
-
-    if [ "$LINK_VALIDATION_FAILED" = true ]; then
-        echo "⚠️  Some links are broken or inaccessible"
-        echo ""
-        echo "To skip link validation, run: $0 $REPO_PATH false"
-    else
-        echo "✅ All links validated successfully"
-    fi
+if [ "$LINK_VALIDATION_FAILED" = true ]; then
+    echo "⚠️  Some links are broken or inaccessible"
 else
-    echo "ℹ️  Link validation skipped (run with 'true' as 2nd arg to enable)"
+    echo "✅ All links validated successfully"
 fi
 
 echo ""

--- a/plugins/agentic-docs/skills/component-docs/templates/AGENTS-template.md
+++ b/plugins/agentic-docs/skills/component-docs/templates/AGENTS-template.md
@@ -17,11 +17,17 @@
 
 **Quick Start**: `oc describe clusteroperator/[name]` | `oc describe [primary-resource]`
 
+## Critical Patterns
+
+[2-3 most important architectural rules discovered from codebase exploration.
+These should be the patterns that, if violated, produce subtly broken code.
+Use comparison tables for contrasting approaches and bold "Never" warnings.]
+
 ## Documentation Structure
 
 ```text
 ai-docs/
-├── domain/                    # Component-specific CRDs
+├── domain/                    # Component-specific APIs/types
 ├── architecture/              # Component internals
 ├── decisions/                 # Component-specific ADRs
 ├── exec-plans/                # Feature planning
@@ -34,22 +40,6 @@ ai-docs/
 **Exec-Plans**: Use `active/` for new features. See [Platform Exec-Plans Guide](Platform documentation).
 
 **Platform Patterns (Platform)**: [Operator](Platform documentation) | [Testing](Platform documentation) | [Security](Platform documentation)
-
-## Knowledge Graph
-
-```text
-                         [AGENTS.md] ← Start here
-                              │
-              ┌───────────────┼───────────────┐
-              │               │               │
-         [domain/]      [architecture/]  [decisions/]
-        CRD concepts    Component design  ADR history
-              │               │               │
-              └───────────────┼───────────────┘
-                              │
-                      [references/ecosystem]
-                      Links to Platform
-```text
 
 **AI Agent Path**: domain/ → architecture/ → decisions/ → [COMPONENT]_DEVELOPMENT.md
 

--- a/plugins/agentic-docs/skills/component-docs/templates/DEVELOPMENT-template.md
+++ b/plugins/agentic-docs/skills/component-docs/templates/DEVELOPMENT-template.md
@@ -8,7 +8,7 @@ This guide covers **[COMPONENT]-specific** development practices.
 
 ### Prerequisites
 
-- Go 1.22+ (check go.mod for exact version)
+- Go [X.XX]+ (from go.mod)
 - Access to OpenShift cluster
 - `KUBECONFIG` environment variable set
 - Container build tool (Podman or Docker)
@@ -24,32 +24,9 @@ make binaries
 
 # Or use go directly
 go build -o _output/[binary-name] ./cmd/[component]
-```text
+```
 
 **Binaries output**: `./_output/linux/amd64/` or `./bin/`
-
-## Repository Structure
-
-```text
-cmd/                           # Binary entrypoints
-├── [component-1]/             # Component 1
-└── [component-2]/             # Component 2
-
-pkg/
-├── controller/                # Controllers
-│   ├── [controller-1]/        # Controller 1
-│   └── [controller-2]/        # Controller 2
-├── [domain-logic]/            # Domain-specific logic
-└── [utilities]/               # Utilities
-
-manifests/                     # Deployment manifests
-├── [component-1]/             # Component 1 deployment
-└── [component-2]/             # Component 2 deployment
-
-test/
-├── e2e/                       # End-to-end tests
-└── integration/               # Integration tests
-```text
 
 ## Development Workflow
 
@@ -137,21 +114,10 @@ Document component-specific business logic here.
 
 ## Common Tasks
 
-### Add New CRD
-
-1. Define types in `pkg/apis/[group]/[version]/types.go`
-2. Run `make manifests` to generate CRD YAML
-3. Update RBAC in `manifests/*/rbac.yaml`
-4. Create controller in `pkg/controller/[name]/`
-5. Register controller in `cmd/[component]/main.go`
-
-### Add New Controller
-
-1. Create `pkg/controller/[name]/controller.go`
-2. Implement `Reconcile()` function
-3. Register in main.go
-4. Add unit tests
-5. Add E2E tests
+[Discover and document the 3-5 most common development tasks for this repo.
+Replace these placeholders with repo-specific steps including exact file paths,
+shared utilities to use, registration/wiring points, and naming conventions.
+If tasks vary in complexity, document tiers with specific file modification lists.]
 
 ### Update Dependencies
 
@@ -159,13 +125,10 @@ Document component-specific business logic here.
 # Update specific dependency
 go get [module]@[version]
 
-# Update all dependencies
-go get -u ./...
-
 # Tidy and vendor
 go mod tidy
 go mod vendor
-```text
+```
 
 ## Build & Release
 
@@ -183,6 +146,13 @@ Component images are built by OpenShift CI on PR merge. See `.ci-operator.yaml`.
 
 Component is released as part of OpenShift release image. See [Platform Release Process](Platform documentation).
 
+## Common Mistakes
+
+[Discover from code patterns, comments, and code reviews. Study 2-3 existing
+implementations to identify anti-patterns. List as numbered "DO NOT" items.]
+
+1. DO NOT [pattern] — [brief explanation of why]
+
 ## Component-Specific Notes
 
 [Add component-specific development notes here]
@@ -190,7 +160,6 @@ Component is released as part of OpenShift release image. See [Platform Release 
 - Special build flags
 - Environment variables
 - Local development quirks
-- Common gotchas
 
 ## See Also
 

--- a/plugins/agentic-docs/skills/component-docs/templates/domain-concept-template.md
+++ b/plugins/agentic-docs/skills/component-docs/templates/domain-concept-template.md
@@ -4,6 +4,8 @@
 **Kind**: `ResourceName`  
 **Scope**: Cluster | Namespaced
 
+**API Definition**: [types.go](<link-to-types.go>) <!-- Replace with actual URL to the type definition -->
+
 ## Purpose
 
 [Brief description of what this resource does - component-specific behavior only]
@@ -14,9 +16,9 @@
 
 ```go
 type ResourceNameSpec struct {
-    Field1 Type  // Description
-    Field2 Type  // Description
-    Field3 Type  // Description
+    Field1 Type  // Description (verified in types.go)
+    Field2 Type  // Description (verified in types.go)
+    Field3 Type  // Description (verified in types.go)
 }
 ```text
 
@@ -57,6 +59,10 @@ spec:
 **For generic patterns**, see:
 - Controller patterns: [Platform](Platform documentation)
 - Status conditions: [Platform](Platform documentation)
+
+## Common Mistakes
+
+[List mistakes specific to this type that would produce incorrect usage or broken code]
 
 ## Related Concepts
 

--- a/plugins/agentic-docs/skills/review-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/review-docs/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: review-docs
+description: Review agentic documentation — verify claims locally against source code first, then use chai-bot for cross-repo and cross-functional verification
+trigger: explicit
+---
+
+# Documentation Review & Verification
+
+Reviews agentic documentation using **two-tier verification**: local codebase checks first, then cross-repo verification via **chai-bot MCP server** for claims that can't be resolved locally. Verify locally when possible, escalate to chai-bot when necessary.
+
+## Prerequisites
+
+**Recommended** (for cross-repo verification): chai-bot MCP server configured with bearer token and Red Hat VPN connection. Without chai-bot, cross-repo claims (enhancements, platform terminology, convention compliance, non-vendored API types) are flagged as "unverified" but local verification still runs fully.
+
+Setup instructions: See [plugin README](../../README.md#setup) for chai-bot configuration steps.
+
+## When to Use
+
+- After `/component-docs` or `/update-platform-docs`
+- Before documentation PRs
+- When docs may contain outdated/incorrect information
+
+## Limitations
+
+This skill verifies **factual accuracy** of what's documented. It does NOT detect:
+- **Missing documentation** — incomplete coverage, absent sections
+- **Low information density** — generic placeholders instead of repo-specific details
+- **Misleading by omission** — technically correct but useless (e.g., "uses controllers" without specifying which framework)
+
+For completeness and specificity, rely on the Implementation Pattern Discovery checklist in `/component-docs` and SME review.
+
+## Claim Classification
+
+Classify each claim by **what it asserts**. A single doc sentence may contain both a local fact and a cross-repo assertion — extract these as separate claims.
+
+### Local: "Can this be verified from the current repo?"
+
+Verifiable by reading the repo's own source code, **including `vendor/`**:
+- File/directory paths exist
+- Makefile targets exist
+- Go version — check both the `go` directive (minimum version) and `toolchain` directive (actual toolchain) in `go.mod`
+- Default branch name
+- Import statements present (which frameworks a controller imports)
+- Code patterns present (apply/update/patch calls, webhook registration code, feature gate checks)
+- Go symbols referenced in examples exist
+- YAML examples parse without errors
+- Internal doc links resolve
+- External links return HTTP 200 (with caveats — see Phase 3)
+- Cross-file consistency (same concept not contradicted across doc files)
+- Test directories and framework imports exist
+- **API/CRD field names, types, defaults** — if `vendor/github.com/openshift/api` exists, verify struct definitions from vendored `types.go` files
+- **Feature gate definitions** — if `vendor/github.com/openshift/library-go` or `vendor/github.com/openshift/api` exists, verify gate names and stages from vendored code
+- **API group/version** — if vendored, check `register.go` for `GroupName` and `SchemeGroupVersion`
+
+### Cross-repo: "Is this correct against external sources?"
+
+Claims that cannot be resolved from local code or `vendor/`:
+- API/CRD fields, feature gates, API group/version **when not vendored**, or when checking whether the vendored version is current
+- Enhancement existence and status (in `openshift/enhancements`)
+- Official terminology (must match `openshift-docs`)
+- Cross-component interactions (how other operators behave)
+- Platform convention compliance (whether a locally-verified pattern follows platform norms)
+- Platform pattern references (whether linked platform docs are accurate)
+- Historical context (design decisions in Slack/Jira, not code)
+
+### Examples
+
+| Documentation Says | Local Claim | Cross-Repo Claim (chai-bot) |
+|-------------------|---------------------|--------------------------|
+| "Uses admission webhooks" | Webhook registration code exists in repo | Webhooks follow platform conventions |
+| "Applies resources via SSA" | SSA apply calls exist in controller code | Field manager names match platform norms |
+| "Feature gate TechPreviewNoUpgrade controls X" | Code checks for this gate name | Gate exists in `openshift/api` with claimed stage (if not vendored) |
+
+Always run the local check first. If a claim fails locally, report it — no need to query chai-bot.
+
+## Execution Workflow
+
+### Phase 1: Document Discovery
+- [ ] Identify doc type (component or platform) and determine component repo from git remote or current working directory
+- [ ] Scope discovery to the generated documentation structure — do not crawl the entire repo:
+  - **Component docs**: `AGENTS.md`, `ai-docs/` tree, `*_DEVELOPMENT.md`, `*_TESTING.md`
+  - **Platform docs**: `enhancements/ai-docs/` tree
+  - If `--path` is specified, scope to that path instead
+- [ ] Use `find` within the scoped paths to catalog ALL markdown files
+- [ ] Read EVERY file found — do not skip any
+
+### Phase 2: Extract & Classify Claims
+
+For each file, systematically extract every verifiable claim and track it internally as a **claims inventory** — the running list of assertions that drives all subsequent verification. For each claim, note: the source file, line number or range, what is being asserted, and whether it is local or cross-repo.
+
+**Extraction rules**:
+- A "claim" is any assertion that can be confirmed or refuted against source code, APIs, or external references. This includes prose statements, code snippet comments, numeric values, symbol names in instructions, enum constraints, and command/target names.
+- Treat every line of documentation content as potentially containing one or more claims. If a line contains no verifiable assertion, skip it — but err on the side of extraction.
+- A doc file with N lines of substantive content should typically yield claims proportional to its density. If a 40-line section yields only 3 claims, re-read it — something was missed.
+
+**Cross-file consistency**: After extracting claims from all files, check for internal contradictions — the same concept described differently across files (e.g., AGENTS.md says "uses SSA" while components.md says "strategic merge"). Flag these before any verification queries.
+
+The claims inventory is internal — it is not written to a file or shown to the user. But every claim in it must receive a verification status (verified, failed, or skipped) before the review can proceed, and the final report must include coverage totals derived from it.
+
+### Phase 3: Local Codebase Verification
+
+Verify all local claims from the Phase 2 claims inventory against the current repo's source code. Every local claim must receive a status: **verified**, **failed**, or **skipped** (with justification). Do not proceed to Phase 4 until all local claims have a status.
+
+**Build & toolchain**:
+- [ ] Read Makefile — extract all target names, compare against documented build/test commands
+- [ ] Read `go.mod` — compare both `go` and `toolchain` directives to documented version
+- [ ] Check default branch: discover the remote first, then inspect its HEAD:
+  ```bash
+  _remote=$(git remote | head -1)
+  git symbolic-ref "refs/remotes/${_remote}/HEAD" # may need: git remote set-head "$_remote" --auto
+  ```
+
+**Directory & file structure**:
+- [ ] Verify all claimed file and directory paths exist
+
+**Framework & pattern claims**:
+- [ ] For each controller claimed to use a specific framework: grep for the framework's import path in that controller's source files
+- [ ] For each apply method claim: grep for the specific apply/update/patch patterns in the controller's code
+- [ ] For webhook claims: grep for admission webhook registration (`admissionregistration`, `WebhookServer`, webhook manifests)
+- [ ] For feature gate claims: grep for the gate name being checked in code
+
+**Vendored API types & feature gates** (if `vendor/github.com/openshift/api` or `vendor/github.com/openshift/library-go` exists):
+- [ ] For API/CRD field claims: find the relevant `types.go` in vendored `openshift/api`, compare struct field names, types, and defaults against documented claims
+- [ ] For API group/version claims: check vendored `register.go` for `GroupName` and `SchemeGroupVersion`
+- [ ] For feature gate claims: find gate definitions in vendored code, verify gate names and stages
+- [ ] If claims reference fields or gates not present in the vendored version, flag as potential version mismatch — escalate to chai-bot in Phase 4 to check if the vendored version is outdated
+
+**Code examples**:
+- [ ] Validate YAML snippets parse without errors
+- [ ] For Go examples: grep that referenced function names, type names, and constants exist in the repo
+
+**Naming conventions**:
+- [ ] For each claimed env var pattern: grep for matching env vars in the codebase
+- [ ] For each claimed label/annotation pattern: grep for matching keys
+
+**Test organization**:
+- [ ] Verify claimed test directories exist
+- [ ] Verify claimed test framework imports appear in test files
+
+**Links**:
+- [ ] Check ALL internal file references resolve locally
+- [ ] Verify external HTTPS links with curl (timeout 10s). Some sites return non-200 for automated requests — GitHub rate-limits, `docs.openshift.com` blocks curl. Treat 403/429 as "needs manual check" not automatic failure
+
+**Cross-file consistency**:
+- [ ] Compare claims about the same concept across doc files — flag contradictions
+
+### Phase 3.5: Self-Audit Re-Read
+
+Re-read each documentation file and compare it against the claims inventory from Phase 2. The goal is to catch claims that were missed during initial extraction — lines that contain verifiable assertions but were not included in the inventory.
+
+For each missed claim found: add it to the inventory, verify it immediately (local or cross-repo classification), and update its status. This step addresses the pattern where category-level verification feels complete but individual claims within those categories were never extracted.
+
+### Phase 4: Cross-Repo Verification via chai-bot
+
+Verify all cross-repo claims that could not be resolved locally.
+
+**Step 1 — Check chai-bot availability**:
+- [ ] Call `mcp__chai-bot__ask_persona` with a simple test question
+- [ ] If unavailable or call fails, inform user and skip to Phase 5 with cross-repo claims marked "unverified":
+  - Tool not found → restart Claude Code to reload MCP servers
+  - 401 → bearer token expired, request new token from chai-bot Slack app
+  - Timeout → check VPN connection to Red Hat network
+  - See [plugin README](../../README.md#setup) for setup details
+
+**Step 2 — Batch verification via chai-bot**:
+
+Batch related claims into grouped queries to reduce round-trips — each call takes ~15-25 seconds. Group all field claims for the same API type into one query, all convention claims for the same repo into one query, all enhancement references into one query, etc.
+
+- [ ] Verify ALL cross-repo claims — prioritize high-risk claims first (API fields, feature gate definitions, cross-component behavior)
+- [ ] Parse responses for confirmations, contradictions, or unknowns
+- [ ] For uncertain chai-bot responses, flag as "unverified" rather than confirmed
+- [ ] Expect 10-20+ queries for a comprehensive review
+
+**Question construction templates** (substitute `{component}`, `{api-type}`, etc.):
+
+```
+API fields (batch all fields for one type): "In github.com/openshift/api,
+what fields are defined in the {api-type}Spec struct? Please list field
+names, types, and any documented default values from the actual Go type
+definition."
+
+Feature gates (batch per operator): "What feature gates are defined for
+{component} in openshift/api? List gate names, stages, and version
+information."
+
+Enhancements (batch related): "Do the following enhancements exist in
+openshift/enhancements, and do they match the claimed descriptions?
+1. enhancements/{area}/{enhancement-file-1}.md
+2. enhancements/{area}/{enhancement-file-2}.md"
+
+Terminology: "In the official OpenShift documentation, how is {component}
+described? What is the correct terminology?"
+
+Cross-component: "How does {other-component} interact with {component}
+during {operation}?"
+
+Convention check: "What are the platform conventions for {pattern} in
+OpenShift operators? Does the pattern used by {component} match?"
+```
+
+### Phase 5: Report Findings
+
+**Severity guide**:
+- **Critical** — factually wrong; would cause an agent to produce incorrect code (wrong fields, wrong methods, wrong framework)
+- **Warning** — outdated, imprecise, or missing reference; won't cause broken code but degrades trust
+- **Cross-file inconsistency** — same concept described differently across files
+- **Unverified** — couldn't confirm or deny (chai-bot uncertain or unavailable for cross-repo claims)
+
+Summarize findings directly to the user with:
+1. **Coverage metrics**: Total claims extracted, total verified, total failed, total skipped — broken down by local vs cross-repo. This gives the user a concrete signal of review thoroughness.
+2. **Verification source breakdown**: Local codebase vs chai-bot vs unverified.
+3. **Issues by severity**: Listed per the severity guide above.
+
+### Phase 6: Offer Fixes
+
+- [ ] Ask user: "Auto-fix verified issues, or manual review?"
+- [ ] If auto-fix, for each issue:
+  - **Local-verified fixes**: use the codebase as source of truth to rewrite incorrect claims
+  - **Chai-bot-verified fixes**: use chai-bot's response as source of truth for factual claims (wrong field names, non-existent enhancements, incorrect terminology)
+  - **Convention mismatches require manual review** — if local code intentionally diverges from platform convention, the docs should describe what the code does, not what convention says. Flag these for the user rather than auto-fixing
+  - Update outdated conventions (branch names, versions, commands) to match verified facts
+  - Fix broken internal links
+  - **Do not** remove content that couldn't be verified — flag as unverified instead
+  - **Stick to verified facts** — do not embellish or add interpretation beyond what was confirmed
+- [ ] **Re-verify changed claims**: re-run local checks on modified content; re-query chai-bot on modified cross-repo claims to confirm fixes didn't introduce new errors
+- [ ] Re-run link validation on modified files
+
+## Success Criteria
+
+- All scoped documentation files reviewed (not sampled)
+- Claims inventory tracked internally with every verifiable assertion extracted — coverage metrics reported
+- Every local claim in the inventory has a verification status (verified, failed, or skipped with justification)
+- Self-audit re-read completed — no unextracted claims remain
+- Links valid, cross-file consistency confirmed
+- All cross-repo claims verified via chai-bot or flagged as unverified
+
+## Arguments
+
+```bash
+/review-docs [--path <docs-path>] [--auto-fix] [--local-only]
+```
+
+- `--path`: Path to documentation file(s) to review (defaults to current directory)
+- `--auto-fix`: Automatically fix issues found (default: prompt user)
+- `--local-only`: Skip chai-bot verification entirely, only run local checks
+
+**Auto-discovery**: Infers component repo from git remote or current working directory
+
+## See Also
+
+- `/component-docs` - Create component documentation
+- `/update-platform-docs` - Update platform documentation
+- [openshift/api](https://github.com/openshift/api) - OpenShift API types
+- [openshift-docs](https://github.com/openshift/openshift-docs) - Official documentation (terminology cross-check)
+- [chai-bot](https://github.com/openshift/chai-bot) - OpenShift AI helpdesk (MCP server)

--- a/plugins/agentic-docs/skills/update-platform-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/update-platform-docs/SKILL.md
@@ -2,7 +2,6 @@
 name: update-platform-docs
 description: Update existing platform documentation with automatic gap detection in openshift/enhancements
 trigger: explicit
-model: sonnet
 ---
 
 # Platform Documentation Updater
@@ -82,11 +81,12 @@ Based on user request, perform ONE OR MORE of:
 - [ ] Preserve existing structure
 - [ ] Maintain file length targets
 
-### Phase 3: Validation
+### Phase 3: Validation & Verification
+
 - [ ] Run validation: `bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH"`
-- [ ] Verify new files follow conventions
-- [ ] Verify AGENTS.md 100-200 lines
-- [ ] Verify internal links work
+- [ ] Verify new files follow conventions, AGENTS.md 100-200 lines, internal links work
+- [ ] **Anti-hallucination**: Pattern claims verified in sample repos, API fields link to github.com/openshift/api or k8s/apimachinery, cross-check terminology with openshift-docs
+- [ ] All technical claims have references (type definitions, implementations, or enhancements)
 
 ### Phase 4: Report
 - [ ] List files created
@@ -156,6 +156,8 @@ Based on user request, perform ONE OR MORE of:
 - Follow existing file structure and style
 - Maintain reference/terse style (tables, checklists)
 - Keep files within length targets (100-400 lines)
+
+**Verification Requirements**: API/CRD claims link to github.com/openshift/api or kubernetes/apimachinery; pattern claims link to implementations; version/convention claims verified in actual repos (3+ samples); architectural claims link to enhancements/ADRs
 
 ### Updating AGENTS.md
 - Always read current content first
@@ -342,6 +344,11 @@ Next Steps:
 ### ❌ Mistake 4: Duplicating Content
 **Wrong:** Copying content from dev-guide/guidelines
 **Right:** Link to authoritative source or reformat for AI agents
+
+### ❌ Mistake 5: Documenting Without Verification
+
+**Wrong**: Patterns from memory, API fields without checking github.com/openshift/api, unverified conventions
+**Right**: Verify in actual code, link to type definitions (k8s/apimachinery, openshift/api), check multiple repos for patterns
 
 ## See Also
 


### PR DESCRIPTION
Add new /review-docs skill for documentation verification: local source code checks first, then cross-repo verification via chai-bot MCP server (OpenShift AI helpdesk persona). Covers API fields, feature gates, enhancement references, and platform conventions.

Rewrite component-docs SKILL.md to reduce hallucination risk:
- Add "verify before documenting" steps for API types, Go version, branch names, and pattern claims with mandatory source references
- Add Implementation Pattern Discovery checklist and Operator-Specific Discovery checklist for Phase 5 architecture exploration
- Generalize "CRDs" to "APIs/types" for non-operator repos
- Add Phase 11 (Verification) recommending /review-docs after creation
- Replace verbose inline examples with actionable checklists
- Add Critical Patterns section to AGENTS-template.md
- Remove Repository Structure from DEVELOPMENT-template.md (lives in components.md), add Common Mistakes section
- Add "verified in types.go" annotations to domain-concept-template.md

Update supporting infrastructure:
- Add .mcp.json.sample for chai-bot MCP server configuration
- Update README with /review-docs usage and chai-bot setup instructions
- Simplify validate.sh: always run link validation (remove toggle), flatten conditional nesting
- Remove exec-plans/completed/ from create-structure.sh
- Remove model: sonnet from component-docs and update-platform-docs
- Add anti-hallucination guidance to update-platform-docs SKILL.md
- Bump version 1.0.0 → 1.2.2, update marketplace and docs index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/review-docs` documentation review skill with local and optional cross-repo verification, plus CLI options.
* **Documentation**
  * Expanded agentic documentation guidance and updated templates to emphasize verification-first workflows, API/type discovery, and improved documentation structure.
* **Bug Fixes**
  * Updated component documentation validation to always run link validation and simplified the validation command interface.
* **Chores**
  * Bumped the `agentic-docs` plugin version to **1.2.2** and added a chai-bot MCP server configuration sample.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->