### PR TITLE
agentic-docs: add generate-docs loop and enrich component-docs with tribal knowledge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -523,7 +523,7 @@
       "name": "agentic-docs",
       "source": "./plugins/agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.2.2"
+      "version": "1.4.0"
     },
     {
       "name": "metrics",

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -16,6 +16,7 @@ rules:
       - "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify.sh '🔔 Claude Code' 'Claude needs your input'"
       - "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify.sh '✅ Claude Code' 'Claude finished your task'"
       - "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-precommit.sh"
+      - "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
       - "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/start-collector.sh"
       - "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop-collector.sh"
   settings-dangerous:

--- a/docs/index.html
+++ b/docs/index.html
@@ -415,9 +415,26 @@ footer a { color: var(--primary); }
     {
       "name": "agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "has_readme": true,
-      "commands": [],
+      "commands": [
+        {
+          "name": "cancel-generate-docs",
+          "full_name": "",
+          "description": "Cancel active generate-docs loop",
+          "description_html": "Cancel active generate-docs loop",
+          "synopsis": "",
+          "body_html": ""
+        },
+        {
+          "name": "generate-docs",
+          "full_name": "",
+          "description": "Generate and iteratively review component docs until all issues are fixed",
+          "description_html": "Generate and iteratively review component docs until all issues are fixed",
+          "synopsis": "",
+          "body_html": ""
+        }
+      ],
       "skills": [
         {
           "name": "component-docs",
@@ -439,7 +456,13 @@ footer a { color: var(--primary); }
         }
       ],
       "agents": [],
-      "hooks": [],
+      "hooks": [
+        {
+          "event_type": "Stop",
+          "matcher": ".*",
+          "hooks_json": "[\n  {\n    \"command\": \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh\",\n    \"type\": \"command\"\n  }\n]"
+        }
+      ],
       "mcp_servers": [],
       "rules": []
     },

--- a/plugins/agentic-docs/.claude-plugin/plugin.json
+++ b/plugins/agentic-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-docs",
   "description": "Create and maintain AI-optimized documentation for OpenShift",
-  "version": "1.2.2",
+  "version": "1.4.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/agentic-docs/commands/cancel-generate-docs.md
+++ b/plugins/agentic-docs/commands/cancel-generate-docs.md
@@ -1,0 +1,20 @@
+---
+description: "Cancel active generate-docs loop"
+allowed-tools:
+  - "Bash(test -f .claude/generate-docs.local.md:*)"
+  - "Bash(rm .claude/generate-docs.local.md)"
+  - "Read(.claude/generate-docs.local.md)"
+---
+
+# Cancel Generate Docs
+
+To cancel the generate-docs loop:
+
+1. Check if `.claude/generate-docs.local.md` exists using Bash: `test -f .claude/generate-docs.local.md && echo "EXISTS" || echo "NOT_FOUND"`
+
+2. **If NOT_FOUND**: Say "No active generate-docs loop found."
+
+3. **If EXISTS**:
+   - Read `.claude/generate-docs.local.md` to get the current iteration number from the `iteration:` field
+   - Remove the file using Bash: `rm .claude/generate-docs.local.md`
+   - Report: "Cancelled generate-docs loop (was at iteration N)" where N is the iteration value

--- a/plugins/agentic-docs/commands/generate-docs.md
+++ b/plugins/agentic-docs/commands/generate-docs.md
@@ -1,0 +1,18 @@
+---
+description: "Generate and iteratively review component docs until all issues are fixed"
+argument-hint: "[PATH] [--max-iterations N] [--review] [--skip-generate]"
+allowed-tools:
+  - "Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-generate-docs.sh:*)"
+---
+
+# Generate Docs Command
+
+Execute the setup script to initialize the docs loop:
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/setup-generate-docs.sh" $ARGUMENTS
+```
+
+Work on the task as described in the prompt output. The docs loop stop hook re-feeds the review prompt on exit, so you iterate on reviews until the documentation is clean.
+
+CRITICAL RULE: Only output `<promise>DOCS VERIFIED</promise>` when `/review-docs` genuinely reports 0 critical issues and 0 warnings. Do not output a false promise to escape the loop.

--- a/plugins/agentic-docs/hooks/hooks.json
+++ b/plugins/agentic-docs/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Agentic generate-docs stop hook for iterative doc review",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/agentic-docs/hooks/stop-hook.sh
+++ b/plugins/agentic-docs/hooks/stop-hook.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Generate Docs Stop Hook
+# Prevents session exit when a generate-docs loop is active
+# Re-feeds the review prompt for iterative doc verification
+
+set -euo pipefail
+
+HOOK_INPUT=$(cat)
+
+STATE_FILE=".claude/generate-docs.local.md"
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  exit 0
+fi
+
+# Parse markdown frontmatter (YAML between ---) and extract values
+FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$STATE_FILE")
+ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
+MAX_ITERATIONS=$(echo "$FRONTMATTER" | grep '^max_iterations:' | sed 's/max_iterations: *//')
+COMPLETION_PROMISE=$(echo "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+
+if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
+  echo "⚠️  Generate-docs: State file corrupted (iteration: '$ITERATION')" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
+  echo "⚠️  Generate-docs: State file corrupted (max_iterations: '$MAX_ITERATIONS')" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
+  echo "🛑 Generate-docs: Max iterations ($MAX_ITERATIONS) reached."
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+# Get transcript path from hook input
+if ! TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path' 2>&1); then
+  echo "⚠️  Generate-docs: Failed to parse transcript_path from hook input" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
+  echo "⚠️  Generate-docs: Transcript file not found ($TRANSCRIPT_PATH)" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
+  echo "⚠️  Generate-docs: No assistant messages in transcript" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+LAST_LINE=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -1)
+if [[ -z "$LAST_LINE" ]]; then
+  echo "⚠️  Generate-docs: Failed to extract last assistant message" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if ! LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
+  .message.content |
+  map(select(.type == "text")) |
+  map(.text) |
+  join("\n")
+' 2>&1); then
+  echo "⚠️  Generate-docs: Failed to parse assistant output" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+if [[ -z "$LAST_OUTPUT" ]]; then
+  echo "⚠️  Generate-docs: Failed to parse assistant output" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+# Check for completion promise
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
+
+  if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
+    echo "✅ Generate-docs: All documentation verified clean after $ITERATION iteration(s)."
+    rm "$STATE_FILE"
+    exit 0
+  fi
+fi
+
+# Not complete — continue loop
+NEXT_ITERATION=$((ITERATION + 1))
+
+PROMPT_TEXT=$(awk '/^---$/ && d<2{d++; next} d>=2' "$STATE_FILE")
+
+if [[ -z "$PROMPT_TEXT" ]]; then
+  echo "⚠️  Generate-docs: No prompt text in state file" >&2
+  rm "$STATE_FILE"
+  exit 0
+fi
+
+TEMP_FILE="${STATE_FILE}.tmp.$$"
+sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$STATE_FILE" > "$TEMP_FILE"
+mv "$TEMP_FILE" "$STATE_FILE"
+
+if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
+  SYSTEM_MSG="🔄 Docs review iteration $NEXT_ITERATION/$MAX_ITERATIONS | Output <promise>$COMPLETION_PROMISE</promise> ONLY when review finds 0 critical issues and 0 warnings"
+else
+  SYSTEM_MSG="🔄 Docs review iteration $NEXT_ITERATION"
+fi
+
+jq -n \
+  --arg prompt "$PROMPT_TEXT" \
+  --arg msg "$SYSTEM_MSG" \
+  '{
+    "decision": "block",
+    "reason": $prompt,
+    "systemMessage": $msg
+  }'
+
+exit 0

--- a/plugins/agentic-docs/scripts/setup-generate-docs.sh
+++ b/plugins/agentic-docs/scripts/setup-generate-docs.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+# Generate Docs Setup Script
+# Creates state file for iterative generate→review doc loop
+
+set -euo pipefail
+
+REPO_PATH=""
+MAX_ITERATIONS=5
+SKIP_GENERATE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      cat << 'HELP_EOF'
+Generate Docs - Iterative documentation generation and review
+
+USAGE:
+  /generate-docs [PATH] [OPTIONS]
+
+ARGUMENTS:
+  PATH              Path to component repository (default: current directory)
+
+OPTIONS:
+  --max-iterations N   Maximum review iterations (default: 5)
+  --review             Review-only mode: skip generation, only run /review-docs loop
+  --skip-generate      Alias for --review
+  -h, --help           Show this help message
+
+DESCRIPTION:
+  Generates component docs with /component-docs, then iteratively reviews
+  with /review-docs --auto-fix until all issues are resolved or max
+  iterations is reached.
+
+  The stop hook prevents exit and re-feeds the review prompt until Claude
+  outputs <promise>DOCS VERIFIED</promise> — which it should only do when
+  /review-docs finds 0 critical issues and 0 warnings.
+
+EXAMPLES:
+  /generate-docs                                    # Current dir, 5 iterations
+  /generate-docs /path/to/repo --max-iterations 3   # Custom path and limit
+  /generate-docs --review                            # Review existing docs only
+  /generate-docs --skip-generate                    # Same as --review
+
+STOPPING:
+  /cancel-generate-docs                         # Cancel the active loop
+HELP_EOF
+      exit 0
+      ;;
+    --max-iterations)
+      if [[ -z "${2:-}" ]] || ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then
+        echo "❌ --max-iterations requires a positive integer (>= 1)" >&2
+        exit 1
+      fi
+      MAX_ITERATIONS="$2"
+      shift 2
+      ;;
+    --review|--skip-generate)
+      SKIP_GENERATE=true
+      shift
+      ;;
+    *)
+      if [[ -z "$REPO_PATH" ]]; then
+        REPO_PATH="$1"
+      else
+        echo "❌ Unexpected argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+REPO_PATH="${REPO_PATH:-$PWD}"
+
+if [[ ! -d "$REPO_PATH" ]]; then
+  echo "❌ Repository path does not exist: $REPO_PATH" >&2
+  exit 1
+fi
+
+mkdir -p .claude
+
+COMPLETION_PROMISE="DOCS VERIFIED"
+
+# Resolve the review-docs skill path so the verification agent can read it directly
+SKILL_PATH="$(cd "$(dirname "$0")/../skills/review-docs" && pwd)"
+
+if [[ "$SKIP_GENERATE" == "true" ]]; then
+  PROMPT_TEXT="Follow these steps IN ORDER. Do not skip any step.
+
+Step 1: Run /review-docs --path \"$REPO_PATH\" --auto-fix to review the documentation.
+
+Step 2: If /review-docs reports ANY critical issues or warnings, fix them:
+  a. For EACH issue, grep the entire doc set for all occurrences of the incorrect claim
+     before making any edit.
+  b. Fix ALL files that contain the incorrect claim in one pass.
+  c. After fixing detailed sections, check whether summaries or diagrams in the SAME file
+     repeat the claim in simplified form. Fix those too.
+  d. After all fixes, do a final grep to confirm no file still contains the old claim.
+  e. Write a brief corrections manifest listing each fix: what was wrong, what it was
+     changed to, and the verification source. Include this manifest in the verification
+     agent's prompt (Step 3).
+
+Step 3 (MANDATORY — independent verification): After fixing issues, you MUST verify
+the fixes using an isolated Agent to prevent confirmation bias. Spawn a fresh
+general-purpose Agent with this prompt:
+
+  \"You are an independent documentation reviewer for $REPO_PATH.
+   Read the review methodology at $SKILL_PATH/SKILL.md, then follow its
+   Phase 1 through Phase 5 workflow to review the agentic documentation.
+   Skip Phase 6 entirely — do NOT fix anything, only report findings.
+   Report: coverage metrics (total claims, verified, failed, skipped),
+   issues by severity (critical/warning/minor), and a clear verdict.
+   If there are 0 critical issues AND 0 warnings, state: VERIFIED CLEAN.
+   Otherwise list every issue with its file, line, and what is wrong.
+
+   CORRECTIONS MANIFEST (from the fixer — verify these were applied consistently):
+   <paste the corrections manifest here>
+
+   For each correction in the manifest:
+   1. Verify the docs now match the stated correction
+   2. Verify the correction is applied consistently across ALL files (grep for the concept)
+   3. Spot-check the cited verification source if accessible
+   Do NOT re-derive the correct value from scratch unless the cited source is
+   unavailable or contradicts itself.\"
+
+CRITICAL: Each verification Agent MUST be a fresh spawn (never resumed) so it
+approaches the docs with zero prior context. This is what prevents the
+confirmation bias that occurs when the same conversation reviews its own fixes.
+
+Step 4: Read the Agent's report.
+  - If the Agent reports VERIFIED CLEAN: output exactly <promise>DOCS VERIFIED</promise>
+  - If the Agent found issues: fix each reported issue, then go back to Step 3
+    (spawn a NEW fresh Agent — never resume the previous one).
+
+RULES:
+- NEVER verify your own fixes by running /review-docs directly — always use a fresh Agent.
+- NEVER output the promise tag without a clean Agent verification report.
+- NEVER resume a previous verification agent — always spawn a new one.
+- If the Agent reports issues you believe are false positives, investigate by reading
+  the source code yourself. If confirmed false positive, you may still output the
+  promise. If confirmed real, fix and re-verify with another Agent."
+else
+  PROMPT_TEXT="Step 1 (first iteration only): If component documentation does not yet exist at $REPO_PATH/ai-docs/, generate it with /component-docs --path \"$REPO_PATH\". If ai-docs/ already exists, skip generation.
+
+IMPORTANT: /component-docs Phase 1 asks the user an SME context question (\"Before I start, is there anything about this repo I should know that isn't obvious from the code?\"). You MUST wait for the user's response before proceeding with codebase exploration and documentation generation. Do NOT start exploring code or writing docs until the user has answered (or explicitly declined). This input shapes what you investigate.
+
+Step 2: Run /review-docs --path \"$REPO_PATH\" --auto-fix to review the documentation.
+
+Step 3: If /review-docs reports ANY critical issues or warnings, fix them:
+  a. For EACH issue, grep the entire doc set for all occurrences of the incorrect claim
+     before making any edit.
+  b. Fix ALL files that contain the incorrect claim in one pass.
+  c. After fixing detailed sections, check whether summaries or diagrams in the SAME file
+     repeat the claim in simplified form. Fix those too.
+  d. After all fixes, do a final grep to confirm no file still contains the old claim.
+  e. Write a brief corrections manifest listing each fix: what was wrong, what it was
+     changed to, and the verification source. Include this manifest in the verification
+     agent's prompt (Step 4).
+
+Step 4 (MANDATORY — independent verification): After fixing issues, you MUST verify
+the fixes using an isolated Agent to prevent confirmation bias. Spawn a fresh
+general-purpose Agent with this prompt:
+
+  \"You are an independent documentation reviewer for $REPO_PATH.
+   Read the review methodology at $SKILL_PATH/SKILL.md, then follow its
+   Phase 1 through Phase 5 workflow to review the agentic documentation.
+   Skip Phase 6 entirely — do NOT fix anything, only report findings.
+   Report: coverage metrics (total claims, verified, failed, skipped),
+   issues by severity (critical/warning/minor), and a clear verdict.
+   If there are 0 critical issues AND 0 warnings, state: VERIFIED CLEAN.
+   Otherwise list every issue with its file, line, and what is wrong.
+
+   CORRECTIONS MANIFEST (from the fixer — verify these were applied consistently):
+   <paste the corrections manifest here>
+
+   For each correction in the manifest:
+   1. Verify the docs now match the stated correction
+   2. Verify the correction is applied consistently across ALL files (grep for the concept)
+   3. Spot-check the cited verification source if accessible
+   Do NOT re-derive the correct value from scratch unless the cited source is
+   unavailable or contradicts itself.\"
+
+CRITICAL: Each verification Agent MUST be a fresh spawn (never resumed) so it
+approaches the docs with zero prior context. This is what prevents the
+confirmation bias that occurs when the same conversation reviews its own fixes.
+
+Step 5: Read the Agent's report.
+  - If the Agent reports VERIFIED CLEAN: output exactly <promise>DOCS VERIFIED</promise>
+  - If the Agent found issues: fix each reported issue, then go back to Step 4
+    (spawn a NEW fresh Agent — never resume the previous one).
+
+RULES:
+- NEVER verify your own fixes by running /review-docs directly — always use a fresh Agent.
+- NEVER output the promise tag without a clean Agent verification report.
+- NEVER resume a previous verification agent — always spawn a new one.
+- If the Agent reports issues you believe are false positives, investigate by reading
+  the source code yourself. If confirmed false positive, you may still output the
+  promise. If confirmed real, fix and re-verify with another Agent."
+fi
+
+cat > .claude/generate-docs.local.md <<EOF
+---
+active: true
+iteration: 1
+max_iterations: $MAX_ITERATIONS
+completion_promise: "$COMPLETION_PROMISE"
+skip_generate: $SKIP_GENERATE
+repo_path: "$REPO_PATH"
+started_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+---
+
+$PROMPT_TEXT
+EOF
+
+cat <<EOF
+
+🔄 Generate-docs loop activated!
+
+Repository:      $REPO_PATH
+Generate docs:   $(if [[ "$SKIP_GENERATE" == "true" ]]; then echo "skipped (--review)"; else echo "yes (/component-docs)"; fi)
+Max iterations:  $MAX_ITERATIONS
+Completion:      When /review-docs finds 0 critical issues and 0 warnings
+
+The stop hook will prevent exit and re-feed the review prompt until docs
+are verified clean. To cancel: /cancel-generate-docs
+
+EOF
+
+echo "$PROMPT_TEXT"

--- a/plugins/agentic-docs/skills/component-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/component-docs/SKILL.md
@@ -56,6 +56,7 @@ component-repo/
 ## Execution Workflow
 
 ### Phase 1: Setup
+- [ ] **SME context**: Ask the user: "Before I start, is there anything about this repo I should know that isn't obvious from the code?" Wait for a response before proceeding. Use their input to guide what you investigate in Phases 5, 6, and 9.
 - [ ] Find skill directory: `SKILL_DIR=$(find ~/.claude/plugins/cache -path "*/component-docs" -type d | head -1)`
 - [ ] Determine repo path: `REPO_PATH="${provided_path:-$PWD}"`
 - [ ] Detect component name from repo (e.g., machine-config-operator → MCO)
@@ -111,9 +112,78 @@ component-repo/
 - [ ] Explain component relationships and data flow
 - [ ] Keep lean but dense (100-200 lines, high information per line)
 
+### Phase 5.5: Tribal Knowledge Enrichment (Optional)
+
+Requires chai-bot MCP server. If unavailable, skip — Phase 5 content stands on its own.
+
+Two prompts, run sequentially via `mcp__chai-bot__ask_persona`. Substitute `{component}` with the repo name.
+
+**Prompt 1 — Operational knowledge** (run immediately after Phase 5):
+
+```
+"I'm generating agentic documentation for {component}
+(github.com/openshift/{component}).
+
+I already have complete architecture, code structure, controller
+design, Makefile targets, and API types from reading the source
+code. DO NOT describe any of these — your answers about repo
+internals will be wrong.
+
+Instead, tell me ONLY things that cannot be learned from the
+source code:
+
+1. OPERATIONAL ISSUES: Production failures, support escalations,
+   upgrade gotchas, or common misconfigurations discussed in
+   Slack or filed in Jira. Include Jira keys if you know them.
+
+2. CROSS-COMPONENT FRICTION: Misunderstood boundaries or
+   surprising interactions between {component} and other
+   OpenShift components (OLM, service-ca, console, CCO,
+   monitoring, etc.).
+
+Format each item as:
+- Title (short)
+- Source (Slack channel, Jira key, or 'team knowledge')
+- Description (2-3 sentences max)
+
+If you don't have tribal knowledge for a category, say so —
+don't fill it with code observations."
+```
+
+**Prompt 2 — Design rationale** (requires Phase 5 findings):
+
+Review Phase 5 results. Identify 3-5 patterns that are surprising, inconsistent, or divergent across components — where the code shows *what* but not *why*. Then:
+
+```
+"I'm documenting design decisions for {component}
+(github.com/openshift/{component}). I already know WHAT the
+code does — I need to know WHY from Slack, Jira, or team
+discussions.
+
+For each question below, only answer if you have actual context
+from Slack threads, Jira issues, PR discussions, or team
+conversations. If you're guessing from code structure, say
+'no tribal knowledge found' — that's more useful than inference.
+
+1. [Specific divergence found in Phase 5]
+2. [Another divergence]
+3. [...]
+
+For each answer, include the source (Slack channel/thread date,
+Jira key, PR number) so I can trace it."
+```
+
+**Filtering**: DISCARD any claims about repo internals (namespaces, file paths, Makefile targets, function names, controller structure) — chai-bot fabricates these. KEEP only Slack/Jira/docs knowledge that cannot be learned from code.
+
+**Placement** (no separate file — findings go where developers already look):
+- Operational issues → `[COMPONENT]_DEVELOPMENT.md` "Known Operational Issues" section (Phase 9)
+- Cross-component friction → `architecture/components.md` under "OpenShift Integrations" (Phase 5)
+- Design rationale → ADR "Context" sections (Phase 6)
+
 ### Phase 6: Component ADRs
 - [ ] Create decisions/adr-template.md (copy from templates)
 - [ ] Create 2-3 component-specific ADRs
+- [ ] **Enrich with Phase 5.5**: If chai-bot provided design rationale, add to the ADR's "Context" section with source (e.g., "Per CM-486 (Jira)..."). If "no tribal knowledge found", note under "SME Review Recommended".
 - [ ] NO cross-repo ADRs (those go in Platform)
 
 ### Phase 7: Exec-Plans
@@ -215,6 +285,8 @@ When the repo is a Kubernetes/OpenShift operator (detected via controller-runtim
 | **Image resolution & OLM bundle** | `grep -r RELATED_IMAGE Makefile bundle/`. Check Makefile for `*_VERSION` vars. Check `bundle/manifests/` for CSV. | Env var naming convention, version variables, how OLM injects images. CSV update checklist (env vars, RBAC, relatedImages). |
 | **Error classification** | Check common/ for error wrapper types (`IrrecoverableError`, `RetryRequiredError`). | Which types exist, effect on requeue behavior. |
 | **Generated code & bindata pipeline** | `find . -name "zz_generated*" -o -name "bindata.go" -o -path "*/clientset/*"`. Check Makefile for generation targets. | Generated files/dirs with "NEVER hand-edit" + make target. For bindata: version var → hack script → output dir → Go loading. |
+| **FIPS compliance** | Check for OpenShift fork references in `go.mod` (`replace` directives), FIPS build tags, or crypto constraints in Dockerfiles. | Whether FIPS is build-time (fork/toolchain) or runtime. Only document if present — not all operators have FIPS requirements. |
+| **OLM lifecycle** | Check `bundle/manifests/` CSV for `spec.replaces`, `skips`, `skipRange`, `installModes`, `spec.relatedImages`, channel annotations. | Which upgrade strategy is used, relatedImages list, install mode constraints. Document if the operator has OLM-specific lifecycle quirks (e.g., cross-namespace cleanup limitations, annotation conflicts on reinstall). |
 | **Status conditions & OpenShift integrations** | Check for library-go `OperatorStatus` vs custom conditions. Grep for proxy, trusted-CA, TLS profile, CCO references. | Which condition system, which integrations exist — only document what's present. |
 
 ### Information Density

--- a/plugins/agentic-docs/skills/review-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/review-docs/SKILL.md
@@ -168,12 +168,15 @@ Batch related claims into grouped queries to reduce round-trips — each call ta
 
 - [ ] Verify ALL cross-repo claims — prioritize high-risk claims first (API fields, feature gate definitions, cross-component behavior)
 - [ ] Parse responses for confirmations, contradictions, or unknowns
-- [ ] For uncertain chai-bot responses, flag as "unverified" rather than confirmed
+- [ ] Classify each chai-bot response by confidence:
+  - **Confirmed** — response cites specific files, structs, or line references that match the claim
+  - **Contradicted** — response cites evidence that conflicts with the claim
+  - **Unverified** — response is hedged ("I think", "probably", "I'm not sure"), lacks source references, or chai-bot was unavailable. These MUST NOT be treated as confirmed
 - [ ] Expect 10-20+ queries for a comprehensive review
 
 **Question construction templates** (substitute `{component}`, `{api-type}`, etc.):
 
-```
+```text
 API fields (batch all fields for one type): "In github.com/openshift/api,
 what fields are defined in the {api-type}Spec struct? Please list field
 names, types, and any documented default values from the actual Go type
@@ -210,19 +213,25 @@ Summarize findings directly to the user with:
 1. **Coverage metrics**: Total claims extracted, total verified, total failed, total skipped — broken down by local vs cross-repo. This gives the user a concrete signal of review thoroughness.
 2. **Verification source breakdown**: Local codebase vs chai-bot vs unverified.
 3. **Issues by severity**: Listed per the severity guide above.
+4. **Issues must include corrections**: Each issue must state what the doc says (incorrect claim with file and line), what the verified-correct value is, and the verification source when available (chai-bot response, local file path + line, or authoritative doc reference). If no citable source exists, state the basis for the correction (e.g., "well-known Kubernetes convention" or "standard Go pattern"). This ensures the fixer applies a single verified-correct value across all files rather than re-deriving the answer and arriving at a different interpretation.
 
 ### Phase 6: Offer Fixes
 
 - [ ] Ask user: "Auto-fix verified issues, or manual review?"
+- [ ] **Investigate full scope before editing**: For each issue, before making any edit:
+  1. Grep the entire doc set for all occurrences of the incorrect claim
+  2. Check whether the same file has summary, diagram, or overview sections that repeat the claim in simplified form
+  3. Collect ALL locations, then fix them all in one pass — never fix a single file and move on
 - [ ] If auto-fix, for each issue:
   - **Local-verified fixes**: use the codebase as source of truth to rewrite incorrect claims
-  - **Chai-bot-verified fixes**: use chai-bot's response as source of truth for factual claims (wrong field names, non-existent enhancements, incorrect terminology)
+  - **Chai-bot-verified fixes** (confirmed responses only): use chai-bot's response as source of truth for factual claims (wrong field names, non-existent enhancements, incorrect terminology). Never auto-fix based on unverified or hedged chai-bot responses — leave those for SME review
   - **Convention mismatches require manual review** — if local code intentionally diverges from platform convention, the docs should describe what the code does, not what convention says. Flag these for the user rather than auto-fixing
   - Update outdated conventions (branch names, versions, commands) to match verified facts
   - Fix broken internal links
   - **Do not** remove content that couldn't be verified — flag as unverified instead
   - **Stick to verified facts** — do not embellish or add interpretation beyond what was confirmed
 - [ ] **Re-verify changed claims**: re-run local checks on modified content; re-query chai-bot on modified cross-repo claims to confirm fixes didn't introduce new errors
+- [ ] **Post-fix consistency grep**: After all fixes, grep for each corrected term across all doc files. Confirm every file that mentions the concept uses the same corrected wording. Fix stragglers before proceeding.
 - [ ] Re-run link validation on modified files
 
 ## Success Criteria


### PR DESCRIPTION
Add iterative generate→review workflow that runs /component-docs then cycles /review-docs with independent Agent verification until all issues are resolved or max iterations is reached. A stop hook prevents session exit and re-feeds the review prompt; a completion promise gate ensures docs are only marked clean after an isolated Agent confirms it.

Component-docs SKILL.md gains:
- Phase 1 SME context question (wait for user input before exploring)
- Phase 5.5 Tribal Knowledge Enrichment via chai-bot (operational issues, cross-component friction, design rationale)
- FIPS compliance and OLM lifecycle operator investigation areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iterative documentation workflow with review, independent verification, and tracked completion.
  * Introduced `generate-docs` and `cancel-generate-docs` commands to start and safely stop in-progress iterations.
  * Added a stop hook that advances iterations or ends the workflow when verification succeeds or limits are reached (including the required “DOCS VERIFIED” condition).
* **Improvements**
  * Updated the `agentic-docs` plugin to version 1.4.0 with expanded command/hook metadata.
  * Enhanced component and operational checklists, plus optional “Tribal Knowledge Enrichment”.
  * Tightened `review-docs` governance by classifying chai-bot responses as Confirmed/Contradicted/Unverified and restricting auto-fixes to confirmed outcomes only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->