### PR TITLE
payload-snapshot: log podman info output when nested podman check fails

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.72",
+      "version": "0.0.73",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.72",
+      "version": "0.0.73",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -2806,15 +2806,36 @@ def _check_podman() -> bool:
     Goes beyond --version: runs 'podman info' which exercises the runtime,
     storage, and namespace setup.  This catches cases where podman is
     installed but cannot operate (e.g. nested containers without
-    appropriate privileges).
+    appropriate privileges).  On failure, stdout/stderr from the probe are
+    logged so the underlying runtime error (e.g. a namespace or storage
+    driver failure under nested podman) is visible instead of a bare
+    "not available" message.
     """
     try:
         result = subprocess.run(
             ["podman", "info"],
             capture_output=True, text=True, timeout=30,
         )
+        if result.returncode != 0:
+            _log(f"'podman info' exited {result.returncode}.")
+            if result.stdout.strip():
+                _log(f"stdout:\n{result.stdout.strip()}")
+            if result.stderr.strip():
+                _log(f"stderr:\n{result.stderr.strip()}")
         return result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
+    except subprocess.TimeoutExpired as e:
+        _log("'podman info' timed out after 30s.")
+        if e.stdout:
+            stdout = e.stdout if isinstance(e.stdout, str) else e.stdout.decode(errors="replace")
+            if stdout.strip():
+                _log(f"stdout:\n{stdout.strip()}")
+        if e.stderr:
+            stderr = e.stderr if isinstance(e.stderr, str) else e.stderr.decode(errors="replace")
+            if stderr.strip():
+                _log(f"stderr:\n{stderr.strip()}")
+        return False
+    except OSError as e:
+        _log(f"'podman info' could not be run: {e}")
         return False
 
 


### PR DESCRIPTION
The RHCOS RPMDB collector runs 'podman info' as a preflight check for nested podman support, but only reported a bare pass/fail. When the check fails, the underlying runtime/storage/namespace error from podman is now logged (stdout and stderr, or the OSError/timeout detail) so failures under nested podman can actually be diagnosed instead of just "podman is not available".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the CI plugin to version 0.0.73 across the marketplace and documentation.

* **Bug Fixes**
  * Improved Podman environment checks with clearer diagnostic details when commands fail, time out, or cannot be started.
  * Podman availability checks continue to report unsuccessful results reliably without interrupting processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->