### PR TITLE
fix node-cve: add cross-team component validation safeguards to triage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -316,7 +316,7 @@
       "name": "node-cve",
       "source": "./plugins/node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1851,7 +1851,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/node-cve/.claude-plugin/plugin.json
+++ b/plugins/node-cve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-cve",
   "description": "CVE triage for OpenShift Node team components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -34,7 +34,7 @@ Triage all open CVEs for Node team components with automated reachability analys
 7. Sends a threaded summary to Slack (with `--notify-slack`)
 
 **Arguments:**
-- `--component <name>`: Filter to a specific component (e.g., "Node / CRI-O")
+- `--component <name>`: Filter to a single specific component (e.g., "Node / CRI-O"). If omitted, ALL Node team components are included — and only Node team components, never all OCPBUGS components.
 - `--notify-jira`: Post analysis results as comments on Jira tracker issues (also enables cross-run caching)
 - `--notify-slack`: Send summary to Slack (API token for threading, or webhook for simple messages)
 - `--days N`: Only include CVEs updated in the last N days (default: all open)
@@ -99,6 +99,15 @@ spec:
                 name: cve-triage-secrets
           restartPolicy: OnFailure
 ```
+
+## Safeguards
+
+Many CVEs (especially Go stdlib or vendored-dependency vulnerabilities) have tracker issues across dozens of OpenShift teams — not just Node. Posting Node-specific reachability analysis to another team's tracker is confusing and erodes trust in the automation. The plugin implements two layers of defense against this:
+
+1. **Component filter at query time (Phase 1):** Every Jira query — whether or not `--component` is passed — is scoped with `component in (...)` to the Node team component list from the [shared components reference](../node-team/skills/node/references/shared/components.md). "No `--component` flag" means "all Node team components," never "no filter."
+2. **Component re-validation at posting time (Phase 3):** Immediately before posting any `--notify-jira` comment, each tracker's component is re-checked against the Node team list, independent of Phase 1's filtering. Trackers that don't match are skipped and recorded in `posting-audit.log` instead of being commented on.
+
+This two-layer design follows an incident (2026-07-15) where a CVE with 200+ multi-team trackers had Node-specific analysis posted to non-Node trackers (HyperShift, Storage, Networking, Installer, etc.) because a downstream step re-searched Jira by CVE ID alone, without a component filter. See [report-findings](skills/report-findings/SKILL.md) for the full validation logic, and never construct a CVE-ID-only Jira search as a shortcut for finding trackers to comment on — always reuse the already-filtered tracker list from Phase 1.
 
 ## Node Team Components
 

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -29,7 +29,7 @@ Designed for both interactive use and headless execution via `claude --print`.
 ### Phase 0: Setup and Argument Parsing
 
 1. **Parse Arguments**
-   - `--component <name>`: Filter to a specific OCPBUGS component (e.g., "Node / CRI-O"). Optional.
+   - `--component <name>`: Filter to a single specific OCPBUGS component (e.g., "Node / CRI-O"). Optional. **If omitted, the command includes ALL Node team components — and only Node team components. It never queries or posts to components outside the Node team.** See the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md) for the canonical list.
    - `--notify-jira`: Post analysis results as comments on Jira tracker issues. Default: off.
    - `--notify-slack`: Send summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (simpler, no threading). Default: off.
    - `--days N`: Only include CVEs created or updated in the last N days. Default: all open.
@@ -55,6 +55,8 @@ Designed for both interactive use and headless execution via `claude --print`.
 - **Input**: Optional `--component` filter, optional `--days` filter
 - **Output**: Deduplicated list of CVEs with metadata
 
+**CRITICAL SAFEGUARD:** The `component in (...)` filter below is mandatory and must never be omitted, regardless of whether `--component` was passed. This is the first of two layers of defense against cross-team contamination — the second is the posting-time re-validation in [report-findings](../skills/report-findings/SKILL.md) Phase 3, Step 2. Both layers exist because a prior incident (2026-07-15) showed that CVE analysis can otherwise be posted to 200+ trackers belonging to other OpenShift teams.
+
 **Steps:**
 
 1. Build the JQL query using the CVE-tracked component list from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md) (the full Jira component list plus Driver Toolkit and Machine Config Operator):
@@ -63,7 +65,7 @@ Designed for both interactive use and headless execution via `claude --print`.
    jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (<components from shared reference>) AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
    ```
 
