### PR TITLE
fix(code-review): correct skill lookup paths in pre-commit-review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -397,7 +397,7 @@
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "category": "development",
       "keywords": [
         "code-review",
@@ -484,7 +484,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.7",
+      "version": "1.1.9",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -954,7 +954,7 @@ footer a { color: var(--primary); }
     {
       "name": "code-review",
       "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "has_readme": true,
       "commands": [
         {
@@ -2467,7 +2467,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Automated code quality review with language-aware analysis for pre-commit verification",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/code-review/commands/pre-commit-review.md
+++ b/plugins/code-review/commands/pre-commit-review.md
@@ -38,8 +38,8 @@ The two layers compose: `--language go --profile hypershift` applies both Go idi
   - `.ts`, `.tsx` -> `typescript`
   - `.java` -> `java`
   - If mixed or unrecognized, proceed without a language skill
-- Check for the language skill file at `skills/lang-<lang>/SKILL.md` relative to the plugin root directory. If the skill exists, read it and store its content for use by sub-agents. If it does not exist, inform the user and proceed with a generic review.
-- If `--profile` is specified, check for the profile skill file at `skills/profile-<name>/SKILL.md` relative to the plugin root directory. If the skill exists, read it and store its content for use by sub-agents. If it does not exist, warn the user and proceed without profile-specific checks.
+- Check for the language skill file at `skills/<lang>-code-review/SKILL.md` relative to the plugin root directory. If the skill exists, read it and store its content for use by sub-agents. If it does not exist, inform the user and proceed with a generic review.
+- If `--profile` is specified, check for the profile skill file at `skills/<name>-code-review/SKILL.md` relative to the plugin root directory. If the skill exists, read it and store its content for use by sub-agents. If it does not exist, warn the user and proceed without profile-specific checks.
 
 ### Step 1 — Identify Changed Files
 
@@ -189,6 +189,6 @@ After all sub-agents and build verification complete, aggregate findings into a 
 
 ## Arguments:
 - `--language <lang>`: Language skill to load. Currently shipped: `go`. Planned: `python`, `rust`, `typescript`, `java`. If omitted, auto-detected from changed file extensions.
-- `--profile <name>`: Project profile skill to load. Loads `skills/profile-<name>/SKILL.md` for project-specific conventions. If omitted, no profile-specific checks are applied.
+- `--profile <name>`: Project profile skill to load. Loads `skills/<name>-code-review/SKILL.md` for project-specific conventions. If omitted, no profile-specific checks are applied.
 - `--skip-build`: Skip the build verification step (Step 3). Useful for documentation-only changes or when build infrastructure is not available locally.
 - `--skip-tests`: Skip the unit test coverage review step (Unit Test Coverage sub-agent). Useful when changes do not affect testable code.

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "author": {
     "name": "github.com/openshift-eng"
   },
@@ -11,6 +11,6 @@
     { "name": "golang", "version": "^0.3.0" },
     { "name": "prodsec-skills" },
     { "name": "git", "version": "^0.0.7" },
-    { "name": "code-review", "version": "^0.0.10" }
+    { "name": "code-review", "version": "^0.0.12" }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed skill lookup paths in `pre-commit-review` command that prevented language and profile skills from loading
- The command searched for `skills/lang-<lang>/SKILL.md` and `skills/profile-<name>/SKILL.md`, but the actual directories are `skills/<lang>-code-review/SKILL.md` and `skills/<name>-code-review/SKILL.md`
- This caused the Go idioms and HyperShift conventions skills to silently fail to load during CI jira-agent runs

## Issue
Discovered in [periodic-jira-agent run 2074563553167151104](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-jira-agent/2074563553167151104/) — the Phase 2 pre-commit review searched for `*pre-commit*`, `*lang-*`, and `*profile-*` SKILL.md files but found none, causing the review to run without Go or HyperShift-specific guidance. See the [transcript](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-jira-agent/2074563553167151104/artifacts/periodic-jira-agent/hypershift-jira-agent-process/artifacts/jira-agent-transcript.html).

## Test plan
- [ ] Run `/code-review:pre-commit-review --language go --profile hypershift` and verify both skills load successfully
- [ ] Verify the jira-agent periodic job's Phase 2 (pre-commit review) picks up the Go and HyperShift skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated marketplace and plugin version metadata for the latest releases.
  * Bumped the `code-review` and `openshift-developer` versions, including updating `openshift-developer`’s `code-review` dependency range.

* **Documentation**
  * Updated `code-review:pre-commit-review` command guidance to use the new language and profile skill-file lookup paths.
  * Adjusted the `--profile` argument description to match the updated path format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->