### PR TITLE
fix(jira): skip PR creation in /jira:solve when --ci flag is passed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "category": "productivity",
       "keywords": [
         "jira",
@@ -484,7 +484,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1455,7 +1455,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "has_readme": true,
       "commands": [
         {
@@ -2467,7 +2467,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/solve.md
+++ b/plugins/jira/commands/solve.md
@@ -115,32 +115,34 @@ This command takes a JIRA URL, fetches the issue description and requirements, a
        - Example: `git commit -m"test: Add tests for X functionality" -m"Ensure the new behavior is covered by unit tests to prevent regressions"`
      - Documentation: Changes in `docs/` directory
        - Example: `git commit -m"docs: Document X feature" -m"Help users understand how to configure and use the new capability"`
+   - Push the branch with all commits against the remote specified in argument $2
 
 5. **PR Creation**: 
-   - Push the branch with all commits against the remote specified in argument $2
-   - Create pull request with:
-     - Clear title referencing JIRA issue as a prefix. For example: "OCPBUGS-12345: ..."
-     - The PR description should satisfy the template within .github/PULL_REQUEST_TEMPLATE.md if the file exists
-     - The "🤖 Generated with Claude Code" sentence should include a reference to the slash command that triggered the execution, for example "via `/jira-solve OCPBUGS-12345 enxebre`"
-     - Always create as draft PR
-     - Always create the PR against the remote origin
-     - Use gh cli if you need to
+   - If `--ci` flag ($3) IS set: Skip PR creation — it will be handled by a subsequent pipeline step (e.g., `/openshift-developer:create-pr`). Output: "Skipping PR creation in CI mode — branch pushed, PR will be created by the pipeline."
+   - If `--ci` flag ($3) is NOT set:
+     - Create pull request with:
+       - Clear title referencing JIRA issue as a prefix. For example: "OCPBUGS-12345: ..."
+       - The PR description should satisfy the template within .github/PULL_REQUEST_TEMPLATE.md if the file exists
+       - The "🤖 Generated with Claude Code" sentence should include a reference to the slash command that triggered the execution, for example "via `/jira:solve OCPBUGS-12345 enxebre`"
+       - Always create as draft PR
+       - Always create the PR against the remote origin
+       - Use gh cli if you need to
 
 6. **PR Description Review**:
-   - After creating the PR, display the PR URL and description to the user
+   - If `--ci` flag ($3) IS set: Skip — no PR was created in CI mode
    - If `--ci` flag ($3) is NOT set:
+     - After creating the PR, display the PR URL and description to the user
      - Ask the user: "Please review the PR description. Would you like me to update it? (yes/no)"
      - If the user says yes or requests changes:
        - Ask what changes they'd like to make
        - Update the PR description using `gh pr edit {PR_NUMBER} --body "{new_description}"`
        - Repeat this review step until the user is satisfied
      - If the user says no or is satisfied, acknowledge and provide next steps
-   - If `--ci` flag ($3) IS set: Skip the review step and proceed to completion
 
 
 ## Arguments:
 - $1: The JIRA issue to solve (required)
-- $2: The remote repository to push the branch. Defaults to "origin".
+- $2: The remote repository to push the branch (required).
 - $3: Optional `--ci` flag for non-interactive CI automation mode. When set, skips all user prompts and proceeds automatically.
 
 The command will provide progress updates and create a comprehensive solution addressing all requirements from the JIRA issue.

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
-    { "name": "jira", "version": "^0.7.0" },
+    { "name": "jira", "version": "^0.8.2" },
     { "name": "ci", "version": "^0.0.52" },
     { "name": "golang", "version": "^0.3.0" },
     { "name": "prodsec-skills" },


### PR DESCRIPTION
## Summary

- Move branch push from Phase 5 (PR Creation) to Phase 4 (Commit Creation) so it always happens regardless of `--ci` flag
- Gate PR creation and PR description review (Phases 5-6) behind `--ci` check — when `--ci` is set, skip PR creation entirely
- Interactive mode (no `--ci`) is unchanged

## Why

The jira-agent CI pipeline handles PR creation in a separate phase (Phase 4 via `/openshift-developer:create-pr`), but `/jira:solve` was always attempting to create a PR in its own Phase 5. This caused:

1. PR creation failures when the GitHub App token lacked permissions
2. Non-zero exit codes propagated to the harness ([CNTRLPLANE-3769](https://redhat.atlassian.net/browse/CNTRLPLANE-3769))
3. Harness skipping phases 2-4 (review, fix, PR creation), wasting the solve work ([CNTRLPLANE-3760](https://redhat.atlassian.net/browse/CNTRLPLANE-3760))

## Test plan

- [ ] Verify interactive mode (`/jira:solve ISSUE origin`) still creates PRs as before
- [ ] Verify CI mode (`/jira:solve ISSUE origin --ci`) pushes the branch but skips PR creation
- [ ] Run a jira-agent periodic job with the updated plugin and confirm all 4 phases complete

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `jira:solve` process flow so PR creation is conditional on the `--ci` flag (CI skips PR creation; non-CI creates a draft PR and specifies title/description/template expectations).
  * Adjusted PR description review behavior: CI omits review, while non-CI continues the interactive prompt loop to update the PR body.
  * Clarified that the remote repository argument (`$2`) is required.
* **Chores**
  * Bumped Jira plugin version (and Marketplace metadata) to `0.8.2`.
  * Bumped OpenShift Developer plugin version to `1.1.7` and updated its Jira dependency version to `^0.8.2` (including Marketplace metadata).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->