### PR TITLE
node-team: fix consistency across plugin family

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -316,7 +316,7 @@
       "name": "node-cve",
       "source": "./plugins/node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "category": "openshift",
       "keywords": [
         "openshift",
@@ -330,7 +330,7 @@
       "name": "node-onboarding",
       "source": "./plugins/node-onboarding",
       "description": "Interactive onboarding workflows for new OpenShift Node team members",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "category": "openshift",
       "keywords": [
         "openshift",
@@ -343,7 +343,7 @@
       "name": "node-rpm",
       "source": "./plugins/node-rpm",
       "description": "RPM package management for OpenShift Node team components",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "category": "openshift",
       "keywords": [
         "openshift",
@@ -356,8 +356,8 @@
     {
       "name": "node-bug",
       "source": "./plugins/node-bug",
-      "description": "Node-specific bug triage, sub-team routing, and assignment suggestions",
-      "version": "0.0.1",
+      "description": "Node-specific bug triage, sub-team routing, and assignment suggestions for OpenShift Node team components",
+      "version": "0.0.2",
       "category": "openshift",
       "keywords": [
         "openshift",
@@ -496,7 +496,7 @@
       "name": "node-team",
       "source": "./plugins/node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks",
-      "version": "0.18.1",
+      "version": "1.0.0",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1869,14 +1869,14 @@ footer a { color: var(--primary); }
     {
       "name": "node-bug",
       "description": "Node-specific bug triage, sub-team routing, and assignment suggestions for OpenShift Node team components",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {
           "name": "triage",
           "full_name": "node-bug:triage",
-          "description": "Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary",
-          "description_html": "Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary",
+          "description": "Query open Node bugs, classify by priority and sub-team, suggest assignments, and generate a triage summary",
+          "description_html": "Query open Node bugs, classify by priority and sub-team, suggest assignments, and generate a triage summary",
           "synopsis": "/node-bug:triage [--sub-team core|devices|kueue] [--sprint \"OCP Node Core Sprint 42\"] [--unassigned-only]",
           "body_html": "\u003cp\u003eQueries all open bugs in OCPBUGS for Node team components using the &quot;Node Bugs&quot; saved filter, classifies them into triage buckets (Release Blockers, Customer Escalations, Potential Blockers, Component Regressions, Untriaged), routes each bug to the correct sub-team, and suggests assignments based on current workload.\u003c/p\u003e\u003cp\u003eDesigned for both interactive triage sessions and headless execution via \u003ccode\u003eclaude --print\u003c/code\u003e.\u003c/p\u003e"
         }
@@ -1901,7 +1901,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "has_readme": true,
       "commands": [
         {
@@ -1952,7 +1952,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-onboarding",
       "description": "Interactive onboarding workflows for new OpenShift Node team members",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {
@@ -1991,7 +1991,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-rpm",
       "description": "RPM package management for OpenShift Node team components",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {
@@ -2023,7 +2023,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-team",
       "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-      "version": "0.18.1",
+      "version": "1.0.0",
       "has_readme": true,
       "commands": [
         {
@@ -2032,7 +2032,7 @@ footer a { color: var(--primary); }
           "description": "Purge cached artifacts and local data produced by Node team plugins",
           "description_html": "Purge cached artifacts and local data produced by Node team plugins",
           "synopsis": "/node-team:cleanup [--older-than N] [--dry-run]",
-          "body_html": "Removes local artifacts created by Node team plugins: triage reports, cloned\u003cbr\u003erepos, and cached roster data. Use this to reclaim disk space or to satisfy\u003cbr\u003edata purge requirements (DATA-05)."
+          "body_html": "Removes local artifacts created by Node team plugins: triage reports, cloned\u003cbr\u003erepos, dist-git clones, Vagrant VMs, and cached roster data. Use this to\u003cbr\u003ereclaim disk space or to satisfy data purge requirements (DATA-05)."
         },
         {
           "name": "overview",
@@ -2048,7 +2048,7 @@ footer a { color: var(--primary); }
           "description": "Verify that GitHub and Jira tokens are valid and the environment is ready for Node team workflows",
           "description_html": "Verify that GitHub and Jira tokens are valid and the environment is ready for Node team workflows",
           "synopsis": "/node-team:preflight [--fix]",
-          "body_html": "\u003cp\u003eTests all authentication tokens and CLI tools required by Node team workflows\u003cbr\u003ein a single pass. Reports pass/fail for each check so you can fix all auth\u003cbr\u003eissues at once instead of discovering them one at a time.\u003c/p\u003e\u003cp\u003eRun this before \u003ccode\u003e/node-team:setup\u003c/code\u003e or \u003ccode\u003e/node-cve:triage\u003c/code\u003e to catch expired or\u003cbr\u003emissing credentials early.\u003c/p\u003e"
+          "body_html": "\u003cp\u003eTests all authentication tokens and CLI tools required by Node team workflows\u003cbr\u003ein a single pass. Reports pass/fail for each check so you can fix all auth\u003cbr\u003eissues at once instead of discovering them one at a time.\u003c/p\u003e\u003cp\u003eRun this before \u003ccode\u003e/node-team:setup\u003c/code\u003e, \u003ccode\u003e/node-cve:triage\u003c/code\u003e, or \u003ccode\u003e/node-bug:triage\u003c/code\u003e\u003cbr\u003eto catch expired or missing credentials early.\u003c/p\u003e"
         },
         {
           "name": "setup",

--- a/plugins/node-bug/.claude-plugin/plugin.json
+++ b/plugins/node-bug/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "node-bug",
   "description": "Node-specific bug triage, sub-team routing, and assignment suggestions for OpenShift Node team components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
     {
       "name": "node-team",
-      "version": "^0.17.0"
+      "version": "^1.0.0"
     }
   ]
 }

--- a/plugins/node-bug/README.md
+++ b/plugins/node-bug/README.md
@@ -1,6 +1,6 @@
 # Node Bug Plugin
 
-Node-specific bug triage for OpenShift Node team components. Queries open bugs from OCPBUGS, classifies by severity and sub-team, suggests assignments based on workload, and generates triage summaries. Complements `/jira:grooming` with Node-specific JQL filters, sub-team routing, and team roster integration.
+Node-specific bug triage for OpenShift Node team components. Queries open bugs from OCPBUGS, classifies by priority and sub-team, suggests assignments based on workload, and generates triage summaries. Complements `/jira:grooming` with Node-specific JQL filters, sub-team routing, and team roster integration.
 
 Part of the [node-team plugin family](../node-team/).
 
@@ -14,9 +14,9 @@ Requires the `node-team` plugin (installed automatically as a dependency).
 
 ## Command
 
-### `/node-bug:triage [--sub-team core|devices|kueue] [--sprint <name>] [--unassigned-only] [--notify-slack]`
+### `/node-bug:triage [--sub-team core|devices|kueue] [--sprint <name>] [--unassigned-only]`
 
-Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary.
+Query open Node bugs, classify by priority and sub-team, suggest assignments, and generate a triage summary.
 
 **Examples:**
 
@@ -29,9 +29,6 @@ Query open Node bugs, classify by severity and sub-team, suggest assignments, an
 
 # Show only unassigned bugs for DRA/Devices
 /node-bug:triage --sub-team devices --unassigned-only
-
-# Triage and notify Slack
-/node-bug:triage --notify-slack
 ```
 
 **Arguments:**
@@ -39,11 +36,8 @@ Query open Node bugs, classify by severity and sub-team, suggest assignments, an
 - `--sub-team core|devices|kueue`: Filter to one sub-team's components (Core, DRA/Devices, or Kueue)
 - `--sprint <name>`: Filter to bugs in a specific sprint
 - `--unassigned-only`: Show only untriaged or unassigned bugs
-- `--notify-slack`: Send summary to Slack (requires `SLACK_API_TOKEN` + `SLACK_CHANNEL` or `SLACK_WEBHOOK`)
 
 ## Prerequisites
 
-- `JIRA_API_TOKEN` environment variable (or macOS Keychain / Linux secret-tool)
-- `curl` (for Jira REST API and Slack)
-- Optional: `SLACK_API_TOKEN` + `SLACK_CHANNEL` or `SLACK_WEBHOOK` (for `--notify-slack`)
-- Optional: `~/.node-assistant/team-roster-{core,dra}.json` (for assignment suggestions)
+- `JIRA_API_TOKEN` (env var, macOS Keychain, or Linux secret-tool) and `curl`
+- Optional: `~/.node-assistant/team-roster-{core,dra,kueue}.json` (for assignment suggestions)

--- a/plugins/node-bug/commands/triage.md
+++ b/plugins/node-bug/commands/triage.md
@@ -1,5 +1,5 @@
 ---
-description: Query open Node bugs, classify by severity and sub-team, suggest assignments, and generate a triage summary
+description: Query open Node bugs, classify by priority and sub-team, suggest assignments, and generate a triage summary
 argument-hint: "[--sub-team core|devices|kueue] [--sprint <name>] [--unassigned-only]"
 ---
 
@@ -109,8 +109,8 @@ Designed for both interactive triage sessions and headless execution via `claude
 
 2. **Classify each bug into triage buckets** using the [Bug Triage Definitions](../../node-team/skills/node/references/jira.md):
 
-   - **Release Blockers**: `"Release Blocker"` field value is "Approved"
-   - **Potential Blockers**: priority is "Blocker" AND `"Release Blocker"` is empty (Blocker priority set but no release blocker decision yet)
+   - **Release Blockers**: `"Release Blocker"` field value is "Approved", OR priority is "Blocker"
+   - **Potential Blockers**: `"Release Blocker"` field value is "Proposed", OR (priority is "Blocker" AND `"Release Blocker"` is empty)
    - **Customer Escalations**: `customfield_10978` (SFDC Cases Counter) is not null/empty, OR `customfield_10689` (Customer Impact) value is "Customer Escalated"
    - **Component Regressions**: labels contain `component-regression`
    - **Untriaged**: priority is "Undefined", OR `"Release Blocker"` is "Proposed", OR assignee is `aos-node@redhat.com`
@@ -150,14 +150,14 @@ Designed for both interactive triage sessions and headless execution via `claude
    Other: X
 
    --- Release Blockers ---
-   * OCPBUGS-XXXXX: <summary> (Component, Severity, Assignee)
-   * OCPBUGS-XXXXX: <summary> (Component, Severity, Unassigned -> suggested: <name>)
+   * OCPBUGS-XXXXX: <summary> (Component, Priority, Assignee)
+   * OCPBUGS-XXXXX: <summary> (Component, Priority, Unassigned -> suggested: <name>)
 
    --- Customer Escalations ---
    * OCPBUGS-XXXXX: <summary> (Component, N support cases, Assignee)
 
    --- Potential Blockers ---
-   * OCPBUGS-XXXXX: <summary> (Component, Severity, Assignee)
+   * OCPBUGS-XXXXX: <summary> (Component, Priority, Assignee)
 
    --- Component Regressions ---
    * OCPBUGS-XXXXX: <summary> (Component, Assignee)

--- a/plugins/node-cve/.claude-plugin/plugin.json
+++ b/plugins/node-cve/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "node-cve",
   "description": "CVE triage for OpenShift Node team components",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
     {
       "name": "node-team",
-      "version": "^0.17.0"
+      "version": "^1.0.0"
     }
   ]
 }

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -2,6 +2,16 @@
 
 CVE triage for OpenShift Node team components. Queries open vulnerability issues from OCPBUGS, runs reachability analysis against affected repositories, and reports findings to Jira and Slack.
 
+Part of the [node-team plugin family](../node-team/).
+
+## Installation
+
+```bash
+/plugin install node-cve@ai-helpers
+```
+
+Requires the `node-team` plugin (installed automatically as a dependency).
+
 ## Command
 
 ### `/node-cve:triage [--component <name>] [--notify-jira] [--notify-slack] [--days N]`

--- a/plugins/node-onboarding/.claude-plugin/plugin.json
+++ b/plugins/node-onboarding/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "node-onboarding",
   "description": "Interactive onboarding workflows for new OpenShift Node team members",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
     {
       "name": "node-team",
-      "version": "^0.17.0"
+      "version": "^1.0.0"
     }
   ]
 }

--- a/plugins/node-onboarding/README.md
+++ b/plugins/node-onboarding/README.md
@@ -12,7 +12,7 @@ Part of the [node-team plugin family](../node-team/).
 /plugin install node-onboarding@ai-helpers
 ```
 
-Requires `node-team` (installed automatically as a dependency).
+Requires the `node-team` plugin (installed automatically as a dependency).
 
 ## Commands
 

--- a/plugins/node-rpm/.claude-plugin/plugin.json
+++ b/plugins/node-rpm/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "node-rpm",
   "description": "RPM package management for OpenShift Node team components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
     {
       "name": "node-team",
-      "version": "^0.17.0"
+      "version": "^1.0.0"
     }
   ]
 }

--- a/plugins/node-rpm/README.md
+++ b/plugins/node-rpm/README.md
@@ -1,6 +1,8 @@
 # Node RPM Plugin
 
-RPM package management for OpenShift Node team components. Part of the [node-team](../node-team/) plugin family.
+RPM package management for OpenShift Node team components.
+
+Part of the [node-team plugin family](../node-team/).
 
 ## Installation
 

--- a/plugins/node-team/.claude-plugin/plugin.json
+++ b/plugins/node-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-team",
   "description": "OpenShift Node team assistant for development, deployment, debugging, and workflow tasks across kubelet, MCO, CRI-O, crun, conmonrs, Kueue operator, Jira, Red Hat KB/support cases, Prometheus, and platform docs.",
-  "version": "0.18.1",
+  "version": "1.0.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/node-team/README.md
+++ b/plugins/node-team/README.md
@@ -34,7 +34,11 @@ Clones a Node team repo and sets up a git worktree for development, optionally t
 
 ### `node-team:preflight`
 
-Tests all authentication tokens (GitHub, Jira) and CLI tools required by Node team workflows in a single pass. Run before `setup` or `node-cve:triage` to catch expired or missing credentials early.
+Tests all authentication tokens (GitHub, Jira) and CLI tools required by Node team workflows in a single pass. Run before `setup`, `node-cve:triage`, or `node-bug:triage` to catch expired or missing credentials early.
+
+### `node-team:cleanup`
+
+Purges cached artifacts produced by Node team plugins: triage reports, cloned repos, dist-git clones, Vagrant VMs, and roster cache.
 
 ## Skill
 

--- a/plugins/node-team/commands/cleanup.md
+++ b/plugins/node-team/commands/cleanup.md
@@ -14,8 +14,8 @@ node-team:cleanup
 ## Description
 
 Removes local artifacts created by Node team plugins: triage reports, cloned
-repos, and cached roster data. Use this to reclaim disk space or to satisfy
-data purge requirements (DATA-05).
+repos, dist-git clones, Vagrant VMs, and cached roster data. Use this to
+reclaim disk space or to satisfy data purge requirements (DATA-05).
 
 ## Options
 
@@ -33,16 +33,19 @@ Scan for these locations relative to the current working directory and home:
 | Location | Contents |
 |----------|----------|
 | `.work/node-cve/repos/` | Shallow repo clones |
-| `.work/node-cve/triage-YYYY-MM-DD/` | Triage reports and analysis |
+| `.work/node-cve/triage-YYYY-MM-DD/` | CVE triage reports and analysis |
+| `.work/node-bug/triage-YYYY-MM-DD/` | Bug triage reports |
+| `.work/node-rpm/` | Dist-git clones and Vagrant VM |
 | `~/.node-assistant/` | Cached team roster JSON files |
 
 For each location that exists, compute the size with `du -sh`.
 
 ### 2. Filter by age
 
-For `.work/node-cve/triage-*/` directories, parse the date from the directory
-name and skip directories newer than `--older-than` days. The `repos/` and
-`~/.node-assistant/` directories are always included (no age filter).
+For `.work/node-cve/triage-*/` and `.work/node-bug/triage-*/` directories,
+parse the date from the directory name and skip directories newer than
+`--older-than` days. The `repos/`, `.work/node-rpm/`, and `~/.node-assistant/`
+directories are always included (no age filter).
 
 ### 3. Show summary
 
@@ -54,9 +57,11 @@ Location                                          Size    Age
 $PWD/.work/node-cve/repos/                        1.2G    -
 $PWD/.work/node-cve/triage-2026-05-01/            45M     59 days
 $PWD/.work/node-cve/triage-2026-06-15/            52M     14 days (skipped, < 30 days)
+$PWD/.work/node-bug/triage-2026-05-01/            12M     59 days
+$PWD/.work/node-rpm/                              380M    -
 $HOME/.node-assistant/                            128K    -
 
-Total to remove: 1.25G
+Total to remove: 1.64G
 ```
 
 ### 4. Delete
@@ -64,17 +69,29 @@ Total to remove: 1.25G
 If `--dry-run` is set, stop after the summary.
 
 Otherwise, ask the user for confirmation ("Remove these artifacts? [y/N]"),
-then delete with `rm -rf`. Report each deletion:
+then delete each location. For `.work/node-rpm/`, run `vagrant destroy -f`
+first to release libvirt VMs before removing the directory:
+
+```bash
+if command -v vagrant &>/dev/null && [ -f .work/node-rpm/Vagrantfile ]; then
+  (cd .work/node-rpm && vagrant destroy -f) || echo "WARNING: vagrant destroy failed; skipping .work/node-rpm/ removal to avoid orphaning libvirt domains"
+fi
+```
+
+Only remove `.work/node-rpm/` if `vagrant destroy` succeeded (or no Vagrantfile was present). Delete all other locations with `rm -rf`. Report each deletion:
 
 ```text
 Removed $PWD/.work/node-cve/repos/ (1.2G)
 Removed $PWD/.work/node-cve/triage-2026-05-01/ (45M)
+Removed $PWD/.work/node-bug/triage-2026-05-01/ (12M)
+Removed $PWD/.work/node-rpm/ (380M)
 Removed $HOME/.node-assistant/ (128K)
-Done. Freed 1.25G.
+Done. Freed 1.64G.
 ```
 
 ## Notes
 
 - This command never deletes source code repositories or plugin files
-- Re-running `/node-cve:triage` recreates `.work/` artifacts automatically
+- Re-running `/node-cve:triage` or `/node-bug:triage` recreates `.work/` artifacts automatically
+- Re-running `/node-rpm:bump` recreates dist-git clones; the Vagrant VM must be reprovisioned with `vagrant up`. The cleanup command runs `vagrant destroy -f` before removing `.work/node-rpm/` to avoid orphaning libvirt domains.
 - Roster cache is re-synced on the next `/node-team:overview` run

--- a/plugins/node-team/commands/overview.md
+++ b/plugins/node-team/commands/overview.md
@@ -44,9 +44,8 @@ to the right tool for a given task.
    - Team Mission and Responsibilities (from `team-info.md`)
    - Component Ownership table (from `components.md`)
    - Sub-teams table (from `components.md`). If roster files exist at
-     `~/.node-assistant/team-roster-{core,dra}.json`, include member count
-     per sub-team. There is no separate roster file for the Kueue sub-team;
-     its members are tracked under Core.
+     `~/.node-assistant/team-roster-{core,dra,kueue}.json`, include member
+     count per sub-team.
    - Ceremonies and sprint cadence (from `team-info.md`)
    - Upstream Communities (from `team-info.md`)
    - Slack Channels and Mailing Lists (from `team-info.md`)

--- a/plugins/node-team/commands/preflight.md
+++ b/plugins/node-team/commands/preflight.md
@@ -17,8 +17,8 @@ Tests all authentication tokens and CLI tools required by Node team workflows
 in a single pass. Reports pass/fail for each check so you can fix all auth
 issues at once instead of discovering them one at a time.
 
-Run this before `/node-team:setup` or `/node-cve:triage` to catch expired or
-missing credentials early.
+Run this before `/node-team:setup`, `/node-cve:triage`, or `/node-bug:triage`
+to catch expired or missing credentials early.
 
 ## Implementation
 
@@ -72,8 +72,8 @@ jira me
 ```
 
 - Pass: returns current user info
-- Fail: not installed or not configured (this is optional since the
-  `node-team` plugin uses `curl` directly, but `node-cve` requires it)
+- Fail: not installed or not configured (required by `node-cve`;
+  `node-team` and `node-bug` use `curl` directly)
 
 ### Summary
 
@@ -86,7 +86,7 @@ GitHub CLI            PASS
 GitHub API            PASS
 Jira API token        PASS
 Jira API connectivity PASS
-Jira CLI              PASS (optional)
+Jira CLI              PASS (node-cve only)
 ```
 
 If any required check fails and `--fix` is specified, print the remediation

--- a/plugins/node-team/docs/compliance/capabilities-inventory.md
+++ b/plugins/node-team/docs/compliance/capabilities-inventory.md
@@ -6,9 +6,9 @@ Control ID: GLC-08
 
 | Tool | Purpose | Plugin |
 |------|---------|--------|
-| `jira` CLI | Query and comment on Jira issues | node-cve, node-team |
+| `jira` CLI | Query and comment on Jira issues | node-cve |
 | `git` | Clone downstream repository forks | node-cve, node-team |
-| `curl` | Jira REST API calls, Slack API calls | node-cve |
+| `curl` | Jira REST API calls, Slack API calls | node-bug, node-cve, node-team |
 | `gh` | GitHub CLI for repo operations | node-team |
 
 ## APIs
@@ -49,11 +49,11 @@ Authentication: `gh` CLI auth or unauthenticated for public repos.
 
 | Source | Type | Data Accessed | Plugin |
 |--------|------|---------------|--------|
-| OCPBUGS (Jira) | Read | Issue summaries, components, assignees, labels, status, custom fields | node-cve |
+| OCPBUGS (Jira) | Read | Issue summaries, components, assignees, labels, status, custom fields | node-cve, node-bug |
 | OCPNODE (Jira) | Read | Team config issue (OCPNODE-4230), roster attachments, sprint info | node-team |
 | Downstream forks (GitHub) | Read | Source code at release branches (shallow clone) | node-cve |
 | NVD / public advisories | Read | CVE descriptions, affected packages, fixed versions | node-cve |
-| `~/.node-assistant/` | Read/Write | Cached team roster JSON files | node-team |
+| `~/.node-assistant/` | Read/Write | Cached team roster JSON files | node-bug, node-team |
 
 ## Write Actions and Guardrails
 

--- a/plugins/node-team/docs/compliance/dataflow.md
+++ b/plugins/node-team/docs/compliance/dataflow.md
@@ -66,6 +66,8 @@ In headless/CronJob mode, secrets are injected via OpenShift `secretRef`
 |----------|----------|-----------|
 | `.work/node-cve/repos/` | Shallow repo clones | Ephemeral; gitignored; can be large |
 | `.work/node-cve/triage-YYYY-MM-DD/` | Reports, JSON, per-CVE analysis | Ephemeral; gitignored; one dir per run |
+| `.work/node-bug/triage-YYYY-MM-DD/` | Bug triage reports | Ephemeral; gitignored; one dir per run |
+| `.work/node-rpm/` | Dist-git clones, Vagrant VM | Ephemeral; gitignored; can be large |
 | `~/.node-assistant/team-roster-*.json` | Cached team roster | Synced from Jira on demand |
 
 Use `/node-team:cleanup` to purge old artifacts.

--- a/plugins/node-team/docs/compliance/user-guide.md
+++ b/plugins/node-team/docs/compliance/user-guide.md
@@ -10,14 +10,20 @@ component management. The suite consists of:
 
 - **node-team**: umbrella plugin for development setup, team overview, debugging,
   and shared reference data
+- **node-onboarding**: guided onboarding for new team members
 - **node-cve**: automated CVE triage with source code reachability analysis
+- **node-bug**: bug triage, sub-team routing, and assignment suggestions
+- **node-rpm**: RPM build and dist-git management
 
 ### Quick Start
 
 ```bash
-# Install both plugins
+# Install the plugin family
 /plugin install node-team@ai-helpers
+/plugin install node-onboarding@ai-helpers
 /plugin install node-cve@ai-helpers
+/plugin install node-bug@ai-helpers
+/plugin install node-rpm@ai-helpers
 
 # Verify credentials are working
 /node-team:preflight

--- a/plugins/node-team/skills/node/references/jira.md
+++ b/plugins/node-team/skills/node/references/jira.md
@@ -4,8 +4,8 @@ Red Hat Jira: `redhat.atlassian.net`. REST API v3. Use `curl` directly —
 this skill's workflows need endpoints the `jira` CLI doesn't cover (Agile
 boards/sprints, attachment downloads, ADF bodies, custom-field writes), and
 curl needs no extra install/config and keeps `allowed-tools` narrow
-(`Bash(curl:*)`). The node-cve plugin uses the `jira` CLI for its simpler
-list/comment flows; both hit the same REST API.
+(`Bash(curl:*)`). The `node-cve` plugin uses the `jira` CLI for its
+list/view flows; it hits the same REST API.
 
 ## Authentication
 
@@ -93,7 +93,7 @@ Team mailing list: `aos-node@redhat.com`
 
 ## Team Roster
 
-Team member lists live in `~/.node-assistant/team-roster-{core,dra}.json`. Format:
+Team member lists live in `~/.node-assistant/team-roster-{core,dra,kueue}.json`. Format:
 
 ```json
 {

--- a/plugins/node-team/skills/node/references/shared/team-info.md
+++ b/plugins/node-team/skills/node/references/shared/team-info.md
@@ -96,9 +96,10 @@ For setup instructions (hostnames, authentication), see
 | `node-team` | `/node-team:overview` | Understand team scope, navigate to the right tool |
 | `node-team` | `/node-team:setup` | Set up a local development environment |
 | `node-team` | `/node-team:preflight` | Verify GitHub and Jira credentials and required CLI tools |
-| `node-team` | `/node-team:cleanup` | Purge cached plugin artifacts: triage reports, cloned repos, roster cache |
+| `node-team` | `/node-team:cleanup` | Purge cached plugin artifacts: triage reports, cloned repos, dist-git clones, Vagrant VMs, roster cache |
 | `node-team` | `node-team:node` (skill) | General Node development, deployment, and debugging questions |
 | `node-cve` | `/node-cve:triage` | CVE triage with reachability analysis |
 | `node-bug` | `/node-bug:triage` | Bug triage, sub-team routing, assignment suggestions |
 | `node-rpm` | `/node-rpm:bump` | Bump downstream RPM packages |
 | `node-onboarding` | `/node-onboarding:checklist` | New team member onboarding |
+| `node-onboarding` | `/node-onboarding:resources` | Quick-reference bookmarks and links |


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes consistency issues across the node-team plugin family after PRs #584, #589, #593, #594, and #595 merged.

**Versioning:**
- Bump node-team to v1.0.0; all satellites depend on `^1.0.0` (the old `^0.17.0` excluded 0.18.x under semver 0.x rules)

**node-bug:**
- Fix triage bucket definitions to match jira.md Bug Triage Definitions table (Blocker+, Blocker?)
- Fix descriptions ("severity" to "priority"), fix roster list to include kueue
- Keep curl-based Jira access (jira CLI silently drops COMPONENT column and injects default project)

**node-team:**
- Cleanup: add .work/node-bug/ and .work/node-rpm/, fix `vagrant destroy -f` to use subshell (prevents orphaning libvirt domains on failure), update description
- Preflight: annotate jira CLI check as node-cve only, mention node-bug:triage
- Overview: fix roster to include Kueue sub-team
- Compliance: add node-bug and node-rpm to dataflow.md and user-guide.md
- Update jira.md, capabilities inventory, team-info routing table, and README for new satellites

**Satellites:**
- node-cve: add satellite README pattern (Part of, Installation, dependency note)
- node-onboarding: fix "Requires" wording
- node-rpm: standardize "Part of" link format

## Which issue(s) this PR fixes:

## Special notes for your reviewer:
The node-bug triage command stays on curl rather than switching to jira CLI. The CLI silently skips the COMPONENT column (not in its valid columns list) and injects the configured default project into JQL, both of which break Phase 1 silently. curl's POST search endpoint returns components as structured JSON and executes JQL as-is.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated `node-team:cleanup` documentation to include cached bug triage reports, cloned artifacts, dist-git clones, Vagrant VMs, and roster cache.
  * Expanded installation and quick-start docs for additional node team plugins, including bug triage and RPM workflows.
* **Bug Fixes**
  * Updated bug triage terminology and command rules to use **priority** (including phase bucket logic and rendered output).
  * Refreshed preflight guidance to require Jira checks and to reference the bug triage flow.
* **Documentation / Chores**
  * Updated plugin READMEs and compliance/data-flow docs; removed Slack-related setup/mentions from bug triage instructions.
  * Bumped plugin versions and aligned `node-team` dependency constraints across the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->