-   If `--component` is specified, replace the component list with the single component.
+   If `--component` is specified, replace the component list with the single component (still using `component in (...)`, never an unfiltered query).
    If `--days N` is specified, add `AND updated >= -${N}d` to the query.
 
 2. Parse results and extract CVE IDs from summaries (regex: `CVE-[0-9]{4}-[0-9]+`).
@@ -218,7 +220,9 @@ The per-branch results are preserved in the report so reviewers can see which ve
    **Recommended action:** <update dependency / apply patch / monitor / investigate>
    ```
 
-2. **If `--notify-jira`**: For each CVE, post a comment on ALL its tracker issues. Each tracker receives the analysis result specific to its OCP version/branch.
+2. **If `--notify-jira`**: For each CVE, post a comment on ALL its **Node-team-validated** tracker issues. Each tracker receives the analysis result specific to its OCP version/branch.
+
+   **Before posting anything, re-validate every tracker's component against the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard" and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component, and record it in the posting audit log.
 
    Use Atlassian wiki markup (not Markdown), matching the format in [report-findings](../skills/report-findings/SKILL.md) Step 2. The comment includes per-branch results across all analyzed versions so reviewers can see the full picture.
 
@@ -265,13 +269,15 @@ See report-findings skill.)
 Report: .work/node-cve/triage-YYYY-MM-DD/report.md
 ```
 
+If any trackers were skipped during posting because their component was not a Node team component (see [report-findings](../skills/report-findings/SKILL.md) Step 2), print a warning line before the report path, e.g. "⚠️ Skipped N non-Node-component trackers during posting — see posting-audit.log". Omit this line entirely when the skip count is 0.
+
 Omit empty sections (e.g., if there are no Uncertain CVEs, skip that heading). Each section heading must be bold or visually distinct from the CVE entries beneath it. The "Present" section groups both "Present but not exploitable" and "Present but not reachable" analysis results together, since both mean no urgent action is needed. The detailed classification is preserved in the per-CVE report and Jira comments. Only show the "(M unassigned)" count when M > 0.
 
 The headline format depends on whether cached results were used. On first run (all CVEs are new): "Node CVE Triage (N CVEs analyzed)". On subsequent runs with cached results: "Node CVE Triage (N CVEs, M new)" where M is the number of CVEs without a prior `node-cve:triage` Jira comment. If classifications changed since the last run, also show "K updated": "Node CVE Triage (N CVEs, M new, K updated)".
 
 ## Arguments
 
-- `--component <name>`: Filter to a specific OCPBUGS component. Must match a Node team component name exactly (e.g., "Node / CRI-O"). Optional.
+- `--component <name>`: Filter to a single specific OCPBUGS component. Must match a Node team component name exactly (e.g., "Node / CRI-O"). Optional. **If omitted, ALL Node team components are included, and only Node team components — never all OCPBUGS components.**
 - `--notify-jira`: Post analysis as a comment on each Jira tracker issue. Requires `JIRA_API_TOKEN`. Also enables cross-run caching via Jira comments.
 - `--notify-slack`: Send a summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (no threading).
 - `--days N`: Only include CVEs created or updated in the last N days. Default: all open CVEs.
@@ -301,6 +307,7 @@ The headline format depends on whether cached results were used. On first run (a
 ## Notes
 
 - The Jira query uses OCPBUGS component names from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md).
