### PR TITLE
feat(openshift-developer): Add evals and move solve skill from jira plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -484,7 +484,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2452,7 +2452,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "has_readme": true,
       "commands": [],
       "skills": [
@@ -2478,6 +2478,12 @@ footer a { color: var(--primary); }
           "name": "generate-test-plan",
           "description": "Generate a comprehensive manual testing guide from a Jira issue, GitHub PR URLs, or both. Use when the user wants test steps, a QE test plan, or a testing guide for code changes.",
           "description_html": "Generate a comprehensive manual testing guide from a Jira issue, GitHub PR URLs, or both. Use when the user wants test steps, a QE test plan, or a testing guide for code changes.",
+          "meta": ""
+        },
+        {
+          "name": "jira-solve",
+          "description": "Analyze a JIRA issue and create a pull request to solve it. Use when the user wants to implement a fix or feature described in a Jira issue, push a branch, and open a draft PR.",
+          "description_html": "Analyze a JIRA issue and create a pull request to solve it. Use when the user wants to implement a fix or feature described in a Jira issue, push a branch, and open a draft PR.",
           "meta": ""
         }
       ],

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/evals/cases/solve/case-001/annotations.yaml
+++ b/plugins/openshift-developer/evals/cases/solve/case-001/annotations.yaml
@@ -1,0 +1,12 @@
+expected_files_changed:
+  - control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+  - control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+  - control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_controller.go
+  - control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_controller_test.go
+expected_tests_pass: true
+min_coverage_pct: 40
+difficulty: simple
+category: bug
+notes: >
+  Manage AWS EBS CSI driver metrics certs via CPO, following the
+  Azure CSI pattern. Adds PKI reconcile function and unit test.

--- a/plugins/openshift-developer/evals/cases/solve/case-001/input.yaml
+++ b/plugins/openshift-developer/evals/cases/solve/case-001/input.yaml
@@ -1,0 +1,4 @@
+issue_key: "https://redhat.atlassian.net/browse/OCPBUGS-34662"
+repo_url: "https://github.com/enxebre/hypershift"
+eval_branch: "eval/jira-solve-pipeline/case-003"
+known_good_pr: "https://github.com/openshift/hypershift/pull/7538"

