### PR TITLE
node-rpm: add RPM package management plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -340,6 +340,20 @@
       ]
     },
     {
+      "name": "node-rpm",
+      "source": "./plugins/node-rpm",
+      "description": "RPM package management for OpenShift Node team components",
+      "version": "0.0.1",
+      "category": "openshift",
+      "keywords": [
+        "openshift",
+        "node",
+        "rpm",
+        "bump",
+        "cri-tools"
+      ]
+    },
+    {
       "name": "bigquery",
       "source": "./plugins/bigquery",
       "description": "BigQuery analysis utilities",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1957,6 +1957,38 @@ footer a { color: var(--primary); }
       }
     },
     {
+      "name": "node-rpm",
+      "description": "RPM package management for OpenShift Node team components",
+      "version": "0.0.1",
+      "has_readme": true,
+      "commands": [
+        {
+          "name": "bump",
+          "full_name": "node-rpm:bump",
+          "description": "Bump a downstream RPM package to a new upstream version",
+          "description_html": "Bump a downstream RPM package to a new upstream version",
+          "synopsis": "/node-rpm:bump \u003cpackage\u003e \u003cnew-version\u003e [--ocp-version \u003cversion\u003e] [--scratch] [--vagrant]",
+          "body_html": "\u003cp\u003eGuides the user through bumping a downstream RPM package to a new upstream version in Red Hat&#x27;s dist-git. Handles spec file updates, source downloads, changelog bumps, and Brew builds.\u003c/p\u003e\u003cp\u003eThe workflow follows the established pattern for Node team RPM packages (cri-tools as the primary template). Each phase presents its changes to the user for review before proceeding.\u003c/p\u003e\u003cp\u003eWhen \u003ccode\u003e--vagrant\u003c/code\u003e is passed, the entire workflow runs inside a Fedora Vagrant VM that is automatically provisioned with all required tools. This is the recommended approach when rhpkg and related tools are not installed locally.\u003c/p\u003e"
+        }
+      ],
+      "skills": [],
+      "agents": [],
+      "hooks": [],
+      "mcp_servers": [],
+      "rules": [],
+      "category": "openshift",
+      "keywords": [
+        "openshift",
+        "node",
+        "rpm",
+        "bump",
+        "cri-tools"
+      ],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
+    },
+    {
       "name": "node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
       "version": "0.17.1",

--- a/plugins/node-rpm/.claude-plugin/plugin.json
+++ b/plugins/node-rpm/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-rpm",
+  "description": "RPM package management for OpenShift Node team components",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  },
+  "dependencies": [
+    {
+      "name": "node-team",
+      "version": "^0.17.0"
+    }
+  ]
+}

--- a/plugins/node-rpm/OWNERS
+++ b/plugins/node-rpm/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- harche
+- mrunalp
+- haircommander
+- rphillips
+- saschagrunert
+reviewers:
+- harche
+- mrunalp
+- haircommander
+- rphillips
+- saschagrunert