+- **Cross-team safeguard:** The command filters to Node team components at query time (Phase 1) AND re-validates each tracker's component immediately before posting any Jira comment (Phase 3). Never write or run an ad-hoc Jira search scoped only by CVE ID to find trackers to comment on — a CVE can span 200+ trackers across dozens of unrelated OpenShift teams, and a CVE-ID-only search will return all of them. Always reuse the already-filtered `tracker_keys` from Phase 1. Any tracker that fails the component re-validation is skipped and logged in `posting-audit.log`, never posted to.
 - Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and analyzes ALL affected release branches. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another.
 - Analysis targets downstream forks only (e.g., openshift/cri-o). If the downstream fork or branch does not exist, the CVE is classified as Uncertain. Dependency versions and Go toolchain versions differ across releases, so version-specific branches are used.
 - Each version tracker receives the analysis result specific to its release branch. The overall classification for a CVE is the most severe result across all analyzed branches.

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -19,21 +19,27 @@ Use this skill when Phase 1 of the `node-cve:triage` command needs to fetch all 
 
 Read the CVE-tracked component list from the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md). Use the full "Jira Components (OCPBUGS)" list plus the additional CVE triage components (Driver Toolkit, Machine Config Operator).
 
-If `--component` was specified, use only that component instead of the full list.
+**Default behavior (no `--component` flag): include ALL Node team components, and ONLY Node team components.** "No flag" does not mean "no filter" — it means "the full Node component list." Never construct a query that omits the component filter entirely, even when no `--component` value was given.
+
+If `--component` was specified, use only that single component instead of the full list. The value must match an entry in the shared reference exactly; if it does not, print an error listing the valid component names and exit rather than silently falling back to an unfiltered query.
 
 The Jira saved filter "Node Components" (ID 91645) does not include Driver Toolkit and Machine Config Operator, so the explicit list from the shared reference is used for CVE queries to ensure completeness.
 
+**CRITICAL SAFEGUARD:** This component filter is what scopes every downstream step (analysis, reporting, and — critically — Jira comment posting in Phase 3) to Node team trackers only. Many CVEs (especially Go stdlib or vendored-dependency vulnerabilities) have 50-200+ tracker issues across dozens of OpenShift teams. Omitting or bypassing this filter — for example by later re-querying Jira with only a CVE ID and no component constraint — is what caused the 2026-07-15 incident where Node-specific analysis was posted to ~200 non-Node trackers (HyperShift, Storage, Networking, Installer, etc.). See the [report-findings](../report-findings/SKILL.md) "Node Team Component Safeguard" section for the posting-time re-validation this feeds into.
+
 ### Step 2: Query Jira
 
-Build and execute the JQL query:
+Build and execute the JQL query. The `component in (...)` clause is mandatory in every invocation of this query, whether or not `--component` was passed:
 
 ```bash
-jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (<components from shared reference>) AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
+jira issue list -q "project = OCPBUGS AND type = Vulnerability AND component in (<components from shared reference, or the single --component value>) AND status not in (Closed, Done, Verified)" --plain --no-headers --columns KEY,SUMMARY,COMPONENT,STATUS,ASSIGNEE,LABELS
 ```
 
 If `--days N` was specified, add `AND updated >= -${N}d` to the JQL.
 
 Handle pagination: the `jira` CLI returns up to 100 results by default (format: `--paginate <from>:<limit>`). If the result count equals 100, paginate by re-running with `--paginate 100:100`, `--paginate 200:100`, etc. until fewer than 100 results are returned.
+
+**Sanity check:** After fetching results, verify that every returned `COMPONENT` value is actually in the Node team component list (or, when `--component` was given, equals that value). If any row has an unexpected component, this indicates a JQL construction bug — log a warning with the offending tracker key and component, and exclude that row rather than propagating it downstream.
 
 ### Step 3: Parse results
 

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when Phase 3 of the `node-cve:triage` command needs to generate t
 
 **This skill may ONLY post comments to trackers whose component is a Node team component.** Many CVEs (especially Go stdlib and vendored-dependency vulnerabilities) span 50-200+ tracker issues across dozens of OpenShift teams (HyperShift, Storage, Networking, Installer, Monitoring, Cloud providers, etc.). Node-specific reachability analysis is meaningless — and confusing — on another team's tracker.
 
