### PR TITLE
Default upload-screenshot to fork repo and token from env vars

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,7 @@
       "name": "github",
       "source": "./plugins/github",
       "description": "GitHub utilities for image uploads, asset management, and PR automation",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "tooling",
       "keywords": [
         "github",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1249,7 +1249,7 @@ footer a { color: var(--primary); }
     {
       "name": "github",
       "description": "GitHub utilities for image uploads, asset management, and PR automation",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "GitHub utilities for image uploads, asset management, and PR automation",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/github/skills/upload-screenshot/SKILL.md
+++ b/plugins/github/skills/upload-screenshot/SKILL.md
@@ -47,11 +47,13 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/upload-screenshot/upload_screenshot.sh" \
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--file`       | Yes      | Path to the image file (png, jpg, gif, svg, webp) |
-| `--repo`       | Yes      | Target GitHub repository in `owner/repo` format |
+| `--repo`       | No       | Target GitHub repository in `owner/repo` format (defaults to `$FORK_REPO` env var) |
 | `--title`      | No       | Alt text for the image (defaults to filename) |
 | `--token-file` | No       | Path to a file containing a GitHub token to use for auth |
 
 When `--token-file` is provided, the token is loaded into `GITHUB_TOKEN` for the duration of the script. This is useful in CI where the default `GITHUB_TOKEN` may not have write access to the target repo.
+
+**Environment variable defaults:** If `--repo` is not provided, the script uses `$FORK_REPO`. If no explicit token is provided via `--token-file`, the script uses `$GH_FORK_TOKEN` when available. This means in CI environments where these env vars are set, you can call the script with just `--file` and it will upload to the correct fork with the right credentials.
 
 ### Output
 

--- a/plugins/github/skills/upload-screenshot/upload_screenshot.sh
+++ b/plugins/github/skills/upload-screenshot/upload_screenshot.sh
@@ -15,7 +15,7 @@ usage() {
 }
 
 FILE=""
-REPO=""
+REPO="${FORK_REPO:-}"
 TITLE=""
 TOKEN_FILE=""
 
@@ -52,6 +52,8 @@ if [[ -n "$TOKEN_FILE" ]]; then
   fi
   export GITHUB_TOKEN
   GITHUB_TOKEN=$(cat "$TOKEN_FILE")
+elif [[ -n "${GH_FORK_TOKEN:-}" ]]; then
+  export GITHUB_TOKEN="$GH_FORK_TOKEN"
 fi
 
 TAG="screenshot-$(date +%s)-$(head -c 4 /dev/urandom | xxd -p)"


### PR DESCRIPTION
When --repo is not provided, fall back to $FORK_REPO. When no explicit token is given, fall back to $GH_FORK_TOKEN. This prevents agentic CI sessions from accidentally uploading screenshots to upstream repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the GitHub plugin to version 0.3.0 across the marketplace and plugin listing.
  * The screenshot upload workflow now uses sensible defaults from environment variables, reducing required input in common setups.

* **Documentation**
  * Clarified that the repository setting is optional and described the new environment-based fallback behavior for credentials and repository selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->