### PR TITLE
node-team: enhance overview command with onboarding content

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -496,7 +496,7 @@
       "name": "node-team",
       "source": "./plugins/node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2023,7 +2023,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "has_readme": true,
       "commands": [
         {
@@ -2037,10 +2037,10 @@ footer a { color: var(--primary); }
         {
           "name": "overview",
           "full_name": "node-team:overview",
-          "description": "Show Node team component ownership, repos, sub-teams, and specialized plugin routing",
-          "description_html": "Show Node team component ownership, repos, sub-teams, and specialized plugin routing",
-          "synopsis": "/node-team:overview [--sub-team core|dra]",
-          "body_html": "\u003cp\u003eDisplays a structured overview of the OpenShift Node team: which components\u003cbr\u003ethe team owns, which repos map to each component, sub-team assignments, active\u003cbr\u003esprint info, and which specialized plugins handle which domain.\u003c/p\u003e\u003cp\u003eThis is the entry point for understanding the Node team&#x27;s scope and navigating\u003cbr\u003eto the right tool for a given task.\u003c/p\u003e"
+          "description": "Show Node team scope, responsibilities, component ownership, and plugin routing",
+          "description_html": "Show Node team scope, responsibilities, component ownership, and plugin routing",
+          "synopsis": "/node-team:overview [--sub-team core|devices|kueue]",
+          "body_html": "\u003cp\u003eDisplays a comprehensive overview of the OpenShift Node team: what the team\u003cbr\u003eowns, its responsibilities, component and repo mappings, sub-team structure,\u003cbr\u003eceremonies, upstream community involvement, active sprints, and which\u003cbr\u003especialized plugins handle which domain.\u003c/p\u003e\u003cp\u003eThis is the entry point for understanding the Node team&#x27;s scope and navigating\u003cbr\u003eto the right tool for a given task.\u003c/p\u003e"
         },
         {
           "name": "preflight",

--- a/plugins/node-team/.claude-plugin/plugin.json
+++ b/plugins/node-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-team",
   "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-team/commands/overview.md
+++ b/plugins/node-team/commands/overview.md
@@ -1,6 +1,6 @@
 ---
-description: Show Node team component ownership, repos, sub-teams, and specialized plugin routing
-argument-hint: "[--sub-team core|dra]"
+description: Show Node team scope, responsibilities, component ownership, and plugin routing
+argument-hint: "[--sub-team core|devices|kueue]"
 ---
 
 ## Name
@@ -8,40 +8,63 @@ node-team:overview
 
 ## Synopsis
 ```text
-/node-team:overview [--sub-team core|dra]
+/node-team:overview [--sub-team core|devices|kueue]
 ```
 
 ## Description
 
-Displays a structured overview of the OpenShift Node team: which components
-the team owns, which repos map to each component, sub-team assignments, active
-sprint info, and which specialized plugins handle which domain.
+Displays a comprehensive overview of the OpenShift Node team: what the team
+owns, its responsibilities, component and repo mappings, sub-team structure,
+ceremonies, upstream community involvement, active sprints, and which
+specialized plugins handle which domain.
 
 This is the entry point for understanding the Node team's scope and navigating
 to the right tool for a given task.
 
 ## Implementation
 
-1. Read the component list and repo mappings from
-   [shared/components.md](../skills/node/references/shared/components.md).
-2. Read sprint and board info from
-   [jira.md](../skills/node/references/jira.md) (boards section, sprint
-   naming conventions).
-3. If `--sub-team` is specified, filter to that sub-team's components using
-   the sub-teams table in `shared/components.md`.
-4. Present a structured summary:
-   - Component ownership table (component, downstream fork, sub-team)
-   - Active sprint names (query the Jira Agile API per the jira.md reference)
-   - Specialized plugin routing:
-     - CVE triage: `/node-cve:triage`
-     - General development/deployment/debugging: `node-team:node` skill
-5. If a team roster file exists at `~/.node-assistant/team-roster-{core,dra}.json`,
-   include a member count per sub-team.
+1. **Read shared references:**
+   - Team mission, responsibilities, ceremonies, Slack channels, customer
+     support tools, key links, and plugin routing from
+     [shared/team-info.md](../skills/node/references/shared/team-info.md)
+   - Component list and repo mappings from
+     [shared/components.md](../skills/node/references/shared/components.md)
+   - Sub-team assignments from the sub-teams table in `shared/components.md`
+   - Sprint and board info from
+     [jira.md](../skills/node/references/jira.md)
+   - OCP-to-K8s version mapping from
+     [shared/version-map.md](../skills/node/references/shared/version-map.md)
+
+2. **If `--sub-team` is specified**, filter the Component Ownership table
+   and Sub-teams table to that sub-team's components. All other sections
+   (ceremonies, Slack channels, upstream communities, key links, plugin
+   routing) are always shown in full since they apply team-wide.
+
+3. **Present a structured summary** with these sections from the references:
+   - Team Mission and Responsibilities (from `team-info.md`)
+   - Component Ownership table (from `components.md`)
+   - Sub-teams table (from `components.md`). If roster files exist at
+     `~/.node-assistant/team-roster-{core,dra}.json`, include member count
+     per sub-team. There is no separate roster file for the Kueue sub-team;
+     its members are tracked under Core.
+   - Ceremonies and sprint cadence (from `team-info.md`)
+   - Upstream Communities (from `team-info.md`)
+   - Slack Channels and Mailing Lists (from `team-info.md`)
+   - Customer Support Tools (from `team-info.md`)
+   - Active Sprints (best-effort): query the Jira Agile API (board 11478)
+     for active sprints per jira.md. List sprint names and dates. If the
+     API call fails (missing credentials, network issues), print
+     "Sprint data unavailable" and continue with the remaining sections.
+   - Version Mapping: show the current OCP-to-K8s version mapping from
+     `shared/version-map.md` for the latest 2-3 OCP releases.
+   - Plugin Routing table (from `team-info.md`)
+   - Key Links (from `team-info.md`)
 
 ## Return Value
 
-- Formatted text summary of team components, repos, sub-teams, sprint info,
-  and plugin routing
+Formatted text summary of team mission, responsibilities, components,
+sub-teams, ceremonies, upstream communities, active sprints, version mapping,
+plugin routing, and key links.
 
 ## Examples
 
@@ -52,10 +75,15 @@ to the right tool for a given task.
 
 2. **DRA/Devices sub-team only**:
    ```text
-   /node-team:overview --sub-team dra
+   /node-team:overview --sub-team devices
+   ```
+
+3. **Kueue sub-team only**:
+   ```text
+   /node-team:overview --sub-team kueue
    ```
 
 ## Arguments
 
-- `--sub-team <name>`: Filter to a specific sub-team (`core` or `dra`).
-  Optional; shows all components when omitted.
+- `--sub-team <name>`: Filter to a specific sub-team (`core`, `devices`, or
+  `kueue`). Optional; shows all components when omitted.

--- a/plugins/node-team/skills/node/references/shared/team-info.md
+++ b/plugins/node-team/skills/node/references/shared/team-info.md
@@ -1,0 +1,104 @@
+# Node Team Info
+
+Operational data for the OpenShift Node team. Referenced by
+`node-team:overview`. For onboarding-specific setup instructions, see
+`/node-onboarding:checklist`.
+
+## Mission
+
+The Node team owns the node-level runtime stack in OpenShift: everything
+between the kubelet and the container. This includes CRI-O, kubelet
+customizations, Machine Config Operator (MCO), node resource managers
+(CPU, memory, topology, device, NUMA), Node Problem Detector, Kueue
+operator, and related components.
+
+## Responsibilities
+
+- Maintain downstream forks of kubelet and node-related Kubernetes components
+- Own CRI-O and conmonrs as the container runtime stack
+- Manage Machine Config Operator for node configuration
+- Handle resource management (CPU, memory, topology, device, NUMA managers)
+- Triage and fix bugs in Node components (OCPBUGS)
+- Track and remediate CVEs affecting Node components
+- Package and ship RPMs (cri-tools, CRI-O) for each OCP release
+- Participate in upstream SIG-Node community
+- Onboard new team members
+
+## Ceremonies
+
+**Daily:**
+- Review Node bugs
+- Review PRs
+- Standups (per sub-team)
+- Feature work
+
+**Weekly:**
+- 1:1s with manager (weekly or every other week)
+
+**Sprintly (every 3 weeks):**
+- Node Team Planning
+- Backlog Refinement
+- Sprint Retrospective
+- Sprint Demos
+
+Sprints are three weeks long and follow the OpenShift Release Dates
+spreadsheet. The "AOS Main Calendar" also has the sprints scheduled.
+
+**Every Release (~4 months):**
+- RFE refinement
+- Feature planning
+- Feature Complete / Code Complete milestones
+- Quarterly goals
+
+## Upstream Communities
+
+The team participates in Kubernetes SIG-Node:
+- SIG-Node weekly meeting (Tuesdays 1 PM EST)
+- SIG-Node CI subgroup (Wednesdays 1 PM EST)
+- Kubernetes contributor guide: https://www.kubernetes.dev/docs/guide/
+
+## Slack Channels
+
+- `#team-node` (private, team members)
+- `#forum-ocp-node` (public)
+- `#4-dev-triage` (general questions)
+- User groups: `@node-team`, `@node-core-team`, `@openshift-kueue`
+
+## Mailing List and Groups
+
+- Mailing list / Google group: `aos-node@redhat.com`
+- LDAP/Rover groups: `openshift-node-team`, `openshift-dev-node-team`
+
+## Customer Support Tools
+
+When investigating customer issues, the team uses:
+- **SupportShell**: remote SSH environment for accessing customer
+  must-gather archives without downloading them locally
+- **yank**: downloads case attachments from S3 to SupportShell
+- **omc**: provides `oc`/`kubectl`-style access to must-gather data offline
+
+For setup instructions (hostnames, authentication), see
+`/node-onboarding:checklist`.
+
+## Key Links
+
+- Homepage: `https://source.redhat.com/groups/public/openshift_node`
+- Bug dashboard: `https://redhat.atlassian.net/jira/dashboards/12991`
+- Bug filter: `https://redhat.atlassian.net/issues/?filter=83963`
+- Sprint board: `https://redhat.atlassian.net/jira/software/c/projects/OCPNODE/boards/11478`
+- Epics board: `https://redhat.atlassian.net/jira/software/c/projects/OCPNODE/boards/4383`
+- Shared Drive: `https://drive.google.com/drive/folders/1rf7-AQVRnxTWqeVrLN7TRAchEDB9Q9xP`
+
+## Plugin Routing
+
+| Plugin | Command / Skill | When to use |
+|--------|----------------|-------------|
+| `node-team` | `/node-team:overview` | Understand team scope, navigate to the right tool |
+| `node-team` | `/node-team:setup` | Set up a local development environment |
+| `node-team` | `/node-team:preflight` | Verify GitHub and Jira credentials and required CLI tools |
+| `node-team` | `/node-team:cleanup` | Purge cached plugin artifacts: triage reports, cloned repos, roster cache |
+| `node-team` | `node-team:node` (skill) | General Node development, deployment, and debugging questions |
+| `node-cve` | `/node-cve:triage` | CVE triage with reachability analysis |
+| `node-bug` | `/node-bug:triage` | Bug triage, sub-team routing, assignment suggestions |
+| `node-rpm` | `/node-rpm:bump` | Bump downstream RPM packages |
+| `node-onboarding` | `/node-onboarding:checklist` | New team member onboarding |


### PR DESCRIPTION
## What this PR does / why we need it:
Rewrites the `node-team:overview` command to be a comprehensive entry point for the Node team. Incorporates content from the Node Team Onboarding Guide and existing shared references.

New sections: team mission, responsibilities, component ownership, sub-team structure (Core, DRA/Devices, Kueue), ceremonies with sprint cadence, upstream SIG-Node community, Slack channels and user groups, mailing lists, customer support tools (SupportShell, yank, omc), plugin routing table (all 8 commands across 5 plugins), and key links.

Also adds a Kueue row to the sub-teams tables in `components.md` and `jira.md`, fixes the "Device Manager" -> "Device Manage" typo in `jira.md`, and renames the `--sub-team` flag value from `dra` to `devices` to match the DRA/Devices sub-team name.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Node team overview guidance to cover more team areas and include additional sub-team options.
  * Added support for the new **Kueue** sub-team in the Node team reference materials.

* **Documentation**
  * Refreshed team reference content with updated responsibilities, links, meeting info, and support resources.
  * Corrected several Node component names and mapping details for clearer navigation.

* **Bug Fixes**
  * Fixed outdated sub-team and component references so the latest team structure is shown consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->