### PR TITLE
OKD-399: Generate REVIEW.md and coderabibit.yaml for Agentic docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -523,7 +523,7 @@
       "name": "agentic-docs",
       "source": "./plugins/agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     {
       "name": "metrics",

--- a/docs/index.html
+++ b/docs/index.html
@@ -415,7 +415,7 @@ footer a { color: var(--primary); }
     {
       "name": "agentic-docs",
       "description": "Create and maintain AI-optimized documentation for OpenShift",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/agentic-docs/.claude-plugin/plugin.json
+++ b/plugins/agentic-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-docs",
   "description": "Create and maintain AI-optimized documentation for OpenShift",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/agentic-docs/skills/component-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/component-docs/SKILL.md
@@ -27,6 +27,8 @@ Creates lean component agentic documentation for OpenShift component repositorie
 ```text
 component-repo/
 ├── AGENTS.md                      # Master entry point (80-100 lines)
+├── REVIEW.md                      # Review instructions (Claude Code Review + CodeRabbit)
+├── .coderabbit.yaml               # CodeRabbit config (points at REVIEW.md)
 └── ai-docs/
     ├── domain/                    # Component APIs/types
     ├── architecture/              # Component internals
@@ -223,6 +225,85 @@ Jira key, PR number) so I can trace it."
 - [ ] Link to Platform for generic practices
 - [ ] Document ONLY verified component-specific details (target: 100-200 lines each)
 
+### Phase 9.5: Generate REVIEW.md + .coderabbit.yaml
+
+Generates review instructions for code review tools (Claude Code Review, CodeRabbit). REVIEW.md is the single source of truth; .coderabbit.yaml is a structured sidecar that translates skip/path rules into CodeRabbit's native format. Target: 60-80 lines (soft cap 100).
+
+**Step 1 — Clone enhancements repo** (if not already present from Phase 4):
+```bash
+[ ! -d "/tmp/openshift-enhancements" ] && git clone --depth 1 https://github.com/openshift/enhancements.git /tmp/openshift-enhancements
+```
+
+**Step 2 — Read applicable dev-guide files** based on repo type detected in Phase 5:
+
+| Repo Type | Files to Read |
+|-----------|---------------|
+| **Operator** | `dev-guide/api-conventions.md`, `dev-guide/breaking-changes.md`, `dev-guide/operators.md`, `CONVENTIONS.md`, `guidelines/supportability.md`, `dev-guide/cluster-version-operator/dev/clusteroperator.md` |
+| **Library** | `dev-guide/api-conventions.md`, `CONVENTIONS.md`, `dev-guide/breaking-changes.md` |
+| **CLI** | `CONVENTIONS.md`, `dev-guide/breaking-changes.md` |
+
+Extract ONLY diff-enforceable rules — rules that can be checked by looking at a code diff. Discard vague guidance ("should consider...") and retain imperative rules ("Flag X as must-fix", "Never allow Y").
+
+**Step 3 — Chai-bot verification** (optional, requires chai-bot MCP server):
+
+Verify extracted platform rules are still current. If chai-bot is unavailable, skip — include all extracted rules (err on side of inclusion).
+
+```
+mcp__chai-bot__ask_persona:
+"I'm generating REVIEW.md for {component} (github.com/openshift/{component}).
+I extracted these enforceable review rules from openshift/enhancements dev-guide.
+Are these still current? Have any been superseded, relaxed, or tightened?
+
+1. [Rule 1 from Step 2]
+2. [Rule 2 from Step 2]
+...
+(list top 5-8 most critical rules for the detected repo type)
+
+For each rule: confirm current, superseded (by what), or unknown."
+```
+
+**Filtering**: Discard rules chai-bot confirms are superseded. Keep confirmed + unverified (err on side of inclusion). DISCARD any claims about repo internals — chai-bot fabricates these.
+
+**Step 4 — Collect skip patterns** from Phase 5 discoveries:
+- [ ] Generated code inventory (zz_generated*, clientset, informers, listers, bindata, protobuf, payload-manifests)
+- [ ] Vendored dependencies (vendor/**)
+- [ ] CI-enforced checks (from Phase 5 CI enforcement discovery)
+- [ ] Lockfiles (go.sum, go.mod)
+- [ ] Generated dashboards/assets if present
+
+**Step 5 — Extract path-specific rules** from Phase 5 discoveries:
+- [ ] Framework split table (which controllers use which apply method)
+- [ ] Anti-patterns per package/directory
+- [ ] Naming conventions per area
+- [ ] Test conventions (Jira annotations, JUnit output, scoping)
+
+**Step 6 — Calibrate severity** by repo type:
+
+| Repo Type | Must-Fix Categories |
+|-----------|-------------------|
+| **Operator** | Incorrect reconciliation logic, unscoped queries crossing tenant boundaries, resource leaks, upgrade/downgrade safety violations, breaking changes to GA openshift.io APIs, security vulnerabilities, `Available=False` or `Degraded=True` during normal upgrade, premature version bump in ClusterOperator status, tolerating `node.kubernetes.io/unschedulable` |
+| **Library** | API convention violations (bool fields, annotation-based APIs, missing validation markers, pointer misuse in CRDs), breaking changes to stable APIs, functions added to openshift/api |
+| **CLI** | Breaking changes to CLI behavior, security vulnerabilities, incorrect error codes |
+
+Style and naming issues are minor at most for all repo types.
+
+**Step 7 — Generate REVIEW.md**:
+- [ ] Use `templates/REVIEW-template.md` for structure
+- [ ] Fill each section from Steps 2-6, stripping template comments from output
+- [ ] Use tool-agnostic severity language ("must fix before merge" / "worth fixing, not blocking" / "suggestion only")
+- [ ] Use glob patterns for skip rules, not prose descriptions
+- [ ] Cite the dev-guide source for each "Always check" rule (parenthetical at end of line)
+- [ ] Validate line count: target 60-80 lines, soft cap 100
+- [ ] **Do NOT** copy CLAUDE.md content — different purposes
+
+**Step 8 — Generate/merge .coderabbit.yaml**:
+- [ ] Use `templates/coderabbit-template.yaml` for structure
+- [ ] Translate "Do not report" globs to negated `path_filters` (e.g., `!zz_generated*`)
+- [ ] Translate "Path-specific rules" subsections to `path_instructions` entries
+- [ ] Set `knowledge_base.filePatterns` to `["REVIEW.md"]` — **NEVER add CLAUDE.md** (auto-detected separately)
+- [ ] If a `.coderabbit.yaml` already exists in the repo, merge: preserve existing settings (profile, auto_review, pre_merge_checks), add/update `knowledge_base`, `path_filters`, and `path_instructions`
+- [ ] Validate YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"`
+
 ### Phase 10: Validation & Verification
 
 - [ ] Run `bash "$SKILL_DIR/scripts/validate.sh" "$REPO_PATH"` (includes link validation)
@@ -230,6 +311,8 @@ Jira key, PR number) so I can trace it."
 - [ ] **Verify specificity**: Repo structure only in components.md (not duplicated in DEVELOPMENT.md), pattern claims backed by code evidence
 - [ ] **Anti-hallucination checks**: Spot-check type fields if applicable, verify branch names in examples match repo, confirm pattern claims reference actual code
 - [ ] **Operator-specific checks** (if operator repo): Verify apply method claims per-controller (`grep -r "client.Apply\|r.Update\|resourceapply" pkg/controller/<name>/`). Verify feature gate claims trace to actual runtime code. Verify image env var names match Makefile/CSV.
