### PR TITLE
fix(ci): bash syntax error in setup-prow-job-analysis.sh

### DIFF
--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/evals/scripts/setup-prow-job-analysis.sh
+++ b/plugins/ci/evals/scripts/setup-prow-job-analysis.sh
@@ -55,7 +55,8 @@ log "Prepared working directory: $WORK_DIR"
 
 # The bucket is public; confirm read access without requiring credentials or
 # gcloud. Uses python3 (already verified above) to hit the GCS JSON API.
-if probe_err=$(python3 - <<'PY' 2>&1 >/dev/null); then
+probe_log=$(mktemp)
+python3 - <<'PY' >"$probe_log" 2>&1 && probe_rc=0 || probe_rc=$?
 import sys
 import urllib.request
 
@@ -68,10 +69,13 @@ except Exception as e:
     print(f"GCS probe failed: {e}", file=sys.stderr)
     sys.exit(1)
 PY
+if [[ "$probe_rc" -eq 0 ]]; then
     log "OK: public GCS bucket test-platform-results is reachable"
 else
+    probe_err=$(cat "$probe_log")
     log "WARN: could not reach the public GCS API (network restricted?)${probe_err:+: ${probe_err}}; cases may not fetch artifacts"
 fi
+rm -f "$probe_log"
 
 # Best-effort pre-warm using the bundled search script, which works with or
 # without gcloud. Never fatal.


### PR DESCRIPTION
## Summary

- Fixes bash syntax error (`syntax error near unexpected token '('`) in `setup-prow-job-analysis.sh:62`
- The heredoc inside `$(...)` command substitution caused bash to misparse Python parentheses as shell subshell syntax
- Moves the heredoc out of `$(...)` and captures the exit code separately

Unblocks rehearsal of `eval-prow-job-analysis` in openshift/release#81386.

## Test plan

- [x] `bash -n` passes on the fixed script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when probing access to the public test-results storage.
  * Clearly reports whether the storage is reachable, including the captured error output when it is not.
  * Continues CI setup with the existing best-effort pre-warming behavior even if the storage check fails.
* **Chores**
  * Updated CI plugin version metadata to the latest patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->