### PR TITLE
jira: use standard parent field and document hierarchy level constraints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,7 +75,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1455,7 +1455,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/reference/cntrlplane.md
+++ b/plugins/jira/reference/cntrlplane.md
@@ -44,24 +44,16 @@ Project-specific conventions for creating Jira issues in the CNTRLPLANE project.
 
 ## CNTRLPLANE-Specific Fields
 
-For shared custom fields (Epic Link, Parent Link, Epic Name, Target Version), see the `create` skill. The table below shows CNTRLPLANE-specific usage:
-
-| Creating | Parent Type | Field | Value Format |
-|----------|-------------|-------|--------------|
-| Story | Epic | `customfield_10014` (Epic Link) | `"CNTRLPLANE-123"` (string) |
-| Task | Epic | `customfield_10014` (Epic Link) | `"CNTRLPLANE-123"` (string) |
-| Epic | Feature | `customfield_10018` (Parent Link) | `"CNTRLPLANE-123"` (string) |
-
-Both fields take STRING values (issue key), NOT objects.
+For shared custom fields (Epic Name, Target Version) and parent linking, see the `create` skill.
 
 **Per issue type:**
 
 | Issue Type | Key Fields |
 |---|---|
-| Story | `customfield_10014` (Epic Link): parent epic key (optional) |
-| Epic | `customfield_10011` (Epic Name): must match summary; `customfield_10018` (Parent Link): parent feature key (optional) |
+| Story | No type-specific custom fields required |
+| Epic | `customfield_10011` (Epic Name): must match summary |
 | Feature | No type-specific custom fields required |
-| Task | `customfield_10014` (Epic Link): parent epic key (optional) |
+| Task | No type-specific custom fields required |
 
 ## Component Requirements
 

--- a/plugins/jira/reference/create-epic.md
+++ b/plugins/jira/reference/create-epic.md
@@ -8,7 +8,7 @@ Type-specific guidance for creating Jira epics.
 
 ## Parent Link
 
-Epic → Feature uses `customfield_10018` (Parent Link) as a STRING value (Feature issue key). Do NOT use Epic Link or the standard `parent` field.
+Epic → Feature uses `{"parent": {"key": "FEATURE-KEY"}}` in `additional_fields`.
 
 ## Epic Description Best Practices
 

--- a/plugins/jira/reference/gcp-hcp.md
+++ b/plugins/jira/reference/gcp-hcp.md
@@ -15,8 +15,6 @@ Team-specific conventions for GCP HCP (Hypershift on GKE) issues in the GCP proj
 | Field | Custom Field ID | Usage | Example |
 |-------|-----------------|-------|---------|
 | **Epic Name** | `customfield_10011` | Required for Epics | `"Multi-cluster metrics aggregation"` |
-| **Epic Link** | `customfield_10014` | Link Story/Task → Epic | `"GCP-456"` |
-| **Parent Link** | `customfield_10018` | Link Epic → Feature | `"GCP-100"` |
 | **Story Points** | `customfield_10028` | Fibonacci scale: 0, 1, 2, 3, 5, 8, 13 | `3.0` |
 | **Blocked** | `customfield_10517` | Mark issue as blocked | `{"value": "True"}` |
 
@@ -35,18 +33,13 @@ Components are **optional** — only specify if work clearly fits. Do not reques
 
 | Issue Type | Key Fields |
 |---|---|
-| Story / Task | `customfield_10014` (Epic Link): parent epic key; `customfield_10028` (Story Points): float, auto-estimated per Sizing Guide; `priority`: `{"name": "Normal"}` (omit unless user specifies) |
-| Epic | `customfield_10011` (Epic Name): must match summary. Do NOT include parent link at creation — add via separate `editJiraIssue` call |
+| Story / Task | `customfield_10028` (Story Points): float, auto-estimated per Sizing Guide; `priority`: `{"name": "Normal"}` (omit unless user specifies) |
+| Epic | `customfield_10011` (Epic Name): must match summary |
 | Feature | No type-specific custom fields required |
 
 **Story Points:** Auto-estimate using the Sizing Guide below. Set `customfield_10028` as float. For estimates of 8+, recommend splitting.
 
 **Priority:** Ask user before setting. Reference the Priority Scheme below. If unset, default is Normal.
