### PR TITLE
feat(ci-extras): add analyze-pr-payload-run skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -119,7 +119,7 @@
       "name": "ci-extras",
       "source": "./plugins/ci-extras",
       "description": "MCP server and extended tooling for OpenShift CI data access",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "category": "ci",
       "keywords": [
         "openshift-ci",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.79",
+      "version": "0.0.80",
       "has_readme": true,
       "commands": [
         {
@@ -609,28 +609,12 @@ footer a { color: var(--primary); }
           "body_html": "\u003cp\u003eDownloads Claude session artifacts from a Prow CI job and allows you to continue one of those sessions locally. This is useful when Claude ran as part of a CI job and you want to pick up where it left off.\u003c/p\u003e\u003cp\u003eThe command accepts:\u003cbr\u003e- \u003cstrong\u003eprowjob-url\u003c/strong\u003e (required): URL to a Prow job run\u003c/p\u003e"
         },
         {
-          "name": "create-symptom",
-          "full_name": "ci:create-symptom",
-          "description": "Interactively create (or update/delete) a Sippy Symptom that auto-labels a known CI failure pattern",
-          "description_html": "Interactively create (or update/delete) a Sippy Symptom that auto-labels a known CI failure pattern",
-          "synopsis": "/ci:create-symptom [description-of-failure]",
-          "body_html": "The \u003ccode\u003eci:create-symptom\u003c/code\u003e command creates a Sippy Symptom — a known-failure signature made of an artifact file pattern and a matcher that, when it matches a CI job run, automatically applies human-readable Labels (like \u003ccode\u003eInfraFailure\u003c/code\u003e) so future failures are recognized without re-debugging. The command walks through an interactive workflow: check for duplicate symptoms, verify (or create) the target labels, confirm the exact payload with the user, then create. It also handles updating or deleting an existing symptom when the user asks."
-        },
-        {
           "name": "detect-permafail",
           "full_name": "ci:detect-permafail",
           "description": "Detect permafail patterns in consecutive job failures",
           "description_html": "Detect permafail patterns in consecutive job failures",
           "synopsis": "/ci:detect-permafail --job-urls=\"[url1,url2,...]\" --job-name=\"job-name\" --pr=\"owner/repo#123\"",
           "body_html": "\u003cp\u003eAnalyzes 2-10 consecutive failures of the same job to determine if they represent a systematic/permanent failure (permafail) versus a flaky failure. This is critical for CI/CD pipeline analysis to distinguish between:\u003c/p\u003e\u003cp\u003e- \u003cstrong\u003ePermafail\u003c/strong\u003e: A systematic failure affecting the same test(s) or infrastructure issue, detected by analyzing comparable runs (same failure type):\u003cbr\u003e  - Separates test failures from infrastructure failures\u003cbr\u003e  - Applies thresholds based on comparable run count (not total URLs)\u003cbr\u003e  - 2-3 comparable runs: All must match (100% required)\u003cbr\u003e  - 4-5 comparable runs: At least 4 must match (80% required)\u003cbr\u003e  - 6-10 comparable runs: At least ceil(count×0.7) must match (70% required)\u003cbr\u003e  - Example: 7 URLs where 5 are test failures and 4 of those 5 have same test → 4/5 = 80% → PERMAFAIL\u003cbr\u003e- \u003cstrong\u003eFlaky\u003c/strong\u003e: Non-deterministic failures with varying root causes, or failures that don&#x27;t meet the permafail thresholds\u003c/p\u003e\u003cp\u003e### How It Works\u003c/p\u003e\u003cp\u003eThe command uses a deterministic Python classifier script for artifact-based failure classification, compares failure signatures across runs, and returns a JSON result with the permafail verdict, confidence score, failure type, and detailed signatures for each run.\u003c/p\u003e"
-        },
-        {
-          "name": "diagnose-job-symptoms",
-          "full_name": "ci:diagnose-job-symptoms",
-          "description": "Explain which Sippy Symptoms and failure Labels apply to a Prow CI job run",
-          "description_html": "Explain which Sippy Symptoms and failure Labels apply to a Prow CI job run",
-          "synopsis": "/ci:diagnose-job-symptoms \u003cprow-job-url\u003e",
-          "body_html": "The \u003ccode\u003eci:diagnose-job-symptoms\u003c/code\u003e command takes a Prow job run URL and explains, in plain language, which Sippy Symptoms — known-failure signatures that match patterns in a run&#x27;s artifact files — applied which Labels (like \u003ccode\u003eInfraFailure\u003c/code\u003e) to that run, including the exact file and line that matched. Use it before debugging a CI failure from scratch to check whether it is already a known failure mode. The default mode needs no authentication."
         },
         {
           "name": "extract-kubeconfig",
@@ -665,28 +649,12 @@ footer a { color: var(--primary); }
           "body_html": "\u003cp\u003eThe ci:list-step command analyzes an OpenShift CI workflow or chain and provides a complete hierarchical breakdown of all the workflow, chain, and ref\u003cbr\u003efiles with their repo paths that make up the workflow or chain.\u003c/p\u003e\u003cp\u003eThe command accepts:\u003cbr\u003e- Workflow/Chain name (required)\u003c/p\u003e\u003cp\u003eIt uses the step-registry-analyzer agent to examine the workflow/chain structure and identify all related components including workflows, chains, refs, and\u003cbr\u003etheir associated command files.\u003c/p\u003e"
         },
         {
-          "name": "list-symptoms",
-          "full_name": "ci:list-symptoms",
-          "description": "List, search, and inspect Sippy Symptoms and Labels (known CI failure signatures)",
-          "description_html": "List, search, and inspect Sippy Symptoms and Labels (known CI failure signatures)",
-          "synopsis": "/ci:list-symptoms [search-text]",
-          "body_html": "The \u003ccode\u003eci:list-symptoms\u003c/code\u003e command lists and searches Sippy Symptoms — known-failure signatures for OpenShift CI that automatically apply human-readable Labels (like \u003ccode\u003eInfraFailure\u003c/code\u003e) to job runs when their artifact files match a pattern. Use it to browse the symptom catalog, check whether a failure pattern already has a symptom before creating one, look up what a label means, or find which symptoms apply a given label. No authentication is required."
-        },
-        {
           "name": "list-unstable-tests",
           "full_name": "ci:list-unstable-tests",
           "description": "List unstable tests with pass rate below 95%",
           "description_html": "List unstable tests with pass rate below 95%",
           "synopsis": "/ci:list-unstable-tests \u003cversion\u003e \u003ckeywords\u003e [sippy-url]",
           "body_html": "\u003cp\u003eThe \u003ccode\u003eci:list-unstable-tests\u003c/code\u003e command queries OpenShift CI test results from Sippy and lists all tests matching the keywords that have a pass rate below 95%. This is useful for quickly identifying unstable tests that need attention.\u003c/p\u003e\u003cp\u003eBy default, it queries the production Sippy instance at \u003ccode\u003esippy.dptools.openshift.org\u003c/code\u003e. You can optionally specify a different Sippy instance URL to query alternative environments (e.g., QE component readiness).\u003c/p\u003e\u003cp\u003eThis command is useful for:\u003cbr\u003e- Identifying unstable tests with inconsistent pass rates\u003cbr\u003e- Finding regression candidates for investigation\u003cbr\u003e- Generating reports of unstable test cases\u003cbr\u003e- Prioritizing test stabilization efforts\u003cbr\u003e- Quality gate checks before releases\u003c/p\u003e"
-        },
-        {
-          "name": "manage-labels",
-          "full_name": "ci:manage-labels",
-          "description": "Create, update, or delete a Sippy Label (the human-readable tags applied by Symptoms)",
-          "description_html": "Create, update, or delete a Sippy Label (the human-readable tags applied by Symptoms)",
-          "synopsis": "/ci:manage-labels [create|update|delete] [label]",
-          "body_html": "The \u003ccode\u003eci:manage-labels\u003c/code\u003e command manages Sippy Labels — the human-readable tags (like \u003ccode\u003eInfraFailure\u003c/code\u003e) that Sippy Symptoms automatically apply to CI job runs when a known failure pattern matches the run&#x27;s artifacts. Use it to create a new label before a symptom references it, fix a label&#x27;s title or explanation, hide a label from certain UI contexts, or remove an obsolete label. Write operations require authentication to the sippy-auth API."
         },
         {
           "name": "payload-experiment",
@@ -719,14 +687,6 @@ footer a { color: var(--primary); }
           "description_html": "Query test results from Sippy by version and test keywords",
           "synopsis": "/ci:query-test-result \u003cversion\u003e \u003ckeywords\u003e [sippy-url]",
           "body_html": "\u003cp\u003eThe \u003ccode\u003eci:query-test-result\u003c/code\u003e command queries OpenShift CI test results from Sippy based on the OpenShift version and test name keywords. It retrieves test statistics including pass rate, number of runs, failures, and links to failed job runs.\u003c/p\u003e\u003cp\u003eBy default, it queries the production Sippy instance at \u003ccode\u003esippy.dptools.openshift.org\u003c/code\u003e. You can optionally specify a different Sippy instance URL to query alternative environments (e.g., QE component readiness).\u003c/p\u003e\u003cp\u003eThis command is useful for:\u003cbr\u003e- Checking the health of specific test cases\u003cbr\u003e- Finding test failure patterns\u003cbr\u003e- Getting links to failed Prow job runs for debugging\u003cbr\u003e- Monitoring test regression trends\u003cbr\u003e- Querying different Sippy instances (production, QE, etc.)\u003c/p\u003e"
-        },
-        {
-          "name": "reevaluate-job-runs",
-          "full_name": "ci:reevaluate-job-runs",
-          "description": "Retroactively re-run Sippy Symptom detection on completed Prow CI job runs",
-          "description_html": "Retroactively re-run Sippy Symptom detection on completed Prow CI job runs",
-          "synopsis": "/ci:reevaluate-job-runs \u003cprow-urls-or-build-ids...\u003e",
-          "body_html": "The \u003ccode\u003eci:reevaluate-job-runs\u003c/code\u003e command asks Sippy to re-scan completed Prow CI job runs against the current set of Symptoms — known-failure signatures that automatically apply human-readable Labels (like \u003ccode\u003eInfraFailure\u003c/code\u003e) when a run&#x27;s artifacts match a pattern. Detection normally runs as artifacts arrive, so reevaluation is for runs that finished \u003cstrong\u003ebefore\u003c/strong\u003e a symptom was created or changed. Reevaluation is idempotent and preserves manually-applied labels."
         },
         {
           "name": "revert-pr",
@@ -814,6 +774,12 @@ footer a { color: var(--primary); }
           "name": "fetch-payloads",
           "description": "Fetch recent release payloads from the OpenShift release controller",
           "description_html": "Fetch recent release payloads from the OpenShift release controller",
+          "meta": ""
+        },
+        {
+          "name": "fetch-prow-job-runs",
+          "description": "List Prow job runs from the Sippy API using its real filter syntax — find run IDs by job name, variant, result, or time window",
+          "description_html": "List Prow job runs from the Sippy API using its real filter syntax — find run IDs by job name, variant, result, or time window",
           "meta": ""
         },
         {
@@ -985,7 +951,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci-extras",
       "description": "MCP server and extended tooling for OpenShift CI data access",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {
@@ -997,7 +963,14 @@ footer a { color: var(--primary); }
           "body_html": "\u003cp\u003eFetches live CI health data for a given OpenShift release and produces a concise summary covering payload acceptance, test regressions, and recent failures.\u003c/p\u003e\u003cp\u003eUseful for a quick read on overall release quality before a payload promotion decision or during a release readiness review.\u003c/p\u003e"
         }
       ],
-      "skills": [],
+      "skills": [
+        {
+          "name": "analyze-pr-payload-run",
+          "description": "Analyze a PR payload validation run by fetching the run page and checking each job's status via prowjob.json from GCS",
+          "description_html": "Analyze a PR payload validation run by fetching the run page and checking each job&#x27;s status via prowjob.json from GCS",
+          "meta": ""
+        }
+      ],
       "agents": [],
       "hooks": [],
       "mcp_servers": [
@@ -1532,7 +1505,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.8.7",
+      "version": "0.9.0",
       "has_readme": true,
       "commands": [
         {
@@ -1662,6 +1635,14 @@ footer a { color: var(--primary); }
           "description_html": "Validate proposed release blockers using Red Hat OpenShift release blocker criteria",
           "synopsis": "```\n/jira:validate-blockers [target-version] [component-filter] [--bug issue-key]\n```\n\n**Note**: `target-version` is required unless `--bug` is provided.",
           "body_html": "\u003cp\u003eThe \u003ccode\u003ejira:validate-blockers\u003c/code\u003e command helps release managers make data-driven decisions on proposed release blockers. It analyzes bugs with &quot;Release Blocker = Proposed&quot; status using Red Hat OpenShift release blocker criteria and provides clear APPROVE/REJECT/DISCUSS recommendations with detailed justification.\u003c/p\u003e\u003cp\u003eThis command is essential for:\u003cbr\u003e- Validating proposed release blockers\u003cbr\u003e- Making blocker approval/rejection decisions\u003cbr\u003e- Understanding why a bug should or shouldn&#x27;t block a release\u003cbr\u003e- Reviewing blocker criteria compliance\u003c/p\u003e"
+        },
+        {
+          "name": "validate-bug",
+          "full_name": "jira:validate-bug",
+          "description": "Diagnose and fix jira/invalid-bug on PRs — runs the same 7 checks as the jira-lifecycle-plugin",
+          "description_html": "Diagnose and fix jira/invalid-bug on PRs — runs the same 7 checks as the jira-lifecycle-plugin",
+          "synopsis": "/jira:validate-bug \u003cPR-URL | PR-number | JIRA-key\u003e [--branch release-4.X|main|master]",
+          "body_html": "\u003cp\u003eThe \u003ccode\u003ejira:validate-bug\u003c/code\u003e command diagnoses why the Prow \u003ccode\u003ejira/invalid-bug\u003c/code\u003e label was applied to a PR. It runs the same 7 validation checks as the \u003ca href=\"https://github.com/openshift-eng/jira-lifecycle-plugin\"\u003ejira-lifecycle-plugin\u003c/a\u003e, reports pass/fail for each check, and offers to fix failing checks via JIRA MCP tools.\u003c/p\u003e\u003cp\u003eThis command is essential for:\u003cbr\u003e- Diagnosing why a PR is stuck with \u003ccode\u003ejira/invalid-bug\u003c/code\u003e\u003cbr\u003e- Understanding which JIRA fields need correction\u003cbr\u003e- Fixing JIRA bugs in-place without manual field hunting\u003cbr\u003e- Batch-diagnosing multiple blocked PRs\u003c/p\u003e"
         }
       ],
       "skills": [
@@ -1735,6 +1716,12 @@ footer a { color: var(--primary); }
           "name": "status-analysis",
           "description": "Shared engine for analyzing Jira issue activity and generating status summaries",
           "description_html": "Shared engine for analyzing Jira issue activity and generating status summaries",
+          "meta": ""
+        },
+        {
+          "name": "validate-bug",
+          "description": "Diagnose and fix jira/invalid-bug on PRs by running the same 7 checks as the jira-lifecycle-plugin",
+          "description_html": "Diagnose and fix jira/invalid-bug on PRs by running the same 7 checks as the jira-lifecycle-plugin",
           "meta": ""
         }
       ],
@@ -2520,7 +2507,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/ci-extras/.claude-plugin/plugin.json
+++ b/plugins/ci-extras/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci-extras",
   "description": "MCP server and extended tooling for OpenShift CI data access",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci-extras/skills/analyze-pr-payload-run/SKILL.md
+++ b/plugins/ci-extras/skills/analyze-pr-payload-run/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: analyze-pr-payload-run
+description: Analyze a PR payload validation run by fetching the run page and checking each job's status via prowjob.json from GCS
+---
+
+# Analyze PR Payload Run
+
+This skill analyzes a PR payload validation run from `pr-payload-tests.ci.openshift.org`, producing a consolidated summary of all jobs with their pass/fail status, test statistics, and failure details.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Check the overall status of a PR payload validation run
+- See which jobs passed and which failed across a payload run
+- Get a quick summary of test failures across all jobs in a run
+- Determine whether all payload jobs have finished
+
+## Prerequisites
+
+1. **Python 3**: Version 3.7 or later
+2. **Network Access**: Must be able to reach `pr-payload-tests.ci.openshift.org`, `gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com`, and optionally `sippy.dptools.openshift.org`
+
+## Implementation
+
+```bash
+script_path="plugins/ci-extras/skills/analyze-pr-payload-run/analyze_pr_payload_run.py"
+
+# Text output (AI-readable)
+python3 "$script_path" <pr-payload-test-url>
+
+# JSON output (structured)
+python3 "$script_path" <pr-payload-test-url> --format json
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `pr_payload_url` | Yes | The full `https://pr-payload-tests.ci.openshift.org/runs/ci/<uuid>` URL |
+| `--format` | No | Output format: `text` (default) or `json` |
+
+## How It Works
+
+1. Fetches the pr-payload-tests HTML page
+2. Extracts all prow job URLs from the page using regex
+3. Extracts PR metadata (repo, PR number) and completion status
+4. Parses each prow URL to extract the job name, run ID, and GCS path
+5. Fetches `prowjob.json` from GCS in parallel for all jobs to get status (success/failure/aborted/pending) and duration
+6. For failed jobs, queries the Sippy API to enrich with test failure details (test counts, failed tests, error patterns) when available
+7. Classifies each job as passed (S), failed (F), aborted (A), error (E), or pending
+
+## Output
+
+### Text Format
+
+Structured markdown output with:
+
+1. **PR Payload Run Summary**: URL, PR reference, completion status
+2. **Job Results Table**: All jobs with result and duration
+3. **Failed Job Details**: For each failed job — reason, duration, top failed tests, error patterns
+4. **Errored Jobs**: Jobs where status could not be fetched (fetch failures)
+5. **Pending Jobs**: Jobs still running
+6. **Next Steps**: Suggested `prow-job-analysis` skill invocation for failed jobs
+
+### JSON Format
+
+```json
+{
+  "url": "https://pr-payload-tests.ci.openshift.org/runs/ci/<uuid>",
+  "uuid": "<uuid>",
+  "pr_metadata": {"repo": "openshift/repo", "pr_number": "1234"},
+  "all_jobs_finished": true,
+  "summary": {"total_jobs": 14, "passed": 12, "failed": 2, "errors": 0, "pending": 0},
+  "jobs": [
+    {
+      "job_name": "periodic-ci-...",
+      "prow_url": "https://prow.ci.openshift.org/...",
+      "run_id": "2071329727112548352",
+      "result": "S",
+      "test_count": 3827,
+      "failure_count": 0,
+      "pass_rate": 100.0
+    }
+  ]
+}
+```
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Invalid URL | Prints error and exits with code 1 |
+| Page unreachable | Prints error and exits with code 1 |
+| No prow jobs found | Prints message and exits with code 1 |
+| GCS prowjob.json unreachable | Job marked as "E" (error) with error detail |
+| Sippy unavailable for a failed job | Job shown as failed without test-level details |
+| AllJobsFinished not on page | Status shown as "Jobs still running" |
+
+## See Also
+
+- Related Skill: `fetch-job-run-summary` — Fetch individual job run summary from Sippy
+- Related Skill: `trigger-payload-job` — Trigger payload jobs and extract the payload test URL
+- Related Skill: `prow-job-analysis` — Comprehensive Prow CI job failure analysis (test, install, disruption, and more)

--- a/plugins/ci-extras/skills/analyze-pr-payload-run/analyze_pr_payload_run.py
+++ b/plugins/ci-extras/skills/analyze-pr-payload-run/analyze_pr_payload_run.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Analyze a PR payload validation run from pr-payload-tests.ci.openshift.org.
+
+Fetches the run page, extracts PR metadata and prow job URLs, then fetches
+each job's prowjob.json from GCS for status. For failed jobs, optionally
+queries the Sippy API for test failure details.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+import urllib.error
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+
+
+GCSWEB_BASE = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com"
+SIPPY_BASE_URL = "https://sippy.dptools.openshift.org/api/job/run/summary"
+
+PROW_URL_PATTERN = re.compile(
+    r"https://prow\.ci\.openshift\.org/view/gs/test-platform-results/logs/[^\"'<>\s\)\]\},;]+(?<![.])"
+)
+PROW_PATH_PATTERN = re.compile(r'/view/gs/(test-platform-results/logs/([^/]+)/([^/?#]+))/?(?:[?#].*)?$')
+PR_URL_PATTERN = re.compile(r'https://github\.com/([^/]+/[^/]+)/pull/(\d+)')
+PAYLOAD_URL_PATTERN = re.compile(
+    r'https://pr-payload-tests\.ci\.openshift\.org/runs/ci/([a-f0-9-]+)', re.IGNORECASE
+)
+
+
+def extract_error_pattern(error_msg):
+    if not error_msg:
+        return "unknown"
+    error_msg = str(error_msg)
+    cleaned = re.sub(
+        r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+        '<uuid>', error_msg,
+    )
+    cleaned = re.sub(
+        r'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[^\s]*',
+        '<timestamp>', cleaned,
+    )
+    first_line = cleaned.split('\n')[0].strip()
+    if len(first_line) > 150:
+        first_line = first_line[:150] + "..."
+    return first_line
+
+
+def fetch_url(url, timeout=30):
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8")
+
+
+def fetch_prowjob_json(gcs_path):
+    url = f"{GCSWEB_BASE}/gcs/{gcs_path}/prowjob.json"
+    try:
+        body = fetch_url(url)
+        result = json.loads(body)
+        if not isinstance(result, dict):
+            return {"error": f"unexpected JSON type: {type(result).__name__}"}
+        return result
+    except urllib.error.HTTPError as e:
+        return {"error": f"HTTP {e.code}: {e.reason}"}
+    except urllib.error.URLError as e:
+        return {"error": f"URL error: {e.reason}"}
+    except Exception as e:
+        return {"error": str(e) or "unknown error"}
+
+
+def fetch_sippy_summary(run_id):
+    url = f"{SIPPY_BASE_URL}?prow_job_run_id={run_id}"
+    req = urllib.request.Request(url)
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            if isinstance(data, dict):
+                return data
+            return None
+    except Exception:
+        return None
+
+
+def parse_page(html):
+    prow_urls = list(dict.fromkeys(PROW_URL_PATTERN.findall(html)))
+
+    seen = set()
+    jobs = []
+    for prow_url in prow_urls:
+        m = PROW_PATH_PATTERN.search(prow_url)
+        if m:
+            key = (m.group(2), m.group(3))
+            if key not in seen:
+                seen.add(key)
+                jobs.append({
+                    "job_name": m.group(2),
+                    "prow_url": prow_url,
+                    "run_id": m.group(3),
+                    "gcs_path": m.group(1),
+                })
+
+    pr_match = PR_URL_PATTERN.search(html)
+    pr_metadata = {}
+    if pr_match:
+        pr_metadata["repo"] = pr_match.group(1)
+        pr_metadata["pr_number"] = pr_match.group(2)
+
+    return {
+        "jobs": jobs,
+        "pr_metadata": pr_metadata,
+        "all_jobs_finished": bool(re.search(r'\bAllJobsFinished\b', html)),
+    }
+
+
+def fetch_job_status(job):
+    prowjob = fetch_prowjob_json(job["gcs_path"])
+    if "error" in prowjob:
+        return {**job, "prowjob": prowjob}
+
+    status = prowjob.get("status") or {}
+    start = status.get("startTime", "")
+    end = status.get("completionTime", "")
+    duration_s = None
+    if start and end:
+        try:
+            t0 = datetime.fromisoformat(start.replace("Z", "+00:00"))
+            t1 = datetime.fromisoformat(end.replace("Z", "+00:00"))
+            duration_s = int((t1 - t0).total_seconds())
+        except Exception:
+            pass
+
+    return {
+        **job,
+        "prowjob": {
+            "state": status.get("state", "unknown"),
+            "description": status.get("description", ""),
+            "start_time": start,
+            "completion_time": end,
+            "duration_seconds": duration_s,
+        },
+    }
+
+
+def fetch_all_statuses(jobs, max_workers=5):
+    results = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_job = {
+            executor.submit(fetch_job_status, job): job
+            for job in jobs
+        }
+        for future in as_completed(future_to_job):
+            try:
+                results.append(future.result())
+            except Exception as e:
+                job = future_to_job[future]
+                results.append({**job, "prowjob": {"error": str(e)}})
+    results.sort(key=lambda x: x["job_name"])
+    return results
+
+
+def enrich_failed_jobs(jobs, max_workers=5):
+    failed = [j for j in jobs if j.get("prowjob", {}).get("state") == "failure"]
+    if not failed:
+        return
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_job = {
+            executor.submit(fetch_sippy_summary, job["run_id"]): job
+            for job in failed
+        }
+        for future in as_completed(future_to_job):
+            job = future_to_job[future]
+            try:
+                sippy = future.result()
+                if sippy:
+                    job["sippy"] = sippy
+            except Exception:
+                pass
+
+
+def analyze_test_failures(test_failures):
+    if not isinstance(test_failures, dict):
+        return {"failed_tests": [], "dominant_error_patterns": [], "total": 0}
+    error_patterns = defaultdict(int)
+    for error_msg in test_failures.values():
+        pattern = extract_error_pattern(error_msg)
+        error_patterns[pattern] += 1
+    threshold = max(1, len(test_failures) * 0.05)
+    dominant = sorted(
+        [(p, c) for p, c in error_patterns.items() if c >= threshold],
+        key=lambda x: -x[1],
+    )
+    return {
+        "failed_tests": sorted(test_failures.keys()),
+        "dominant_error_patterns": dominant,
+        "total": len(test_failures),
+    }
+
+
+def classify_job(job):
+    prowjob = job.get("prowjob", {})
+    if "error" in prowjob:
+        return "E"
+    state = prowjob.get("state", "")
+    if state == "success":
+        return "S"
+    if state == "failure":
+        return "F"
+    if state == "aborted":
+        return "A"
+    return "pending"
+
+
+def format_duration(seconds):
+    if seconds is None or seconds < 0:
+        return "-"
+    if seconds == 0:
+        return "<1s"
+    h = seconds // 3600
+    m = (seconds % 3600) // 60
+    s = seconds % 60
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    return f"{m}m {s}s"
+
+
+def format_text(data):
+    lines = []
+
+    lines.append("## PR Payload Run Summary")
+    lines.append("")
+    lines.append(f"- **URL**: {data['url']}")
+    pr = data.get("pr_metadata", {})
+    if pr.get("repo"):
+        lines.append(f"- **PR**: {pr['repo']}#{pr['pr_number']}")
+    status = "All jobs finished" if data["all_jobs_finished"] else "Jobs still running"
+    lines.append(f"- **Status**: {status}")
+    lines.append("")
+
+    jobs = data["jobs"]
+    passed = sum(1 for j in jobs if j["_result"] == "S")
+    failed = sum(1 for j in jobs if j["_result"] == "F")
+    aborted = sum(1 for j in jobs if j["_result"] == "A")
+    errors = sum(1 for j in jobs if j["_result"] == "E")
+    pending = sum(1 for j in jobs if j["_result"] == "pending")
+
+    parts = [f"{passed} passed", f"{failed} failed"]
+    if aborted:
+        parts.append(f"{aborted} aborted")
+    if errors:
+        parts.append(f"{errors} errors")
+    if pending:
+        parts.append(f"{pending} pending")
+    lines.append(f"## Job Results ({len(jobs)} total: {', '.join(parts)})")
+    lines.append("")
+    lines.append("| Job | Result | Duration |")
+    lines.append("|-----|--------|----------|")
+
+    failed_jobs = []
+    for job in jobs:
+        result = job["_result"]
+        prowjob = job.get("prowjob", {})
+        duration = format_duration(prowjob.get("duration_seconds"))
+        lines.append(f"| {job['job_name']} | {result} | {duration} |")
+        if result == "F":
+            failed_jobs.append(job)
+    lines.append("")
+
+    if failed_jobs:
+        lines.append("## Failed Job Details")
+        lines.append("")
+        for job in failed_jobs:
+            prowjob = job["prowjob"]
+            lines.append(f"### {job['job_name']}")
+            lines.append("")
+
+            desc = prowjob.get("description", "")
+            duration = format_duration(prowjob.get("duration_seconds"))
+
+            lines.append(f"- **Description**: {desc}")
+            lines.append(f"- **Duration**: {duration}")
+            lines.append(f"- **Prow URL**: {job['prow_url']}")
+
+            sippy = job.get("sippy", {})
+            test_failures = sippy.get("testFailures", {})
+            if test_failures:
+                test_count = sippy.get("testCount", 0)
+                failure_count = sippy.get("testFailureCount", 0)
+                pass_rate = (
+                    f"{(test_count - failure_count) / test_count * 100:.1f}%"
+                    if test_count > 0 else "N/A"
+                )
+                lines.append(f"- **Tests**: {test_count} total, {failure_count} failures ({pass_rate} pass rate)")
+
+                analysis = analyze_test_failures(test_failures)
+                if analysis["dominant_error_patterns"]:
+                    lines.append("- **Dominant Error Patterns**:")
+                    for pattern, count in analysis["dominant_error_patterns"][:5]:
+                        pct = count / analysis["total"] * 100
+                        lines.append(f"  - {count}/{analysis['total']} ({pct:.0f}%): {pattern}")
+
+                top_n = analysis["failed_tests"][:10]
+                lines.append(f"- **Failed Tests** (showing {len(top_n)}/{analysis['total']}):")
+                for test_name in top_n:
+                    lines.append(f"  - {test_name}")
+            lines.append("")
+
+    error_jobs = [j for j in jobs if j["_result"] == "E"]
+    if error_jobs:
+        lines.append("## Errored Jobs")
+        lines.append("")
+        for job in error_jobs:
+            err = job.get("prowjob", {}).get("error", "")
+            lines.append(f"- {job['job_name']} ({err})")
+            lines.append(f"  {job['prow_url']}")
+        lines.append("")
+
+    pending_jobs = [j for j in jobs if j["_result"] == "pending"]
+    if pending_jobs:
+        lines.append("## Pending Jobs")
+        lines.append("")
+        for job in pending_jobs:
+            lines.append(f"- {job['job_name']}")
+            lines.append(f"  {job['prow_url']}")
+        lines.append("")
+
+    if failed_jobs:
+        lines.append("## Next Steps")
+        lines.append("")
+        lines.append("To analyze specific failures in detail, use the `prow-job-analysis` skill with the prow URL.")
+        lines.append("")
+        lines.append("Failed job URLs:")
+        for job in failed_jobs:
+            lines.append(f"- {job['prow_url']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json(data):
+    jobs = data["jobs"]
+    passed = sum(1 for j in jobs if j["_result"] == "S")
+    failed = sum(1 for j in jobs if j["_result"] == "F")
+    aborted = sum(1 for j in jobs if j["_result"] == "A")
+    errors = sum(1 for j in jobs if j["_result"] == "E")
+    pending = sum(1 for j in jobs if j["_result"] == "pending")
+
+    job_entries = []
+    for job in jobs:
+        result = job["_result"]
+        prowjob = job.get("prowjob", {})
+        entry = {
+            "job_name": job["job_name"],
+            "prow_url": job["prow_url"],
+            "run_id": job["run_id"],
+            "result": result,
+            "state": prowjob.get("state", "unknown"),
+            "description": prowjob.get("description", ""),
+            "duration_seconds": prowjob.get("duration_seconds"),
+        }
+        if prowjob.get("error"):
+            entry["error"] = prowjob["error"]
+
+        sippy = job.get("sippy", {})
+        test_failures = sippy.get("testFailures", {})
+        if test_failures:
+            test_count = sippy.get("testCount", 0)
+            failure_count = sippy.get("testFailureCount", 0)
+            entry["test_count"] = test_count
+            entry["failure_count"] = failure_count
+            entry["pass_rate"] = (
+                round((test_count - failure_count) / test_count * 100, 1)
+                if test_count > 0 else None
+            )
+            analysis = analyze_test_failures(test_failures)
+            entry["failed_tests"] = analysis["failed_tests"]
+            entry["dominant_error_patterns"] = [
+                {"pattern": p, "count": c,
+                 "percentage": round(c / analysis["total"] * 100, 1)}
+                for p, c in analysis["dominant_error_patterns"]
+            ] if analysis["dominant_error_patterns"] else []
+        job_entries.append(entry)
+
+    output = {
+        "url": data["url"],
+        "uuid": data["uuid"],
+        "pr_metadata": data.get("pr_metadata", {}),
+        "all_jobs_finished": data["all_jobs_finished"],
+        "summary": {
+            "total_jobs": len(jobs),
+            "passed": passed,
+            "failed": failed,
+            "aborted": aborted,
+            "errors": errors,
+            "pending": pending,
+        },
+        "jobs": job_entries,
+    }
+    return json.dumps(output, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze a PR payload validation run"
+    )
+    parser.add_argument(
+        "url",
+        help="PR payload test URL (https://pr-payload-tests.ci.openshift.org/runs/ci/<uuid>)",
+    )
+    parser.add_argument(
+        "--format", choices=["text", "json"], default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args()
+
+    m = PAYLOAD_URL_PATTERN.match(args.url)
+    if not m:
+        print("Error: invalid PR payload test URL", file=sys.stderr)
+        print("Expected: https://pr-payload-tests.ci.openshift.org/runs/ci/<uuid>", file=sys.stderr)
+        sys.exit(1)
+    uuid = m.group(1)
+
+    try:
+        html = fetch_url(args.url)
+    except Exception as e:
+        print(f"Error fetching page: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    page_data = parse_page(html)
+
+    if not page_data["jobs"]:
+        print("No prow jobs found on the page. The run may not have been triggered yet.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    job_results = fetch_all_statuses(page_data["jobs"])
+    enrich_failed_jobs(job_results)
+    for job in job_results:
+        job["_result"] = classify_job(job)
+
+    data = {
+        "url": args.url,
+        "uuid": uuid,
+        "pr_metadata": page_data["pr_metadata"],
+        "all_jobs_finished": page_data["all_jobs_finished"],
+        "jobs": job_results,
+    }
+
+    if args.format == "json":
+        print(format_json(data))
+    else:
+        print(format_text(data))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--

** Thanks for your contribution to ai-helpers. In order for your PR to be
automatically tested, you must join the openshift-eng GitHub
organization. You may need to close and reopen your PR after you've
joined to re-trigger organization membership checks.

** Please consider contributing by reviewing others' PR's as well.

See https://redhat-internal.slack.com/archives/C08JL32HNMU/p1761923501606379
for more instructions.

-->

## What this PR does / why we need it:

New command to analyze a payload run triggered from a PR (`/payload` on github)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes N/A

## Special notes for your reviewer:

Probably conflicts/interacts with #604 

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool for analyzing PR payload validation runs, including job statuses, durations, failures, and test error patterns.
  * Added text and JSON output formats with detailed job summaries and aggregated results.
  * Added the `validate-bug` command and skill to the Jira plugin.
  * Added the `fetch-prow-job-runs` skill to the CI plugin.

* **Updates**
  * Refreshed marketplace plugin metadata and version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->