### PR TITLE
TRT-2847: payload-snapshot: fall back to Sippy for historical payloads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.72",
+      "version": "0.0.73",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.72",
+      "version": "0.0.73",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/references/sippy-apis.md
+++ b/plugins/ci/references/sippy-apis.md
@@ -12,3 +12,72 @@ curl "https://sippy.dptools.openshift.org/api/payloads/diff?toPayload=<payload_t
 
 - **Parameters**: `toPayload` (required), `fromPayload` (optional, for checking a wider range)
 - **When to use**: When you have a specific payload tag and want to see what changed. The `fetch-new-prs-in-payload` skill wraps this API.
+
+## Historical Release Payloads
+
+Sippy retains release payload metadata after older tags have been garbage
+collected from the release controller. The `payload-snapshot` skill uses these
+APIs automatically to restore the complete time-ordered payload history while
+continuing to prefer release-controller data for tags that are still retained.
+
+### List release tags
+
+```text
+GET /api/releases/tags
+  ?release=<major.minor>
+  &filter={"items":[
+    {"columnField":"architecture","operatorValue":"equals","value":"amd64"},
+    {"columnField":"stream","operatorValue":"equals","value":"nightly"}
+  ]}
+  &sortField=release_time
+  &sort=desc
+```
+
+Important fields:
+
+- `release_tag`: payload tag
+- `previous_release_tag`: prior release used for payload comparison (not
+  necessarily the immediately preceding assembled payload)
+- `phase`, `release_time`, `architecture`, and `stream`: payload metadata
+- `failed_job_names`: failed job summary
+
+### List PRs introduced by a payload
+
+```text
+GET /api/releases/pull_requests
+  ?filter={"items":[
+    {"columnField":"release_tag","operatorValue":"equals","value":"<payload-tag>"}
+  ]}
+  &sortField=pull_request_id
+  &sort=asc
+```
+
+Each row includes `url`, `pull_request_id`, component `name`, `description`,
+and (when present) `bug_url`. When the chronological predecessor is known,
+`payload-snapshot` first uses `/api/payloads/diff` to retain an incremental
+changelog. This per-payload endpoint is the fallback when that diff cannot be
+computed.
+
+### List payload job runs
+
+```text
+GET /api/releases/job_runs
+  ?filter={"items":[
+    {"columnField":"release_tag","operatorValue":"equals","value":"<payload-tag>"}
+  ]}
+  &sortField=kind
+  &sort=asc
+```
+
+Each row includes `job_name`, `kind` (`Blocking` or `Informing`), `state`,
+`url`, and `retries`.
+
+### Payload UI
+
+```text
+https://sippy.dptools.openshift.org/sippy-ng/release/<release>/tags/<payload-tag>
+```
+
+Sippy does not preserve every release-controller-only field. In particular,
+its PR data has no `nodeImageStreams` RHCOS RPM diff, and its job data does
+not include release-controller async jobs or `previousAttemptURLs`.

--- a/plugins/ci/references/sippy-apis.md
+++ b/plugins/ci/references/sippy-apis.md
@@ -50,6 +50,7 @@ GET /api/releases/pull_requests
   ]}
   &sortField=pull_request_id
   &sort=asc
+  &limit=1000
 ```
 
 Each row includes `url`, `pull_request_id`, component `name`, `description`,
@@ -67,6 +68,7 @@ GET /api/releases/job_runs
   ]}
   &sortField=kind
   &sort=asc
+  &limit=1000
 ```
 
 Each row includes `job_name`, `kind` (`Blocking` or `Informing`), `state`,

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -94,6 +94,13 @@ python3 "$SNAPSHOT_SCRIPT" <payload_tag>
 
 After locating `summary.json`, set `SNAPSHOT_DIR` to the directory containing it. All relative paths in `summary.json` (e.g., `job_json`, `junit_results`, `build_log`, PR paths) resolve from this directory.
 
+The snapshot script automatically prefers release-controller data and falls
+back to Sippy for payloads that have been garbage collected. Do not truncate
+the analysis chain merely because an originating tag is absent from the live
+release controller; use the Sippy-backed `payloads[]` entry and its PR data.
+Check each entry's `source` and `changelog_source` fields when provenance or
+field completeness matters.
+
 ### Step 3: Extract Failure Data from Snapshot
 
 Read `summary.json` to extract all data needed for analysis. The snapshot has already done the work of fetching payloads, building the chain, tracking streaks, and collecting PR data.
@@ -101,7 +108,7 @@ Read `summary.json` to extract all data needed for analysis. The snapshot has al
 #### 3.1: Payload Metadata
 
 From `summary.json` top-level fields:
-- `payload_tag`, `phase`, `release_url`, `architecture`, `stream`, `version`
+- `payload_tag`, `phase`, `release_url`, `source`, `architecture`, `stream`, `version`
 - `chain_length`, `baseline_tag`, `hours_since_baseline`
 
 **Record `phase` verbatim** from the `summary.json` metadata (`Accepted`, `Rejected`, or `Ready`). Never infer the phase from the job results or from whether failures exist — a payload can be `Accepted` *with* blocking failures (force-accepted) or `Ready` while jobs are still running. The stored phase drives the force-accept decision (Step 6.4) and the executive summary (Step 7.1), so an inferred phase silently corrupts both.
@@ -140,6 +147,12 @@ For each failed job's `streak.originating_payload`, find the matching entry in `
 - Paths to local artifacts: `diff`, `comments`, `jobs`
 
 Treat this as a **preliminary** list only. The job-level streak merges unrelated failure modes, so its originating payload is frequently earlier than the regression being investigated — and candidates gathered from it can omit the causal PR entirely. Before scoring, re-derive the originating payload **per failure mode** from `test_failures.blocking[].first_failed_in` (Step 5) and collect the candidates from *that* payload.
+
+For a Sippy-backed originating payload, the PR list remains usable for
+candidate scoring and the normal GitHub diff/comment/job artifacts are still
+collected. Sippy does not provide release-controller-only
+`nodeImageStreams`, async jobs, or `previousAttemptURLs`; treat those fields as
+unavailable rather than empty evidence.
 
 #### 3.4: Test Failure Details
 

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -40,6 +40,7 @@ Use this skill when you need to:
 
 5. **Network access** to:
    - `*.ocp.releases.ci.openshift.org` (release controller)
