### PR TITLE
fix(openshift-developer): refresh GitHub tokens before push/reply

### DIFF
--- a/plugins/openshift-developer/skills/address-review-pr/SKILL.md
+++ b/plugins/openshift-developer/skills/address-review-pr/SKILL.md
@@ -193,6 +193,18 @@ When multiple comments relate to the same concern/fix:
 
 ### Step 4: Post Replies and Push
 
+#### Pre-step: Refresh GitHub tokens
+
+GitHub App tokens expire after 1 hour. Long sessions may outlast the initial token. Before posting replies or pushing, refresh the tokens:
+
+```bash
+if [ -x /tmp/refresh-github-tokens.sh ]; then
+  /tmp/refresh-github-tokens.sh
+fi
+```
+
+If the refresh fails, continue anyway — the token may still be valid for shorter sessions.
+
 #### 4a. Post all replies
 
 - **Template**: `Done. [1-line what changed]. [Optional 1-line why]`


### PR DESCRIPTION
## Summary

- Add a pre-step to `address-review-pr` skill that refreshes GitHub App tokens before posting replies or pushing
- Calls `/tmp/refresh-github-tokens.sh` if it exists (written by the CI process step in openshift/release)
- No-op outside CI — the script only exists when the review-agent process step creates it

## Problem

GitHub App installation tokens expire after 1 hour. The [PR #9102 review-agent session](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2080723339151675392) ran for 1h17m — the agent processed everettraven's review comment correctly but couldn't post a reply or push because the token had expired.

## Companion PR

- openshift/release#82494 — writes the refresh script and switches to file-based token storage

## Test plan

- [ ] Verify skill still works locally (no `/tmp/refresh-github-tokens.sh` → skipped gracefully)
- [ ] Verify in CI with companion PR: tokens refresh before push/reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when posting review replies or pushing changes by refreshing GitHub authentication tokens beforehand when needed.
  * Operations now continue gracefully if token refresh is unavailable or unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->