### PR TITLE
ci: analyze-disruption: root-cause attribution rules, onset/suspect-PR step, existing-bug discovery

### DIFF
--- a/plugins/ci/skills/analyze-disruption/SKILL.md
+++ b/plugins/ci/skills/analyze-disruption/SKILL.md
@@ -368,6 +368,39 @@ Tests appearing during disruption in 3+ runs are especially interesting — they
 the resource pressure causing disruption. Tests that *fail* during disruption are usually
 *victims*; tests that *pass* consistently during disruption windows are more likely causes.
 
+#### 3.5: Root-Cause Attribution Rules (learned from real triage incidents)
+
+Apply these before naming an owning component in the report — disruption is almost always a
+*symptom chain*, and attributing it one link too early has misdirected owning teams for weeks
+in real incidents:
+
+1. **A component whose error names a missing upstream dependency is a victim, not an owner —
+   but corroborate before reassigning.** If a disrupted backend's serving pods log
+   "cannot list/watch/reach X" (e.g., a router crash-looping on
+   `failed to list *v1.Route: the server could not find the requested resource`), check X's
+   provider directly (ClusterOperator conditions, APIService availability, endpoints) before
+   blaming either side: provider unhealthy → the disruption belongs upstream (in one real case,
+   router disruption traced through openshift-apiserver to etcd never deploying its static
+   pods); provider healthy → the fault is inside the "victim" after all (RBAC — a real
+   crash-looper failed on `configmaps is forbidden` — client config, or network reachability).
+2. **The end-state oracle is `clusteroperators.json`, not pod existence.** Check the etcd and
+   apiserver ClusterOperator conditions from gather-extra before declaring the control plane
+   healthy — pods scheduled and Running prove nothing about whether cluster etcd/apiservers
+   were actually serving (during bootstrap and some upgrade windows, a different control plane
+   serves the API).
+3. **Extract condition *messages*, not just condition flips.** `ClusterVersion` and
+   `ClusterOperator` interval entries carry the underlying controller error string — a bare
+   "Available=False" interval hides the cause, but its message often names it outright (a real
+   ClusterVersion flap's message named the exact broken controller). Quote the recovered
+   message in the report.
+4. **Read `*_previous.log` for any container that restarted during the disruption window.**
+   The crashed instance's last lines are primary evidence and outrank inferences from the
+   replacement container's healthy logs; a container with `restartCount > 0` whose previous
+   log you did not read is an analysis gap.
+5. **Condition churn ≠ slow rollout.** If an operator's condition flaps continuously (many
+   transitions with `DurationSinceTransition` of ~1s), that is a sync-loop bug (permafail
+   class), not a transient — count transitions before classifying severity.
+
 ### Step 4: Deep-Dive Artifact Download (Optional)
 
 **Only perform this step if the parser output from Step 3 is insufficient for root cause
@@ -425,6 +458,45 @@ Check audit logs for endpoint slice modification events during disruption window
 
 - Look for audit events related to `endpointslices` resources
 - Verify that readiness changes triggered appropriate endpoint updates
+
+#### 5.3: Onset Determination and Suspect PRs (when disruption is new or worsening)
+
+If the disruption pattern is a *change* (a backend that used to be clean now disrupts, or
+counts jumped), anchor the onset before hypothesizing:
+
+1. Find the newest **clean** run and the oldest **disrupted** run of the same job (job-history)
+   and compare their payloads (`artifacts/release/artifacts/release-images-latest`, and
+   `release-images-initial` for upgrade jobs — upgrade jobs can regress via either endpoint,
+   and a *skew* between initial and target payloads is itself a known failure mode).
+2. Feed the failing payload to the `fetch-new-prs-in-payload` skill and vet candidates with
+   `gh` — a LIKELY PR names the owning component.
+3. **Scan the owning repo's newest merges for revert PRs**: a fresh `Revert "..."` title citing
+   a TRT/OCPBUGS key hands you the trigger PR, the tracking ticket, and the expected recovery
+   in one query — for currently-live breakage this is frequently faster than any artifact
+   analysis.
+4. Never write "resolved/appeared due to an unidentified payload change" without having run
+   steps 1–3; a real duplicate bug was filed because a cessation was written off as
+   unidentified while the owning repo had merged an `OCPBUGS-*`-titled fix at exactly that
+   boundary.
+
+#### 5.4: Existing Bugs and Known Disruption Families
+
+Before presenting a root-cause hypothesis as novel, check whether it is already tracked
+(complementary to the known-disruption-card lookup in Step 8, which searches TRT's own
+disruption Jira cards):
+
+1. Query `fetch-related-triages` for any Component Readiness regression associated with the
+   disrupted backends' tests, and treat confidence scores as clustering hints — verify against
+   this run's evidence before adopting a match.
+2. Run a **component-scoped JIRA listing** for the suspected owner
+   (`project = OCPBUGS AND component = "<owner>" AND created >= -21d`) and read summaries —
+   owning teams describe defects in developer vocabulary that shares no keywords with the
+   disruption symptom, so text search alone misses existing bugs.
+3. Known recurring disruption families worth ruling in/out first: etcd slow-fdatasync /
+   disk-pressure on Azure control planes (cache-backend disruption), CNI gaps during OVN
+   upgrades (host-to-host + API disruption in the upgrade phase), single-node OVS stalls under
+   CPU starvation (single-source fan-out), and cloud LB/DNS churn (ingress-routed backends
+   only). Each has had tracking tickets — search before filing.
 
 ### Step 6: Cross-Run Comparison (Multiple Runs Only)
 
