### PR TITLE
node-bug: add bug triage and assignment plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -354,6 +354,20 @@
       ]
     },
     {
+      "name": "node-bug",
+      "source": "./plugins/node-bug",
+      "description": "Node-specific bug triage, sub-team routing, and assignment suggestions",
+      "version": "0.0.1",
+      "category": "openshift",
+      "keywords": [
+        "openshift",
+        "node",
+        "bugs",
+        "triage",
+        "jira"
+      ]
+    },
+    {
       "name": "bigquery",
       "source": "./plugins/bigquery",
       "description": "BigQuery analysis utilities",
@@ -482,7 +496,7 @@
       "name": "node-team",
       "source": "./plugins/node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1867,6 +1867,38 @@ footer a { color: var(--primary); }
       }
     },
     {
+      "name": "node-bug",
+      "description": "Node-specific bug triage, sub-team routing, and assignment suggestions for OpenShift Node team components",
+      "version": "0.0.1",
+      "has_readme": true,
+      "commands": [
+        {
+          "name": "triage",
+          "full_name": "node-bug:triage",
+          "description": "Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary",
+          "description_html": "Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary",
+          "synopsis": "/node-bug:triage [--sub-team core|devices|kueue] [--sprint \"OCP Node Core Sprint 42\"] [--unassigned-only]",
+          "body_html": "\u003cp\u003eQueries all open bugs in OCPBUGS for Node team components using the &quot;Node Bugs&quot; saved filter, classifies them into triage buckets (Release Blockers, Customer Escalations, Potential Blockers, Component Regressions, Untriaged), routes each bug to the correct sub-team, and suggests assignments based on current workload.\u003c/p\u003e\u003cp\u003eDesigned for both interactive triage sessions and headless execution via \u003ccode\u003eclaude --print\u003c/code\u003e.\u003c/p\u003e"
+        }
+      ],
+      "skills": [],
+      "agents": [],
+      "hooks": [],
+      "mcp_servers": [],
+      "rules": [],
+      "category": "openshift",
+      "keywords": [
+        "openshift",
+        "node",
+        "bugs",
+        "triage",
+        "jira"
+      ],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
+    },
+    {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
       "version": "0.0.4",
@@ -1991,7 +2023,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "has_readme": true,
       "commands": [
         {
@@ -2030,8 +2062,8 @@ footer a { color: var(--primary); }
       "skills": [
         {
           "name": "node",
-          "description": "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to the node-cve plugin.",
-          "description_html": "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to the node-cve plugin.",
+          "description": "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to node-cve. For bug triage and assignment, defer to node-bug.",
+          "description_html": "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to node-cve. For bug triage and assignment, defer to node-bug.",
           "meta": "Tools: Bash(curl:*)"
         }
       ],

--- a/plugins/node-bug/.claude-plugin/plugin.json
+++ b/plugins/node-bug/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-bug",
+  "description": "Node-specific bug triage, sub-team routing, and assignment suggestions for OpenShift Node team components",
+  "version": "0.0.1",
+  "author": {
+    "name": "github.com/openshift-eng"
+  },
+  "dependencies": [
+    {
+      "name": "node-team",
+      "version": "^0.17.0"
+    }
+  ]
+}

--- a/plugins/node-bug/OWNERS
+++ b/plugins/node-bug/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+- harche
+- mrunalp
+- haircommander
+- rphillips
+- saschagrunert
+reviewers:
+- harche
+- mrunalp
+- haircommander
+- rphillips
+- saschagrunert

--- a/plugins/node-bug/README.md
+++ b/plugins/node-bug/README.md
@@ -1,0 +1,49 @@
+# Node Bug Plugin
+
+Node-specific bug triage for OpenShift Node team components. Queries open bugs from OCPBUGS, classifies by severity and sub-team, suggests assignments based on workload, and generates triage summaries. Complements `/jira:grooming` with Node-specific JQL filters, sub-team routing, and team roster integration.
+
+Part of the [node-team plugin family](../node-team/).
+
+## Installation
+
+```bash
+/plugin install node-bug@ai-helpers
+```
+
+Requires the `node-team` plugin (installed automatically as a dependency).
+
+## Command
+
+### `/node-bug:triage [--sub-team core|devices|kueue] [--sprint <name>] [--unassigned-only] [--notify-slack]`
+
+Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary.
+
+**Examples:**
+
+```text
+# Full triage across all sub-teams
+/node-bug:triage
+
+# Core sub-team only, current sprint
+/node-bug:triage --sub-team core --sprint "OCP Node Core Sprint 42"
+
+# Show only unassigned bugs for DRA/Devices
+/node-bug:triage --sub-team devices --unassigned-only
+
+# Triage and notify Slack
+/node-bug:triage --notify-slack
+```
+
+**Arguments:**
+
+- `--sub-team core|devices|kueue`: Filter to one sub-team's components (Core, DRA/Devices, or Kueue)
+- `--sprint <name>`: Filter to bugs in a specific sprint
+- `--unassigned-only`: Show only untriaged or unassigned bugs
+- `--notify-slack`: Send summary to Slack (requires `SLACK_API_TOKEN` + `SLACK_CHANNEL` or `SLACK_WEBHOOK`)
+
+## Prerequisites
+
+- `JIRA_API_TOKEN` environment variable (or macOS Keychain / Linux secret-tool)
+- `curl` (for Jira REST API and Slack)
+- Optional: `SLACK_API_TOKEN` + `SLACK_CHANNEL` or `SLACK_WEBHOOK` (for `--notify-slack`)
+- Optional: `~/.node-assistant/team-roster-{core,dra}.json` (for assignment suggestions)

--- a/plugins/node-bug/commands/triage.md
+++ b/plugins/node-bug/commands/triage.md
@@ -1,0 +1,224 @@
+---
+description: Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary
+argument-hint: "[--sub-team core|devices|kueue] [--sprint <name>] [--unassigned-only]"
+---
+
+## Name
+node-bug:triage
+
+## Synopsis
+```text
+/node-bug:triage [--sub-team core|devices|kueue] [--sprint "OCP Node Core Sprint 42"] [--unassigned-only]
+```
+
+## Description
+
+Queries all open bugs in OCPBUGS for Node team components using the "Node Bugs" saved filter, classifies them into triage buckets (Release Blockers, Customer Escalations, Potential Blockers, Component Regressions, Untriaged), routes each bug to the correct sub-team, and suggests assignments based on current workload.
+
+Designed for both interactive triage sessions and headless execution via `claude --print`.
+
+## Implementation
+
+### Phase 0: Setup and Argument Parsing
+
+1. **Parse Arguments**
+   - `--sub-team core|devices|kueue`: Filter results to one sub-team's components. Optional. Read sub-team component lists from the sub-teams table in [shared/components.md](../../node-team/skills/node/references/shared/components.md) rather than hardcoding names.
+     - `core`: all Node components not listed under another sub-team
+     - `devices`: components listed under DRA/Devices in the sub-teams table
+     - `kueue`: components listed under Kueue in the sub-teams table
+   - `--sprint <name>`: Filter to bugs in a specific sprint (e.g., "OCP Node Core Sprint 42"). Optional.
+   - `--unassigned-only`: Show only untriaged or unassigned bugs. Optional.
+2. **Validate Jira Credentials**
+
+   Use the authentication chain from the [jira reference](../../node-team/skills/node/references/jira.md):
+
+   ```bash
+   JIRA_API_TOKEN="${JIRA_API_TOKEN:-$(security find-generic-password -s "JIRA_API_TOKEN" -w 2>/dev/null || secret-tool lookup service redhat key JIRA_API_TOKEN 2>/dev/null)}"
+   JIRA_USER="${JIRA_EMAIL:-$(security find-generic-password -s "JIRA_API_TOKEN" -g 2>&1 | grep acct | sed 's/.*="//;s/"//')}"
+   : "${JIRA_USER:=$(git config user.email)}"
+   [[ "$JIRA_USER" != *@* ]] && JIRA_USER="${JIRA_USER}@redhat.com"
+   ```
+
+   Exit with error if `JIRA_API_TOKEN` is empty after the chain.
+
+3. **Create work directory**: `mkdir -p .work/node-bug/triage-$(date +%Y-%m-%d)`
+
+---
+
+### Phase 1: Query Bugs
+
+1. **Use the Jira saved filter** "Node Bugs" (ID 83963) for the base query. The filter defines which components are in scope.
+
+2. **Build JQL**:
+
+   ```text
+   filter = "Node Bugs" AND status not in (Closed, Done, Verified)
+   ```
+
+   Apply optional filters (read sub-team component names from the sub-teams table in [shared/components.md](../../node-team/skills/node/references/shared/components.md)):
+   - If `--sub-team devices`: append `AND component in (<DRA/Devices components>)`
+   - If `--sub-team kueue`: append `AND component in (<Kueue components>)`
+   - If `--sub-team core`: append `AND component not in (<DRA/Devices components>, <Kueue components>)`
+   - If `--sprint <name>`: append `AND sprint = "<name>"`
+   - If `--unassigned-only`: append `AND (assignee is EMPTY OR assignee in ("aos-node@redhat.com") OR priority = Undefined OR "Release Blocker" = Proposed)`
+
+3. **Execute the query** using the POST search endpoint:
+
+   ```bash
+   curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -X POST "https://redhat.atlassian.net/rest/api/3/search/jql" \
+     -d '{
+       "jql": "<constructed JQL>",
+       "maxResults": 100,
+       "fields": [
+         "key", "summary", "status", "priority", "assignee",
+         "components", "labels",
+         "customfield_10689",
+         "customfield_10840",
+         "customfield_10847",
+         "customfield_10978",
+         "customfield_10020"
+       ]
+     }'
+   ```
+
+   Custom field mapping:
+   - `customfield_10689`: Customer Impact
+   - `customfield_10840`: Severity
+   - `customfield_10847`: Release Blocker
+   - `customfield_10978`: SFDC Cases Counter
+   - `customfield_10020`: Sprint
+
+   Handle pagination via `nextPageToken`: while the response has `isLast: false`, repeat the request with `"nextPageToken": "<token from previous response>"` in the body. This endpoint does not return `total` and does not accept `startAt`.
+
+4. **Print intermediate summary**: "Found N open bugs for Node team components."
+
+**Decision Point:**
+- IF 0 bugs found: print "No open bugs matching filters." and exit.
+- IF bugs found: continue to Phase 2.
+
+---
+
+### Phase 2: Classify and Route
+
+1. **Route each bug to its sub-team** using the sub-teams table from [shared/components.md](../../node-team/skills/node/references/shared/components.md):
+   - DRA/Devices: bugs whose component appears in the DRA/Devices row of the sub-teams table
+   - Kueue: bugs whose component appears in the Kueue row of the sub-teams table
+   - Core: all remaining Node components
+
+2. **Classify each bug into triage buckets** using the [Bug Triage Definitions](../../node-team/skills/node/references/jira.md):
+
+   - **Release Blockers**: `"Release Blocker"` field value is "Approved"
+   - **Potential Blockers**: priority is "Blocker" AND `"Release Blocker"` is empty (Blocker priority set but no release blocker decision yet)
+   - **Customer Escalations**: `customfield_10978` (SFDC Cases Counter) is not null/empty, OR `customfield_10689` (Customer Impact) value is "Customer Escalated"
+   - **Component Regressions**: labels contain `component-regression`
+   - **Untriaged**: priority is "Undefined", OR `"Release Blocker"` is "Proposed", OR assignee is `aos-node@redhat.com`
+   - **Other**: all remaining bugs
+
+   A bug can appear in multiple buckets (e.g., a release blocker that is also a customer escalation). Count it in each applicable bucket.
+
+3. **Assignment suggestions** (when team roster files exist):
+
+   Load team rosters from `~/.node-assistant/team-roster-{core,dra,kueue}.json`. If roster files do not exist, skip assignment suggestions and print "Roster files not found, skipping assignment suggestions."
+
+   Query all team members' open bug counts in a single call:
+   ```text
+   filter = "Node Bugs" AND status not in (Closed, Done, Verified) AND assignee in (<all roster members>)
+   ```
+   Group results by assignee in code to build a workload map.
+
+   For each unassigned or mailing-list-assigned bug:
+   - Determine the correct sub-team from step 1
+   - Exclude "Node Team Bot Account" from suggestions
+   - Suggest the team member with the fewest open bugs from the appropriate sub-team roster
+
+---
+
+### Phase 3: Generate Triage Summary
+
+1. **Print the triage summary** grouped by classification with counts:
+
+   ```text
+   Node Bug Triage (N bugs)
+
+   Release Blockers: X
+   Customer Escalations: X
+   Potential Blockers: X
+   Component Regressions: X
+   Untriaged: X
+   Other: X
+
+   --- Release Blockers ---
+   * OCPBUGS-XXXXX: <summary> (Component, Severity, Assignee)
+   * OCPBUGS-XXXXX: <summary> (Component, Severity, Unassigned -> suggested: <name>)
+
+   --- Customer Escalations ---
+   * OCPBUGS-XXXXX: <summary> (Component, N support cases, Assignee)
+
+   --- Potential Blockers ---
+   * OCPBUGS-XXXXX: <summary> (Component, Severity, Assignee)
+
+   --- Component Regressions ---
+   * OCPBUGS-XXXXX: <summary> (Component, Assignee)
+
+   --- Untriaged ---
+   * OCPBUGS-XXXXX: <summary> (Component, Unassigned -> suggested: <name>)
+
+   --- Other ---
+   * OCPBUGS-XXXXX: <summary> (Component, Priority, Assignee)
+
+   Workload Distribution:
+   | Team Member | Open Bugs | Sub-team |
+   |-------------|-----------|----------|
+   | <name>      | N         | Core     |
+   | <name>      | N         | DRA      |
+
+   Filter: https://redhat.atlassian.net/issues/?filter=83963
+   Dashboard: https://redhat.atlassian.net/jira/dashboards/12991
+   ```
+
+   Omit empty sections. Include the workload distribution table only when roster files are available. Show assignment suggestions inline for unassigned bugs.
+
+2. **Save the report** to `.work/node-bug/triage-$(date +%Y-%m-%d)/report.md`.
+
+## Return Value
+
+Prints the triage summary to stdout. Saves a report file to `.work/node-bug/triage-$(date +%Y-%m-%d)/report.md`. No write operations are performed on Jira (read-only).
+
+## Examples
+
+1. **Full triage across all sub-teams**:
+   ```text
+   /node-bug:triage
+   ```
+
+2. **Core sub-team bugs in the current sprint**:
+   ```text
+   /node-bug:triage --sub-team core --sprint "OCP Node Core Sprint 42"
+   ```
+
+3. **Unassigned DRA/Devices bugs only**:
+   ```text
+   /node-bug:triage --sub-team devices --unassigned-only
+   ```
+
+4. **Headless run for CI/scheduled jobs**:
+   ```bash
+   claude --print "/node-bug:triage --unassigned-only"
+   ```
+
+## Arguments
+
+- `--sub-team core|devices|kueue`: Filter to one sub-team's components. `core` includes all Node components not listed under another sub-team. `devices` includes only components listed under DRA/Devices. `kueue` includes only components listed under Kueue. Sub-team definitions are in the [sub-teams table](../../node-team/skills/node/references/shared/components.md). Optional.
+- `--sprint <name>`: Filter to bugs in a specific sprint. Use the exact sprint name from Jira (e.g., "OCP Node Core Sprint 42"). Optional.
+- `--unassigned-only`: Show only bugs that are untriaged or unassigned (priority Undefined, Release Blocker Proposed, assignee is the mailing list, or assignee is empty). Optional.
+
+## Notes
+
+- The Jira query uses the "Node Bugs" saved filter (ID 83963) as the base. This filter is maintained in Jira and defines which bugs are in scope. The "Node Bugs" dashboard (ID 12991) provides a visual overview at `https://redhat.atlassian.net/jira/dashboards/12991`.
+- Sub-team routing uses the sub-teams table from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md). Core owns all Node components not listed under DRA/Devices or Kueue.
+- Assignment suggestions require team roster files at `~/.node-assistant/team-roster-{core,dra,kueue}.json`. Sync these from Jira config issue OCPNODE-4230 (see [jira.md](../../node-team/skills/node/references/jira.md) Team Roster section).
+- The command is read-only. It does not modify bugs, change assignments, or transition issues. All suggestions are advisory.
+- Reports and artifacts are saved to `.work/node-bug/` (gitignored).
+- For CVE-specific triage with reachability analysis, use `/node-cve:triage` instead.

--- a/plugins/node-team/.claude-plugin/plugin.json
+++ b/plugins/node-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-team",
   "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-team/README.md
+++ b/plugins/node-team/README.md
@@ -60,7 +60,7 @@ plugins depend on node-team's shared data and extend its capabilities:
 |--------|--------|--------|
 | `node-team` | Development, deployment, debugging (see [Commands](#commands)) | Active |
 | [`node-cve`](../node-cve/) | CVE triage with reachability analysis | Active |
-| `node-bug-triage` | General bug triage and assignment | Planned |
+| [`node-bug`](../node-bug/) | General bug triage and assignment | Active |
 | [`node-onboarding`](../node-onboarding/) | Team onboarding workflows | Active |
 | [`node-rpm`](../node-rpm/) | RPM management (cri-tools pattern) | Active |
 

--- a/plugins/node-team/skills/node/SKILL.md
+++ b/plugins/node-team/skills/node/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: node
-description: "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to the node-cve plugin."
+description: "OpenShift Node team assistant. Covers kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira (OCPNODE/OCPBUGS), Red Hat KB/support cases, Prometheus, and K8s/OCP docs. Triggers on OpenShift node-layer development, deployment, debugging, or team workflow tasks. For CVE/vulnerability triage, analysis, or reporting, defer to node-cve. For bug triage and assignment, defer to node-bug."
 allowed-tools: Bash(curl:*)
 ---
 

--- a/plugins/node-team/skills/node/references/jira.md
+++ b/plugins/node-team/skills/node/references/jira.md
@@ -14,8 +14,8 @@ API token from env, macOS Keychain, or Linux secret-tool:
 ```bash
 JIRA_API_TOKEN="${JIRA_API_TOKEN:-$(security find-generic-password -s "JIRA_API_TOKEN" -w 2>/dev/null || secret-tool lookup service redhat key JIRA_API_TOKEN 2>/dev/null)}"
 JIRA_USER="${JIRA_EMAIL:-$(security find-generic-password -s "JIRA_API_TOKEN" -g 2>&1 | grep acct | sed 's/.*="//;s/"//')}"
-[[ "$JIRA_USER" != *@* ]] && JIRA_USER="${JIRA_USER}@redhat.com"
 : "${JIRA_USER:=$(git config user.email)}"
+[[ "$JIRA_USER" != *@* ]] && JIRA_USER="${JIRA_USER}@redhat.com"
 ```
 
 All requests: `curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" -H "Content-Type: application/json"`.
@@ -118,8 +118,9 @@ Bot account treated as unassigned: `Node Team Bot Account`.
 
 | Team | Sprint filter | Roster file | Bug components |
 |------|--------------|-------------|----------------|
-| Core | `Node Core` | `team-roster-core.json` | All Node components |
+| Core | `Node Core` | `team-roster-core.json` | All Node components not listed under another sub-team |
 | DRA/Devices | `Node Devices` | `team-roster-dra.json` | Node / Device Manager, Node / Instaslice-operator |
+| Kueue | `OCP Kueue` | `team-roster-kueue.json` | Node / Kueue |
 
 ## Custom Field IDs
 
@@ -137,6 +138,7 @@ Use field names in JQL, IDs in REST API calls:
 | `customfield_10847` | Release Blocker | Object: `{"value": "Approved"}` or `{"value": "Proposed"}` |
 | `customfield_10517` | Blocked | Object: `{"value": "True"}` or `{"value": "False"}` |
 | `customfield_10483` | Blocked Reason | ADF document |
+| `customfield_10689` | Customer Impact | Object: `{"value": "Customer Escalated"}` |
 | `customfield_10978` | SFDC Cases Counter | Number |
 | `customfield_10979` | SFDC Cases Links | |
 

--- a/plugins/node-team/skills/node/references/shared/components.md
+++ b/plugins/node-team/skills/node/references/shared/components.md
@@ -12,7 +12,7 @@ list.
 
 Full list (filter 91645): Node, Node / CRI-O, Node / Kubelet, Node / CPU
 manager, Node / Memory manager, Node / Topology manager, Node / Numa aware
-Scheduling, Node / Device Manage, Node / Pod resource API, Node / Node Problem
+Scheduling, Node / Device Manager, Node / Pod resource API, Node / Node Problem
 Detector, Node / Kueue, Node / Instaslice-operator
 
 Additional components owned for CVE triage (not in filter 91645):
@@ -29,7 +29,7 @@ shipped releases.
 | Node / CRI-O | https://github.com/openshift/cri-o | https://github.com/cri-o/cri-o | `release-1.X` | Go |
 | Node / Kubelet | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
 | Node / CPU manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
-| Node / Device Manage | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
+| Node / Device Manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
 | Node / Memory manager | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
 | Node / Numa aware Scheduling | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
 | Node / Pod resource API | https://github.com/openshift/kubernetes | https://github.com/kubernetes/kubernetes | `release-1.X` | Go |
@@ -75,5 +75,6 @@ upstream for community contributions):
 
 | Team | Sprint filter | Roster file | Bug components |
 |------|--------------|-------------|----------------|
-| Core | `Node Core` | `team-roster-core.json` | All Node components |
-| DRA/Devices | `Node Devices` | `team-roster-dra.json` | Node / Device Manage, Node / Instaslice-operator |
+| Core | `Node Core` | `team-roster-core.json` | All Node components not listed under another sub-team |
+| DRA/Devices | `Node Devices` | `team-roster-dra.json` | Node / Device Manager, Node / Instaslice-operator |
+| Kueue | `OCP Kueue` | `team-roster-kueue.json` | Node / Kueue |


### PR DESCRIPTION
## What this PR does / why we need it:
Adds a `node-bug` plugin for Node team bug triage. Queries open bugs from OCPBUGS using the "Node Bugs" saved filter (ID 83963), classifies into triage buckets (Release Blockers, Potential Blockers, Customer Escalations, Component Regressions, Untriaged), routes to sub-teams (Core/Devices/Kueue), suggests assignments based on workload, and generates triage summaries. Optionally posts to Slack.
Part of the [node-team plugin family](../node-team/).

## Which issue(s) this PR fixes:

## Special notes for your reviewer:
- Independent from #593 (node-rpm)
- Read-only: no Jira writes, all suggestions are advisory
- Requires `JIRA_API_TOKEN` for Jira access
- Optional team roster files at `~/.node-assistant/team-roster-{core,dra}.json` for assignment suggestions
- References the "Node Bugs" dashboard (ID 12991) for visual overview

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `node-bug` plugin with the `/node-bug:triage` command, including sub-team/sprint and unassigned-only filtering, severity bucketing, workload-aware assignment suggestions, and saved triage reports (with optional Slack notifications).
* **Bug Fixes**
  * Updated the Node team workflow so bug triage/assignment route to the new `node-bug` flow.
* **Documentation**
  * Published plugin and command documentation; updated marketplace entries and corrected Node component/sub-team and JIRA guidance.
* **Chores**
  * Updated plugin versioning and clarified plugin ownership/reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->