+   - `sippy.dptools.openshift.org` (historical payload fallback)
    - `api.github.com` (via `gh` CLI)
    - `storage.googleapis.com` (via `gcloud` CLI)
 
@@ -64,13 +65,16 @@ python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-junit
 
 # Skip RPMDB extraction
 python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-rpmdb
+
+# Force Sippy for all payload metadata (normally fallback is automatic)
+python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --sippy
 ```
 
 The script will:
 1. Parse the payload tag to determine version, stream, and architecture
 2. Probe all available streams for the version (nightly, ci, across architectures)
-3. Chain backwards through previous payloads until finding one where all blocking jobs passed
-4. For each payload in the chain, download release controller data and the changelog (PR diff)
+3. Chain backwards through Sippy's time-ordered release tag list until finding one where all blocking jobs passed, restoring tags garbage collected from the release controller
+4. For each payload in the chain, prefer release controller data and changelogs; fall back per historical tag or cross-tag diff to Sippy payload, PR, and job data
 5. Split jobs into blocking/informing directories with metadata and GCS browser links
 6. For each failed blocking job, download and parse JUnit XML test results
 7. For each failed blocking job, download build-log.txt from GCS and extract error/warning lines + log tail
@@ -167,6 +171,8 @@ Options:
   --workers N          Parallel workers for API calls (default: 8)
   --no-junit           Skip JUnit download and regression tracking
   --no-rpmdb           Skip RHCOS RPMDB extraction
+  --sippy              Force Sippy for all payload metadata instead of using
+                       the automatic release-controller-first fallback
   --fail-on-incomplete Exit 1 if any requested data could not be collected
 ```
 
@@ -179,12 +185,12 @@ Lists all available streams for the payload's version.
 ### `summary.json`
 
 Comprehensive stream-level triage data — start here. Contains:
-- Payload metadata: `payload_tag`, `phase`, `release_url`, `architecture`, `stream`, `version`
+- Payload metadata: `payload_tag`, `phase`, `release_url`, `source`, `architecture`, `stream`, `version`
 - Chain data: `chain_length`, `baseline_tag`, `hours_since_baseline`
 - `blocking_jobs.failed_jobs[]` — detailed objects with `name`, `state`, `prow_url`, `gcs_url`, and relative path `job_json`. May include: `rhcos_version`, `streak` (with `streak_length`, `originating_payload`, `is_new_failure`, `failure_pattern`), `build_log_errors`, `test_failure_count`, and relative paths `junit_results`, `build_log`
 - `informing_jobs.failed_jobs[]` — job name strings
 - `test_failures.blocking[]` — `test_name`, `jobs`, `first_failed_in`, `payloads_failing`, `failure_message`, `failure_text` (full, not truncated)