-
-## Epic Linking
-
-1. Create the Epic first via `createJiraIssue` WITHOUT the parent link field
-2. Link to Feature in a separate call: `editJiraIssue` to set `customfield_10018` to the Feature key
 
 ## Team Standards
 

--- a/plugins/jira/skills/create/SKILL.md
+++ b/plugins/jira/skills/create/SKILL.md
@@ -109,28 +109,24 @@ Applied defaults:
 
 | Field | ID | Type | Usage |
 |---|---|---|---|
-| Epic Link | `customfield_10014` | String | Links Story/Task/Bug → parent Epic |
-| Parent Link | `customfield_10018` | String | Links Epic → parent Feature |
 | Epic Name | `customfield_10011` | String | Required for Epics; must match summary |
 | Target Version | `customfield_10855` | Array | Format: `[{"id": "VERSION_ID"}]` — fetch via `getJiraIssueTypeMetaWithFields`. Some projects use string format; project conventions take precedence |
 
 ## Issue Hierarchy and Parent Linking
 
+Jira issue types have a `hierarchyLevel` that determines valid parent-child relationships. The parent field only accepts an issue whose `hierarchyLevel` is exactly one level above the child. Not all projects have all levels — use `getJiraProjectIssueTypesMetadata` to discover available types and their levels for a given project.
+
 ```plaintext
-Feature → Epic → Story/Task
+Level 3: Outcome
+Level 2: Feature
+Level 1: Epic
+Level 0: Story / Task / Bug
+Level -1: Sub-task
 ```
 
-### Field Reference
+### Parent Field
 
-| Relationship | Field | Value Format |
-|---|---|---|
-| Story → Epic | `customfield_10014` (Epic Link) | `"PROJ-123"` (string) |
-| Task → Epic | `customfield_10014` (Epic Link) | `"PROJ-123"` (string) |
-| Task → Story | `customfield_10014` (Epic Link) | `"PROJ-123"` (string) |
-| Bug → Epic | `customfield_10014` (Epic Link) | `"PROJ-123"` (string) |
-| Epic → Feature | `customfield_10018` (Parent Link) | `"PROJ-123"` (string) |
-
-The standard `parent` field does NOT work for these relationships.
+Use `{"parent": {"key": "PARENT-KEY"}}` in `additional_fields` for all parent-child relationships (Story→Epic, Task→Epic, Bug→Epic, Epic→Feature, Feature→Outcome).
 
 ### Pre-Validation (when `--parent` is provided)
 
@@ -139,32 +135,24 @@ Fetch the parent via `getJiraIssue` to verify it exists and its type matches the
 | Creating | Parent Should Be | If Wrong Type |
 |----------|------------------|---------------|
 | Story | Epic | Warn user, ask to confirm or correct |
-| Task | Epic or Story | Warn user, ask to confirm or correct |
+| Task | Epic | Warn user, ask to confirm or correct |
+| Bug | Epic | Warn user, ask to confirm or correct |
 | Epic | Feature | Warn user, ask to confirm or correct |
+| Feature | Outcome | Warn user, ask to confirm or correct |
 
 If parent not found, offer options: proceed without parent, specify different parent, or cancel.
 
 ### Parent Linking Fallback
 
-Some projects require creating without the parent link and updating separately — project conventions take precedence over this generic fallback.
+If creation fails with a parent-related error, create without the parent and link via `editJiraIssue` with `{"parent": {"key": "PARENT-KEY"}}`.
 
-If creation fails with a 4xx error referencing `customfield_10014` or `customfield_10018`:
+### Changing Issue Type Across Hierarchy Levels
 
