### PR TITLE
fix(eval): use setup script for plugin deps, widen dependency ranges

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-"version": "0.0.78",
+      "version": "0.0.78",
       "category": "ci",
       "keywords": [
         "prow",
@@ -484,7 +484,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,16 +1,16 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "author": {
     "name": "github.com/openshift-eng"
   },
   "dependencies": [
-    { "name": "jira", "version": "^0.8.6" },
-    { "name": "ci", "version": "^0.0.52" },
-    { "name": "golang", "version": "^0.3.0" },
+    { "name": "jira", "version": ">=0.8.6" },
+    { "name": "ci", "version": ">=0.0.52" },
+    { "name": "golang", "version": ">=0.3.0" },
     { "name": "prodsec-skills" },
-    { "name": "git", "version": "^0.0.7" },
-    { "name": "code-review", "version": "^0.0.13" }
+    { "name": "git", "version": ">=0.0.7" },
+    { "name": "code-review", "version": ">=0.0.13" }
   ]
 }

--- a/plugins/openshift-developer/evals/scripts/run-solve.sh
+++ b/plugins/openshift-developer/evals/scripts/run-solve.sh
@@ -30,25 +30,12 @@ WORKSPACE="$(pwd)"
 OUTPUT_DIR="${WORKSPACE}/output"
 REPO_DIR="${EVAL_REPO_DIR:-$(mktemp -d "${HOME}/.cache/eval-solve.XXXXXX")/repo}"
 
-OPENSHIFT_DEV_PLUGIN="$AI_HELPERS_DIR/plugins/openshift-developer"
-CODE_REVIEW_PLUGIN="$AI_HELPERS_DIR/plugins/code-review"
-
 echo "=== Solve Eval: $ISSUE_KEY ==="
 echo "Repo: $REPO_URL"
 echo "Branch: $EVAL_BRANCH"
 echo "Model: $SKILL_MODEL"
 echo "Workspace: $WORKSPACE"
 echo "ai-helpers: $AI_HELPERS_DIR"
-
-# Validate plugins
-if [ ! -f "$OPENSHIFT_DEV_PLUGIN/skills/jira-solve/SKILL.md" ]; then
-  echo "ERROR: solve SKILL.md not found at $OPENSHIFT_DEV_PLUGIN/skills/jira-solve/SKILL.md" >&2
-  exit 1
-fi
-if [ ! -d "$CODE_REVIEW_PLUGIN/.claude-plugin" ]; then
-  echo "ERROR: code-review plugin not found at $CODE_REVIEW_PLUGIN" >&2
-  exit 1
-fi
 
 # Helper: extract token/cost JSON from stream-json output
 extract_tokens() {
@@ -104,7 +91,6 @@ PHASE1_START=$(date +%s)
 
 set +e
 claude -p "/openshift-developer:jira-solve ${ISSUE_KEY} origin --ci" \
-  --plugin-dir "$OPENSHIFT_DEV_PLUGIN" \
   --allowedTools "Bash Read Write Edit Grep Glob WebFetch Agent Skill Task" \
   --max-turns 300 \
   --effort max \
@@ -156,7 +142,6 @@ PHASE2_START=$(date +%s)
 
 set +e
 claude -p "/code-review:pre-commit-review --language go --profile hypershift" \
-  --plugin-dir "$CODE_REVIEW_PLUGIN" \
   --allowedTools "Bash Read Grep Glob Task Agent Skill" \
   --max-turns 225 \
   --effort max \
@@ -187,7 +172,6 @@ PHASE3_START=$(date +%s)
 if [ -n "$REVIEW_FINDINGS" ]; then
   set +e
   claude -p "/openshift-developer:address-review-precommit" \
-    --plugin-dir "$OPENSHIFT_DEV_PLUGIN" \
     --allowedTools "Bash Read Write Edit Grep Glob Agent Skill Task" \
     --max-turns 225 \
     --effort max \

--- a/plugins/openshift-developer/evals/scripts/setup-solve-eval.sh
+++ b/plugins/openshift-developer/evals/scripts/setup-solve-eval.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Setup script for the jira-solve eval.
+#
+# Installs the openshift-developer plugin and all its dependencies
+# (jira, golang, code-review, etc.) system-wide so inner claude -p
+# sessions spawned by run-solve.sh can resolve them.
+#
+# Called by the CI workflow via EVAL_SETUP_SCRIPT before the eval runs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+
+echo "Installing ai-helpers plugins from ${REPO_ROOT}..."
+git config --global url."https://github.com/".insteadOf "git@github.com:" 2>/dev/null || true
+claude plugin marketplace add "${REPO_ROOT}"
+claude plugin install openshift-developer@ai-helpers
+
+# Validate
+if ! claude plugin list --json 2>/dev/null | jq -e '.[] | select(.id | test("^openshift-developer@"))' > /dev/null 2>&1; then
+    echo "ERROR: openshift-developer plugin not found after installation"
+    claude plugin list 2>/dev/null || true
+    exit 1
+fi
+
+echo "Plugins installed and validated."


### PR DESCRIPTION
## Summary

- Removes plugin install from `run-solve.sh` — it didn't work because each `claude -p` subprocess is a fresh session
- Adds `setup-solve-eval.sh` that installs plugins via marketplace before the eval runs (called via `EVAL_SETUP_SCRIPT` in the release repo CI config)
- Changes dependency ranges from `^` (caret) to `>=` in `plugin.json` — caret ranges on `0.x.y` versions only allow patch bumps, which breaks when dependent plugins are bumped to newer minor versions

## Why

The jira-solve eval uses `runner.type: cli` which spawns separate `claude -p` processes. Plugin installs inside `run-solve.sh` don't propagate to those inner sessions. The setup script runs before the eval starts, installing plugins system-wide so all subprocesses can find them.

The `^0.0.52` constraint rejects `0.0.77` because semver caret on `0.x` is patch-only (`>=0.0.52 <0.0.53`). Using `>=` allows any newer version.

## Companion PR

openshift/release#82470 — adds `EVAL_SETUP_SCRIPT` pointing to this setup script

## Test plan

- [x] `make lint` passes (A+)
- [ ] Release repo rehearsal with setup script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated setup and validation for the OpenShift Developer plugin in evaluation environments.
* **Improvements**
  * Updated the plugin bundle to version 1.1.14.
  * Relaxed dependency requirements to support compatible newer versions.
  * Simplified evaluation startup and execution by removing manual plugin directory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->