-- `payloads[]` — per-payload entries with `tag`, `phase`, relative file paths, `prs[]` with component/diff/comments paths, and `rhcos_changes[]` with RPM diffs per RHCOS variant
+- `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments paths, and `rhcos_changes[]` with RPM diffs per RHCOS variant
 - `rhcos_rpms[]` — RPMDB metadata for the target payload's RHCOS variants: `tag`, `name`, `pullspec`, `rpmdb` (relative path to rpmdb.sqlite)
 - `data_complete` — `true` when all requested data was ultimately collected, including via a fallback after an initial read failed. `false` means some requested data could not be read at all.
 - `collection_errors[]` — every read failure encountered. Each entry has `reason`, `command`, and optionally `detail`, `stage`, `job`, `payload_tag`, `recovered`. Reasons: `auth`, `timeout`, `gcloud_missing`, `command_failed`, `junit_unavailable` (nothing readable), `junit_missing` (nothing discovered), `junit_unparseable` (corrupt XML), `junit_partial` (some files unread), `build_log_unavailable`.
@@ -301,6 +307,18 @@ PR artifacts from GitHub (unchanged from previous version).
 
 The script chains backwards from the target payload until it finds a payload where **all blocking jobs succeeded**. This is stricter than the `Accepted` phase — a payload can be force-accepted with failed blocking jobs, which does not count as a stop point.
 
+Sippy's release tag list, sorted by `release_time`, is used to identify every
+preceding assembled payload. If a tag is still retained, its payload details
+and changelog come from the release controller. If it has been garbage
+collected, the script constructs compatible `payload.json` and
+`changelog.json` files from Sippy's release tags, pull requests, and job runs
+APIs. A changelog that crosses a garbage-collected tag also comes from Sippy
+because the release controller can no longer compute that diff.
+
+The generated `source` and `changelog_source` fields expose this provenance.
+Sippy-backed data is intentionally partial: RHCOS `nodeImageStreams`, async
+jobs, and `previousAttemptURLs` are unavailable.
+
 For terminal payloads (Accepted/Rejected), jobs showing `Pending` on the release controller are cross-checked against the actual Prow `prowjob.json` artifact to get their real state.
 
 ## Aggregated Jobs
@@ -314,6 +332,7 @@ Aggregated jobs run the same underlying test multiple times with statistical ana
 
 - **Tag not found**: Exits with code 2 and a descriptive error
 - **Release controller unreachable**: Exits with code 1
+- **Historical tag missing from release controller**: Automatically uses Sippy
 - **`gh` not authenticated**: Prints a warning and continues without PR data
 - **`gcloud` not available**: Warns, skips JUnit download, and records
   `gcloud_missing` so the snapshot is reported incomplete
@@ -338,4 +357,3 @@ Aggregated jobs run the same underlying test multiple times with statistical ana
 - Related Skill: `fetch-payloads` (fetches recent payloads from the release controller)
 - Related Skill: `fetch-new-prs-in-payload` (fetches PRs new in a specific payload)
 - Related Skill: `payload-analysis` (analyzes a payload snapshot for revert candidates)
-

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -48,6 +48,14 @@ PROW_STATE_MAP = {
     "error": "Failed",
 }
 
+FALLBACK_FETCH_ERRORS = (
+    urllib.error.HTTPError,
+    urllib.error.URLError,
+    json.JSONDecodeError,
+    TimeoutError,
+    SystemExit,
+)
+
 
 # ---------------------------------------------------------------------------
 # PayloadTag — immutable value object for parsed payload tags
@@ -279,10 +287,10 @@ class SippyClient:
 
     def _get_tags(self) -> list[dict]:
         if self._tags_cache is None:
-            filter_items = [("architecture", self.architecture)]
-            if self.stream in STREAM_TYPES:
-                filter_items.append(("stream", self.stream))
-            filter_value = self._encoded_filter(*filter_items)
+            filter_value = self._encoded_filter(
+                ("architecture", self.architecture),
+                ("stream", self.stream),
+            )
             url = (
                 f"{self.SIPPY_BASE}/releases/tags"
                 f"?filter={filter_value}"
@@ -335,7 +343,7 @@ class SippyClient:
             )
             try:
                 return fetch_json(url, timeout=60)
-            except (Exception, SystemExit) as exc:
+            except FALLBACK_FETCH_ERRORS as exc:
                 _log(
                     "  Sippy incremental payload diff unavailable; "
                     f"using per-payload PR data: {exc}"
@@ -432,10 +440,10 @@ class PayloadChain:
 
         try:
             start_idx = tag_names.index(start_tag)
-        except ValueError:
+        except ValueError as exc:
             raise ValueError(
                 f"Tag {start_tag} not found in stream {self.stream_name}"
-            )
+            ) from exc
 
         chain = []
         for i in range(start_idx, min(start_idx + self.max_depth, len(tag_names))):
@@ -477,7 +485,15 @@ class SippyPayloadChain:
         """Check whether every blocking job in a payload succeeded."""
         runs = self.sippy.fetch_job_runs(tag_name)
         blocking = [r for r in runs if r.get("kind") == "Blocking"]
-        return not blocking or all(
+        if not blocking:
+            tag_meta = self.sippy.find_tag(tag_name)
+            return bool(
+                tag_meta
+                and tag_meta.get("phase") == "Accepted"
+                and not tag_meta.get("forced", False)
+                and tag_meta.get("failed_job_names") == []
+            )
+        return all(
             r.get("state") == "Succeeded" for r in blocking
         )
 
@@ -488,8 +504,8 @@ class SippyPayloadChain:
         ]
         try:
             start_index = tag_names.index(start_tag)
-        except ValueError:
-            raise ValueError(f"Tag {start_tag} not found in Sippy")
+        except ValueError as exc:
+            raise ValueError(f"Tag {start_tag} not found in Sippy") from exc
 
         chain = []
         for tag_name in tag_names[
@@ -535,7 +551,7 @@ class HybridPayloadChain:
                 if tag.get("release_tag")
             ]
             return self._sippy_tags
-        except (Exception, SystemExit) as exc:
+        except FALLBACK_FETCH_ERRORS as exc:
             self._sippy_available = False
             if not self._warned_sippy:
                 _log(

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -248,17 +248,47 @@ class ReleaseController:
 # ---------------------------------------------------------------------------
 
 class SippyClient:
-    """Client for Sippy APIs, used when release controller data is unavailable."""
+    """Client for Sippy's release-controller mirror APIs."""
 
     SIPPY_BASE = "https://sippy.dptools.openshift.org/api"
+    SIPPY_UI = "https://sippy.dptools.openshift.org/sippy-ng"
 
-    def __init__(self, release: str):
+    def __init__(
+        self, release: str, architecture: str = "amd64", stream: str = "nightly"
+    ):
         self.release = release
+        self.architecture = architecture
+        self.stream = stream
         self._tags_cache: Optional[list] = None
+        self._job_runs_cache: dict[str, list[dict]] = {}
+
+    @staticmethod
+    def _filter(column: str, value: str) -> dict:
+        return {
+            "columnField": column,
+            "operatorValue": "equals",
+            "value": value,
+        }
+
+    @classmethod
+    def _encoded_filter(cls, *items: tuple[str, str]) -> str:
+        filter_json = {
+            "items": [cls._filter(column, value) for column, value in items]
+        }
+        return urllib.parse.quote(json.dumps(filter_json))
 
     def _get_tags(self) -> list[dict]:
         if self._tags_cache is None:
-            url = f"{self.SIPPY_BASE}/releases/tags?release={urllib.parse.quote(self.release)}"
+            filter_items = [("architecture", self.architecture)]
+            if self.stream in STREAM_TYPES:
+                filter_items.append(("stream", self.stream))
+            filter_value = self._encoded_filter(*filter_items)
+            url = (
+                f"{self.SIPPY_BASE}/releases/tags"
+                f"?filter={filter_value}"
+                f"&release={urllib.parse.quote(self.release)}"
+                "&sortField=release_time&sort=desc"
+            )
             self._tags_cache = fetch_json(url, timeout=60)
         return self._tags_cache
 
@@ -268,29 +298,55 @@ class SippyClient:
                 return t
         return None
 
+    def fetch_tags(self) -> list[dict]:
+        """Fetch release tags newest first for this release/arch/stream."""
+        return self._get_tags()
+
     def fetch_job_runs(self, tag_name: str) -> list[dict]:
-        filter_json = json.dumps({"items": [
-            {"columnField": "release_tag", "operatorValue": "equals",
-             "value": tag_name}
-        ]})
+        if tag_name in self._job_runs_cache:
+            return self._job_runs_cache[tag_name]
+        filter_value = self._encoded_filter(("release_tag", tag_name))
         url = (f"{self.SIPPY_BASE}/releases/job_runs"
-               f"?filter={urllib.parse.quote(filter_json)}"
-               f"&sortField=kind&sort=asc&limit=200")
+               f"?filter={filter_value}"
+               f"&sortField=kind&sort=asc&limit=1000")
+        runs = fetch_json(url, timeout=60)
+        self._job_runs_cache[tag_name] = runs
+        return runs
+
+    def fetch_pull_requests(self, tag_name: str) -> list[dict]:
+        """Fetch PRs introduced by a payload from Sippy."""
+        filter_value = self._encoded_filter(("release_tag", tag_name))
+        url = (
+            f"{self.SIPPY_BASE}/releases/pull_requests"
+            f"?filter={filter_value}"
+            "&sortField=pull_request_id&sort=asc&limit=1000"
+        )
         return fetch_json(url, timeout=60)
 
-    def fetch_changelog(self, tag_name: str, from_tag: Optional[str] = None) -> list[dict]:
-        params = f"toPayload={urllib.parse.quote(tag_name)}"
-        if not from_tag:
-            tag_meta = self.find_tag(tag_name)
-            if tag_meta:
-                from_tag = tag_meta.get("previous_release_tag", "")
+    def fetch_changelog(
+        self, tag_name: str, from_tag: Optional[str] = None
+    ) -> list[dict]:
+        """Fetch the incremental PR diff, with per-payload PR fallback."""
         if from_tag:
-            params += f"&fromPayload={urllib.parse.quote(from_tag)}"
-        url = f"{self.SIPPY_BASE}/payloads/diff?{params}"
-        try:
-            return fetch_json(url, timeout=60)
-        except Exception:
-            return []
+            url = (
+                f"{self.SIPPY_BASE}/payloads/diff"
+                f"?toPayload={urllib.parse.quote(tag_name)}"
+                f"&fromPayload={urllib.parse.quote(from_tag)}"
+            )
+            try:
+                return fetch_json(url, timeout=60)
+            except (Exception, SystemExit) as exc:
+                _log(
+                    "  Sippy incremental payload diff unavailable; "
+                    f"using per-payload PR data: {exc}"
+                )
+        return self.fetch_pull_requests(tag_name)
+
+    def release_url(self, tag_name: str) -> str:
+        return (
+            f"{self.SIPPY_UI}/release/{urllib.parse.quote(self.release)}"
+            f"/tags/{urllib.parse.quote(tag_name)}"
+        )
 
     def build_synthetic_payload(self, tag_name: str, tag: "PayloadTag") -> dict:
         tag_meta = self.find_tag(tag_name)
@@ -315,18 +371,19 @@ class SippyClient:
             else:
                 informing_jobs[name] = entry
 
-        rc = ReleaseController(tag.architecture, stream=tag.stream)
         return {
             "phase": phase,
             "results": {
                 "blockingJobs": blocking_jobs,
                 "informingJobs": informing_jobs,
             },
-            "_release_url": rc.release_url(tag.stream_name, tag_name),
+            "_release_url": self.release_url(tag_name),
             "_source": "sippy",
         }
 
-    def build_synthetic_changelog(self, tag_name: str, from_tag: Optional[str] = None) -> dict:
+    def build_synthetic_changelog(
+        self, tag_name: str, from_tag: Optional[str] = None
+    ) -> dict:
         prs = self.fetch_changelog(tag_name, from_tag=from_tag)
         if not isinstance(prs, list):
             return {"changeLogJson": {"updatedImages": []}, "_source": "sippy"}
@@ -410,41 +467,140 @@ class PayloadChain:
 
 
 class SippyPayloadChain:
-    """Walks backwards through payloads using Sippy tag data."""
+    """Walks backwards through Sippy's time-ordered payload tags."""
 
     def __init__(self, sippy: SippyClient, max_depth: int = 20):
         self.sippy = sippy
         self.max_depth = max_depth
 
-    def _has_blocking_failures(self, tag_name: str) -> bool:
-        """Check whether a payload has any failed blocking jobs."""
+    def _all_blocking_passed(self, tag_name: str) -> bool:
+        """Check whether every blocking job in a payload succeeded."""
         runs = self.sippy.fetch_job_runs(tag_name)
-        return any(
-            r.get("kind") == "Blocking" and r.get("state") == "Failed"
-            for r in runs
+        blocking = [r for r in runs if r.get("kind") == "Blocking"]
+        return not blocking or all(
+            r.get("state") == "Succeeded" for r in blocking
         )
 
     def build(self, start_tag: str) -> list[str]:
-        chain = [start_tag]
+        tag_names = [
+            tag["release_tag"] for tag in self.sippy.fetch_tags()
+            if tag.get("release_tag")
+        ]
+        try:
+            start_index = tag_names.index(start_tag)
+        except ValueError:
+            raise ValueError(f"Tag {start_tag} not found in Sippy")
+
+        chain = []
+        for tag_name in tag_names[
+            start_index:start_index + self.max_depth
+        ]:
+            chain.append(tag_name)
+            if self._all_blocking_passed(tag_name):
+                break
+        return chain
+
+
+class HybridPayloadChain:
+    """Build a complete payload chain from RC data plus Sippy history.
+
+    Release-controller details remain authoritative for retained tags. Sippy's
+    time-ordered tag list identifies payloads that were garbage collected
+    between retained release-controller entries.
+    """
+
+    def __init__(
+        self,
+        rc: ReleaseController,
+        sippy: SippyClient,
+        stream_name: str,
+        max_depth: int = 20,
+    ):
+        self.rc = rc
+        self.sippy = sippy
+        self.stream_name = stream_name
+        self.max_depth = max_depth
+        self.sources: dict[str, str] = {}
+        self._rc_tags: list[str] = []
+        self._sippy_tags: list[str] = []
+        self._sippy_available = True
+        self._warned_sippy = False
+
+    def _load_sippy_tags(self) -> list[str]:
+        if not self._sippy_available:
+            return []
+        try:
+            self._sippy_tags = [
+                tag["release_tag"] for tag in self.sippy.fetch_tags()
+                if tag.get("release_tag")
+            ]
+            return self._sippy_tags
+        except (Exception, SystemExit) as exc:
+            self._sippy_available = False
+            if not self._warned_sippy:
+                _log(
+                    "Warning: Sippy release ancestry is unavailable; "
+                    f"falling back to release-controller ordering: {exc}"
+                )
+                self._warned_sippy = True
+            return []
+
+    @staticmethod
+    def _previous(tag_names: list[str], tag_name: str) -> str:
+        try:
+            index = tag_names.index(tag_name)
+        except ValueError:
+            return ""
+        if index + 1 >= len(tag_names):
+            return ""
+        return tag_names[index + 1]
+
+    def _fetch_details(self, tag_name: str, rc_tag_names: set[str]) -> dict:
+        if tag_name in rc_tag_names:
+            self.sources[tag_name] = "release-controller"
+            return self.rc.fetch_release(self.stream_name, tag_name)
+
+        tag = PayloadTag.parse(tag_name)
+        self.sources[tag_name] = "sippy"
+        return self.sippy.build_synthetic_payload(tag_name, tag)
+
+    def build(self, start_tag: str) -> list[str]:
+        rc_tags = self.rc.fetch_tags(self.stream_name)
+        self._rc_tags = [t["name"] for t in rc_tags]
+        rc_tag_names = set(self._rc_tags)
+        sippy_tag_names = set(self._load_sippy_tags())
+
+        if start_tag not in rc_tag_names and start_tag not in sippy_tag_names:
+            raise ValueError(
+                f"Tag {start_tag} not found in release controller or Sippy"
+            )
+
+        chain: list[str] = []
         current = start_tag
-        for _ in range(self.max_depth - 1):
-            tag_meta = self.sippy.find_tag(current)
-            if not tag_meta:
+        for _ in range(self.max_depth):
+            if current in chain:
+                _log(f"Warning: payload ancestry cycle detected at {current}")
                 break
-            prev = tag_meta.get("previous_release_tag", "")
-            if not prev:
+            chain.append(current)
+
+            details = self._fetch_details(current, rc_tag_names)
+            rc_chain = PayloadChain(self.rc, self.stream_name)
+            if rc_chain._all_blocking_passed(details):
                 break
-            chain.append(prev)
-            if not self._has_blocking_failures(prev):
-                # First payload with all blocking jobs green — include
-                # one more predecessor so this payload gets a changelog.
-                prev_meta = self.sippy.find_tag(prev)
-                if prev_meta:
-                    anchor = prev_meta.get("previous_release_tag", "")
-                    if anchor:
-                        chain.append(anchor)
+
+            sippy_previous = self._previous(self._sippy_tags, current)
+            rc_previous = self._previous(self._rc_tags, current)
+            previous = sippy_previous or rc_previous
+            if not previous:
                 break
-            current = prev
+
+            if sippy_previous and sippy_previous not in rc_tag_names:
+                _log(
+                    "  Sippy history restored garbage-collected payload "
+                    f"{sippy_previous} before {current}"
+                )
+            current = previous
+
         return chain
 
 
@@ -534,6 +690,7 @@ class PayloadDetailCollector(Collector):
         _log(f"  Fetching payload details: {self.tag}")
         details = self.rc.fetch_release(self.stream_name, self.tag)
         details["_release_url"] = self.rc.release_url(self.stream_name, self.tag)
+        details["_source"] = "release-controller"
         return details
 
 
@@ -550,7 +707,11 @@ class ChangelogCollector(Collector):
 
     def _fetch(self) -> dict:
         _log(f"  Fetching changelog: {self.tag} from {self.from_tag}")
-        return self.rc.fetch_changelog(self.stream_name, self.tag, self.from_tag)
+        changelog = self.rc.fetch_changelog(
+            self.stream_name, self.tag, self.from_tag
+        )
+        changelog["_source"] = "release-controller"
+        return changelog
 
 
 class PullRequestCollector(Collector):
@@ -1407,6 +1568,8 @@ class SummaryGenerator:
         phase = payload_data.get("phase", "Unknown") if payload_data else "Unknown"
         release_url = (payload_data.get("_release_url", "")
                        if payload_data else "")
+        source = (payload_data.get("_source", "release-controller")
+                  if payload_data else "unknown")
         results = payload_data.get("results", {}) if payload_data else {}
 
         blocking = results.get("blockingJobs", {}) or {}
@@ -1434,6 +1597,7 @@ class SummaryGenerator:
             "payload_tag": self.target_tag,
             "phase": phase,
             "release_url": release_url,
+            "source": source,
             "architecture": self.tag.architecture,
             "stream": self.tag.stream,
             "version": self.tag.version,
@@ -1596,6 +1760,8 @@ class SummaryGenerator:
             "  payload acceptance. Informing jobs are tracked but don't block.",
             "- **Chain**: The sequence of payloads walking backwards from the",
             "  target until one where all blocking jobs passed (the baseline).",
+            "  Sippy's time-ordered tag list restores garbage-collected tags;",
+            "  retained payload data comes from the release controller.",
             "- **Streaks**: Per-job consecutive failure count from the target",
             "  backwards. `failure_pattern` shows the full history (F=fail,",
             "  S=succeed) across the chain.",
@@ -1608,8 +1774,8 @@ class SummaryGenerator:
             "## summary.json Schema",
             "",
             "Top-level fields:",
-            "- `payload_tag`, `phase`, `release_url`, `architecture`,",
-            "  `stream`, `version`",
+            "- `payload_tag`, `phase`, `release_url`, `source`,",
+            "  `architecture`, `stream`, `version`",
             "- `chain_length`, `baseline_tag`, `hours_since_baseline`",
             "- `blocking_jobs.failed_jobs[]` — each entry has: `name`,",
             "  `state`, `prow_url`, `gcs_url`, `streak` (with",
@@ -1621,7 +1787,8 @@ class SummaryGenerator:
             "  `first_failed_in`, `payloads_failing`, `failure_message`,",
             "  `failure_text`",
             "- `payloads[]` — per-payload entries with `tag`, `phase`,",
-            "  relative paths, `prs[]` with component/diff/comments paths,",
+            "  `source`, `changelog_source`, relative paths, `prs[]` with",
+            "  component/diff/comments paths,",
             "  `rhcos_changes[]` with RPM diffs per RHCOS variant, and",
             "  `rhcos_rpms[]` with rpmdb.sqlite per variant",
             "- `rhcos_rpms[]` — RPMDB per RHCOS variant for the target",
@@ -1742,6 +1909,7 @@ class SummaryGenerator:
             )
             if pd:
                 entry["phase"] = pd.get("phase", "")
+                entry["source"] = pd.get("_source", "release-controller")
 
             changelog_path = os.path.join(
                 self.base_dir, tag_name, "changelog.json"
@@ -1749,6 +1917,10 @@ class SummaryGenerator:
             if os.path.exists(changelog_path):
                 entry["changelog"] = f"{tag_rel}/changelog.json"
                 changelog = _read_json(changelog_path)
+                if changelog:
+                    entry["changelog_source"] = changelog.get(
+                        "_source", "release-controller"
+                    )
                 prs = _extract_prs(changelog) if changelog else []
                 if prs:
                     entry["prs"] = [
@@ -1851,9 +2023,10 @@ class Snapshotter:
         self.use_sippy = use_sippy
         self.collect_rpmdb = collect_rpmdb
         self.rc = ReleaseController(tag.architecture, stream=tag.stream)
-        self.sippy: Optional[SippyClient] = None
-        if use_sippy:
-            self.sippy = SippyClient(tag.version)
+        self.sippy = SippyClient(
+            tag.version, architecture=tag.architecture, stream=tag.stream
+        )
+        self._payload_sources: dict[str, str] = {}
 
     def run(self) -> None:
         """Execute the full snapshot."""
@@ -1902,7 +2075,7 @@ class Snapshotter:
     def _collect_streams(self, base_dir: str) -> None:
         """Collect the streams list for this version."""
         path = os.path.join(base_dir, "streams.json")
-        if self.sippy:
+        if self.use_sippy:
             if os.path.exists(path):
                 return
             _log("Skipping streams collection in Sippy mode (RC-only feature)")
@@ -1912,13 +2085,22 @@ class Snapshotter:
 
     def _build_chain(self) -> list[str]:
         """Build the backward payload chain."""
-        if self.sippy:
+        if self.use_sippy:
             chain_builder = SippyPayloadChain(self.sippy, self.max_chain)
-            return chain_builder.build(self.tag.raw)
-        chain_builder = PayloadChain(
-            self.rc, self.tag.stream_name, self.max_chain
+            chain = chain_builder.build(self.tag.raw)
+            self._payload_sources = {tag: "sippy" for tag in chain}
+            return chain
+        chain_builder = HybridPayloadChain(
+            self.rc, self.sippy, self.tag.stream_name, self.max_chain
         )
-        return chain_builder.build(self.tag.raw)
+        chain = chain_builder.build(self.tag.raw)
+        self._payload_sources = chain_builder.sources
+        return chain
+
+    def _payload_source(self, tag_name: str) -> str:
+        if self.use_sippy:
+            return "sippy"
+        return self._payload_sources.get(tag_name, "release-controller")
 
     def _collect_payloads(
         self, base_dir: str, chain: list[str]
@@ -1932,7 +2114,8 @@ class Snapshotter:
             _log(f"\nProcessing payload: {tag_name}")
 
             payload_path = os.path.join(tag_dir, "payload.json")
-            if self.sippy:
+            payload_source = self._payload_source(tag_name)
+            if payload_source == "sippy":
                 if not os.path.exists(payload_path):
                     _log(f"  Fetching payload details from Sippy: {tag_name}")
                     tag_obj = PayloadTag.parse(tag_name)
@@ -1952,10 +2135,21 @@ class Snapshotter:
 
             prev_tag = chain[i + 1]
             changelog_path = os.path.join(tag_dir, "changelog.json")
-            if self.sippy:
+            # The release controller cannot diff across a tag it has already
+            # garbage collected. Use Sippy's incremental diff (with its
+            # per-payload PR fallback) whenever either side is unavailable.
+            changelog_source = (
+                "release-controller"
+                if payload_source == "release-controller"
+                and self._payload_source(prev_tag) == "release-controller"
+                else "sippy"
+            )
+            if changelog_source == "sippy":
                 if not os.path.exists(changelog_path):
                     _log(f"  Fetching changelog from Sippy: {tag_name}")
-                    data = self.sippy.build_synthetic_changelog(tag_name, from_tag=prev_tag)
+                    data = self.sippy.build_synthetic_changelog(
+                        tag_name, from_tag=prev_tag
+                    )
                     os.makedirs(os.path.dirname(changelog_path), exist_ok=True)
                     _write_json(changelog_path, data)
                 else:
@@ -3107,7 +3301,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--sippy", action="store_true",
-        help="Use Sippy APIs instead of release controller (for historical payloads)",
+        help=(
+            "Force Sippy for all payload metadata (default: prefer release "
+            "controller and automatically fall back for historical tags)"
+        ),
     )
 
     args = parser.parse_args()
@@ -3155,7 +3352,7 @@ def main() -> None:
         collect_rpmdb = False
 
     if args.sippy:
-        _log("Using Sippy APIs for release controller data.\n")
+        _log("Forcing Sippy APIs for all release payload data.\n")
 
     try:
         snapshotter = Snapshotter(

--- a/plugins/ci/skills/payload-snapshot/scripts/test_sippy_fallback.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/test_sippy_fallback.py
@@ -4,6 +4,7 @@
 import importlib.util
 import json
 import os
+import urllib.error
 import urllib.parse
 
 
@@ -92,13 +93,34 @@ def test_sippy_release_endpoints_are_filtered(monkeypatch):
     }
 
 
+def test_sippy_tags_always_filter_nonstandard_stream(monkeypatch):
+    urls = []
+
+    def fake_fetch_json(url, timeout=30, max_retries=6):
+        urls.append(url)
+        return []
+
+    monkeypatch.setattr(ps, "fetch_json", fake_fetch_json)
+    client = ps.SippyClient("4.22", stream="okd-scos-nightly")
+
+    client.fetch_tags()
+
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(urls[0]).query)
+    tag_filter = json.loads(query["filter"][0])
+    assert tag_filter["items"][1] == {
+        "columnField": "stream",
+        "operatorValue": "equals",
+        "value": "okd-scos-nightly",
+    }
+
+
 def test_sippy_changelog_falls_back_to_per_payload_prs(monkeypatch):
     urls = []
 
     def fake_fetch_json(url, timeout=30, max_retries=6):
         urls.append(url)
         if "/payloads/diff" in url:
-            raise OSError("diff unavailable")
+            raise urllib.error.URLError("diff unavailable")
         return [{"url": "https://github.com/openshift/origin/pull/3"}]
 
     monkeypatch.setattr(ps, "fetch_json", fake_fetch_json)
@@ -109,6 +131,48 @@ def test_sippy_changelog_falls_back_to_per_payload_prs(monkeypatch):
     assert prs[0]["url"].endswith("/pull/3")
     assert "/api/payloads/diff" in urls[0]
     assert "/api/releases/pull_requests" in urls[1]
+
+
+def test_sippy_chain_does_not_treat_unindexed_jobs_as_green():
+    class FakeSippy:
+        def fetch_tags(self):
+            return [
+                {"release_tag": TARGET},
+                {"release_tag": BASELINE},
+            ]
+
+        def fetch_job_runs(self, tag_name):
+            if tag_name == TARGET:
+                return []
+            return [{"kind": "Blocking", "state": "Succeeded"}]
+
+        def find_tag(self, tag_name):
+            return {
+                "phase": "Rejected",
+                "forced": False,
+                "failed_job_names": [],
+            }
+
+    chain = ps.SippyPayloadChain(FakeSippy(), max_depth=10)
+
+    assert chain.build(TARGET) == [TARGET, BASELINE]
+
+
+def test_sippy_chain_accepts_confirmed_jobless_baseline():
+    class FakeSippy:
+        def fetch_job_runs(self, tag_name):
+            return []
+
+        def find_tag(self, tag_name):
+            return {
+                "phase": "Accepted",
+                "forced": False,
+                "failed_job_names": [],
+            }
+
+    chain = ps.SippyPayloadChain(FakeSippy())
+
+    assert chain._all_blocking_passed(BASELINE) is True
 
 
 def test_hybrid_chain_restores_culled_predecessor():

--- a/plugins/ci/skills/payload-snapshot/scripts/test_sippy_fallback.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/test_sippy_fallback.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Tests for hybrid release-controller/Sippy payload collection."""
+
+import importlib.util
+import json
+import os
+import urllib.parse
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "payload_snapshot_sippy", os.path.join(_HERE, "payload_snapshot.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ps = _load_module()
+
+TARGET = "5.0.0-0.nightly-2026-07-26-222842"
+CULLED = "5.0.0-0.nightly-2026-07-23-224236"
+BASELINE = "5.0.0-0.nightly-2026-07-22-000000"
+
+
+def _payload(state):
+    return {
+        "phase": "Rejected" if state != "Succeeded" else "Accepted",
+        "results": {
+            "blockingJobs": {
+                "job-a": {"state": state, "url": ""},
+            }
+        },
+    }
+
+
+def test_sippy_release_endpoints_are_filtered(monkeypatch):
+    urls = []
+
+    def fake_fetch_json(url, timeout=30, max_retries=6):
+        urls.append(url)
+        if "/releases/tags" in url:
+            return []
+        if "/releases/job_runs" in url:
+            return []
+        if "/releases/pull_requests" in url:
+            return [{"url": "https://github.com/openshift/origin/pull/1"}]
+        if "/payloads/diff" in url:
+            return [{"url": "https://github.com/openshift/origin/pull/2"}]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(ps, "fetch_json", fake_fetch_json)
+    client = ps.SippyClient("5.0", architecture="arm64", stream="nightly")
+
+    client._get_tags()
+    client.fetch_job_runs(TARGET)
+    prs = client.fetch_pull_requests(TARGET)
+    diff = client.fetch_changelog(TARGET, from_tag=CULLED)
+
+    assert len(prs) == 1
+    assert diff[0]["url"].endswith("/pull/2")
+    tag_query = urllib.parse.parse_qs(urllib.parse.urlparse(urls[0]).query)
+    tag_filter = json.loads(tag_query["filter"][0])
+    assert tag_query["release"] == ["5.0"]
+    assert tag_query["sortField"] == ["release_time"]
+    assert tag_filter["items"] == [
+        {
+            "columnField": "architecture",
+            "operatorValue": "equals",
+            "value": "arm64",
+        },
+        {
+            "columnField": "stream",
+            "operatorValue": "equals",
+            "value": "nightly",
+        },
+    ]
+
+    assert "/api/releases/job_runs" in urls[1]
+    assert json.loads(
+        urllib.parse.parse_qs(urllib.parse.urlparse(urls[1]).query)["filter"][0]
+    )["items"][0]["value"] == TARGET
+    assert "/api/releases/pull_requests" in urls[2]
+    assert "/api/payloads/diff" in urls[3]
+    diff_query = urllib.parse.parse_qs(urllib.parse.urlparse(urls[3]).query)
+    assert diff_query == {
+        "toPayload": [TARGET],
+        "fromPayload": [CULLED],
+    }
+
+
+def test_sippy_changelog_falls_back_to_per_payload_prs(monkeypatch):
+    urls = []
+
+    def fake_fetch_json(url, timeout=30, max_retries=6):
+        urls.append(url)
+        if "/payloads/diff" in url:
+            raise OSError("diff unavailable")
+        return [{"url": "https://github.com/openshift/origin/pull/3"}]
+
+    monkeypatch.setattr(ps, "fetch_json", fake_fetch_json)
+    client = ps.SippyClient("5.0")
+
+    prs = client.fetch_changelog(TARGET, from_tag=CULLED)
+
+    assert prs[0]["url"].endswith("/pull/3")
+    assert "/api/payloads/diff" in urls[0]
+    assert "/api/releases/pull_requests" in urls[1]
+
+
+def test_hybrid_chain_restores_culled_predecessor():
+    class FakeReleaseController:
+        def fetch_tags(self, stream_name):
+            return [{"name": TARGET}, {"name": BASELINE}]
+
+        def fetch_release(self, stream_name, tag_name):
+            return _payload("Failed" if tag_name == TARGET else "Succeeded")
+
+        def resolve_prow_state(self, prow_url):
+            return None
+
+    class FakeSippy:
+        def fetch_tags(self):
+            return [
+                {"release_tag": TARGET},
+                {"release_tag": CULLED},
+                {"release_tag": BASELINE},
+            ]
+
+        def build_synthetic_payload(self, tag_name, tag):
+            assert tag_name == CULLED
+            payload = _payload("Failed")
+            payload["_source"] = "sippy"
+            return payload
+
+    chain_builder = ps.HybridPayloadChain(
+        FakeReleaseController(),
+        FakeSippy(),
+        "5.0.0-0.nightly",
+        max_depth=10,
+    )
+
+    assert chain_builder.build(TARGET) == [TARGET, CULLED, BASELINE]
+    assert chain_builder.sources == {
+        TARGET: "release-controller",
+        CULLED: "sippy",
+        BASELINE: "release-controller",
+    }
+
+
+def test_hybrid_chain_can_start_from_culled_target():
+    class FakeReleaseController:
+        def fetch_tags(self, stream_name):
+            return [{"name": BASELINE}]
+
+        def fetch_release(self, stream_name, tag_name):
+            assert tag_name == BASELINE
+            return _payload("Succeeded")
+
+        def resolve_prow_state(self, prow_url):
+            return None
+
+    class FakeSippy:
+        def fetch_tags(self):
+            return [
+                {"release_tag": TARGET},
+                {"release_tag": CULLED},
+                {"release_tag": BASELINE},
+            ]
+
+        def build_synthetic_payload(self, tag_name, tag):
+            assert tag_name in (TARGET, CULLED)
+            payload = _payload("Failed")
+            payload["_source"] = "sippy"
+            return payload
+
+    chain_builder = ps.HybridPayloadChain(
+        FakeReleaseController(),
+        FakeSippy(),
+        "5.0.0-0.nightly",
+        max_depth=10,
+    )
+
+    assert chain_builder.build(TARGET) == [TARGET, CULLED, BASELINE]
+    assert chain_builder.sources[TARGET] == "sippy"
+    assert chain_builder.sources[BASELINE] == "release-controller"
+
+
+def test_payload_collection_falls_back_per_tag_and_diff(tmp_path):
+    class FakeReleaseController:
+        def __init__(self):
+            self.changelog_calls = []
+
+        def fetch_release(self, stream_name, tag_name):
+            return _payload("Succeeded")
+
+        def release_url(self, stream_name, tag_name):
+            return f"https://release-controller.example/{tag_name}"
+
+        def fetch_changelog(self, stream_name, tag_name, from_tag):
+            self.changelog_calls.append((tag_name, from_tag))
+            return {"changeLogJson": {"updatedImages": []}}
+
+    class FakeSippy:
+        def __init__(self):
+            self.payload_calls = []
+            self.changelog_calls = []
+
+        def build_synthetic_payload(self, tag_name, tag):
+            self.payload_calls.append(tag_name)
+            payload = _payload("Failed")
+            payload["_release_url"] = f"https://sippy.example/{tag_name}"
+            payload["_source"] = "sippy"
+            return payload
+
+        def build_synthetic_changelog(self, tag_name, from_tag=None):
+            self.changelog_calls.append((tag_name, from_tag))
+            return {
+                "changeLogJson": {"updatedImages": []},
+                "_source": "sippy",
+            }
+
+    snapshotter = ps.Snapshotter(
+        ps.PayloadTag.parse(TARGET),
+        output_dir=str(tmp_path),
+        collect_junit=False,
+        collect_rpmdb=False,
+    )
+    snapshotter.rc = FakeReleaseController()
+    snapshotter.sippy = FakeSippy()
+    snapshotter._payload_sources = {
+        TARGET: "release-controller",
+        CULLED: "sippy",
+        BASELINE: "release-controller",
+    }
+
+    base_dir = tmp_path / "5.0" / "nightly"
+    collectors = snapshotter._collect_payloads(
+        str(base_dir), [TARGET, CULLED, BASELINE]
+    )
+
+    assert collectors == []
+    assert snapshotter.sippy.payload_calls == [CULLED]
+    assert snapshotter.sippy.changelog_calls == [
+        (TARGET, CULLED),
+        (CULLED, BASELINE),
+    ]
+    assert snapshotter.rc.changelog_calls == []
+
+    with open(base_dir / TARGET / "payload.json", encoding="utf-8") as handle:
+        assert json.load(handle)["_source"] == "release-controller"
+    with open(base_dir / CULLED / "payload.json", encoding="utf-8") as handle:
+        assert json.load(handle)["_source"] == "sippy"
+    with open(base_dir / TARGET / "changelog.json", encoding="utf-8") as handle:
+        assert json.load(handle)["_source"] == "sippy"


### PR DESCRIPTION
## Summary

- build payload history from Sippy's time-ordered release tags so garbage-collected payloads remain in failure streaks
- continue using release-controller payload details and changelogs whenever both tags are retained
- synthesize compatible payload/job/changelog data from Sippy only for missing tags or diffs that cross them
- record payload and changelog provenance in `summary.json`, document the degraded fields, and add focused hybrid-source tests

## Why

The release controller is the authoritative source and has the freshest, richest payload data, but it garbage-collects older releases. That can truncate a rejected-payload chain before the originating failure and discard the PR history needed for attribution.

Sippy preserves enough historical release-tag, pull-request, and job-run data to reconstruct that missing portion of the chain, but it is not a complete replacement: its ingestion trails the release controller, and the APIs deliberately expose different data. Release-controller responses include information Sippy does not retain, including async jobs, previous-attempt URLs, and `nodeImageStreams`/RHCOS RPM diffs.

Neither source is sufficient by itself, so this PR uses a release-controller-first hybrid. Sippy identifies and fills historical gaps; retained tags continue to use the richer release-controller representation. This is an awkward boundary between two differently scoped data stores, but keeping the workaround centralized and making provenance explicit lets payload analysis remain useful without overstating Sippy-backed completeness.

## Behavior

- The default path merges Sippy's architecture/stream-filtered, time-sorted tag history with the retained release-controller tag set.
- Payload details stay release-controller-backed whenever a tag is retained.
- Changelogs stay release-controller-backed when both adjacent tags are retained.
- Missing payloads are reconstructed from Sippy release tags and job runs.
- Cross-gap changelogs use Sippy's incremental payload diff, with `/api/releases/pull_requests` as a fallback.
- `--sippy` remains available to force Sippy for the full snapshot.

## Validation

- `python3 -m pytest -q plugins/ci/skills/payload-snapshot/scripts/test_collection_completeness.py plugins/ci/skills/payload-snapshot/scripts/test_sippy_fallback.py` (30 passed)
- `make test` (passed)
- `make update` (passed)
- `make lint` against a clean tracked-file copy (43 rules, 0 errors, 0 warnings)
- live chain check against `5.0.0-0.nightly-2026-07-26-222842`, confirming retained tags use release-controller data and garbage-collected tags are restored from Sippy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payload snapshots can now combine release-controller data with historical Sippy data.
  * Added a `--sippy` mode to force Sippy-backed metadata retrieval.
  * Snapshot outputs now include clearer provenance for payload and changelog data.
  * Improved fallback behavior when historical changelog/payload details are unavailable.

* **Documentation**
  * Expanded documentation for historical release payloads and Sippy fallback/provenance and partial-data behavior.

* **Maintenance**
  * Updated the CI plugin version to `0.0.73`.
  * Added/updated tests covering Sippy fallback, filtering, and chain behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->