-The canonical Node team component list lives in the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md) ("Jira Components (OCPBUGS)" section, plus Driver Toolkit and Machine Config Operator, plus the `pscomponent:` label mappings). **Do not hardcode or duplicate that list here or anywhere else** — always read it from the shared reference so it stays in sync as Node team components change.
+The canonical Node team component list lives in the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md) ("Jira Components (OCPBUGS)" section, plus Driver Toolkit and Machine Config Operator). **Do not hardcode or duplicate that list here or anywhere else** — always read it from the shared reference so it stays in sync as Node team components change. Note: the shared reference also documents `pscomponent:` label mappings, but those are for Phase 1 CVE discovery and Phase 2 repo mapping only — the posting-time validation in Step 2 below checks the tracker's COMPONENT field exclusively (see Step 2 for why).
 
 **Never do this (this is exactly what caused the 2026-07-15 incident where analysis was posted to ~200 non-Node trackers):**
 - Do NOT run an ad-hoc/one-off Jira search scoped only by CVE ID (e.g. `summary ~ "CVE-XXXX-XXXXX"`) to find trackers to comment on. A CVE ID alone is not enough to scope a search — it will return trackers for every team affected by that CVE.
@@ -92,23 +92,24 @@ List CVEs that are Reachable or Uncertain with unassigned owners. These need imm
 **VALIDATION (MANDATORY, before posting anything):** For each unique CVE, take its `tracker_keys` list from Phase 1 (`query-open-cves`) and re-validate every tracker's component immediately before posting — do not trust cached or upstream filtering alone:
 
 ```bash
-# component_ok() checks a tracker's component/labels against the canonical
-# Node team component list from the shared components reference (link above),
-# NOT a hardcoded list.
+# component_is_node_team() checks the tracker's COMPONENT field against the
+# canonical Node team component list from the shared components reference
+# (link above), NOT a hardcoded list.
 for tracker_key in $TRACKER_KEYS; do
   component=$(jira issue view "$tracker_key" --plain --no-headers --columns COMPONENT | tail -1)
-  labels=$(jira issue view "$tracker_key" --plain --no-headers --columns LABELS | tail -1)
 
-  if ! component_is_node_team "$component" "$labels"; then
+  if ! component_is_node_team "$component"; then
     echo "⚠️  SKIPPING $tracker_key: component '$component' is not a Node team component" | tee -a "$SKIPPED_LOG"
+    sleep 1
     continue
   fi
 
   # Component validated — proceed with posting for $tracker_key
+  sleep 1
 done
 ```
 
-A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) or one of the `pscomponent:` labels in the shared components reference. If a tracker's component cannot be confidently classified as Node team, **skip it and log the reason** — never post "just in case." This check must run even when `--component` was passed, and even if Phase 1 already filtered by component, since this is the last line of defense before an irreversible write to another team's tracker.
+A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) in the shared components reference. **Check the COMPONENT field only — do not treat a `pscomponent:` label as an alternative pass condition.** `pscomponent:` labels are used in Phase 1/Phase 2 for CVE discovery and repo mapping, not for determining tracker ownership; a non-Node tracker (e.g. component "Security") could incidentally carry a `pscomponent:cri-o` label, and accepting that as a pass would silently reintroduce the exact cross-team contamination this safeguard exists to prevent. If a tracker's component cannot be confidently classified as Node team, **skip it and log the reason** — never post "just in case." This check must run even when `--component` was passed, and even if Phase 1 already filtered by component, since this is the last line of defense before an irreversible write to another team's tracker. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
 
 For each unique CVE, post a comment on every **validated** tracker issue. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
 
