### PR TITLE
ci(dependabot): group skillsaw action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+    groups:
+      skillsaw:
+        patterns:
+          - "stbenjam/skillsaw*"


### PR DESCRIPTION
## Summary

- Groups `stbenjam/skillsaw` and `stbenjam/skillsaw/review` Dependabot updates into a single PR using the `groups` feature.

## Test plan

- [ ] Verify YAML is valid
- [ ] Confirm next Dependabot run produces a single grouped PR for skillsaw updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated update management by grouping related GitHub Actions dependency updates together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->