### PR TITLE
Document OKD stream type mapping in autodl JSON schema

### DIFF
--- a/plugins/ci/skills/payload-autodl-json/SKILL.md
+++ b/plugins/ci/skills/payload-autodl-json/SKILL.md
@@ -150,7 +150,7 @@ The filename **must** end with `-autodl.json`. Sanitize the tag for filename saf
 |-------|------|-------------|
 | `payload_tag` | string | Full payload tag |
 | `version` | string | OCP version (e.g., `"4.22"`) |
-| `stream` | string | `"nightly"` or `"ci"` |
+| `stream` | string | Canonical stream type: `"nightly"` or `"ci"`. For OKD payloads (e.g. `okd-scos-nightly`, `okd-scos`), map to the base type: `okd-scos-nightly` → `"nightly"`, `okd-scos` → `"ci"`. |
 | `architecture` | string | `"amd64"`, `"arm64"`, `"multi"`, etc. |
 | `phase` | string | Payload phase: `"Rejected"`, `"Accepted"`, `"Ready"` |
 | `release_controller_url` | string | URL to the payload on the release controller |


### PR DESCRIPTION
## Summary

- Updates the `stream` field documentation in the payload-autodl-json SKILL.md to include OKD stream mapping rules
- Tells Claude to map OKD stream names (`okd-scos-nightly`, `okd-scos`) to canonical types (`nightly`, `ci`) when generating autodl JSON

## Why this is needed

The payload agent now runs on OKD SCOS releases (openshift/release#80392, openshift/release#81940). When analyzing rejected OKD payloads, Claude generates the autodl JSON independently and sets the `stream` field to the literal stream name (e.g. `okd-scos-nightly`). The validator rejects this because the BigQuery schema only accepts `nightly` or `ci`.

See the failed run: [Prow logs](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-claude-payload-agent-okd-scos-no-slack/2079588941513625600)

```
FAIL: 1 error(s)
  - rows[0] invalid stream 'okd-scos-nightly' (must be 'ci' or 'nightly')
```

## Companion PR

- openshift/release#82266 — maps OKD stream names in the shell script for accepted payloads (the deterministic path)

## What changed

Updated the `stream` field description in the field reference table to explicitly document the OKD mapping:
- `okd-scos-nightly` → `"nightly"`
- `okd-scos` → `"ci"`

This ensures Claude uses canonical values when generating autodl JSON for OKD payloads. OCP payloads are unaffected — their stream names are already canonical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how OKD payload stream values should map to the canonical stream types “nightly” and “ci.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->