@@ -539,7 +611,11 @@ The [timeline data]({gcsweb_timeline_url}) shows OVS vswitchd poll intervals up 
 [etcd pod logs]({gcsweb_etcd_url}) confirm apply-too-long warnings at 03:56:00Z...
 
 ## Root Cause Hypothesis
-{Analysis with inline links to supporting evidence}
+{Analysis with inline links to supporting evidence. State the full causal chain (trigger →
+intermediate symptoms → disrupted backends), the owning component with the corroboration
+required by Step 3.5 (upstream health checked, condition messages quoted, previous.log read
+for any restarted container), and whether the issue matches an existing bug/triage or known
+disruption family (Step 5.4) — with the ticket reference if so.}
 
 ## Other Disrupted Backends
 {When --backends filter was used, list other backends that were disrupted during the
@@ -583,7 +659,9 @@ Run 2 [timeline]({gcsweb_timeline_url_2}) shows disk IOPS at 100% ([cloud metric
 {Pattern analysis referencing specific runs with inline links}
 
 ## Root Cause Hypothesis
-{Synthesis with links to key evidence}
+{Synthesis with links to key evidence. Apply the Step 3.5 attribution rules (victim-vs-owner
+with upstream corroboration, quoted condition messages, previous.log for restarted containers)
+and cite any existing bug/triage or known family match from Step 5.4.}
 
 ## Other Disrupted Backends
 {When --backends filter was used, list other backends that were disrupted during the


### PR DESCRIPTION
## Summary

Recent AI-assisted Component Readiness triage duty for `5.0-main` surfaced several root-cause-attribution failure modes that cost real time (regressions attached to the wrong bug, a router change blamed for an etcd defect, a duplicate bug filed for an already-fixed issue). Most of them apply directly to disruption analysis, which is symptom-chain work by nature. This PR folds those lessons into `analyze-disruption`.

Related: #651 (same lessons applied to the prow-job-analysis / triage-adjacent skills); #635 (the bulk-triage skill where they were learned).

## Changes

**Step 5.6 (new) — Root-Cause Attribution Rules**
- *Victim-vs-owner with corroboration*: a disrupted/crash-looping component whose error names a missing upstream dependency is usually a victim — but check the provider's actual health (CO conditions, APIService, endpoints) before reassigning, because RBAC/config faults masquerade as dependency errors (real cases in both directions: router→apiserver→etcd, and a capi-installer crash-looping on its own `configmaps is forbidden` RBAC bug).
- *`clusteroperators.json` as the end-state oracle*: pods Running proves nothing about whether cluster etcd/apiservers were serving.
- *Extract condition messages*: ClusterVersion/ClusterOperator interval entries carry the controller error string that names the culprit — quote it, don't stop at the Available=False flip.
- *`*_previous.log` is mandatory reading* for any container that restarted in the disruption window.
- *Count condition transitions*: ~1s-interval flapping is a sync-loop bug (permafail class), not a transient.

**Step 7.3 (new) — Onset Determination and Suspect PRs** for new/worsening disruption: clean-vs-disrupted payload comparison (including initial/target skew on upgrade jobs — a real regression was pure skew between a pre-GA base and post-GA target), `fetch-new-prs-in-payload` vetting, and the revert-PR shortcut (a fresh `Revert "..."` citing a TRT/OCPBUGS key yields trigger PR + tracking ticket + recovery ETA in one query). Unanchored "unidentified payload change" claims are banned.

**Step 7.4 (new) — Existing Bugs and Known Disruption Families**: `fetch-related-triages` with verify-before-adopt (confidence is clustering, not root cause), component-scoped JIRA listing (owning teams write summaries in developer vocabulary that keyword search misses — the exact mechanism behind a real duplicate filing), and the recurring disruption families to rule out first (etcd/Azure disk pressure, OVN upgrade CNI gaps, single-node OVS stalls, cloud LB churn).

**Report templates**: both Root Cause Hypothesis sections now require the full causal chain, the 5.6 corroboration evidence, and existing-ticket references.

Also bumps the `ci` plugin version (0.0.74 → 0.0.75).

---
**AI-generated content:** This PR was created by AI based on lessons from AI-assisted triage duty. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved disruption analysis guidance for identifying root causes and distinguishing affected components from responsible components.
  * Added instructions for validating operator end states, reviewing condition messages, examining prior container logs, and interpreting rapid status changes.
  * Added guidance for determining disruption onset, comparing healthy and disrupted runs, and reviewing related changes, known bugs, and recurring disruption patterns.
  * Updated root-cause report requirements to include corroborating evidence and references to relevant issues or disruption families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->