-1. **Duplicate guard:** Search for an issue with the same summary in the target project — the original call may have partially succeeded
-2. **Retry** WITHOUT the parent/epic link field
-3. **Link via update:** Call `editJiraIssue` (with `contentFormat: "markdown"`) to set the link field
-4. **Report outcome:** If the update also fails, inform the user and suggest manual linking
-5. **Last stand fallback:** If all strategies fail, retry with absolute minimal fields (project, summary, type, description only). Inform user which fields need manual configuration.
+When changing an existing issue's type to a different hierarchy level, the current parent may become invalid. Jira validates the one-level-higher constraint on every edit, so you must change the parent and type in separate steps:
 
-### Common Parent Linking Errors
-
-| Error Message | Cause | Solution |
-|---|---|---|
-| `Field 'parent' does not exist` | Using standard `parent` field | Use `customfield_10018` or `customfield_10014` |
-| `customfield_10014 is not valid` | Epic Link field issue | Use fallback: create then update |
-| `customfield_10018 is not valid` | Parent Link field issue | Use fallback: create then update |
-| `Parent issue not found` | Invalid parent key | Verify parent exists first |
-| `Cannot link to issue of type X` | Wrong parent type | Verify hierarchy |
+1. Unset the parent: `editJiraIssue` with `{"parent": null}`
+2. Change the issue type: `editJiraIssue` with `{"issuetype": {"name": "NewType"}}`
+3. Set the new parent if needed: `editJiraIssue` with `{"parent": {"key": "NEW-PARENT"}}`
 
 ## Error Handling
 
@@ -189,8 +177,7 @@ Usage: /jira:create story PROJECT-KEY "summary"
 | Field | Wrong | Correct |
 |---|---|---|
 | Target Version | `"customfield_10855": "openshift-4.21"` | `"customfield_10855": [{"id": "12448830"}]` |
-| Epic Link | `"parent": {"key": "EPIC-123"}` | `"customfield_10014": "EPIC-123"` (string) |
-| Component | `"components": "Name"` | `"components": ["Name"]` (array) |
+| Component | `"components": "Name"` | `"components": [{"name": "Name"}]` |
 
 ### MCP Tool Errors
 


### PR DESCRIPTION
## Summary

- Replace `customfield_10014` (Epic Link) and `customfield_10018` (Parent Link) with the standard Jira `parent` field for all parent-child relationships (Story→Epic, Task→Epic, Bug→Epic, Epic→Feature, Feature→Outcome)
- Remove the elaborate 5-step fallback, error tables, and format guidance that existed only because of custom field fragility
- Document the Jira `hierarchyLevel` system (Outcome=3, Feature=2, Epic=1, Story/Task/Bug=0, Sub-task=-1) and the constraint that parents must be exactly one level higher
- Fix pre-validation table: Task's parent is Epic only (not Story, which is the same hierarchy level), add missing rows for Bug and Feature
- Add guidance for changing issue types across hierarchy levels — parent must be unset before changing type, then re-set afterward

**Why:** Empirical testing on redhat.atlassian.net confirmed that `{"parent": {"key": "PARENT-KEY"}}` works for all hierarchy levels. The `parent` field is simpler, more portable, and eliminates the need to know instance-specific custom field IDs. The hierarchy level documentation prevents silent failures when setting invalid parent-child relationships.

## Test plan

- [ ] Run `/jira:create story GCP "Test parent linking" --parent GCP-248` and verify the Story is linked to the Epic
- [ ] Run `/jira:create epic GCP "Test epic parent" --parent GCP-100` and verify the Epic is linked to the Feature
- [ ] Verify `make lint` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined Jira issue-creation guidance for setting parent-child relationships using `additional_fields` and clarified hierarchy-level constraints.
  * Updated fallback flow to create first when parent-related errors occur, then link via an edit step; clarified how changing issue type across hierarchy levels must be handled.
  * Refreshed Epic/Feature linking and custom field/format examples across Jira reference docs, including CNTRLPLANE and GCP HCP conventions.
* **Chores**
  * Bumped Jira plugin version to **0.8.3** in marketplace and embedded site documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->