### PR TITLE
feat(address-review-pr): add --ci flag for non-interactive CI mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2467,7 +2467,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/skills/address-review-pr/SKILL.md
+++ b/plugins/openshift-developer/skills/address-review-pr/SKILL.md
@@ -8,11 +8,13 @@ openshift-developer:address-review-pr
 
 ## Synopsis
 ```
-/openshift-developer:address-review-pr [PR number] [--preview]
+/openshift-developer:address-review-pr [PR number] [--preview] [--ci]
 ```
 
 ## Description
 Automates addressing PR review comments by fetching all comments from a pull request, categorizing them by priority (blocking, change requests, questions, suggestions), and systematically addressing each one. Intelligently filters out outdated comments, bot-generated content, and oversized responses to optimize context usage. Handles code changes, posts replies to reviewers, and maintains a clean git history by amending relevant commits rather than creating unnecessary new ones.
+
+When `--ci` is passed: NEVER ask interactive questions or wait for user input. Make autonomous decisions. When in doubt, proceed with the safest action.
 
 ## Implementation
 
@@ -238,6 +240,7 @@ Show: total comments found, filtered out, addressed with code changes, replied t
 ## Arguments
 - `$1`: PR number (optional — uses current branch if omitted)
 - `--preview`: Preview each comment's proposed action and reply before proceeding
+- `--ci`: Non-interactive CI automation mode
 
 ## Duplicate Prevention
 


### PR DESCRIPTION
## Summary

Add `--ci` flag to the `address-review-pr` skill that makes it fully non-interactive.

When `--ci` is passed: NEVER ask interactive questions or wait for user input. Make autonomous decisions. When in doubt, proceed with the safest action.

## Why

The review-agent runs this skill in CI with no human on the other end. When the skill encounters ambiguity or pre-push hook failures, it asks for confirmation and the session ends without completing.

Example: [build 2074442484376670208](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2074442484376670208/artifacts/periodic-review-agent/hypershift-review-agent-report/artifacts/review-agent-report.html) — the agent wrote correct ratcheting tests for PR #8937, committed locally, but asked "Should I push with `--no-verify`?" and the session ended with no push. 64 turns, $3.81 spent, work lost.

Ref: [CNTRLPLANE-3788](https://redhat.atlassian.net/browse/CNTRLPLANE-3788)

## Test plan

- [ ] Run review-agent with `--ci` flag and verify it pushes without asking
- [ ] Verify interactive mode (no `--ci`) still prompts as before

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new `--ci` option to the review-pr workflow docs for non-interactive automation.
  * Clarified that CI mode will not prompt for input and will choose the safest action when unsure.
* **Chores**
  * Bumped the OpenShift Developer plugin version to `1.1.8` in the marketplace and plugin metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->