--- a/plugins/openshift-developer/evals/eval-solve.yaml
+++ b/plugins/openshift-developer/evals/eval-solve.yaml
@@ -1,0 +1,344 @@
+name: solve-eval
+description: >
+  End-to-end eval of the solve pipeline (solve -> code-review ->
+  address-review). Runs 3 phases against snapshot branches, judges
+  per-phase quality and final output (make verify, make test, coverage).
+skill: openshift-developer:jira-solve
+
+execution:
+  mode: case
+  arguments: "{issue_key} {repo_url} {eval_branch}"
+  timeout: 3600
+  max_budget_usd: 25.0
+  env:
+    AI_HELPERS_DIR: "$PWD"
+
+runner:
+  type: cli
+  command:
+    - "bash"
+    - "-c"
+    - "exec \"$AI_HELPERS_DIR/plugins/openshift-developer/evals/scripts/run-solve.sh\" \"$@\""
+    - "--"
+    - "{issue_key}"
+    - "{repo_url}"
+    - "{eval_branch}"
+    - "{model}"
+
+models:
+  skill: claude-opus-4-6
+  judge: claude-opus-4-6
+
+mlflow:
+  experiment: solve-eval
+
+dataset:
+  path: cases/solve
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+      - 'issue_key' — Jira issue key (e.g., OCPBUGS-12345)
+      - 'repo_url' — target repo clone URL
+      - 'eval_branch' — snapshot branch (e.g., eval/solve/case-001)
+      - 'issue_description' — full issue text (fallback if Jira unavailable)
+      - 'known_good_pr' — URL of the merged human-reviewed PR (optional)
+    - annotations.yaml: Expected outcomes and metadata:
+      - 'expected_files_changed': list of file paths the fix should touch
+      - 'expected_tests_pass': boolean
+      - 'min_coverage_pct': integer (e.g., 40)
+      - 'difficulty': simple|medium|complex
+      - 'category': bug|feature|refactor
+      - 'notes': context for LLM judges
+
+outputs:
+  - path: "output"
+    schema: |
+      The pipeline script produces these files in the working directory:
+
+      Per-phase:
+        phase1-diff.patch — diff after solve (before review/fix)
+        phase1-diffstat.txt — diffstat after solve
+        phase1-tokens.json — token usage for solve phase
+        review-findings.txt — code review output text
+        phase2-tokens.json — token usage for review phase
+        phase3-tokens.json — token usage for fix phase
+
+      Final state (after all 3 phases):
+        diff.patch — full diff
+        files-changed.txt — list of modified files
+        commit-log.txt — git log of all commits
+        make-test.log — test output
+        make-test-exit — test exit code (0 = pass)
+        make-verify.log — verify output
+        make-verify-exit — verify exit code (0 = pass)
+        coverage.txt — go test -cover output
+        total-cost.json — aggregated token/cost metrics
+
+      Judges should check outputs["files"] and outputs["modified_files"]
+      for files matching these naming patterns.
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  # ── Final-output deterministic judges (hard gates) ──
+
+  - name: has_code_changes
+    description: Verify the pipeline produced code changes (non-empty diff)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      diff_files = {k: v for k, v in all_f.items() if k.endswith("diff.patch") and "phase1" not in k}
+      if not diff_files:
+          return (False, "No diff.patch found")
+      content = list(diff_files.values())[0]
+      if not content or not content.strip():
+          return (False, "diff.patch is empty — no code changes produced")
+      lines = len(content.strip().splitlines())
+      return (True, f"diff.patch has {lines} lines")
+
+  - name: make_verify_passes
+    description: Verify make verify passes (exit code 0)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      exit_files = {k: v for k, v in all_f.items() if k.endswith("make-verify-exit")}
+      if not exit_files:
+          return (False, "No make-verify-exit file found")
+      code = list(exit_files.values())[0].strip()
+      if code == "0":
+          return (True, "make verify passed (exit 0)")
+      log_files = {k: v for k, v in all_f.items() if k.endswith("make-verify.log")}
+      log_tail = ""
+      if log_files:
+          log_tail = list(log_files.values())[0].strip()[-500:]
+      return (False, f"make verify failed (exit {code}). Tail: {log_tail}")
+
+  - name: make_test_passes
+    description: Verify make test passes (exit code 0)
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      exit_files = {k: v for k, v in all_f.items() if k.endswith("make-test-exit")}
+      if not exit_files:
+          return (False, "No make-test-exit file found")
+      code = list(exit_files.values())[0].strip()
+      if code == "0":
+          return (True, "make test passed (exit 0)")
+      log_files = {k: v for k, v in all_f.items() if k.endswith("make-test.log")}
+      log_tail = ""
+      if log_files:
+          log_tail = list(log_files.values())[0].strip()[-500:]
+      return (False, f"make test failed (exit {code}). Tail: {log_tail}")
+
+  - name: commit_message_format
+    description: "Verify commit messages use conventional-commit style (type(scope): or type:)"
+    check: |
+      import re
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      log_files = {k: v for k, v in all_f.items() if k.endswith("commit-log.txt")}
+      if not log_files:
+          return (False, "No commit-log.txt found")
+      content = list(log_files.values())[0].strip()
+      if not content:
+          return (False, "commit-log.txt is empty")
+      lines = content.splitlines()
+      conv_pattern = r'(feat|fix|refactor|chore|test|docs|style|perf|ci|build|revert)(\(.+?\))?:'
+      bad = []
+      for line in lines:
+          parts = line.split(" ", 1)
+          if len(parts) < 2:
+              bad.append(line)
+              continue
+          msg = parts[1]
+          if not re.match(conv_pattern, msg):
+              bad.append(line)
+      if bad:
+          return (False, f"{len(bad)}/{len(lines)} commits lack conventional-commit format: {bad[0][:80]}")
+      return (True, f"All {len(lines)} commits use conventional-commit format")
+
+  - name: coverage_meets_threshold
+    description: Verify diff coverage (changed lines) meets minimum threshold
+    check: |
+      import re
+      ann = outputs.get("annotations", {})
+      min_pct = ann.get("min_coverage_pct", 0)
+      if min_pct == 0:
+          return (True, "No coverage threshold set in annotations")
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      cov_files = {k: v for k, v in all_f.items() if k.endswith("coverage.txt")}
+      if not cov_files:
+          return (False, "No coverage.txt found")
+      content = list(cov_files.values())[0]
+      if "no go" in content.lower():
+          return (True, "No Go source files changed")
+      diff_match = re.search(r'diff-coverage:\s+([\d.]+)%', content)
+      if diff_match:
+          pct = float(diff_match.group(1))
+          if pct < min_pct:
+              return (False, f"Diff coverage {pct}% below threshold {min_pct}%")
+          return (True, f"Diff coverage {pct}% >= {min_pct}%")
+      coverages = re.findall(r'coverage:\s+([\d.]+)%', content)
+      if not coverages:
+          return (False, "Could not parse coverage from output")
+      pcts = [float(c) for c in coverages]
+      avg = sum(pcts) / len(pcts)
+      if avg < min_pct:
+          return (False, f"Avg package coverage {avg:.1f}% below threshold {min_pct}%")
+      return (True, f"Avg package coverage {avg:.1f}% >= {min_pct}%")
+
+  # ── Per-phase LLM judges ──
+
+  - name: solve_quality
+    description: |
+      Assess Phase 1 (solve) — does the initial implementation address the
+      issue with reasonable changes?
+    prompt: |
+      You are evaluating Phase 1 (solve) of a solve pipeline. The agent
+      was given a Jira issue and asked to implement a fix.
+
+      Below are the pipeline outputs. Focus on "phase1-diff.patch" for the
+      Phase 1 diff (before review/fix phases). If "known-good.patch" is present,
+      it contains the human-reviewed reference PR diff — compare the agent's
+      approach against it structurally (same files, same pattern, same fix).
+
+      {{ outputs }}
+
+      Expected outcomes from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: No meaningful changes, or changes completely unrelated to the issue.
+      Score 2: Some relevant changes but major gaps — missing test coverage,
+               incomplete fix, or wrong approach.
+      Score 3: Reasonable first attempt — addresses the core issue, may have
+               minor gaps the review phase should catch.
+      Score 4: Good implementation — correct fix, includes tests, changes are
+               scoped to the issue. Minor style issues acceptable.
+      Score 5: Excellent — correct, complete, well-tested, idiomatic code.
+
+  - name: review_thoroughness
+    description: |
+      Assess Phase 2 (review) — did it catch real issues and provide
+      actionable feedback?
+    prompt: |
+      You are evaluating Phase 2 (code review) of a solve pipeline.
+
+      Below are the pipeline outputs. Focus on "phase1-diff.patch" for the
+      code that was reviewed, and "review-findings.txt" for the review output.
+
+      {{ outputs }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: No findings, or findings are generic/irrelevant to the actual code.
+      Score 2: Superficial — mentions obvious issues but misses important ones.
+      Score 3: Adequate — catches some real issues with specific references.
+      Score 4: Thorough — identifies important issues with file:line references.
+      Score 5: Excellent — catches subtle issues, prioritized findings.
+
+  - name: fix_completeness
+    description: |
+      Assess Phase 3 (address review) — were review findings actually fixed?
+    prompt: |
+      You are evaluating Phase 3 (address review findings) of a solve pipeline.
+
+      Below are the pipeline outputs. Focus on "review-findings.txt" for the
+      Phase 2 findings, and "diff.patch" for the final diff after all 3 phases.
+      Compare the findings against the final diff to assess whether the review
+      issues were addressed.
+
+      {{ outputs }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Review findings completely ignored.
+      Score 2: Some findings addressed but most blocking issues remain.
+      Score 3: Most blocking issues addressed, some suggestions skipped.
+      Score 4: All blocking issues and most suggestions addressed.
+      Score 5: All findings fully addressed with high-quality fixes.
+
+  # ── Final-output LLM judges ──
+
+  - name: solution_correctness
+    description: |
+      Does the final output correctly solve the original Jira issue?
+    prompt: |
+      You are evaluating whether a solve pipeline correctly solved a
+      Jira issue.
+
+      Below are the pipeline outputs. Focus on "diff.patch" for the final diff
+      and "files-changed.txt" for the list of modified files. If
+      "known-good.patch" is present, it contains the human-reviewed reference
+      PR diff — compare the agent's solution against it for correctness,
+      completeness, and approach.
+
+      {{ outputs }}
+
+      Expected outcomes from annotations:
+
+      {{ annotations }}
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: Does not address the issue at all, or introduces new bugs.
+      Score 2: Partially addresses the issue with significant gaps.
+      Score 3: Addresses the core issue correctly with minor gaps.
+      Score 4: Correctly and completely addresses the issue with good tests.
+      Score 5: Excellent — correct, complete, well-tested, matches or exceeds
+               the known-good PR approach.
+
+  - name: code_quality
+    description: |
+      Overall code quality — idiomatic Go, error handling, test quality.
+    prompt: |
+      You are a senior Go engineer reviewing the final output of a
+      solve pipeline.
+
+      Below are the pipeline outputs. Focus on "diff.patch" for the final
+      diff to review.
+
+      {{ outputs }}
+
+      Evaluate code quality on a 1-5 scale:
+
+      Score 1: Broken code or fundamental Go mistakes.
+      Score 2: Works but has significant issues: no error handling, no tests,
+               non-idiomatic patterns.
+      Score 3: Acceptable — compiles, passes tests, room for improvement.
+      Score 4: Good — idiomatic Go, proper error handling, meaningful tests.
+      Score 5: Excellent — clean, idiomatic, well-tested, proper godoc.
+
+thresholds:
+  has_code_changes:
+    min_pass_rate: 1.0
+  make_verify_passes:
+    min_pass_rate: 1.0
+  make_test_passes:
+    min_pass_rate: 1.0
+  commit_message_format:
+    min_pass_rate: 1.0
+  coverage_meets_threshold:
+    min_pass_rate: 0.8
+  solve_quality:
+    min_mean: 3.0
+  review_thoroughness:
+    min_mean: 3.0
+  fix_completeness:
+    min_mean: 3.0
+  solution_correctness:
+    min_mean: 3.5
+  code_quality:
+    min_mean: 3.5

--- a/plugins/openshift-developer/evals/scripts/run-solve.sh
+++ b/plugins/openshift-developer/evals/scripts/run-solve.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+set -euo pipefail
+
+# run-solve.sh — eval runner for the 3-phase solve pipeline
+#
+# Runs: solve → code-review → address-review against a snapshot branch.
+# Each phase invokes the skill directly, matching the CI pipeline in
+# openshift/release jira-agent-process-commands.sh.
+#
+# Produces output files for agent-eval-harness judges to evaluate.
+# Does NOT push or create PRs.
+#
+# Called by the eval harness via runner.type: cli. The harness sets cwd to
+# the case workspace which contains input.yaml and a pre-created output/ dir.
+#
+# Usage:
+#   run-solve.sh <issue_key> <repo_url> <eval_branch> [model]
+#
+# Env vars:
+#   AI_HELPERS_DIR  — path to ai-helpers checkout (default: auto-detect)
+
+ISSUE_KEY=${1:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+REPO_URL=${2:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+EVAL_BRANCH=${3:?"Usage: $0 <issue_key> <repo_url> <eval_branch> [model]"}
+SKILL_MODEL=${4:-claude-opus-4-6}
+AI_HELPERS_DIR=${AI_HELPERS_DIR:-$(cd "$(dirname "$0")/../../../.." && pwd)}
+
+# The harness pre-creates output/ in the workspace (cwd)
+WORKSPACE="$(pwd)"
+OUTPUT_DIR="${WORKSPACE}/output"
+REPO_DIR="${EVAL_REPO_DIR:-$(mktemp -d "${HOME}/.cache/eval-solve.XXXXXX")/repo}"
+
+OPENSHIFT_DEV_PLUGIN="$AI_HELPERS_DIR/plugins/openshift-developer"
+CODE_REVIEW_PLUGIN="$AI_HELPERS_DIR/plugins/code-review"
+
+echo "=== Solve Eval: $ISSUE_KEY ==="
+echo "Repo: $REPO_URL"
+echo "Branch: $EVAL_BRANCH"
+echo "Model: $SKILL_MODEL"
+echo "Workspace: $WORKSPACE"
+echo "ai-helpers: $AI_HELPERS_DIR"
+
+# Validate plugins
+if [ ! -f "$OPENSHIFT_DEV_PLUGIN/skills/jira-solve/SKILL.md" ]; then
+  echo "ERROR: solve SKILL.md not found at $OPENSHIFT_DEV_PLUGIN/skills/jira-solve/SKILL.md" >&2
+  exit 1
+fi
+if [ ! -d "$CODE_REVIEW_PLUGIN/.claude-plugin" ]; then
+  echo "ERROR: code-review plugin not found at $CODE_REVIEW_PLUGIN" >&2
+  exit 1
+fi
+
+# Helper: extract token/cost JSON from stream-json output
+extract_tokens() {
+  local file=$1
+  grep '"type":"result"' "$file" 2>/dev/null \
+    | head -1 \
+    | jq '{
+        total_cost_usd: (.total_cost_usd // 0),
+        duration_ms: (.duration_ms // 0),
+        num_turns: (.num_turns // 0),
+        input_tokens: (.usage.input_tokens // 0),
+        output_tokens: (.usage.output_tokens // 0),
+        cache_read_input_tokens: (.usage.cache_read_input_tokens // 0),
+        cache_creation_input_tokens: (.usage.cache_creation_input_tokens // 0),
+        model: ((.modelUsage // {} | keys | first) // "unknown")
+      }' 2>/dev/null \
+    || echo '{"total_cost_usd":0,"duration_ms":0,"num_turns":0,"input_tokens":0,"output_tokens":0,"model":"unknown"}'
+}
+
+# Helper: extract assistant text from stream-json
+extract_text() {
+  local file=$1
+  jq -j 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$file" 2>/dev/null || true
+}
+
+# ── Verify tool dependencies ──
+export PATH="${GOPATH:-$HOME/go}/bin:$HOME/.local/bin:$PATH"
+for cmd in gopls cov-diff; do
+  command -v "$cmd" >/dev/null 2>&1 || echo "WARNING: $cmd not found — install before running eval"
+done
+
+# ── Setup: clone repo and prepare workspace ──
+echo ""
+echo "--- Setup ---"
+rm -rf "$REPO_DIR"
+git clone "$REPO_URL" "$REPO_DIR"
+cd "$REPO_DIR"
+git checkout "$EVAL_BRANCH"
+BASE_SHA=$(git rev-parse HEAD)
+
+git config user.name "Eval Runner"
+git config user.email "eval@test.local"
+
+NO_PUSH_CONTEXT="IMPORTANT: Do NOT create a Pull Request. Do NOT push to any remote. Just implement the changes, run tests, and commit to the local branch."
+
+# ── Phase 1: Solve ──
+echo ""
+echo "=========================================="
+echo "Phase 1: Solve ($ISSUE_KEY)"
+echo "=========================================="
+
+PHASE1_START=$(date +%s)
+
+set +e
+claude -p "/openshift-developer:jira-solve ${ISSUE_KEY} origin --ci" \
+  --plugin-dir "$OPENSHIFT_DEV_PLUGIN" \
+  --allowedTools "Bash Read Write Edit Grep Glob WebFetch Agent Skill Task" \
+  --max-turns 300 \
+  --effort max \
+  --model "$SKILL_MODEL" \
+  --output-format stream-json \
+  --verbose \
+  --append-system-prompt "$NO_PUSH_CONTEXT" \
+  2>"$OUTPUT_DIR/phase1-stderr.log" \
+  | tee "$OUTPUT_DIR/phase1-output.json"
+PHASE1_EXIT=$?
+set -e
+
+PHASE1_END=$(date +%s)
+echo "Phase 1 duration: $((PHASE1_END - PHASE1_START))s (exit $PHASE1_EXIT)"
+
+{ git diff "$BASE_SHA"..HEAD 2>/dev/null; git diff HEAD 2>/dev/null; } > "$OUTPUT_DIR/phase1-diff.patch" || true
+{ git diff "$BASE_SHA"..HEAD --stat 2>/dev/null; git diff HEAD --stat 2>/dev/null; } > "$OUTPUT_DIR/phase1-diffstat.txt" || true
+extract_tokens "$OUTPUT_DIR/phase1-output.json" > "$OUTPUT_DIR/phase1-tokens.json"
+extract_text "$OUTPUT_DIR/phase1-output.json" > "$OUTPUT_DIR/phase1-text.txt"
+
+CHANGED_FILES=$( { git diff "$BASE_SHA"..HEAD --name-only 2>/dev/null; git diff HEAD --name-only 2>/dev/null; } | sort -u || echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No code changes produced by Phase 1"
+  touch "$OUTPUT_DIR/diff.patch" "$OUTPUT_DIR/files-changed.txt" "$OUTPUT_DIR/commit-log.txt"
+  touch "$OUTPUT_DIR/review-findings.txt" "$OUTPUT_DIR/coverage.txt"
+  echo "1" > "$OUTPUT_DIR/make-test-exit"
+  echo "No code changes — make test not run" > "$OUTPUT_DIR/make-test.log"
+  echo "1" > "$OUTPUT_DIR/make-verify-exit"
+  echo "No code changes — make verify not run" > "$OUTPUT_DIR/make-verify.log"
+  echo '{"total_cost_usd":0}' > "$OUTPUT_DIR/phase2-tokens.json"
+  echo '{"total_cost_usd":0}' > "$OUTPUT_DIR/phase3-tokens.json"
+  jq -s '{total_cost_usd: (map(.total_cost_usd // 0) | add), phases: length}' \
+    "$OUTPUT_DIR"/phase*-tokens.json > "$OUTPUT_DIR/total-cost.json" 2>/dev/null || true
+  echo "=== Pipeline complete (no changes) ==="
+  exit 0
+fi
+
+echo "Changed files:"
+echo "$CHANGED_FILES" | sed 's/^/  /'
+
+# ── Phase 2: Code Review ──
+echo ""
+echo "=========================================="
+echo "Phase 2: Code Review"
+echo "=========================================="
+
+PHASE2_START=$(date +%s)
+
+set +e
+claude -p "/code-review:pre-commit-review --language go --profile hypershift" \
+  --plugin-dir "$CODE_REVIEW_PLUGIN" \
+  --allowedTools "Bash Read Grep Glob Task Agent Skill" \
+  --max-turns 225 \
+  --effort max \
+  --model "$SKILL_MODEL" \
+  --output-format stream-json \
+  --verbose \
+  2>"$OUTPUT_DIR/phase2-stderr.log" \
+  | tee "$OUTPUT_DIR/phase2-output.json"
+PHASE2_EXIT=$?
+set -e
+
+PHASE2_END=$(date +%s)
+echo "Phase 2 duration: $((PHASE2_END - PHASE2_START))s (exit $PHASE2_EXIT)"
+
+extract_text "$OUTPUT_DIR/phase2-output.json" > "$OUTPUT_DIR/review-findings.txt"
+extract_tokens "$OUTPUT_DIR/phase2-output.json" > "$OUTPUT_DIR/phase2-tokens.json"
+
+# ── Phase 3: Address Review Findings ──
+echo ""
+echo "=========================================="
+echo "Phase 3: Address Review Findings"
+echo "=========================================="
+
+REVIEW_FINDINGS=$(cat "$OUTPUT_DIR/review-findings.txt" 2>/dev/null || echo "")
+
+PHASE3_START=$(date +%s)
+
+if [ -n "$REVIEW_FINDINGS" ]; then
+  set +e
+  claude -p "/openshift-developer:address-review-precommit" \
+    --plugin-dir "$OPENSHIFT_DEV_PLUGIN" \
+    --allowedTools "Bash Read Write Edit Grep Glob Agent Skill Task" \
+    --max-turns 225 \
+    --effort max \
+    --model "$SKILL_MODEL" \
+    --output-format stream-json \
+    --verbose \
+    --append-system-prompt "REVIEW FINDINGS:
+${REVIEW_FINDINGS}
+
+${NO_PUSH_CONTEXT}" \
+    2>"$OUTPUT_DIR/phase3-stderr.log" \
+    | tee "$OUTPUT_DIR/phase3-output.json"
+  PHASE3_EXIT=$?
+  set -e
+else
+  echo "No review findings to address, skipping Phase 3"
+  echo '{}' > "$OUTPUT_DIR/phase3-output.json"
+  PHASE3_EXIT=0
+fi
+
+PHASE3_END=$(date +%s)
+echo "Phase 3 duration: $((PHASE3_END - PHASE3_START))s (exit $PHASE3_EXIT)"
+extract_tokens "$OUTPUT_DIR/phase3-output.json" > "$OUTPUT_DIR/phase3-tokens.json"
+
+# ── Capture final outputs ──
+echo ""
+echo "=========================================="
+echo "Final Output Capture"
+echo "=========================================="
+
+{ git diff "$BASE_SHA"..HEAD 2>/dev/null; git diff HEAD 2>/dev/null; } > "$OUTPUT_DIR/diff.patch"
+{ git diff "$BASE_SHA"..HEAD --name-only 2>/dev/null; git diff HEAD --name-only 2>/dev/null; } | sort -u > "$OUTPUT_DIR/files-changed.txt"
+git log --oneline "$BASE_SHA"..HEAD > "$OUTPUT_DIR/commit-log.txt"
+
+echo "Final diff: $(wc -l < "$OUTPUT_DIR/diff.patch") lines"
+echo "Files changed: $(wc -l < "$OUTPUT_DIR/files-changed.txt")"
+echo "Commits: $(wc -l < "$OUTPUT_DIR/commit-log.txt")"
+
+# Clean up skill workspace artifacts
+rm -rf .work/ 2>/dev/null || true
+git checkout -- .work/ 2>/dev/null || true
+git clean -fd .work/ 2>/dev/null || true
+
+# Run make test and make verify independently
+echo ""
+echo "Running make test..."
+set +e
+make test 2>&1 | tee "$OUTPUT_DIR/make-test.log"
+echo $? > "$OUTPUT_DIR/make-test-exit"
+echo "make test exit: $(cat "$OUTPUT_DIR/make-test-exit")"
+
+echo "Running make verify..."
+make verify 2>&1 | tee "$OUTPUT_DIR/make-verify.log"
+echo $? > "$OUTPUT_DIR/make-verify-exit"
+echo "make verify exit: $(cat "$OUTPUT_DIR/make-verify-exit")"
+set -e
+
+# Diff coverage
+CHANGED_PKGS=$( { git diff "$BASE_SHA"..HEAD --name-only -- '*.go' 2>/dev/null; git diff HEAD --name-only -- '*.go' 2>/dev/null; } \
+  | grep -v '_test.go$' \
+  | xargs -I{} dirname {} 2>/dev/null \
+  | sort -u \
+  | sed 's|^|./|' || echo "")
+if [ -n "$CHANGED_PKGS" ]; then
+  echo "Running diff coverage for changed packages..."
+  set +e
+  go test -coverprofile="$OUTPUT_DIR/cover.out" $CHANGED_PKGS 2>&1 | tee "$OUTPUT_DIR/coverage-raw.txt"
+  if command -v cov-diff >/dev/null 2>&1 && [ -f "$OUTPUT_DIR/cover.out" ]; then
+    git diff "$BASE_SHA"..HEAD > "$OUTPUT_DIR/pr.diff"
+    GO_MODULE=$(grep "^module " go.mod | awk '{print $2}')
+    DIFF_COV=$(cov-diff -coverprofile "$OUTPUT_DIR/cover.out" -diff "$OUTPUT_DIR/pr.diff" -path . -module "$GO_MODULE" 2>/dev/null | sed -n 's/.*: \([0-9]*\)%.*/\1/p' || echo "")
+    if [ -n "$DIFF_COV" ]; then
+      echo "diff-coverage: ${DIFF_COV}% of changed lines covered" > "$OUTPUT_DIR/coverage.txt"
+    else
+      echo "diff-coverage: could not compute" > "$OUTPUT_DIR/coverage.txt"
+      cat "$OUTPUT_DIR/coverage-raw.txt" >> "$OUTPUT_DIR/coverage.txt"
+    fi
+  else
+    cp "$OUTPUT_DIR/coverage-raw.txt" "$OUTPUT_DIR/coverage.txt"
+  fi
+  set -e
+else
+  echo "no go source files changed" > "$OUTPUT_DIR/coverage.txt"
+fi
+
+# Aggregate cost across all phases
+jq -s '{
+  total_cost_usd: (map(.total_cost_usd // 0) | add),
+  total_duration_ms: (map(.duration_ms // 0) | add),
+  total_turns: (map(.num_turns // 0) | add),
+  total_input_tokens: (map(.input_tokens // 0) | add),
+  total_output_tokens: (map(.output_tokens // 0) | add),
+  phases: length
+}' "$OUTPUT_DIR"/phase*-tokens.json > "$OUTPUT_DIR/total-cost.json" 2>/dev/null \
+  || echo '{"total_cost_usd":0,"phases":0}' > "$OUTPUT_DIR/total-cost.json"
+
+# Write metrics.json for the eval harness (CLI runner contract)
+jq '{
+  token_usage: {input: .total_input_tokens, output: .total_output_tokens},
+  cost_usd: .total_cost_usd,
+  num_turns: .total_turns,
+  model: "'"$SKILL_MODEL"'"
+}' "$OUTPUT_DIR/total-cost.json" > "$OUTPUT_DIR/metrics.json" 2>/dev/null \
+  || echo '{"cost_usd":0,"num_turns":0}' > "$OUTPUT_DIR/metrics.json"
+
+# Fetch known-good PR diff for judge comparison
+KNOWN_PR=$(grep 'known_good_pr' "${WORKSPACE}/input.yaml" 2>/dev/null | sed 's/.*: *//' | tr -d '"' || echo "")
+if [ -n "$KNOWN_PR" ]; then
+  echo "Fetching known-good PR diff: $KNOWN_PR"
+  PR_NUM=$(echo "$KNOWN_PR" | grep -oE '[0-9]+$')
+  PR_REPO=$(echo "$KNOWN_PR" | sed 's|https://github.com/||;s|/pull/.*||')
+  set +e
+  gh pr diff "$PR_NUM" --repo "$PR_REPO" > "$OUTPUT_DIR/known-good.patch" 2>/dev/null
+  set -e
+  if [ -s "$OUTPUT_DIR/known-good.patch" ]; then
+    echo "Known-good PR diff: $(wc -l < "$OUTPUT_DIR/known-good.patch") lines"
+  else
+    echo "Could not fetch known-good PR diff"
+    rm -f "$OUTPUT_DIR/known-good.patch"
+  fi
+fi
+
+# Remove large stream-json files that would blow up {{ outputs }}
+rm -f "$OUTPUT_DIR"/phase*-output.json "$OUTPUT_DIR"/phase*-stderr.log
+rm -f "$OUTPUT_DIR/cover.out" "$OUTPUT_DIR/pr.diff" "$OUTPUT_DIR/coverage-raw.txt"
+
+echo ""
+echo "=== Pipeline complete ==="
+echo "Cost: $(jq -r '.total_cost_usd' "$OUTPUT_DIR/total-cost.json") USD"

--- a/plugins/openshift-developer/skills/jira-solve/SKILL.md
+++ b/plugins/openshift-developer/skills/jira-solve/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: jira-solve
+description: Analyze a JIRA issue and create a pull request to solve it. Use when the user wants to implement a fix or feature described in a Jira issue, push a branch, and open a draft PR.
+---
+
+## Name
+openshift-developer:jira-solve
+
+## Synopsis
+```text
+/openshift-developer:jira-solve <jira-issue-id> [remote] [--ci]
+```
+
+## Description
+
+Analyzes a JIRA issue, implements a solution in the current repository, and creates a comprehensive pull request with the necessary changes.
+
+Takes a JIRA URL or issue key, fetches the issue description and requirements, analyzes the codebase to understand how to implement the solution, and produces a branch with well-structured commits.
+
+## Implementation
+
+### Step 1: Issue Analysis
+
+Parse the JIRA issue and fetch details:
+
+1. Use curl to fetch JIRA issue data:
+   ```bash
+   curl -s -u "$JIRA_USERNAME:$JIRA_API_TOKEN" "https://redhat.atlassian.net/rest/api/3/issue/{$1}"
+   ```
+2. Parse JSON response to extract:
+   - Issue summary and description
+   - From within the description expect the following sections:
+     - Required: Context, Acceptance criteria
+     - Optional: Steps to reproduce (for bugs), Expected vs actual behavior
+3. If `--ci` flag (`$3`) is NOT set: Ask the user for further issue grooming if the required sections are missing
+4. If `--ci` flag (`$3`) IS set: Proceed with available information, making reasonable assumptions where needed
+
+### Step 2: Codebase Analysis
+
+Search and analyze relevant code:
+
+- Find related files and functions
+- Understand current implementation
+- Identify areas that need changes
+- Use Grep and Glob tools to search for:
+  - Related function names mentioned in JIRA
+  - File patterns related to the component
+  - Similar existing implementations
+  - Test files that need updates
+
+### Step 3: Solution Implementation
+
+1. Think hard and create a detailed, step-by-step plan. Save it to `spec-$1.md` within the `.work/solve/` folder (e.g. `.work/solve/spec-OCPBUGS-12345.md`)
+2. If `--ci` flag (`$3`) is NOT set: Ask the user to review the plan and give them the choice to modify it before starting
+3. If `--ci` flag (`$3`) IS set: Proceed immediately without waiting for approval
+4. Implement the plan:
+   - Make necessary code changes using Edit/MultiEdit tools
+   - Follow existing code patterns and conventions
+   - Add or update tests when code behavior changes or new functions are introduced
+   - Update documentation if needed within the `docs/` folder
+   - If the problem is too complex consider delegating to one of the SME agents
+   - Ensure godoc comments are generated for any newly created public functions
+     - Use your best judgement if godoc comments are needed for private functions
+     - A comment should not be generated for a simple function like `func add(int a, b) int { return a + b }`
+   - Create unit tests for any newly created functions
+
+### Step 4: Commit Creation
+
+1. Create feature branch using the jira-key `$1` as the branch name (e.g. `git checkout -b fix-{jira-key}`)
+2. Break commits into logical components based on the nature of the changes
+3. Each commit must honor https://www.conventionalcommits.org/en/v1.0.0/ and always include a commit message body articulating the "why"
+4. Use your judgment to organize commits in a way that makes them easy to review and understand
+5. Common logical groupings (use as guidance, not rigid rules):
+   - API changes: Changes in `api/` directory (types, CRDs)
+     - Example: `git commit -m"feat(api): Update HostedCluster API for X" -m"Add new fields to support Y functionality"`
+   - Vendor changes: Dependency updates in `vendor/` directory
+     - Example: `git commit -m"chore(vendor): Update dependencies for X" -m"Required to pick up bug fixes in upstream library Y"`
+   - Generated code: Auto-generated clients, informers, listers, and CRDs
+     - Example: `git commit -m"chore(generated): Regenerate clients and CRDs" -m"Regenerate after API changes to ensure client code is in sync"`
+   - CLI changes: User-facing command changes in `cmd/` directory
+     - Example: `git commit -m"feat(cli): Add support for X flag" -m"This allows users to configure Y behavior at cluster creation time"`
+   - Operator changes: Controller logic in `operator/` or `controllers/`
+     - Example: `git commit -m"feat(operator): Implement X controller logic" -m"Without this the controller won't reconcile when Y condition occurs"`
+   - Support/utilities: Shared code in `support/` directory
+     - Example: `git commit -m"refactor(support): Extract common X utility" -m"Consolidate duplicated logic from multiple controllers into shared helper"`
+   - Tests: Test additions or modifications
+     - Example: `git commit -m"test: Add tests for X functionality" -m"Ensure the new behavior is covered by unit tests to prevent regressions"`
+   - Documentation: Changes in `docs/` directory
+     - Example: `git commit -m"docs: Document X feature" -m"Help users understand how to configure and use the new capability"`
+6. Push the branch with all commits against the remote specified in argument `$2`
+
+### Step 5: PR Creation
+
+- If `--ci` flag (`$3`) IS set: Skip PR creation — it will be handled by a subsequent pipeline step (e.g. `/openshift-developer:create-pr`). Output: "Skipping PR creation in CI mode — branch pushed, PR will be created by the pipeline."
+- If `--ci` flag (`$3`) is NOT set:
+  - Create pull request with:
+    - Clear title referencing JIRA issue as a prefix (e.g. `OCPBUGS-12345: ...`)
+    - The PR description should satisfy the template within `.github/PULL_REQUEST_TEMPLATE.md` if the file exists
+    - Always include the following footer:
+      ```text
+      Always review AI generated responses prior to use.
+      Generated with [Claude Code](https://claude.com/claude-code) via openshift-developer plugin
+      ```
+    - Always create as draft PR
+    - Always create the PR against the remote origin
+    - Use gh cli if you need to
+
+### Step 6: PR Description Review
+
+- If `--ci` flag (`$3`) IS set: Skip — no PR was created in CI mode
+- If `--ci` flag (`$3`) is NOT set:
+  - After creating the PR, display the PR URL and description to the user
+  - Ask the user: "Please review the PR description. Would you like me to update it? (yes/no)"
+  - If the user says yes or requests changes:
+    - Ask what changes they'd like to make
+    - Update the PR description using `gh pr edit {PR_NUMBER} --body "{new_description}"`
+    - Repeat this review step until the user is satisfied
+  - If the user says no or is satisfied, acknowledge and provide next steps
+
+## Arguments
+- `$1` — The JIRA issue to solve (required)
+- `$2` — The remote repository to push the branch (required)
+- `$3` — Optional `--ci` flag for non-interactive CI automation mode. When set, skips all user prompts and proceeds automatically.
+
+## Examples
+
+1. **Solve a specific JIRA issue**:
+   ```text
+   /openshift-developer:jira-solve OCPBUGS-12345 origin
+   ```
+
+2. **Solve in CI mode (non-interactive)**:
+   ```text
+   /openshift-developer:jira-solve OCPBUGS-12345 origin --ci
+   ```
+
+## Guidelines
+
+- Authentication uses Basic auth with `JIRA_USERNAME` and `JIRA_API_TOKEN` for Atlassian Cloud
+- The command will provide progress updates and create a comprehensive solution addressing all requirements from the JIRA issue


### PR DESCRIPTION
## Summary

- Adds a `jira-solve` skill to `openshift-developer` (`/openshift-developer:jira-solve`) — same content as the existing `jira:solve` command, converted to SKILL.md format
- The original `/jira:solve` command is kept unchanged for backwards compatibility with the CI pipeline in `openshift/release`
- Adds an integration eval (`eval-solve.yaml`) with a CLI runner that runs the 3-phase pipeline (solve → code-review → address-review) against a HyperShift snapshot branch, with 10 judges (5 deterministic + 5 LLM)

## Why

The solve skill is tightly coupled with `create-pr` and `address-review-precommit` which already live in `openshift-developer`. Adding it there groups the full solve pipeline under one plugin. The original `jira:solve` stays untouched until the CI pipeline is updated.

## Test plan

- [x] `make lint` passes (A+)
- [x] `make update` syncs marketplace and docs
- [x] Eval run passes all 10 judges with 0 regressions
- [x] `/jira:solve` unchanged — backwards compatible
- [ ] Follow-up PR to `openshift/release` to migrate from `/jira:solve` to `/openshift-developer:jira-solve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)