### PR TITLE
payload-analysis: do not recommend revert or force-reject for kube rebase version skew

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -518,7 +518,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -399,7 +399,7 @@ For each revert candidate, record: PR URL, description, component, confidence sc
 The kubelet binary is built **from** the `openshift/kubernetes` source. After a rebase merges, there is an expected lag of hours while the kubelet is rebuilt against the new source and delivered via an updated RHCOS image. During this window the skew is **transient build lag**, not a regression:
 
 - Reverting the rebase would only prevent the kubelet from ever picking up the new version — it does not fix anything.
-- Classify this failure mode as **"transient build lag"** rather than a revert candidate.
+- In the structured output, `failure_type` MUST stay one of the fixed enum values (`install`/`test`/`upgrade`/`infra`) — set it to **`test`**, since kubelet version skew produces real test failures. Do **not** put "transient build lag" in `failure_type`. Record the **"transient build lag"** classification in the free-text `root_cause_summary` (e.g., `"kubelet version skew — transient build lag pending kubelet rebuild"`), and treat it as build lag rather than a revert candidate.
 - In the report, record the failure as pending kubelet rebuild: the kubelet must be rebuilt from the rebased source and delivered via an updated RHCOS image. Recommend **monitoring for the rebuilt kubelet (updated RHCOS) to land** so the skew resolves on its own.
 
 #### 6.3: Check if Revert Candidates Were Already Reverted

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -394,6 +394,14 @@ For each revert candidate, record: PR URL, description, component, confidence sc
 
 **Do NOT propose reverts for**: Infrastructure failures, flaky tests that also fail on accepted payloads, jobs where analysis is inconclusive.
 
+**Special case — Kubernetes rebase version skew.** When the candidate PR is a **Kubernetes rebase** (a PR in the `openshift/kubernetes` repo, typically a rebase/version-bump onto a new upstream Kubernetes release) **AND** the failures show **kubelet version skew** — the kubelet reporting an older Kubernetes version than the kube-apiserver (e.g., kube-apiserver at `1.36.2` while nodes still run kubelet `1.35.3`) — do **NOT** mark the rebase as a revert candidate, even when its rubric score is >= 85.
+
+The kubelet binary is built **from** the `openshift/kubernetes` source. After a rebase merges, there is an expected lag of hours while the kubelet is rebuilt against the new source and delivered via an updated RHCOS image. During this window the skew is **transient build lag**, not a regression:
+
+- Reverting the rebase would only prevent the kubelet from ever picking up the new version — it does not fix anything.
+- Classify this failure mode as **"transient build lag"** rather than a revert candidate.
+- In the report, record the failure as pending kubelet rebuild: the kubelet must be rebuilt from the rebased source and delivered via an updated RHCOS image. Recommend **monitoring for the rebuilt kubelet (updated RHCOS) to land** so the skew resolves on its own.
+
 #### 6.3: Check if Revert Candidates Were Already Reverted
 
 For each revert candidate:
@@ -421,6 +429,13 @@ Otherwise, recommend force-accepting when **all** of the following are true:
 
 - **Yes → temporary (force-accept eligible):** Boskos/lease acquisition failures, cloud quota exhaustion, transient cloud-provider API errors or throttling, a one-off network timeout to a cloud endpoint, a CI control-plane blip. These clear themselves on retry.
 - **No → persistent (NOT force-accept eligible):** stale or expired credentials, a broken or misconfigured CI step/workflow, a bad mirror/registry URL, a persistent misconfiguration, or any product regression. These fail again on the next run until a human intervenes — force-accepting only defers the problem. Do not classify these as a temporary infra pass; a causal CI-config change is scored as a candidate (Steps 3.6 and 6.1) instead.
+
+**Guard — kubelet version skew from a Kubernetes rebase.** When the blocking failures are caused by kubelet version skew following a Kubernetes rebase (the "transient build lag" case in Step 6.2), recommend **neither force-accept nor force-reject**:
+
+- **Force-accepting is NOT appropriate.** Kubelet version skew produces real test failures, not temporary infrastructure flakes, so it does not satisfy the `failure_type: "infra"` criterion above. Set `force_accept_recommended` to `false`.
+- **Force-rejecting is also NOT appropriate.** Rejecting the payload only makes the next payload assemble sooner, which will hit the **same** skew unless the RHCOS carrying the rebuilt kubelet is ready by then — so it accomplishes nothing except churn.
+
+Instead, recommend the correct action: **wait for the RHCOS with the rebuilt kubelet to land** (i.e., for the transient build lag from Step 6.2 to resolve). Once the updated kubelet is delivered, the skew clears and the payload passes on its own.
 
 #### 6.5: Write Payload Results YAML
 


### PR DESCRIPTION
## Summary

When a Kubernetes rebase merges in `openshift/kubernetes`, there is an expected lag of hours while the kubelet is rebuilt against the new source and delivered via an updated RHCOS image. During this window, kubelet version skew (kubelet on an older kube version than kube-apiserver) causes widespread test failures across all platforms.

The payload agent currently treats this like any other PR-caused regression: it scores the rebase PR at high confidence and recommends reverting it. This is incorrect — the kubelet binary is built *from* `openshift/kubernetes`, so the rebase must remain for the kubelet to pick up the new version. Reverting would prevent the kubelet from ever being updated.

## Changes

Two additive sections in `plugins/ci/skills/payload-analysis/SKILL.md`:

**Step 6.2 — Special case: Kubernetes rebase version skew**
- When the candidate PR is a kube rebase AND failures show kubelet version skew, do NOT propose a revert even at score >= 85
- Classify as "transient build lag" and recommend monitoring for the rebuilt kubelet to land via RHCOS

**Step 6.4 — Guard: kubelet version skew from a Kubernetes rebase**
- Force-accepting is inappropriate (real test failures, not infra flakes)
- Force-rejecting is also inappropriate (just accelerates the next payload into the same skew)
- Correct action: wait for the RHCOS with the rebuilt kubelet

## Context

This was identified during analysis of `5.0.0-0.nightly-2026-07-17-034502` where the agent incorrectly recommended reverting `openshift/kubernetes#2653` (Kubernetes 1.36.2 rebase). Feedback from TRT in https://redhat-internal.slack.com/archives/C02K89U2EV8/p1752756363338069.

---
same initial content as https://github.com/openshift-eng/ai-helpers/pull/627 but that one is hung up getting the eval case committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated payload analysis guidance for Kubernetes rebases affected by kubelet version skew.
  * These cases are now classified as test failures with a transient build lag root cause.
  * Added guidance to wait for the updated RHCOS image rather than accept or reject the change immediately.

* **Chores**
  * Updated the CI plugin version to 0.0.70 across marketplace metadata and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->