### PR TITLE
TRT-2612: Fix nested podman subuid/subgid range for hostUsers: false pods

### DIFF
--- a/images/nested-podman-entrypoint.sh
+++ b/images/nested-podman-entrypoint.sh
@@ -46,8 +46,21 @@ fi
 
 # Create subuid/gid entries for rootless podman
 USER_NAME="$(whoami)"
-SUBID_START="${SUBID_START:-100000}"
-SUBID_COUNT="${SUBID_COUNT:-65536}"
+# In OpenShift CI, the pod runs with hostUsers: false, which maps only 65536
+# UIDs/GIDs (0-65535) into the pod's user namespace. The host rootless-podman
+# default of 100000:65536 falls outside that range, so newuidmap/newgidmap
+# fail with EPERM. Compute the range dynamically so it always fits in 0-65535.
+# Outside hostUsers: false (e.g. a normal OpenShift pod with a large
+# SCC-assigned arbitrary UID), that computation goes negative or zero, so
+# fall back to the host rootless-podman default in that case.
+SUBID_START_DEFAULT=$(( $(id -u) + 1 ))
+SUBID_COUNT_DEFAULT=$(( 65536 - SUBID_START_DEFAULT ))
+if (( SUBID_COUNT_DEFAULT <= 0 )); then
+  SUBID_START_DEFAULT=100000
+  SUBID_COUNT_DEFAULT=65536
+fi
+SUBID_START="${SUBID_START:-$SUBID_START_DEFAULT}"
+SUBID_COUNT="${SUBID_COUNT:-$SUBID_COUNT_DEFAULT}"
 echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subuid
 echo "${USER_NAME}:${SUBID_START}:${SUBID_COUNT}" > /etc/subgid
 


### PR DESCRIPTION
OpenShift CI pods running with hostUsers: false only get 65536 UIDs/GIDs (0-65535) mapped into the pod's user namespace. The entrypoint's hardcoded subuid/subgid range (100000:65536) falls entirely outside that window, so podman's newuidmap/newgidmap invocations fail with EPERM (`newuidmap: write to uid_map failed: Operation not permitted`), breaking nested rootless podman.

This computes the subuid/subgid start and count dynamically from the runtime UID (e.g. uid 1000 -> 1001:64535), so the range always fits within 0-65535. Env var overrides are preserved.

Trade-off: nested containers get ~64.5k subordinate IDs instead of 65536, so images with files owned by UIDs above ~64535 won't run nested. That's inherent to the 65536-wide pod user namespace.

Exercised by re-running the rehearsal on openshift/release PR #81145 after merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rootless container startup in OpenShift environments by dynamically configuring user and group ID mappings.
  * Prevented mapping ranges from exceeding pod user-namespace limits, improving compatibility with restricted containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->