@@ -354,6 +355,7 @@ Write `cves.json` to `.work/node-cve/triage-YYYY-MM-DD/cves.json` containing the
 Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
 - `report.md` - full report
 - `cves.json` - structured CVE data (for programmatic consumption)
+- `posting-audit.log` - only when `--notify-jira` was used (see Step 2); do not expect this file otherwise
 - `<CVE-ID>-<branch>-analysis.md` - per-CVE per-branch source code analysis (from Phase 2)
 
 ## Return Value
@@ -369,11 +371,12 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
   "slack_notified": true,
   "artifacts": [
     ".work/node-cve/triage-2026-05-20/report.md",
-    ".work/node-cve/triage-2026-05-20/cves.json",
-    ".work/node-cve/triage-2026-05-20/posting-audit.log"
+    ".work/node-cve/triage-2026-05-20/cves.json"
   ]
 }
 ```
+
+`posting-audit.log` is only produced when `--notify-jira` is used (see Step 2). When present, add it to the `artifacts` list; omit it entirely on runs without `--notify-jira` rather than reporting a file that was never written.
 
 ## Error Handling
 

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -14,6 +14,23 @@ Use this skill when Phase 3 of the `node-cve:triage` command needs to generate t
 - Environment variables: `JIRA_API_TOKEN` (for Jira)
 - For Slack: either `SLACK_API_TOKEN` + `SLACK_CHANNEL` (preferred, enables threading) or `SLACK_WEBHOOK` (simpler, no threading)
 
+## Node Team Component Safeguard (CRITICAL)
+
+**This skill may ONLY post comments to trackers whose component is a Node team component.** Many CVEs (especially Go stdlib and vendored-dependency vulnerabilities) span 50-200+ tracker issues across dozens of OpenShift teams (HyperShift, Storage, Networking, Installer, Monitoring, Cloud providers, etc.). Node-specific reachability analysis is meaningless — and confusing — on another team's tracker.
+
+The canonical Node team component list lives in the [node-team shared components reference](../../../node-team/skills/node/references/shared/components.md) ("Jira Components (OCPBUGS)" section, plus Driver Toolkit and Machine Config Operator, plus the `pscomponent:` label mappings). **Do not hardcode or duplicate that list here or anywhere else** — always read it from the shared reference so it stays in sync as Node team components change.
+
+**Never do this (this is exactly what caused the 2026-07-15 incident where analysis was posted to ~200 non-Node trackers):**
+- Do NOT run an ad-hoc/one-off Jira search scoped only by CVE ID (e.g. `summary ~ "CVE-XXXX-XXXXX"`) to find trackers to comment on. A CVE ID alone is not enough to scope a search — it will return trackers for every team affected by that CVE.
+- Do NOT write a separate "batch posting script" that re-queries Jira outside of the `tracker_keys` produced by the `query-open-cves` skill in Phase 1.
+- Do NOT assume that because Phase 1 already filtered by component, it is safe to skip validation here. Always re-validate at posting time (defense in depth) — Phase 1's `tracker_keys` may have been supplemented, cached from a stale run, or copy-pasted into a manual follow-up.
+
+**Only post to tracker keys that are:**
+1. Present in the `tracker_keys` list of the CVE record produced by `query-open-cves` (Phase 1), AND
+2. Re-validated against the Node team component list immediately before posting (see Step 2 below).
+
+If you ever find yourself constructing a new JQL query or Jira search specifically to find trackers to comment on, STOP — that is the anti-pattern that caused this incident. Reuse the already-filtered tracker list from Phase 1 instead.
+
 ## Implementation Steps
 
 ### Step 1: Generate markdown report
@@ -72,7 +89,28 @@ List CVEs that are Reachable or Uncertain with unassigned owners. These need imm
 
 ### Step 2: Post Jira comments (if --notify-jira)
 
-For each unique CVE, post a comment on ALL its tracker issues. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
+**VALIDATION (MANDATORY, before posting anything):** For each unique CVE, take its `tracker_keys` list from Phase 1 (`query-open-cves`) and re-validate every tracker's component immediately before posting — do not trust cached or upstream filtering alone:
+
+```bash
+# component_ok() checks a tracker's component/labels against the canonical
+# Node team component list from the shared components reference (link above),
+# NOT a hardcoded list.
+for tracker_key in $TRACKER_KEYS; do
+  component=$(jira issue view "$tracker_key" --plain --no-headers --columns COMPONENT | tail -1)
+  labels=$(jira issue view "$tracker_key" --plain --no-headers --columns LABELS | tail -1)
+
+  if ! component_is_node_team "$component" "$labels"; then
+    echo "⚠️  SKIPPING $tracker_key: component '$component' is not a Node team component" | tee -a "$SKIPPED_LOG"
+    continue
+  fi
+
+  # Component validated — proceed with posting for $tracker_key
+done
+```
+
+A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) or one of the `pscomponent:` labels in the shared components reference. If a tracker's component cannot be confidently classified as Node team, **skip it and log the reason** — never post "just in case." This check must run even when `--component` was passed, and even if Phase 1 already filtered by component, since this is the last line of defense before an irreversible write to another team's tracker.
+
+For each unique CVE, post a comment on every **validated** tracker issue. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
 
 ```bash
 jira issue comment add OCPBUGS-XXXXX "$(cat <<'COMMENT'