--- a/plugins/node-rpm/README.md
+++ b/plugins/node-rpm/README.md
@@ -1,0 +1,56 @@
+# Node RPM Plugin
+
+RPM package management for OpenShift Node team components. Part of the [node-team](../node-team/) plugin family.
+
+## Installation
+
+```bash
+/plugin install node-rpm@ai-helpers
+```
+
+Requires the `node-team` plugin (installed automatically as a dependency).
+
+## Command
+
+### `/node-rpm:bump <package> <new-version> [--ocp-version <version>] [--scratch] [--vagrant]`
+
+Bump a downstream RPM package to a new upstream version.
+
+**Examples:**
+```text
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0 --vagrant
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0 --scratch
+```
+
+**What it does:**
+
+1. Checks VPN connectivity to Red Hat internal systems
+2. Validates prerequisites (locally or inside a Vagrant VM with `--vagrant`)
+3. Clones the dist-git repo and checks out the correct release branch
+4. Updates the spec file with the new upstream version and commit hash
+5. Downloads sources, declares new sources, bumps the changelog
+6. Commits, pushes, and kicks off a Brew build (or scratch build with `--scratch`)
+7. Prints a summary with build URL and next steps
+
+**Arguments:**
+- `<package>`: Package name (required, e.g. "cri-tools")
+- `<new-version>`: Target upstream version (required, e.g. "1.36.0")
+- `--ocp-version <version>`: Target OCP version (prompted if omitted)
+- `--scratch`: Run a scratch build instead of a full build
+- `--vagrant`: Run the workflow inside a Vagrant VM (auto-provisions if needed)
+
+## Prerequisites
+
+**Local execution (default):**
+- `rhpkg` (Red Hat package tool)
+- `spectool` / `rpmdev-bumpspec` (from `rpmdevtools`)
+- `krb5-workstation` for Kerberos authentication (`kinit user@IPA.REDHAT.COM`)
+- VPN access to Red Hat internal systems
+
+**With `--vagrant`:**
+- `vagrant` and libvirt (`virsh`)
+- VPN access to Red Hat internal systems
+- All other tools are installed automatically inside the VM
+
+See the [rpm-workflow reference](references/rpm-workflow.md) for full environment setup. A [vendored Vagrantfile](references/Vagrantfile) is included for the `--vagrant` flag.

