### PR TITLE
ci-extras: add blind payload analysis comparison skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -102,7 +102,7 @@
       "name": "ci-extras",
       "source": "./plugins/ci-extras",
       "description": "MCP server and extended tooling for OpenShift CI data access",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "category": "ci",
       "keywords": [
         "openshift-ci",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-"version": "0.0.77",
+      "version": "0.0.77",
       "has_readme": true,
       "commands": [
         {
@@ -915,7 +915,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci-extras",
       "description": "MCP server and extended tooling for OpenShift CI data access",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "has_readme": true,
       "commands": [
         {
@@ -927,7 +927,14 @@ footer a { color: var(--primary); }
           "body_html": "\u003cp\u003eFetches live CI health data for a given OpenShift release and produces a concise summary covering payload acceptance, test regressions, and recent failures.\u003c/p\u003e\u003cp\u003eUseful for a quick read on overall release quality before a payload promotion decision or during a release readiness review.\u003c/p\u003e"
         }
       ],
-      "skills": [],
+      "skills": [
+        {
+          "name": "compare-payload-analysis",
+          "description": "Blindly analyze an OpenShift payload from another AI agent's snapshot, then adjudicate both agents' findings in a concise evidence-backed HTML comparison. Use when asked to compare payload analyses, audit the payload agent, or produce a \"what the other agent got right and wrong\" report.",
+          "description_html": "Blindly analyze an OpenShift payload from another AI agent&#x27;s snapshot, then adjudicate both agents&#x27; findings in a concise evidence-backed HTML comparison. Use when asked to compare payload analyses, audit the payload agent, or produce a &quot;what the other agent got right and wrong&quot; report.",
+          "meta": ""
+        }
+      ],
       "agents": [],
       "hooks": [],
       "mcp_servers": [

--- a/plugins/ci-extras/.claude-plugin/plugin.json
+++ b/plugins/ci-extras/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci-extras",
   "description": "MCP server and extended tooling for OpenShift CI data access",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci-extras/README.md
+++ b/plugins/ci-extras/README.md
@@ -28,6 +28,25 @@ Fetches live CI health data for a given OpenShift release and produces a concise
 
 **Prerequisites:** Requires the openshift-ci-mcp server (bundled with this plugin).
 
+## Skills
+
+### compare-payload-analysis
+
+Independently analyzes a payload from the other payload agent's frozen
+snapshot, then unseals that agent's report and produces an evidence-backed
+"right, wrong, and best combined take" HTML table.
+
+The skill enforces the blind boundary with a two-phase artifact helper: it
+downloads only the snapshot before analysis and will not download the other
+report until the independent HTML, YAML, and JSON outputs have been frozen.
+
+```bash
+/ci-extras:compare-payload-analysis <payload-tag> [--publish-gist]
+```
+
+**Prerequisites:** Requires the `ci` plugin's `payload-analysis` skill,
+`gcloud`, and `gh` when publishing a gist.
+
 ## MCP Server
 
 This plugin bundles the [openshift-ci-mcp](https://github.com/openshift-eng/openshift-ci-mcp) server, which exposes OpenShift CI data directly as tools.

--- a/plugins/ci-extras/skills/compare-payload-analysis/SKILL.md
+++ b/plugins/ci-extras/skills/compare-payload-analysis/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: compare-payload-analysis
+description: Blindly analyze an OpenShift payload from another AI agent's snapshot, then adjudicate both agents' findings in a concise evidence-backed HTML comparison. Use when asked to compare payload analyses, audit the payload agent, or produce a "what the other agent got right and wrong" report.
+---
+
+# Compare Payload Analysis
+
+Produce an independent payload analysis before exposing the other agent's
+findings. Then resolve disagreements against primary artifacts and render a
+self-contained comparison report.
+
+## Arguments
+
+```text
+<payload-tag> [--other-job-url URL] [--work-dir DIR] [--publish-gist]
+```
+
+- `payload-tag` is required.
+- `--other-job-url` overrides async-job discovery. Use the Prow URL for the
+  other payload agent.
+- `--work-dir` defaults to
+  `.work/compare-payload-analysis/<sanitized-payload-tag>`.
+- `--publish-gist` publishes the final HTML and returns an HTMLPreview link.
+
+## Required Skill
+
+Load and use `payload-analysis` for the independent investigation. Its
+required schema skills and job-analysis workflow still apply.
+
+## Phase 1: Stage the Snapshot Blindly
+
+Locate this skill's scripts:
+
+```bash
+SKILL_ROOT="${CLAUDE_PLUGIN_ROOT}/skills/compare-payload-analysis"
+if [ ! -f "$SKILL_ROOT/scripts/artifact_bridge.py" ]; then
+  SKILL_ROOT=$(find ~/.claude/plugins -type f \
+    -path "*/ci-extras/skills/compare-payload-analysis/scripts/artifact_bridge.py" \
+    -print 2>/dev/null | sort | head -1 | xargs dirname | xargs dirname)
+fi
+```
+
+Run the bridge's `stage` command:
+
+```bash
+python3 "$SKILL_ROOT/scripts/artifact_bridge.py" stage \
+  "<payload-tag>" --work-dir "<work-dir>"
+```
+
+Add `--job-url "<other-job-url>"` when supplied. The helper:
+
+1. Discovers the succeeded `claude-payload-agent` async job from release
+   controller metadata.
+2. Lists artifact names without opening their contents.
+3. Downloads and safely extracts only `snapshot-<payload-tag>.tar*`.
+4. Records the other HTML report URI in a sealed state file.
+5. Refuses archives containing HTML or unsafe tar members.
+
+Read the helper's JSON output and use its `snapshot_dir`. Confirm the
+snapshot's `summary.json` has the requested `payload_tag`.
+
+### Blindness Rules
+
+Until Phase 3, do not:
+
+- Open, download, render, fetch, grep, summarize, or screenshot the other
+  agent's HTML.
+- Open the other job's session archive, console log, or any artifact that can
+  reveal its conclusions.
+- Search for quotations or conclusions from the other analysis elsewhere.
+
+Artifact filenames, job metadata, and snapshot contents are allowed. If the
+other findings are exposed accidentally, stop and disclose that the run is
+not blind; start a fresh context before claiming an independent comparison.
+
+## Phase 2: Perform and Freeze the Independent Analysis
+
+Create `<work-dir>/independent/` and make it the output working directory.
+Load and invoke the `payload-analysis` skill in the current context with:
+
+```text
+/ci:payload-analysis <payload-tag> --snapshot-dir <absolute-snapshot-dir>
+```
+
+Apply one task-specific override while following that skill: **skip its
+"Consult Previous Claude Analyses" step entirely.** The current report is
+sealed, so do not discover, fetch, or read any prior analysis through a
+separate path. Follow every other payload-analysis step, including its deep
+job investigations, scoring, output schemas, completeness review, and final
+self-check.
+
+Do the full deep analysis. Do not treat the supplied snapshot as the other
+agent's conclusions; it is primary-source scaffolding. Investigate job
+artifacts, retries, underlying aggregated runs, exact failing operations,
+candidate diffs, CI step changes, and RHCOS changes as required by
+`payload-analysis`.
+
+Before unsealing, mechanically confirm these independent outputs exist:
+
+```text
+payload-analysis-<payload-tag>-summary.html
+payload-analysis-<payload-tag>-autodl.json
+payload-results-<payload-tag>.yaml
+```
+
+Freeze their hashes and unseal the other report:
+
+```bash
+python3 "$SKILL_ROOT/scripts/artifact_bridge.py" unseal \
+  "<payload-tag>" \
+  --work-dir "<work-dir>" \
+  --independent-html "<independent-html>" \
+  --independent-json "<independent-autodl-json>" \
+  --independent-yaml "<independent-results-yaml>"
+```
+
+The helper refuses to download the other report unless all three independent
+outputs are non-empty and match the exact payload-analysis filenames. It
+records their SHA-256 hashes before changing the state from `staged` to
+`unsealed`.
+
+## Phase 3: Read and Adjudicate
+
+Only now read the downloaded `other_report` returned by `unseal`.
+
+Build a claim matrix covering every material conclusion from either report:
+
+| Area | Required comparison |
+|---|---|
+| Payload verdict | phase, blocking status, force-accept/revert conclusion |
+| Job inventory | every failed blocking job, exact Prow run, retries |
+| Failure mechanics | exact failing operation, error, timestamps, child run |
+| History | failure-mode onset, accepted baseline, recurrence evidence |
+| Attribution | payload PRs, CI changes, RHCOS changes, score rationale |
+| Non-gating signal | informing jobs, informing tests, flakes |
+| Completeness | passed jobs, omitted failures, mislabeled tables or counts |
+
+For each disagreement:
+
+1. State both claims precisely.
+2. Identify evidence that distinguishes them.
+3. Re-open the primary artifact for the exact failing operation.
+4. Record the supported conclusion and link the evidence.
+
+Never choose a claim because it sounds more plausible or because two agents
+agree. Adjacent successful activity does not clear the operation that failed.
+Missing lines in truncated logs are unknown, not negative evidence. Mark a
+disagreement unresolved when the artifacts cannot discriminate.
+
+Credit useful findings even when the other report's final interpretation is
+wrong. Separate:
+
+- `right`: supported facts or helpful context from the other analysis.
+- `wrong`: factual errors, unsupported claims, omissions, or misleading
+  labels.
+- `combined`: the best evidence-backed conclusion after adjudication.
+
+## Phase 4: Render the Comparison
+
+Write `<work-dir>/comparison.json` with this shape:
+
+```json
+{
+  "payload_tag": "5.0.0-0.ci-YYYY-MM-DD-HHMMSS",
+  "verdict": "One concise combined verdict.",
+  "independent_report": {
+    "label": "Independent analysis",
+    "path": "/absolute/path/to/independent-report.html"
+  },
+  "other_report": {
+    "label": "Other AI analysis",
+    "url": "https://example.invalid/other-report"
+  },
+  "rows": [
+    {
+      "topic": "High-level verdict",
+      "assessment": "correct",
+      "right": "What was supported.",
+      "wrong": "What was missing, or “No material issue.”",
+      "combined": "Best conclusion after checking artifacts.",
+      "evidence": [
+        {"label": "Primary artifact", "url": "https://example.invalid/artifact"}
+      ]
+    }
+  ]
+}
+```
+
+`assessment` must be `correct`, `mixed`, or `incorrect`. Use one row per
+meaningful topic; do not inflate the table with trivial wording differences.
+Report sources accept either an HTTPS `url` or a local `path`. Use primary
+artifact URLs in `evidence` wherever possible.
+
+Render:
+
+```bash
+python3 "$SKILL_ROOT/scripts/render_comparison.py" \
+  "<work-dir>/comparison.json" \
+  --output "payload-analysis-comparison-<payload-tag>.html"
+```
+
+The renderer escapes all supplied text and produces a responsive,
+self-contained HTML file using the bundled template.
+
+## Final Checks
+
+Before presenting:
+
+1. Every failed blocking job appears in the table.
+2. Every `wrong` claim is tied to discriminating evidence or labeled
+   `unresolved`.
+3. Job-level failure, test failure, informing job, and informing test counts
+   are not conflated.
+4. The combined verdict agrees with the detailed rows.
+5. The blind-state manifest is `unsealed` and contains hashes for all three
+   independent outputs.
+6. The final HTML is non-empty and contains no unescaped source content.
+
+Report the saved HTML path and a short combined verdict.
+
+If `--publish-gist` was requested:
+
+```bash
+gist_url=$(gh gist create --public \
+  "payload-analysis-comparison-<payload-tag>.html" \
+  -d "Payload analysis comparison for <payload-tag>")
+gist_id=${gist_url##*/}
+raw_url=$(gh api "gists/$gist_id" \
+  --jq '.files | to_entries[0].value.raw_url')
+echo "https://htmlpreview.github.io/?${raw_url}"
+```
+
+Return both the gist URL and HTMLPreview link.
+
+## Error Handling
+
+- If no succeeded other-agent async job exists, stop and report that the
+  comparison is waiting for it. Do not generate a replacement snapshot.
+- If the snapshot is incomplete, follow `payload-analysis` and collect the
+  missing primary artifacts yourself.
+- If the other report is absent after a succeeded job, preserve the
+  independent analysis and report the missing artifact.
+- If a contradiction cannot be resolved from available artifacts, label it
+  `unresolved`; never manufacture certainty.

--- a/plugins/ci-extras/skills/compare-payload-analysis/agents/openai.yaml
+++ b/plugins/ci-extras/skills/compare-payload-analysis/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compare Payload Analyses"
+  short_description: "Blindly compare independent payload analyses"
+  default_prompt: "Use $compare-payload-analysis from CI Extras to independently analyze a payload from the other agent snapshot, then adjudicate both reports."

--- a/plugins/ci-extras/skills/compare-payload-analysis/assets/comparison-report.html
+++ b/plugins/ci-extras/skills/compare-payload-analysis/assets/comparison-report.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Payload analysis comparison · @@PAYLOAD_TAG@@</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f8fa;
+      --surface: #ffffff;
+      --surface-soft: #f3f6f9;
+      --text: #1f2328;
+      --muted: #59636e;
+      --border: #d0d7de;
+      --accent: #0969da;
+      --green: #1a7f37;
+      --green-bg: #dafbe1;
+      --orange: #9a6700;
+      --orange-bg: #fff8c5;
+      --red: #cf222e;
+      --red-bg: #ffebe9;
+      --shadow: 0 12px 34px rgba(31, 35, 40, .08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(9, 105, 218, .10), transparent 30rem),
+        var(--bg);
+      color: var(--text);
+      font: 15px/1.55 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1500px, calc(100% - 32px)); margin: 46px auto 64px; }
+    .eyebrow {
+      color: var(--accent);
+      font-size: .78rem;
+      font-weight: 750;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    h1 { max-width: 1100px; margin: .25rem 0 .5rem; font-size: clamp(1.8rem, 4vw, 3rem); line-height: 1.12; }
+    .subtitle { margin: 0; color: var(--muted); overflow-wrap: anywhere; }
+    .verdict {
+      margin: 26px 0 18px;
+      padding: 22px 24px;
+      border: 1px solid color-mix(in srgb, var(--accent), var(--border) 72%);
+      border-radius: 14px;
+      background: linear-gradient(135deg, color-mix(in srgb, var(--accent), transparent 94%), var(--surface));
+      box-shadow: var(--shadow);
+    }
+    .verdict strong { display: block; margin-bottom: 6px; color: var(--accent); font-size: .78rem; letter-spacing: .09em; text-transform: uppercase; }
+    .verdict p { margin: 0; font-size: 1.08rem; }
+    .stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 18px 0; }
+    .stat { padding: 15px 17px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+    .stat b { display: block; font-size: 1.45rem; line-height: 1; }
+    .stat span { color: var(--muted); font-size: .82rem; }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); box-shadow: var(--shadow); }
+    table { width: 100%; min-width: 1040px; border-collapse: collapse; }
+    th, td { padding: 17px 18px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+    thead th { position: sticky; top: 0; background: var(--surface-soft); color: var(--muted); font-size: .78rem; letter-spacing: .045em; text-transform: uppercase; }
+    tbody th { width: 17%; background: color-mix(in srgb, var(--surface-soft), transparent 35%); }
+    tbody td { width: 27.66%; }
+    tbody tr:last-child > * { border-bottom: 0; }
+    .topic { display: block; margin-top: 9px; font-size: .96rem; }
+    .status { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: .7rem; font-weight: 750; text-transform: uppercase; }
+    .status-correct { color: var(--green); background: var(--green-bg); }
+    .status-mixed { color: var(--orange); background: var(--orange-bg); }
+    .status-incorrect { color: var(--red); background: var(--red-bg); }
+    .right { border-top: 3px solid color-mix(in srgb, var(--green), transparent 28%); }
+    .wrong { border-top: 3px solid color-mix(in srgb, var(--red), transparent 28%); }
+    .combined { border-top: 3px solid color-mix(in srgb, var(--accent), transparent 28%); }
+    .evidence { margin-top: 11px; color: var(--muted); font-size: .82rem; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    footer { margin-top: 18px; color: var(--muted); font-size: .82rem; }
+    footer p { margin: 5px 0; }
+    @media (max-width: 700px) {
+      main { width: min(100% - 20px, 1500px); margin-top: 24px; }
+      .stats { grid-template-columns: 1fr; }
+      .verdict { padding: 18px; }
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --surface: #161b22;
+        --surface-soft: #21262d;
+        --text: #e6edf3;
+        --muted: #8b949e;
+        --border: #30363d;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --green-bg: rgba(46, 160, 67, .15);
+        --orange: #d29922;
+        --orange-bg: rgba(187, 128, 9, .15);
+        --red: #f85149;
+        --red-bg: rgba(248, 81, 73, .15);
+        --shadow: 0 14px 38px rgba(0, 0, 0, .25);
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="eyebrow">CI Extras · Blind, evidence-backed adjudication</div>
+      <h1>Payload analysis comparison</h1>
+      <p class="subtitle">@@PAYLOAD_TAG@@</p>
+    </header>
+
+    <section class="verdict">
+      <strong>Best combined verdict</strong>
+      <p>@@VERDICT@@</p>
+    </section>
+
+    <section class="stats" aria-label="Assessment counts">
+      <div class="stat"><b>@@CORRECT_COUNT@@</b><span>supported topics</span></div>
+      <div class="stat"><b>@@MIXED_COUNT@@</b><span>mixed topics</span></div>
+      <div class="stat"><b>@@INCORRECT_COUNT@@</b><span>unsupported topics</span></div>
+    </section>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Topic</th>
+            <th scope="col">What the other agent got right</th>
+            <th scope="col">What it got wrong or missed</th>
+            <th scope="col">Best combined take</th>
+          </tr>
+        </thead>
+        <tbody>
+          @@ROWS@@
+        </tbody>
+      </table>
+    </div>
+
+    <footer>
+      <p><strong>Reports:</strong> @@SOURCES@@</p>
+      <p>The independent outputs were frozen before the other report was unsealed. Contradictions were adjudicated against primary CI artifacts.</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/plugins/ci-extras/skills/compare-payload-analysis/scripts/artifact_bridge.py
+++ b/plugins/ci-extras/skills/compare-payload-analysis/scripts/artifact_bridge.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Enforce CI Extras' blind stage/unseal boundary for payload-agent artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+ASYNC_JOB_NAME = "claude-payload-agent"
+PHASE_STAGED = "staged"
+PHASE_UNSEALED = "unsealed"
+TAG_RE = re.compile(
+    r"^(?P<stream_name>(?P<version>\d+\.\d+)\.0-0\."
+    r"(?P<stream>[\w-]+?)(?:-(?P<arch>arm64|ppc64le|s390x|multi))?)"
+    r"-(?P<timestamp>\d{4}-\d{2}-\d{2}-\d{6})$"
+)
+
+
+class BridgeError(RuntimeError):
+    """A user-actionable staging or unsealing failure."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_tag(tag: str) -> dict[str, str]:
+    match = TAG_RE.fullmatch(tag)
+    if not match:
+        raise BridgeError(f"Cannot parse payload tag: {tag}")
+    values = match.groupdict()
+    return {
+        "stream_name": values["stream_name"],
+        "version": values["version"],
+        "stream": values["stream"],
+        "architecture": values["arch"] or "amd64",
+    }
+
+
+def sanitize_tag(tag: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", tag).strip("-")
+
+
+def default_work_dir(tag: str) -> Path:
+    return Path(".work") / "compare-payload-analysis" / sanitize_tag(tag)
+
+
+def release_api_url(tag: str) -> str:
+    parsed = parse_tag(tag)
+    product = "origin" if parsed["stream"].startswith("okd") else "ocp"
+    host = f"{parsed['architecture']}.{product}.releases.ci.openshift.org"
+    stream = urllib.parse.quote(parsed["stream_name"], safe="")
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    return f"https://{host}/api/v1/releasestream/{stream}/release/{encoded_tag}"
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        raise BridgeError(f"Could not read release metadata from {url}: {exc}") from exc
+
+
+def discover_job_url(tag: str) -> str:
+    payload = fetch_json(release_api_url(tag))
+    async_jobs = payload.get("results", {}).get("asyncJobs")
+    if not isinstance(async_jobs, dict):
+        async_jobs = payload.get("asyncJobs", {})
+    job = async_jobs.get(ASYNC_JOB_NAME) if isinstance(async_jobs, dict) else None
+    if not isinstance(job, dict):
+        raise BridgeError(
+            f"No {ASYNC_JOB_NAME!r} async job is recorded for payload {tag}"
+        )
+    if job.get("state") != "Succeeded":
+        raise BridgeError(
+            f"{ASYNC_JOB_NAME} is {job.get('state', 'unknown')}, not Succeeded"
+        )
+    url = job.get("url")
+    if not isinstance(url, str) or not url:
+        raise BridgeError(f"{ASYNC_JOB_NAME} has no Prow URL")
+    return url
+
+
+def prow_to_gs_prefix(url: str) -> str:
+    marker = "/view/gs/"
+    if marker in url:
+        suffix = url.split(marker, 1)[1].strip("/")
+        return f"gs://{suffix}"
+    if url.startswith("gs://"):
+        return url.rstrip("/")
+    raise BridgeError("Other job URL must be a Prow /view/gs/ URL or a gs:// prefix")
+
+
+def run_gcloud(arguments: list[str]) -> str:
+    if shutil.which("gcloud") is None:
+        raise BridgeError("gcloud is required to access the public CI artifacts")
+    command = ["gcloud", "storage", *arguments]
+    process = subprocess.run(command, text=True, capture_output=True, check=False)
+    if process.returncode != 0:
+        detail = process.stderr.strip() or process.stdout.strip()
+        raise BridgeError(f"{' '.join(command)} failed: {detail}")
+    return process.stdout
+
+
+def list_artifacts(prefix: str) -> list[str]:
+    output = run_gcloud(["ls", "--recursive", f"{prefix}/**"])
+    return [line.strip() for line in output.splitlines() if line.startswith("gs://")]
+
+
+def select_artifacts(uris: list[str], tag: str) -> tuple[str, str]:
+    snapshot_names = {
+        f"snapshot-{tag}.tar",
+        f"snapshot-{tag}.tar.gz",
+        f"snapshot-{tag}.tgz",
+    }
+    report_name = f"payload-analysis-{tag}-summary.html"
+    snapshots = [uri for uri in uris if PurePosixPath(uri).name in snapshot_names]
+    reports = [uri for uri in uris if PurePosixPath(uri).name == report_name]
+    if len(snapshots) != 1:
+        raise BridgeError(
+            f"Expected one snapshot archive for {tag}, found {len(snapshots)}"
+        )
+    if len(reports) != 1:
+        raise BridgeError(
+            f"Expected one sealed HTML report for {tag}, found {len(reports)}"
+        )
+    return snapshots[0], reports[0]
+
+
+def safe_member_path(name: str) -> PurePosixPath:
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise BridgeError(f"Unsafe archive path: {name}")
+    if path.suffix.lower() in {".html", ".htm"}:
+        raise BridgeError(
+            f"Snapshot archive contains HTML and cannot stay blind: {name}"
+        )
+    return path
+
+
+def extract_snapshot(archive: Path, destination: Path) -> None:
+    if destination.exists() and any(destination.iterdir()):
+        raise BridgeError(f"Snapshot destination is not empty: {destination}")
+    destination.mkdir(parents=True, exist_ok=True)
+    destination_root = destination.resolve()
+    with tarfile.open(archive, mode="r:*") as bundle:
+        for member in bundle.getmembers():
+            relative = safe_member_path(member.name)
+            target = (destination / Path(*relative.parts)).resolve()
+            if os.path.commonpath((destination_root, target)) != str(destination_root):
+                raise BridgeError(f"Archive member escapes destination: {member.name}")
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise BridgeError(
+                    f"Snapshot archive contains unsupported member: {member.name}"
+                )
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise BridgeError(f"Could not read archive member: {member.name}")
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+
+
+def find_snapshot_dir(root: Path, tag: str) -> Path:
+    matches: list[Path] = []
+    for summary in root.rglob("summary.json"):
+        try:
+            data = json.loads(summary.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("payload_tag") == tag:
+            matches.append(summary.parent.resolve())
+    if len(matches) != 1:
+        raise BridgeError(f"Expected one summary.json for {tag}, found {len(matches)}")
+    return matches[0]
+
+
+def atomic_write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(path)
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BridgeError(f"Blind-state manifest not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BridgeError(f"Blind-state manifest is invalid: {path}") from exc
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def expected_independent_names(tag: str) -> dict[str, str]:
+    safe_tag = sanitize_tag(tag)
+    return {
+        "html": f"payload-analysis-{safe_tag}-summary.html",
+        "json": f"payload-analysis-{safe_tag}-autodl.json",
+        "yaml": f"payload-results-{safe_tag}.yaml",
+    }
+
+
+def validate_independent_outputs(
+    tag: str,
+    html: Path,
+    autodl_json: Path,
+    results_yaml: Path,
+    independent_root: Path,
+    staged_at: str,
+) -> dict[str, dict[str, Any]]:
+    paths = {"html": html, "json": autodl_json, "yaml": results_yaml}
+    expected = expected_independent_names(tag)
+    try:
+        staged_timestamp = datetime.fromisoformat(staged_at).timestamp()
+    except (TypeError, ValueError) as exc:
+        raise BridgeError("Manifest has an invalid staged_at timestamp") from exc
+    frozen: dict[str, dict[str, Any]] = {}
+    for kind, path in paths.items():
+        resolved = path.resolve()
+        if not resolved.is_relative_to(independent_root):
+            raise BridgeError(
+                f"Independent {kind} must be under {independent_root}, got {resolved}"
+            )
+        if resolved.name != expected[kind]:
+            raise BridgeError(
+                f"Independent {kind} must be named {expected[kind]}, got {resolved.name}"
+            )
+        if not resolved.is_file() or resolved.stat().st_size == 0:
+            raise BridgeError(f"Independent {kind} is missing or empty: {resolved}")
+        if resolved.stat().st_mtime < staged_timestamp:
+            raise BridgeError(
+                f"Independent {kind} predates snapshot staging: {resolved}"
+            )
+        frozen[kind] = {
+            "path": str(resolved),
+            "bytes": resolved.stat().st_size,
+            "modified_at": datetime.fromtimestamp(
+                resolved.stat().st_mtime, timezone.utc
+            ).isoformat(),
+            "sha256": hash_file(resolved),
+        }
+    return frozen
+
+
+def stage(args: argparse.Namespace) -> dict[str, Any]:
+    work_dir = args.work_dir.resolve()
+    manifest_path = work_dir / "blind-state.json"
+    if manifest_path.exists():
+        manifest = load_manifest(manifest_path)
+        if manifest.get("payload_tag") != args.payload_tag:
+            raise BridgeError("Existing manifest belongs to another payload")
+        if manifest.get("phase") in {PHASE_STAGED, PHASE_UNSEALED}:
+            return {
+                "manifest": str(manifest_path),
+                "phase": manifest["phase"],
+                "snapshot_dir": manifest["snapshot_dir"],
+            }
+        raise BridgeError(f"Unexpected manifest phase: {manifest.get('phase')}")
+
+    job_url = args.job_url or discover_job_url(args.payload_tag)
+    prefix = prow_to_gs_prefix(job_url)
+    snapshot_uri, sealed_report_uri = select_artifacts(
+        list_artifacts(prefix), args.payload_tag
+    )
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = PurePosixPath(snapshot_uri).name
+    archive_path = work_dir / archive_name
+    run_gcloud(["cp", snapshot_uri, str(archive_path)])
+    snapshot_extract_root = work_dir / "snapshot"
+    if snapshot_extract_root.exists():
+        raise BridgeError(
+            f"Snapshot destination already exists without a manifest: "
+            f"{snapshot_extract_root}"
+        )
+    with tempfile.TemporaryDirectory(dir=work_dir) as temporary:
+        temporary_root = Path(temporary) / "snapshot"
+        extract_snapshot(archive_path, temporary_root)
+        relative_snapshot_dir = find_snapshot_dir(
+            temporary_root, args.payload_tag
+        ).relative_to(temporary_root.resolve())
+        temporary_root.replace(snapshot_extract_root)
+    snapshot_dir = (snapshot_extract_root / relative_snapshot_dir).resolve()
+
+    manifest = {
+        "schema_version": 1,
+        "payload_tag": args.payload_tag,
+        "phase": PHASE_STAGED,
+        "staged_at": utc_now(),
+        "other_job_url": job_url,
+        "artifact_prefix": prefix,
+        "snapshot_uri": snapshot_uri,
+        "snapshot_archive": str(archive_path.resolve()),
+        "snapshot_dir": str(snapshot_dir),
+        "sealed_report_uri": sealed_report_uri,
+        "other_report": None,
+        "independent_outputs": None,
+    }
+    atomic_write_json(manifest_path, manifest)
+    return {
+        "manifest": str(manifest_path.resolve()),
+        "phase": PHASE_STAGED,
+        "snapshot_dir": str(snapshot_dir),
+    }
+
+
+def unseal(args: argparse.Namespace) -> dict[str, Any]:
+    work_dir = args.work_dir.resolve()
+    manifest_path = work_dir / "blind-state.json"
+    manifest = load_manifest(manifest_path)
+    if manifest.get("payload_tag") != args.payload_tag:
+        raise BridgeError("Blind-state manifest belongs to another payload")
+    if manifest.get("phase") == PHASE_UNSEALED:
+        return {
+            "manifest": str(manifest_path),
+            "phase": PHASE_UNSEALED,
+            "other_report": manifest["other_report"],
+            "independent_outputs": manifest["independent_outputs"],
+        }
+    if manifest.get("phase") != PHASE_STAGED:
+        raise BridgeError(f"Cannot unseal from phase {manifest.get('phase')!r}")
+
+    independent_root = (work_dir / "independent").resolve()
+    frozen = validate_independent_outputs(
+        args.payload_tag,
+        args.independent_html,
+        args.independent_json,
+        args.independent_yaml,
+        independent_root,
+        manifest.get("staged_at"),
+    )
+    report_uri = manifest.get("sealed_report_uri")
+    if not isinstance(report_uri, str) or not report_uri.endswith(".html"):
+        raise BridgeError("Manifest does not contain a sealed HTML report URI")
+    report_path = work_dir / f"other-agent-{PurePosixPath(report_uri).name}"
+    run_gcloud(["cp", report_uri, str(report_path)])
+    if not report_path.is_file() or report_path.stat().st_size == 0:
+        raise BridgeError(f"Downloaded other report is empty: {report_path}")
+
+    manifest.update(
+        {
+            "phase": PHASE_UNSEALED,
+            "unsealed_at": utc_now(),
+            "independent_outputs": frozen,
+            "other_report": {
+                "path": str(report_path.resolve()),
+                "bytes": report_path.stat().st_size,
+                "sha256": hash_file(report_path),
+                "source_uri": report_uri,
+            },
+        }
+    )
+    atomic_write_json(manifest_path, manifest)
+    return {
+        "manifest": str(manifest_path),
+        "phase": PHASE_UNSEALED,
+        "other_report": manifest["other_report"],
+        "independent_outputs": frozen,
+    }
+
+
+def self_test() -> dict[str, Any]:
+    tag = "5.0.0-0.ci-2026-07-30-113831"
+    parsed = parse_tag(tag)
+    assert parsed["architecture"] == "amd64"
+    assert parsed["stream_name"] == "5.0.0-0.ci"
+    arm = parse_tag("4.22.0-0.nightly-arm64-2026-07-30-113831")
+    assert arm["architecture"] == "arm64"
+    assert arm["stream"] == "nightly"
+    assert (
+        prow_to_gs_prefix("https://prow.ci.openshift.org/view/gs/bucket/logs/job/123")
+        == "gs://bucket/logs/job/123"
+    )
+    snapshot, report = select_artifacts(
+        [
+            f"gs://bucket/path/snapshot-{tag}.tar",
+            f"gs://bucket/path/payload-analysis-{tag}-summary.html",
+        ],
+        tag,
+    )
+    assert snapshot.endswith(".tar")
+    assert report.endswith(".html")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        archive = root / "snapshot.tar"
+        summary = json.dumps({"payload_tag": tag}).encode()
+        with tarfile.open(archive, "w") as bundle:
+            info = tarfile.TarInfo("5.0/ci/summary.json")
+            info.size = len(summary)
+            bundle.addfile(info, io.BytesIO(summary))
+        destination = root / "out"
+        extract_snapshot(archive, destination)
+        assert find_snapshot_dir(destination, tag) == (destination / "5.0/ci").resolve()
+
+        independent_root = root / "independent"
+        independent_root.mkdir()
+        expected = expected_independent_names(tag)
+        outputs = {}
+        for kind, name in expected.items():
+            output = independent_root / name
+            output.write_text(f"{kind} output", encoding="utf-8")
+            outputs[kind] = output
+        frozen = validate_independent_outputs(
+            tag,
+            outputs["html"],
+            outputs["json"],
+            outputs["yaml"],
+            independent_root.resolve(),
+            datetime.fromtimestamp(0, timezone.utc).isoformat(),
+        )
+        assert all(len(item["sha256"]) == 64 for item in frozen.values())
+
+        bad_archive = root / "bad.tar"
+        with tarfile.open(bad_archive, "w") as bundle:
+            info = tarfile.TarInfo("../findings.html")
+            info.size = 0
+            bundle.addfile(info, io.BytesIO())
+        try:
+            extract_snapshot(bad_archive, root / "bad-out")
+        except BridgeError:
+            pass
+        else:
+            raise AssertionError("unsafe archive was accepted")
+    return {"self_test": "passed"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Blindly stage a payload snapshot, then unseal the other report"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    stage_parser = subparsers.add_parser(
+        "stage", help="Download only the other agent's snapshot"
+    )
+    stage_parser.add_argument("payload_tag")
+    stage_parser.add_argument("--job-url")
+    stage_parser.add_argument("--work-dir", type=Path)
+
+    unseal_parser = subparsers.add_parser(
+        "unseal", help="Freeze independent outputs and download the other report"
+    )
+    unseal_parser.add_argument("payload_tag")
+    unseal_parser.add_argument("--work-dir", type=Path)
+    unseal_parser.add_argument("--independent-html", type=Path, required=True)
+    unseal_parser.add_argument("--independent-json", type=Path, required=True)
+    unseal_parser.add_argument("--independent-yaml", type=Path, required=True)
+
+    subparsers.add_parser("self-test", help="Run offline safety checks")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if args.command == "self-test":
+            result = self_test()
+        else:
+            if args.work_dir is None:
+                args.work_dir = default_work_dir(args.payload_tag)
+            result = stage(args) if args.command == "stage" else unseal(args)
+    except BridgeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/ci-extras/skills/compare-payload-analysis/scripts/render_comparison.py
+++ b/plugins/ci-extras/skills/compare-payload-analysis/scripts/render_comparison.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Render a safe, self-contained payload analysis comparison report."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+ASSESSMENTS = {
+    "correct": ("Supported", "status-correct"),
+    "mixed": ("Mixed", "status-mixed"),
+    "incorrect": ("Unsupported", "status-incorrect"),
+}
+REQUIRED_ROW_FIELDS = ("topic", "assessment", "right", "wrong", "combined")
+
+
+class RenderError(RuntimeError):
+    """Invalid comparison input or template."""
+
+
+def escaped(value: Any) -> str:
+    if not isinstance(value, str):
+        raise RenderError(f"Expected a string, got {type(value).__name__}")
+    return html.escape(value, quote=True).replace("\n", "<br>")
+
+
+def safe_url(value: Any) -> str:
+    if not isinstance(value, str):
+        raise RenderError("Report and evidence URLs must be strings")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RenderError(f"Only http(s) URLs are allowed: {value}")
+    return html.escape(value, quote=True)
+
+
+def source_link(source: Any) -> str:
+    if source is None:
+        return ""
+    if not isinstance(source, dict):
+        raise RenderError("Report source must be an object")
+    label = escaped(source.get("label"))
+    if source.get("url"):
+        return (
+            f'<a href="{safe_url(source.get("url"))}" target="_blank" '
+            f'rel="noopener noreferrer">{label}</a>'
+        )
+    if source.get("path"):
+        return f"{label} (<code>{escaped(source.get('path'))}</code>)"
+    raise RenderError("Report source must contain url or path")
+
+
+def evidence_links(evidence: Any) -> str:
+    if evidence is None:
+        return ""
+    if not isinstance(evidence, list):
+        raise RenderError("Row evidence must be a list")
+    links = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            raise RenderError("Each evidence entry must be an object")
+        links.append(
+            f'<a href="{safe_url(item.get("url"))}" target="_blank" '
+            f'rel="noopener noreferrer">{escaped(item.get("label"))}</a>'
+        )
+    if not links:
+        return ""
+    return (
+        '<div class="evidence"><strong>Evidence:</strong> '
+        + " · ".join(links)
+        + "</div>"
+    )
+
+
+def render_rows(rows: Any) -> tuple[str, dict[str, int]]:
+    if not isinstance(rows, list) or not rows:
+        raise RenderError("rows must be a non-empty list")
+    rendered: list[str] = []
+    counts = {assessment: 0 for assessment in ASSESSMENTS}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise RenderError("Each row must be an object")
+        missing = [field for field in REQUIRED_ROW_FIELDS if field not in row]
+        if missing:
+            raise RenderError(f"Comparison row is missing: {', '.join(missing)}")
+        assessment = row["assessment"]
+        if assessment not in ASSESSMENTS:
+            raise RenderError(
+                f"assessment must be one of {', '.join(ASSESSMENTS)}, got {assessment}"
+            )
+        counts[assessment] += 1
+        label, css_class = ASSESSMENTS[assessment]
+        rendered.append(
+            "<tr>"
+            f'<th scope="row"><span class="status {css_class}">{label}</span>'
+            f'<span class="topic">{escaped(row["topic"])}</span></th>'
+            f'<td class="right">{escaped(row["right"])}</td>'
+            f'<td class="wrong">{escaped(row["wrong"])}</td>'
+            f'<td class="combined">{escaped(row["combined"])}'
+            f"{evidence_links(row.get('evidence'))}</td>"
+            "</tr>"
+        )
+    return "\n".join(rendered), counts
+
+
+def render(data: dict[str, Any], template: str) -> str:
+    for key in ("payload_tag", "verdict", "rows"):
+        if key not in data:
+            raise RenderError(f"Missing top-level field: {key}")
+    rows, counts = render_rows(data["rows"])
+    sources = [
+        link
+        for link in (
+            source_link(data.get("independent_report")),
+            source_link(data.get("other_report")),
+        )
+        if link
+    ]
+    replacements = {
+        "@@PAYLOAD_TAG@@": escaped(data["payload_tag"]),
+        "@@VERDICT@@": escaped(data["verdict"]),
+        "@@ROWS@@": rows,
+        "@@CORRECT_COUNT@@": str(counts["correct"]),
+        "@@MIXED_COUNT@@": str(counts["mixed"]),
+        "@@INCORRECT_COUNT@@": str(counts["incorrect"]),
+        "@@SOURCES@@": " · ".join(sources) if sources else "No report links supplied",
+    }
+    output = template
+    for marker, value in replacements.items():
+        output = output.replace(marker, value)
+    leftovers = [marker for marker in replacements if marker in output]
+    if leftovers:
+        raise RenderError(f"Template markers were not replaced: {leftovers}")
+    return output
+
+
+def self_test(template: str) -> None:
+    data = {
+        "payload_tag": "5.0.0-0.ci-test",
+        "verdict": "No product regression <script>alert(1)</script>",
+        "independent_report": {
+            "label": "Independent",
+            "url": "https://example.com/independent.html",
+        },
+        "other_report": {
+            "label": "Other",
+            "url": "https://example.com/other.html",
+        },
+        "rows": [
+            {
+                "topic": "AWS upgrade",
+                "assessment": "mixed",
+                "right": "Upgrade disruption was real.",
+                "wrong": "The run ID was wrong.",
+                "combined": "Use build 09.",
+                "evidence": [{"label": "Prow", "url": "https://example.com/prow"}],
+            }
+        ],
+    }
+    output = render(data, template)
+    assert "<script>alert(1)</script>" not in output
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in output
+    assert "AWS upgrade" in output
+    assert "@@ROWS@@" not in output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render a payload analysis comparison JSON file as HTML"
+    )
+    parser.add_argument("input", type=Path, nargs="?")
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    template_path = (
+        Path(__file__).resolve().parent.parent / "assets" / "comparison-report.html"
+    )
+    try:
+        template = template_path.read_text(encoding="utf-8")
+        if args.self_test:
+            self_test(template)
+            print("self-test passed")
+            return 0
+        if args.input is None:
+            raise RenderError("input JSON is required unless --self-test is used")
+        data = json.loads(args.input.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise RenderError("Top-level comparison input must be an object")
+        output = args.output
+        if output is None:
+            tag = data.get("payload_tag", "payload")
+            output = Path(f"payload-analysis-comparison-{tag}.html")
+        rendered = render(data, template)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    except (OSError, json.JSONDecodeError, RenderError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(output.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add `ci-extras:compare-payload-analysis` for blind, independent payload analysis followed by evidence-backed adjudication
- add a two-phase artifact bridge that downloads only the other agent snapshot, then requires and hashes all independent outputs before unsealing the other report
- add a safe, responsive HTML renderer for the “right / wrong / best combined take” table and optional gist publication
- document the skill and bump `ci-extras` to 0.0.2; the core `ci` plugin remains unchanged

## Validation

- `make lint` — A+, zero errors and zero warnings
- skill-creator `quick_validate.py`
- artifact bridge offline self-test
- comparison renderer escaping/template self-test
- `ruff check` and `ruff format --check`
- live stage and unseal test against payload `5.0.0-0.ci-2026-07-30-113831`

## Overlap review

The existing `ci:payload-analysis` can consult a previous report after its own job investigations. This auxiliary skill stays in `ci-extras` and adds the missing blind snapshot staging, enforced freeze/unseal boundary, claim-by-claim adjudication, and standalone comparison report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `compare-payload-analysis` skill for independently comparing payload analyses and producing evidence-backed results.
  * Added workflow support for safely staging, validating, and unsealing analysis artifacts.
  * Added self-contained HTML comparison reports with verdict summaries, evidence links, responsive styling, and optional Gist publishing.
  * Added an OpenAI agent configuration for running the comparison workflow.

* **Documentation**
  * Added usage instructions, prerequisites, command examples, validation rules, and error-handling guidance.

* **Chores**
  * Updated plugin metadata and marketplace versions to `0.0.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->