@@ -119,8 +157,24 @@ Search the output for comments containing `[node-cve:triage|`. This pattern anch
 
 **Important:**
 - Rate limit: sleep 1 second between Jira API calls to avoid HTTP 429 throttling
-- Post to ALL tracker issues for a CVE (all version trackers), each with its version-specific result
+- Post to ALL **validated** tracker issues for a CVE (all version trackers), each with its version-specific result
 - If commenting fails on a specific issue (e.g., permissions), log a warning and continue
+
+**POST-POSTING AUDIT (MANDATORY when --notify-jira is used):** Write an audit log to `.work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log` summarizing what was posted and what was skipped, so cross-team contamination is caught immediately instead of discovered days later:
+
+```bash
+{
+  echo "=== Node CVE Triage Posting Audit — $(date +%Y-%m-%d) ==="
+  echo "CVEs processed: $CVE_COUNT"
+  echo "Trackers commented: $POSTED_COUNT"
+  echo "Trackers skipped (non-Node component): $SKIPPED_COUNT"
+  echo ""
+  echo "Skipped trackers (tracker, component, reason):"
+  cat "$SKIPPED_LOG"
+} > ".work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log"
+```
+
+If `$SKIPPED_COUNT` is greater than zero, print a visible warning in the command summary output (Phase 4) so the operator notices immediately, e.g. "⚠️ Skipped N non-Node-component trackers — see posting-audit.log". A non-zero skip count is expected and healthy for multi-team CVEs; it means the safeguard is working. A skip count that is unexpectedly large relative to Phase 1's tracker count may indicate a bug and should be investigated before re-running.
 
 ### Step 3: Send Slack notification (if --notify-slack)
 
@@ -311,16 +365,19 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
   "report_path": ".work/node-cve/triage-2026-05-20/report.md",
   "jira_comments_posted": 45,
   "jira_comments_failed": 0,