--- a/plugins/node-rpm/commands/bump.md
+++ b/plugins/node-rpm/commands/bump.md
@@ -1,0 +1,275 @@
+---
+description: Bump a downstream RPM package to a new upstream version
+argument-hint: "<package> <new-version> [--ocp-version <version>] [--scratch] [--vagrant]"
+---
+
+## Name
+node-rpm:bump
+
+## Synopsis
+```text
+/node-rpm:bump <package> <new-version> [--ocp-version <version>] [--scratch] [--vagrant]
+```
+
+## Description
+
+Guides the user through bumping a downstream RPM package to a new upstream version in Red Hat's dist-git. Handles spec file updates, source downloads, changelog bumps, and Brew builds.
+
+The workflow follows the established pattern for Node team RPM packages (cri-tools as the primary template). Each phase presents its changes to the user for review before proceeding.
+
+When `--vagrant` is passed, the entire workflow runs inside a Fedora Vagrant VM that is automatically provisioned with all required tools. This is the recommended approach when rhpkg and related tools are not installed locally.
+
+## Implementation
+
+### Phase 0: Setup and Argument Parsing
+
+1. **Parse required arguments:**
+   - `<package>` (required): The package name, e.g. `cri-tools`. Must exist in the Packages table in [`../references/rpm-workflow.md`](../references/rpm-workflow.md). If not found, list supported packages and stop.
+   - `<new-version>` (required): The target upstream version, e.g. `1.36.0`
+
+2. **Parse optional arguments:**
+   - `--ocp-version <version>`: Target OCP version. If omitted, prompt the user to specify one.
+   - `--scratch`: Run a scratch build instead of a full build.
+   - `--vagrant`: Run the workflow inside a Vagrant VM.
+
+3. **Check VPN connectivity:**
+   ```bash
+   curl -s --connect-timeout 5 http://download.devel.redhat.com > /dev/null 2>&1 || echo "UNREACHABLE"
+   ```
+   If unreachable, warn the user to connect to the Red Hat VPN and stop.
+
+4. **Validate prerequisites:**
+
+   **Without `--vagrant` (local execution):**
+   ```bash
+   which rhpkg 2>/dev/null || echo "MISSING: rhpkg"
+   which spectool 2>/dev/null || echo "MISSING: spectool"
+   which rpmdev-bumpspec 2>/dev/null || echo "MISSING: rpmdev-bumpspec"
+   klist -s 2>/dev/null || echo "MISSING: valid Kerberos ticket (run kinit)"
+   ```
+   If any tool is missing, print installation instructions and stop.
+
+   **With `--vagrant`:**
+   - Verify `vagrant` is installed locally.
+   - Verify libvirt is available (`virsh --version`).
+   - Create the work directory: `mkdir -p .work/node-rpm`
+   - If `.work/node-rpm/Vagrantfile` does not exist, copy it from the vendored reference:
+     ```bash
+     cp "${CLAUDE_PLUGIN_ROOT}/references/Vagrantfile" .work/node-rpm/Vagrantfile
+     ```
+   - Check if the VM is already running:
+     ```bash
+     cd .work/node-rpm && vagrant status --machine-readable | grep ",state," | grep -q "running"
+     ```
+     If not running, provision and start it:
+     ```bash
+     cd .work/node-rpm && vagrant up
+     ```
+   - Verify VPN connectivity from inside the VM (NAT may not inherit host routes with split-tunnel VPN):
+     ```bash
+     cd .work/node-rpm && vagrant ssh -c "curl -s --connect-timeout 5 http://download.devel.redhat.com > /dev/null 2>&1" || echo "VM cannot reach Red Hat network"
+     ```
+     If unreachable, warn about potential split-tunnel or DNS issues and stop.
+   - Validate prerequisites inside the VM:
+     ```bash
+     cd .work/node-rpm && vagrant ssh -c "which rhpkg && which spectool && which rpmdev-bumpspec"
+     ```
+   - Check Kerberos ticket inside the VM:
+     ```bash
+     cd .work/node-rpm && vagrant ssh -c "klist -s 2>/dev/null" || echo "MISSING: valid Kerberos ticket"
+     ```
+     If no valid ticket, tell the user to authenticate interactively:
+     ```bash
+     cd .work/node-rpm && vagrant ssh
+     # inside the VM:
+     kinit <user>@IPA.REDHAT.COM
+     exit
+     ```
+     Then re-run the command. `kinit` requires interactive password input that does not work through `vagrant ssh -c`.
+   - Check git user config inside the VM:
+     ```bash
+     cd .work/node-rpm && vagrant ssh -c "git config user.name && git config user.email" 2>/dev/null
+     ```
+     If not set, tell the user to configure them interactively:
+     ```bash
+     cd .work/node-rpm && vagrant ssh
+     # inside the VM:
+     git config --global user.name "Your Name"
+     git config --global user.email "you@redhat.com"
+     exit
+     ```
+
+5. **Resolve the dist-git branch:**
+   - Look up the package in [`../references/rpm-workflow.md`](../references/rpm-workflow.md) for the branch pattern and RHEL version cutoff. The branch comes from `--ocp-version` plus the Dist-git Branch Pattern column (e.g. `rhaos-<version>-rhel-{8,9,10}`).
+   - For cri-tools: branches follow `rhaos-<version>-rhel-{8,9,10}`. Most OCP versions have two RHEL branches (e.g. RHEL 9 + RHEL 10 for OCP 5.0). Check which branches exist for the target version and repeat Phases 1-3 for each branch.
+
+---
+
+### Execution Mode
+
+All shell commands in Phases 1-3 run differently depending on `--vagrant`:
+
+- **Local (default):** Commands run directly in the shell.
+- **Vagrant:** Commands are prefixed with `cd .work/node-rpm && vagrant ssh -c "cd <package> && ..."`. Each `vagrant ssh -c` invocation opens a fresh session in `/home/vagrant`, so every command after the initial clone must include the `cd <package>` prefix. The dist-git clone and build happen inside the VM. Output is captured and shown to the user as normal.
+- **Exception:** `git ls-remote` against public GitHub repos (Phase 2 step 1) always runs locally, since it does not require Red Hat internal access.
+
+---
+
+### Phase 1: Clone and Checkout
+
+1. **Create work directory** (local mode only; Vagrant mode already created this in Phase 0):
+   ```bash
+   mkdir -p .work/node-rpm
+   ```
+
+2. **Clone the dist-git repo:**
+   ```bash
+   cd .work/node-rpm
+   ```
+   Check if `<package>` already exists (from a prior interrupted run). In vagrant mode, check inside the VM: `cd .work/node-rpm && vagrant ssh -c "test -d <package>"`. In local mode, check `.work/node-rpm/<package>`. If it exists, offer to reuse it (`cd <package> && git fetch && git checkout <branch> && git reset --hard origin/<branch>`) or remove it (`rm -rf <package>`) before proceeding.
+   ```bash
+   rhpkg clone <package>
+   cd <package>
+   git checkout <branch>
+   ```
+   With `--vagrant`, this runs inside the VM. The clone lives in the VM's filesystem.
+
+3. **Read the current spec file** and extract:
+   - Current `Version:` value
+   - Current `Release:` value
+   - Current `%global commit0` value (the upstream commit hash)
+
+4. **Display current state** to the user:
+   - Package name, current version, current commit hash, branch name
+
+---
+
+### Phase 2: Update Spec File
+
+1. **Get the upstream commit for the new version:**
+   Look up the upstream org and repo from the Packages table in [`../references/rpm-workflow.md`](../references/rpm-workflow.md) (e.g. `kubernetes-sigs` / `cri-tools`).
+   ```bash
+   git ls-remote https://github.com/<upstream-org>/<upstream-repo> "v<new-version>" "v<new-version>^{}" | tail -1 | cut -f1
+   ```
+   The `^{}` suffix dereferences annotated tags to the underlying commit SHA. For lightweight tags, only the first pattern matches. `tail -1` picks the dereferenced line when both are present.
+
+   Verify the result is a non-empty 40-character hex SHA. If empty, the tag does not exist upstream; stop with a clear error (e.g. "Tag v<new-version> not found in <upstream-org>/<upstream-repo>").
+
+2. **Update the spec file:**
+   - Set `%global commit0` to the new upstream commit SHA
+   - Set `Version:` to `<new-version>`
+   - Save the spec file to disk before proceeding (spectool reads macros from it).
+
+3. **Clean old sources and download new ones:**
+   ```bash
+   rm -f <package>-*.tar.gz
+   spectool -g <package>.spec
+   ```
+
+4. **Declare new sources:**
+   ```bash
+   rhpkg new-sources <package>-*.tar.gz
+   ```
+
+5. **Reset Release and bump the changelog:**
+   First, reset Release in the spec file for the new Version:
+   ```bash
+   sed -i 's/^Release:.*/Release: 0%{?dist}/' <package>.spec
+   ```
+   Then bump the changelog (this also increments Release from 0 to 1):
+   ```bash
+   rpmdev-bumpspec -c "Bump to v<new-version>" <package>.spec
+   ```
+   The result is `Release: 1%{?dist}` with a new changelog entry.
+
+6. **Show the full diff** to the user and wait for confirmation before proceeding:
+   ```bash
+   git diff
+   ```
+
+---
+
+### Phase 3: Build
+
+1. **Commit the changes:**
+   ```bash
+   git commit -asm "Bump to v<new-version>"
+   ```
+
+2. **Push** (confirm with the user first):
+   ```bash
+   git push
+   ```
+
+3. **Start the build:**
+   - Full build: `rhpkg build`
+   - Scratch build (if `--scratch`): `rhpkg build --scratch --srpm`
+   - If `rhpkg build --scratch` fails on a private branch, fall back to the two-step approach: `rhpkg srpm` (capture the exact SRPM filename from its output), then `brew build --scratch <branch>-candidate <srpm-file>`
+
+4. **Report the build task URL** from the rhpkg output.
+
+---
+
+### Phase 4: Summary
+
+Print a summary table:
+- Package name
+- Old version (from Phase 1)
+- New version
+- Dist-git branch
+- Build status and task URL
+
+List next steps:
+- Verify the build in Brew
+- Update cri-tools version in `kubernetes/kubernetes` (if applicable)
+- Update cri-tools in `cri-o/packaging` (if applicable)
+- Open a PR or notify the team
+
+## Return Value
+
+Prints a structured summary to stdout including old version, new version, branch, and build URL. Exit status reflects the build outcome.
+
+## Examples
+
+### Bump cri-tools for OCP 5.0
+```text
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0
+```
+Clones cri-tools from dist-git, checks out the matching release branch, updates the spec to version 1.36.0, and starts a full Brew build.
+
+### Scratch build to test changes
+```text
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0 --scratch
+```
+Same workflow but runs `rhpkg build --scratch --srpm` instead of a full build. Useful for validating spec changes before committing.
+
+### Bump using a Vagrant VM
+```text
+/node-rpm:bump cri-tools 1.36.0 --ocp-version 5.0 --vagrant
+```
+Provisions a Fedora VM (if not already running), runs the entire workflow inside it, and reports the build URL.
+
+### Bump with version prompt
+```text
+/node-rpm:bump cri-tools 1.36.0
+```
+Omits `--ocp-version`, so the command prompts the user to select the target OCP version.
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<package>` | Yes | Package name (e.g. `cri-tools`) |
+| `<new-version>` | Yes | Target upstream version (e.g. `1.36.0`) |
+| `--ocp-version <version>` | No | Target OCP version; prompted if omitted |
+| `--scratch` | No | Run a scratch build instead of a full build |
+| `--vagrant` | No | Run the workflow inside a Vagrant VM |
+
+## Notes
+
+- The upstream repo and dist-git branch pattern for each package are defined in [`../references/rpm-workflow.md`](../references/rpm-workflow.md).
+- VPN connection to the Red Hat network is required. The command checks connectivity before starting.
+- Kerberos tickets expire; run `kinit` before starting if your ticket is stale. With `--vagrant`, open an interactive session (`cd .work/node-rpm && vagrant ssh`) and run `kinit` inside the VM.
+- Scratch builds do not produce official Brew builds. They are disposable test builds.
+- The command operates in `.work/node-rpm/` to keep dist-git clones and the Vagrant VM separate from other work directories.
+- The Vagrant VM persists between runs. Run `cd .work/node-rpm && vagrant destroy` to clean up.

--- a/plugins/node-rpm/references/Vagrantfile
+++ b/plugins/node-rpm/references/Vagrantfile
@@ -1,0 +1,87 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/42-cloud-base"
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-libvirt-42-1.1.x86_64.vagrant.libvirt.box"
+  memory = 6144
+  cpus = 4
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provision "setup", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+      set -euxo pipefail
+
+      curl -fsSL -o /tmp/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
+      cp /tmp/2022-IT-Root-CA.pem /etc/pki/ca-trust/source/anchors/
+      update-ca-trust
+
+      curl -fsSL -o /etc/yum.repos.d/rcm-tools-fedora.repo http://download.devel.redhat.com/rel-eng/internal/rcm-tools-fedora.repo
+
+      dnf install -y \
+        chkconfig \
+        git \
+        java-headless \
+        krb5-workstation \
+        rhpkg \
+        rpmdevtools \
+        vim
+
+      mkdir -p /etc/pki/brew
+      cp /tmp/2022-IT-Root-CA.pem /etc/pki/brew/RH-IT-Root-CA.crt
+
+      cat > /home/vagrant/.rpmmacros <<'EOF'
+%_topdir %(echo $(pwd))
+%_sourcedir     %{_topdir}
+%_specdir       %{_sourcedir}
+%_rpmdir        %{_topdir}/RPMS
+%_srcrpmdir     %{_topdir}/SRPMS
+%_builddir      %{_topdir}/BUILD
+%_tmppath       %(echo ${TMPDIR:-/var/tmp})
+%_buildroot     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+EOF
+      chown vagrant:vagrant /home/vagrant/.rpmmacros
+
+      cat > /home/vagrant/.ssh/config <<'EOF'
+StrictHostKeyChecking      accept-new
+Compression                yes
+ServerAliveInterval        30
+ServerAliveCountMax        120
+
+Host iad2
+    Hostname                   bastion-iad2.corp.redhat.com
+    ProxyJump                  none
+
+Host *.iad2.dc.redhat.com
+    ProxyJump                  iad2
+
+Host rdu2
+    Hostname                   bastion-rdu2.corp.redhat.com
+    ProxyJump                  none
+
+Host *.rdu2.redhat.com *.rdu2.dc.redhat.com
+    ProxyJump                  rdu2
+
+Host pkgs.devel.redhat.com
+    ProxyJump                  iad2
+
+Host pkgs-stage.devel.redhat.com
+    ProxyJump                  iad2
+
+Host *.redhat.com
+    GSSAPIAuthentication       yes
+    GSSAPIDelegateCredentials  yes
+    ForwardAgent               no
+    ForwardX11                 no
+    ForwardX11Trusted          no
+    HashKnownHosts             no
+EOF
+      chown vagrant:vagrant /home/vagrant/.ssh/config
+      chmod 600 /home/vagrant/.ssh/config
+    SHELL
+  end
+end

--- a/plugins/node-rpm/references/rpm-workflow.md
+++ b/plugins/node-rpm/references/rpm-workflow.md
@@ -1,0 +1,128 @@
+# RPM Packaging Workflow
+
+Reference for RPM packaging workflows used by the OpenShift Node team.
+
+## Packages
+
+| Package | Upstream Org | Upstream Repo | Dist-git Branch Pattern | Spec Conventions |
+|---------|-------------|--------------|------------------------|------------------|
+| cri-tools | kubernetes-sigs | cri-tools | `rhaos-<version>-rhel-{8,9,10}` (most OCP versions have two RHEL branches; check which exist for the target version) | `commit0`, `Version`, `Release` |
+
+> **Note:** Only cri-tools is currently supported. To add a new package, add a
+> row to this table with its upstream org, repo, branch pattern, and spec
+> conventions. The `/node-rpm:bump` command currently hardcodes the cri-tools
+> workflow (commit0, v-prefixed tags, Release reset via sed). Adding a package
+> with different conventions (e.g. `1.git%{shortcommit0}%{?dist}` Release
+> format, no tag prefix, or different tarball naming) will require updating
+> bump.md to read the Spec Conventions column and adapt accordingly.
+
+## Workflow Steps
+
+1. **Clone the dist-git repo:**
+   ```bash
+   rhpkg clone <package>
+   cd <package>
+   git checkout <release-branch>
+   ```
+
+2. **Update the spec file:**
+   - Set `%global commit0` to the upstream tag's full commit SHA
+   - Set `Version:` to the new upstream version
+   - Save the file before proceeding (spectool reads macros from it)
+
+3. **Clean old sources and download new ones:**
+   ```bash
+   rm -f <package>-*.tar.gz
+   spectool -g <package>.spec
+   ```
+
+4. **Declare new sources in dist-git:**
+   ```bash
+   rhpkg new-sources <package>-*.tar.gz
+   ```
+
+5. **Reset Release and bump the changelog:**
+   ```bash
+   sed -i 's/^Release:.*/Release: 0%{?dist}/' <package>.spec
+   rpmdev-bumpspec -c "Bump to v<new-version>" <package>.spec
+   ```
+
+6. **Commit and push:**
+   ```bash
+   git commit -asm "Bump to v<new-version>"
+   git push
+   ```
+
+7. **Start the build:**
+   ```bash
+   rhpkg build
+   ```
+
+## Scratch Builds
+
+Use scratch builds to test changes before committing to a full build.
+
+Standard approach (works on public release branches):
+
+```bash
+rhpkg build --scratch --srpm
+```
+
+For private branches where `rhpkg build --scratch` may not work, use the
+two-step approach:
+
+```bash
+rhpkg srpm
+brew build --scratch <branch>-candidate <package>-<version>-<release>.src.rpm
+```
+
+Scratch builds do not produce official builds in Brew. They are disposable
+and useful for verifying spec changes compile correctly.
+
+## cri-tools Upstream Release Checklist
+
+1. Vendor the final RC of Kubernetes into `kubernetes-sigs/cri-tools`
+2. Create a GitHub release (tag `v<version>`)
+3. Ask the Kubernetes Release Manager to run OBS stage and release
+4. Update the cri-tools version in `kubernetes-sigs/cri-tools`
+5. Update the cri-tools version references in `kubernetes/kubernetes`
+6. Update cri-tools in `cri-o/packaging`
+7. Bump the downstream RPM for OpenShift (this is the `/node-rpm:bump` workflow)
+
+## Prerequisites
+
+- **VPN**: Connected to the Red Hat VPN
+- **Kerberos auth**: `kinit user@IPA.REDHAT.COM` (verify with `klist`)
+- **Tools installed**: `rhpkg`, `spectool`, `rpmdev-bumpspec`
+
+## Environment Setup
+
+A Fedora Vagrant VM (Fedora 42+) is the recommended environment for RPM
+packaging. The vendored [`Vagrantfile`](Vagrantfile) is the source of truth for
+provisioning: it installs Red Hat CA certs, RCM tools (rhpkg, spectool,
+rpmdev-bumpspec, krb5-workstation), configures RPM macros, and sets up SSH
+config for dist-git access (including bastion ProxyJump entries). For bare-metal
+Fedora setups, refer to the Vagrantfile provisioning script for the exact steps.
+
+## Vagrant Lifecycle
+
+The `--vagrant` flag on `/node-rpm:bump` manages a Fedora VM automatically:
+
+- **First run:** Copies the vendored Vagrantfile into `.work/node-rpm/` and
+  runs `vagrant up`. Provisioning installs all tools
+  (rhpkg, spectool, rpmdev-bumpspec, krb5-workstation) and configures SSH
+  and RPM macros. This takes a few minutes on first boot.
+- **Subsequent runs:** Detects the existing VM and reuses it. No re-provisioning.
+- **Kerberos:** Tickets inside the VM expire independently. If `klist -s`
+  fails, the command stops and asks you to authenticate. Open an interactive
+  session to refresh:
+  ```bash
+  cd .work/node-rpm && vagrant ssh
+  # inside the VM:
+  kinit user@IPA.REDHAT.COM
+  exit
+  ```
+- **Cleanup:** The VM persists between runs. To remove it:
+  ```bash
+  cd .work/node-rpm && vagrant destroy -f
+  ```

--- a/plugins/node-team/README.md
+++ b/plugins/node-team/README.md
@@ -62,7 +62,7 @@ plugins depend on node-team's shared data and extend its capabilities:
 | [`node-cve`](../node-cve/) | CVE triage with reachability analysis | Active |
 | `node-bug-triage` | General bug triage and assignment | Planned |
 | [`node-onboarding`](../node-onboarding/) | Team onboarding workflows | Active |
-| `node-rpm` | RPM management (cri-tools pattern) | Planned |
+| [`node-rpm`](../node-rpm/) | RPM management (cri-tools pattern) | Active |
 
 ### Shared Data Contract
 


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the `node-rpm` plugin for RPM package management of OpenShift Node team components. Part of the registered Node Team AI Assistant plugin family.

- `/node-rpm:bump` command walks through spec file updates, source downloads, changelog bumps, and Brew builds
- `--vagrant` flag auto-provisions a Fedora libvirt VM with all required tools, reuses it on subsequent runs
- Vendored Vagrantfile (no external gist dependency)
- VPN connectivity check before starting any work
- Handles multiple RHEL branches per OCP version (e.g. RHEL 9 + RHEL 10 for OCP 5.0)
- Proper Release reset on version bumps (sed to 0, then rpmdev-bumpspec increments to 1)
- Annotated tag support via `git ls-remote` with `^{}` dereference
- Reference doc covering the end-to-end RPM workflow, environment setup, scratch build patterns, and VM lifecycle
- Currently supports cri-tools, extensible via the packages table in `rpm-workflow.md`
- Registered in marketplace and node-team plugin family table

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.