+- [ ] **REVIEW.md checks** (if generated): exists at repo root, ≤100 lines (`wc -l REVIEW.md`), skip paths reference real directories (`test -d`), platform citations present (grep for "dev-guide" or "CONVENTIONS"), no content overlap with CLAUDE.md
+- [ ] **.coderabbit.yaml checks** (if generated): valid YAML (`python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"`), `filePatterns` contains "REVIEW.md" but NOT "CLAUDE.md", `path_filters` match "Do not report" globs, `path_instructions` match "Path-specific rules"
 - [ ] Verify all domain/*.md files link to actual type definitions
 - [ ] Cross-check with openshift-docs if time permits
 - [ ] **Flag discovery gaps**: At the end of components.md and DEVELOPMENT.md, add a brief "SME Review Recommended" note listing areas where automated discovery may be incomplete — typically: implementation recipes for adding new components, anti-patterns from institutional knowledge, and rationale behind pattern choices. This sets expectations that the docs are a verified foundation, not a complete implementation guide
@@ -272,6 +355,9 @@ Use this checklist during Phase 5 when exploring the codebase. These patterns pr
 | **Naming conventions** | Grep for patterns in env vars, labels, file names, package names | Exact format with examples |
 | **Feature toggles** | Are there feature gates, flags, or config-driven enablement? | Definition → runtime check → wiring chain |
 | **Anti-patterns** | Search for "DO NOT", "NEVER", "MUST", "HACK" in code comments. Study 2-3 existing implementations to identify shared patterns and things they avoid | Numbered "DO NOT" list with brief explanation |
+| **CI enforcement** | `grep -E "^(lint\|fmt\|vet\|check\|verify):" Makefile` | CI-enforced checks → "Do not report" in REVIEW.md |
+| **High-risk areas** | `git log --since="1 year" --name-only --pretty=format: \| sort \| uniq -c \| sort -rn \| head -20` | High-churn files → severity tuning in REVIEW.md |
+| **Vendored API boundaries** | `ls vendor/github.com/openshift/api 2>/dev/null` | Vendored API types → "Always check" in REVIEW.md |
 
 ### Operator-Specific Discovery
 
@@ -329,6 +415,8 @@ When the repo is a Kubernetes/OpenShift operator (detected via controller-runtim
 
 ✅ **Operator accuracy** (if operator repo): Apply method documented per-controller (not assumed uniform), feature gate runtime behavior traced, generated code inventory listed, image resolution mechanism documented
 
+✅ **REVIEW.md** (if generated): At repo root, 60-80 lines (cap 100), skip paths valid, platform citations present, no CLAUDE.md overlap, .coderabbit.yaml in sync
+
 ## Anti-Patterns
 
 ### ❌ DON'T duplicate Platform content
@@ -379,6 +467,8 @@ Repository: [path]
 
 Structure:
   ✅ AGENTS.md (root): XX lines (target: 80-100)
+  ✅ REVIEW.md: XX lines (target: 60-80)
+  ✅ .coderabbit.yaml: valid, synced with REVIEW.md
   ✅ Domain concepts: N files
   ✅ Architecture: components.md
   ✅ Component ADRs: N files

--- a/plugins/agentic-docs/skills/component-docs/SKILL.md
+++ b/plugins/agentic-docs/skills/component-docs/SKILL.md
@@ -293,15 +293,18 @@ Style and naming issues are minor at most for all repo types.
 - [ ] Use tool-agnostic severity language ("must fix before merge" / "worth fixing, not blocking" / "suggestion only")
 - [ ] Use glob patterns for skip rules, not prose descriptions
 - [ ] Cite the dev-guide source for each "Always check" rule (parenthetical at end of line)
+- [ ] Include "Verification bar" section — require file:line citations for every comment
+- [ ] Include "Re-review" section — suppress new nits on unchanged code during re-reviews
 - [ ] Validate line count: target 60-80 lines, soft cap 100
 - [ ] **Do NOT** copy CLAUDE.md content — different purposes
 
 **Step 8 — Generate/merge .coderabbit.yaml**:
-- [ ] Use `templates/coderabbit-template.yaml` for structure
-- [ ] Translate "Do not report" globs to negated `path_filters` (e.g., `!zz_generated*`)
+- [ ] Use `templates/coderabbit-template.yaml` for structure — always set `inheritance: true` (inherits org-wide config from `openshift/coderabbit` which already excludes `vendor/**`, `zz_generated*`, `node_modules/**`)
+- [ ] Only add repo-specific exclusions to `path_filters` — skip patterns already covered by org config (vendor, zz_generated, boilerplate)
 - [ ] Translate "Path-specific rules" subsections to `path_instructions` entries
-- [ ] Set `knowledge_base.filePatterns` to `["REVIEW.md"]` — **NEVER add CLAUDE.md** (auto-detected separately)
-- [ ] If a `.coderabbit.yaml` already exists in the repo, merge: preserve existing settings (profile, auto_review, pre_merge_checks), add/update `knowledge_base`, `path_filters`, and `path_instructions`
+- [ ] Set `knowledge_base.filePatterns` to `["REVIEW.md", "AGENTS.md"]` — **NEVER add CLAUDE.md** (auto-detected separately)
+- [ ] `tone_instructions` is optional — only add if the repo has a distinct review culture; org default applies otherwise
+- [ ] If a `.coderabbit.yaml` already exists in the repo, merge: preserve existing settings (profile, auto_review, pre_merge_checks, tools, slop_detection), add/update `knowledge_base`, `path_filters`, and `path_instructions`
 - [ ] Validate YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"`
 
 ### Phase 10: Validation & Verification

--- a/plugins/agentic-docs/skills/component-docs/scripts/validate.sh
+++ b/plugins/agentic-docs/skills/component-docs/scripts/validate.sh
@@ -273,6 +273,75 @@ fi
 
 echo ""
 
+# Check REVIEW.md
+if [ -f "$REPO_PATH/REVIEW.md" ]; then
+    echo "  ✅ REVIEW.md exists"
+    REVIEW_LINES=$(wc -l < "$REPO_PATH/REVIEW.md")
+    if [ "$REVIEW_LINES" -gt 100 ]; then
+        echo "  ⚠️  REVIEW.md is $REVIEW_LINES lines (soft cap: 100)"
+    else
+        echo "     $REVIEW_LINES lines (target: 60-80, cap: 100) ✅"
+    fi
+    # Check for platform citations
+    if grep -qi "dev-guide\|CONVENTIONS\|enhancements" "$REPO_PATH/REVIEW.md"; then
+        echo "  ✅ Platform rule citations found"
+    else
+        echo "  ⚠️  No platform rule citations found"
+    fi
+    # Check skip paths reference real directories
+    while IFS= read -r skip_path; do
+        clean_path=$(echo "$skip_path" | sed 's/[`*]//g' | xargs)
+        if [ -n "$clean_path" ] && [[ "$clean_path" != vendor* ]] && [[ "$clean_path" != go.* ]]; then
+            base_dir=$(echo "$clean_path" | cut -d'/' -f1)
+            if [ -d "$REPO_PATH/$base_dir" ] || [ -f "$REPO_PATH/$base_dir" ]; then
+                if [ "${VERBOSE:-false}" = "true" ]; then
+                    echo "  ✅ Skip path base exists: $base_dir"
+                fi
+            else
+                echo "  ⚠️  Skip path base not found: $base_dir (from $skip_path)"
+            fi
+        fi
+    done < <(grep -oP '`[^`]+\*\*[^`]*`' "$REPO_PATH/REVIEW.md" 2>/dev/null || true)
+    # Check no overlap with CLAUDE.md
+    if [ -f "$REPO_PATH/CLAUDE.md" ]; then
+        overlap=$(comm -12 \
+            <(grep -v '^$\|^#\|^-' "$REPO_PATH/REVIEW.md" 2>/dev/null | sort -u) \
+            <(grep -v '^$\|^#\|^-' "$REPO_PATH/CLAUDE.md" 2>/dev/null | sort -u) \
+            | wc -l)
+        if [ "$overlap" -gt 3 ]; then
+            echo "  ⚠️  REVIEW.md has $overlap lines overlapping with CLAUDE.md"
+        else
+            echo "  ✅ No significant CLAUDE.md overlap"
+        fi
+    fi
+else
+    echo "  ℹ️  REVIEW.md not found (optional — run Phase 9.5 to generate)"
+fi
+
+echo ""
+
+# Check .coderabbit.yaml
+if [ -f "$REPO_PATH/.coderabbit.yaml" ]; then
+    echo "  ✅ .coderabbit.yaml exists"
+    if python3 -c "import yaml; yaml.safe_load(open('$REPO_PATH/.coderabbit.yaml'))" 2>/dev/null; then
+        echo "  ✅ Valid YAML syntax"
+    else
+        echo "  ❌ Invalid YAML syntax"
+    fi
+    if grep -q "REVIEW.md" "$REPO_PATH/.coderabbit.yaml"; then
+        echo "  ✅ filePatterns includes REVIEW.md"
+    else
+        echo "  ⚠️  filePatterns missing REVIEW.md"
+    fi
+    if grep -q "CLAUDE.md" "$REPO_PATH/.coderabbit.yaml" 2>/dev/null; then
+        echo "  ⚠️  filePatterns includes CLAUDE.md (auto-detected, remove)"
+    fi
+else
+    echo "  ℹ️  .coderabbit.yaml not found (optional — run Phase 9.5 to generate)"
+fi
+
+echo ""
+
 # Check for forbidden patterns (generic content duplication)
 echo "Checking for generic duplication..."
 
@@ -313,6 +382,20 @@ if [ -f "$REPO_PATH/AGENTS.md" ]; then
     fi
     echo "  🔗 Internal links:"
     if ! validate_internal_links "$REPO_PATH/AGENTS.md"; then
+        LINK_VALIDATION_FAILED=true
+    fi
+    echo ""
+fi
+
+# Check links in REVIEW.md
+if [ -f "$REPO_PATH/REVIEW.md" ]; then
+    echo "📄 Checking REVIEW.md:"
+    echo "  🔗 External links:"
+    if ! validate_links "$REPO_PATH/REVIEW.md"; then
+        LINK_VALIDATION_FAILED=true
+    fi
+    echo "  🔗 Internal links:"
+    if ! validate_internal_links "$REPO_PATH/REVIEW.md"; then
         LINK_VALIDATION_FAILED=true
     fi
     echo ""

--- a/plugins/agentic-docs/skills/component-docs/templates/REVIEW-template.md
+++ b/plugins/agentic-docs/skills/component-docs/templates/REVIEW-template.md
@@ -94,6 +94,26 @@
      Cite the dev-guide source for each rule (parenthetical at end of line).
 -->
 
+## Verification bar
+
+<!-- Phase 9.5 — Default: "Every comment must cite file:line evidence from the diff
+     or linked source. If you cannot point to a specific line, do not post the comment.
+     Read surrounding context (at minimum the enclosing function) before flagging — the
+     answer may be ten lines below the diff hunk."
+
+     This prevents hallucinated or context-free comments. Adjust wording to match
+     repo conventions if needed, but always require concrete evidence. -->
+
+## Re-review
+
+<!-- Phase 9.5 — Default: "On re-review of an updated PR, only comment on lines that
+     changed since the last review. Do not re-raise resolved issues or introduce new
+     nits on unchanged code. Converge toward approval."
+
+     This prevents review ping-pong where the reviewer raises new issues on
+     unchanged code each round. Adjust wording if the repo has a different
+     re-review policy. -->
+
 ## Path-specific rules
 
 <!-- Phase 9.5 — Fill from Phase 5 framework split + naming conventions.

--- a/plugins/agentic-docs/skills/component-docs/templates/REVIEW-template.md
+++ b/plugins/agentic-docs/skills/component-docs/templates/REVIEW-template.md
@@ -1,0 +1,117 @@
+# Review instructions
+
+<!-- REVIEW.md is the single source of truth for code review tools (Claude Code Review, CodeRabbit).
+     .coderabbit.yaml is a structured sidecar that points CodeRabbit at this file and translates
+     skip/path rules into native format. Keep them in sync — one is the translation of the other.
+
+     Writing conventions:
+     - Tool-agnostic severity: "must fix before merge" / "worth fixing, not blocking" / "suggestion only"
+     - Glob patterns for skips (e.g., `**/clientset/**`) rather than prose
+     - Path rules as markdown subsections with glob headers
+     - Imperative phrasing: "Flag X as must-fix" rather than "X is considered important"
+     - Target 60-80 lines, soft cap 100 — length dilutes signal
+
+     Don'ts:
+     - Don't copy CLAUDE.md content into REVIEW.md — different purposes
+     - Don't include vague dev-guide guidance — only diff-enforceable rules
+     - Don't duplicate CI — suppress those categories, don't re-enforce
+     - Don't use tool-specific severity markers — natural language only
+-->
+
+## Must fix before merge
+
+<!-- Phase 9.5 — Fill based on repo type detected in Phase 5:
+
+     OPERATORS: Flag as must-fix: incorrect reconciliation logic, unscoped queries
+     crossing tenant boundaries, resource leaks, upgrade/downgrade safety violations,
+     breaking changes to GA openshift.io APIs, unmitigated security vulnerabilities,
+     Available=False or Degraded=True during normal upgrade, premature version bump
+     in ClusterOperator status. Style and naming are minor at most.
+
+     LIBRARIES: Flag as must-fix: API convention violations (bool fields, annotation-based
+     APIs, missing validation markers, pointer misuse in CRDs), breaking changes to
+     stable APIs, functions added to openshift/api.
+
+     CLIs: Flag as must-fix: breaking changes to CLI behavior, security vulnerabilities,
+     incorrect error codes or output format changes.
+
+     Source: openshift/enhancements dev-guide/api-conventions.md, dev-guide/breaking-changes.md,
+     CONVENTIONS.md, dev-guide/operators.md, guidelines/supportability.md
+-->
+
+## Minor issue volume
+
+<!-- Phase 9.5 — Default: "Report at most five minor issues. Overflow: 'plus N similar items'
+     in the summary. If all minor, lead with 'No blocking issues.'"
+     Adjust count based on repo complexity if needed. -->
+
+## Do not report
+
+<!-- Phase 9.5 — Fill from Phase 5 CI enforcement discovery + generated code inventory.
+
+     Always include these categories:
+     - CI-enforced: lint, gofmt, govet, type-check (discovered from `grep Makefile`)
+     - Generated: `zz_generated*`, `**/clientset/**`, `**/informers/**`, `**/listers/**`
+     - Vendored: `vendor/**`
+     - Lockfiles: `go.sum`, `go.mod` (review dep bumps separately)
+
+     Repo-specific additions from Phase 5:
+     - Generated dashboards/assets if present (e.g., `assets/**`)
+     - Bindata files if present (e.g., `**/bindata.go`)
+     - Protobuf generated files (e.g., `generated.pb.go`, `generated.proto`)
+     - Payload manifests if present (e.g., `payload-manifests/**`)
+
+     Use glob patterns, not prose descriptions.
+-->
+
+## Always check
+
+<!-- Phase 9.5 — Fill from repo-type platform rules + Phase 5 discoveries.
+
+     OPERATORS (all apply):
+     - Feature gates: alpha behind TechPreviewNoUpgrade (guidelines/supportability.md)
+     - API fields: no bool fields, no CRD pointers unless zero vs unset; config APIs
+       default in controller (dev-guide/api-conventions.md)
+     - HA: 2 replicas + hard anti-affinity on hostname (CONVENTIONS.md)
+     - "OpenShift" never "Openshift" (CONVENTIONS.md)
+     - Breaking GA API changes -> must-fix (dev-guide/breaking-changes.md)
+     - No PII in logs (email, tokens, request bodies)
+     - Resource requests required, limits forbidden (CONVENTIONS.md)
+     - Never tolerate node.kubernetes.io/unschedulable (CONVENTIONS.md)
+     - Status conditions: reason+message for happy AND sad states (clusteroperator.md)
+     - Leader election: 137/107/26s defaults (CONVENTIONS.md)
+     - Metrics: HTTPS + TLS client certs (CONVENTIONS.md)
+
+     LIBRARIES:
+     - API conventions: no bool fields, no functions in openshift/api, no annotation APIs
+     - Validation markers match godoc constraints
+     - Object references use resource-specific types
+
+     CLIs:
+     - "OpenShift" never "Openshift"
+     - CLI elements default to API tier 1
+
+     Cite the dev-guide source for each rule (parenthetical at end of line).
+-->
+
+## Path-specific rules
+
+<!-- Phase 9.5 — Fill from Phase 5 framework split + naming conventions.
+
+     Use glob headers for each path. Example:
+
+     ### `pkg/controller/**`
+     Verify apply method matches existing controllers. Do not mix SSA
+     and strategic merge within the same controller package.
+
+     ### `test/**`
+     Jira component annotation required. Always produce JUnit result.
+     Narrow scope; exclude must-gather namespaces (dev-guide/test-conventions.md).
+
+     ### `vendor/**`
+     Do not review — vendored code is upstream's responsibility.
+     Review go.mod changes for dependency bumps separately.
+
+     Add subsections based on Phase 5 discoveries — only for paths where
+     the repo has specific conventions that differ from the repo-wide rules.
+-->

--- a/plugins/agentic-docs/skills/component-docs/templates/coderabbit-template.yaml
+++ b/plugins/agentic-docs/skills/component-docs/templates/coderabbit-template.yaml
@@ -1,0 +1,43 @@
+# CodeRabbit configuration — structured sidecar for REVIEW.md
+#
+# Phase 9.5 generates this file alongside REVIEW.md. The two must stay in sync:
+# - knowledge_base.filePatterns points at REVIEW.md (NEVER add CLAUDE.md — auto-detected)
+# - path_filters mirrors "Do not report" skip patterns from REVIEW.md (negated globs)
+# - path_instructions mirrors "Path-specific rules" from REVIEW.md
+#
+# This template shows the structure. Phase 9.5 fills in repo-specific values.
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "REVIEW.md"
+      # NEVER add CLAUDE.md here — CodeRabbit auto-detects it separately
+
+reviews:
+  path_filters:
+    # Phase 9.5: Translate "Do not report" globs to negated path_filters.
+    # Each entry is a negated glob — CodeRabbit skips matching files.
+    # Example entries (replace with actual Phase 5 discoveries):
+    #
+    # - "!zz_generated*"
+    # - "!**/clientset/**"
+    # - "!**/informers/**"
+    # - "!**/listers/**"
+    # - "!vendor/**"
+    # - "!assets/**"
+
+  path_instructions:
+    # Phase 9.5: Translate "Path-specific rules" subsections to path_instructions.
+    # Each entry maps a glob path to review instructions.
+    # Example entries (replace with actual Phase 5 discoveries):
+    #
+    # - path: "pkg/controller/**"
+    #   instructions: |
+    #     Verify apply method matches existing controllers. Do not mix
+    #     SSA and strategic merge within the same controller.
+    #
+    # - path: "test/**"
+    #   instructions: |
+    #     Jira component annotation required. Always produce JUnit
+    #     result. Narrow scope.

--- a/plugins/agentic-docs/skills/component-docs/templates/coderabbit-template.yaml
+++ b/plugins/agentic-docs/skills/component-docs/templates/coderabbit-template.yaml
@@ -1,31 +1,39 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
 # CodeRabbit configuration — structured sidecar for REVIEW.md
 #
 # Phase 9.5 generates this file alongside REVIEW.md. The two must stay in sync:
-# - knowledge_base.filePatterns points at REVIEW.md (NEVER add CLAUDE.md — auto-detected)
+# - knowledge_base.filePatterns points at REVIEW.md + AGENTS.md
 # - path_filters mirrors "Do not report" skip patterns from REVIEW.md (negated globs)
 # - path_instructions mirrors "Path-specific rules" from REVIEW.md
 #
 # This template shows the structure. Phase 9.5 fills in repo-specific values.
+# Inherits org-wide settings from https://github.com/openshift/coderabbit
 
-knowledge_base:
-  code_guidelines:
-    enabled: true
-    filePatterns:
-      - "REVIEW.md"
-      # NEVER add CLAUDE.md here — CodeRabbit auto-detects it separately
+inheritance: true
+language: en-US
+
+# Phase 9.5: Adjust tone to match repo review culture. Remove if org default is fine.
+# tone_instructions: >
+#   Be direct and technical. State the issue, cite file:line, suggest a fix.
+#   No pleasantries or filler.
 
 reviews:
+  profile: chill
+  high_level_summary: true
+  poem: false
+  collapse_walkthrough: false
+  request_changes_workflow: false
+
   path_filters:
     # Phase 9.5: Translate "Do not report" globs to negated path_filters.
-    # Each entry is a negated glob — CodeRabbit skips matching files.
+    # Org config already excludes vendor/** and zz_generated* — only add
+    # repo-specific exclusions here.
     # Example entries (replace with actual Phase 5 discoveries):
     #
-    # - "!zz_generated*"
-    # - "!**/clientset/**"
-    # - "!**/informers/**"
-    # - "!**/listers/**"
-    # - "!vendor/**"
     # - "!assets/**"
+    # - "!**/bindata.go"
+    # - "!payload-manifests/**"
 
   path_instructions:
     # Phase 9.5: Translate "Path-specific rules" subsections to path_instructions.
@@ -41,3 +49,17 @@ reviews:
     #   instructions: |
     #     Jira component annotation required. Always produce JUnit
     #     result. Narrow scope.
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "REVIEW.md"
+      - "AGENTS.md"
+      # NEVER add CLAUDE.md here — CodeRabbit auto-detects it separately
+  learnings:
+    scope: local


### PR DESCRIPTION
This PR adds the ability to agentic docs to create a review.md and coderabbit.yaml file. [Example files](https://github.com/openshift/machine-config-operator/commit/b340aee7140a46cb6eb7c24f81e88a23ea06c550)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component documentation workflows now generate review guidance and optional automated review configuration.
  * Added repository-specific review checks for platform rules, high-risk areas, CI patterns, and vendored API boundaries.
  * Added configurable review templates covering severity, evidence, re-review behavior, and path-specific rules.

* **Validation**
  * Added checks for review documentation structure, links, YAML validity, file patterns, path coverage, and rule overlap.

* **Chores**
  * Updated the documentation plugin release version to 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->