+  "jira_trackers_skipped_non_node_component": 0,
   "slack_notified": true,
   "artifacts": [
     ".work/node-cve/triage-2026-05-20/report.md",
-    ".work/node-cve/triage-2026-05-20/cves.json"
+    ".work/node-cve/triage-2026-05-20/cves.json",
+    ".work/node-cve/triage-2026-05-20/posting-audit.log"
   ]
 }
 ```
 
 ## Error Handling
 
+- Non-Node-team component detected on a tracker: skip that tracker and log it in the audit log (see Step 2). Never post to it. Do not fail the entire command — other trackers for the same CVE may still be valid Node team trackers.
 - Jira comment failures: log and continue. Do not fail the entire command because one tracker issue is inaccessible.
 - Slack failure: log warning. Common causes: invalid token/webhook URL, missing channel permissions, network issues, payload too large (Slack limit: 3000 chars per text block).
 - If the Slack payload exceeds the character limit, truncate the CVE list and add "... and N more. See full report."


### PR DESCRIPTION
## What this PR does / why we need it:

Add cross-team component validation safeguards to `node-cve:triage` to prevent Node-specific CVE analysis from being posted to non-Node team Jira trackers.

On 2026-07-15, `/node-cve:triage --notify-jira` posted Node-specific reachability analysis for CVE-2026-27136 to non-Node OCPBUGS trackers (HyperShift, Storage, Networking/PTP, Installer, Monitoring, Cloud providers, Security, Windows Containers, etc.). Root cause: at posting time, trackers were looked up by CVE ID alone, without a component filter, so all of that CVE's  multi-team trackers were treated as a single batch to comment on.

This PR adds two independent layers of defense:

**`query-open-cves` :**
- Makes explicit that omitting `--component` means "all Node team components," never "no filter" — the `component in (...)` clause in the JQL query is now mandatory in every invocation, whether or not `--component` was passed.
- Adds a sanity check after querying: any returned tracker whose component is outside the Node team list is dropped and logged as a warning, to catch JQL construction bugs.

**`report-findings`:**
- Adds a mandatory "Node Team Component Safeguard" validation gate: immediately before posting any comment, each tracker's component is re-checked against the Node team list, independent of whatever Phase 1 already filtered. This is defense-in-depth so a stale cache, manual re-run, or ad-hoc script can't bypass it.
- Explicitly documents the anti-pattern that caused the incident (CVE-ID-only Jira search, ad-hoc "batch posting scripts" that bypass the normal filtered tracker list) so it isn't repeated.
- Adds a posting audit log (`posting-audit.log`) recording every tracker skipped and why, and surfaces a warning in the command summary output when any trackers are skipped.

Both safeguards reference the canonical Node team component list in the `node-team` shared reference (`plugins/node-team/skills/node/references/shared/components.md`) rather than duplicating a hardcoded list, so they can't drift out of sync as Node team components change.

Also bumps `node-cve` to `0.0.6` and syncs marketplace/docs metadata.

## Which issue(s) this PR fixes:

<!-- internal incident, no tracked issue number -->
N/A — prompted by an internal incident (2026-07-15), not a filed issue.

## Special notes for your reviewer:

- An earlier internal fix proposal suggested hardcoding a 3-component allowlist (`Node / CRI-O`, `Node / kubelet`, `Node / cri-tools`). That list is incomplete — the real Node team component list has ~14 Jira components (CPU manager, Memory manager, Topology manager, Device Manager, Kueue, etc.) plus `pscomponent:` label mappings (cadvisor, conmon, conmon-rs, cri-tools). This PR instead points both safeguards at the existing canonical shared reference so the safeguard itself doesn't become a new source of drift.
- These are Claude-instruction skills (Markdown), not executable code, so "validation" is enforced via explicit, repeated instructions plus a posting audit log for visibility — not a unit-testable function. Manual testing is recommended with a known multi-component CVE (e.g. CVE-2026-27136) to confirm only Node trackers receive comments and everything else is logged as skipped.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Strengthened CVE/Jira safeguards to ensure only validated Node team components are queried and notified.
  * Added clearer handling for mismatched trackers, including user-visible warnings and skip behavior.
  * When Jira notifications are enabled, now generates a `posting-audit.log` with posted vs. skipped tracker details.

* **Documentation**
  * Updated `node-cve:triage` and related skills with explicit, non-optional component scoping and re-validation guidance.

* **Chores**
  * Updated the `node-cve` plugin version to `0.0.6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->