### PR TITLE
payload-snapshot: extract RPM changelogs for packages changed vs. baseline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,7 +41,7 @@
         "repo": "rh-uxd/ai-helpers",
         "path": "plugins/patternfly"
       },
-      "description": "PatternFly development tools from the UXD team — component scaffolding, design guidance, auditing, migration, test generation, and an MCP server.",
+      "description": "PatternFly development tools from the UXD team \u2014 component scaffolding, design guidance, auditing, migration, test generation, and an MCP server.",
       "category": "development",
       "keywords": [
         "patternfly",
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.79",
+      "version": "0.0.80",
       "category": "ci",
       "keywords": [
         "prow",

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -66,6 +66,9 @@ python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-junit
 # Skip RPMDB extraction
 python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-rpmdb
 
+# Skip RPM changelog extraction (RPMDB is still extracted)
+python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-rpm-changelogs
+
 # Force Sippy for all payload metadata (normally fallback is automatic)
 python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --sippy
 ```
@@ -82,7 +85,8 @@ The script will:
 9. Track per-job failure streaks — consecutive failures, originating payload, failure pattern
 10. For each unique PR across all changelogs, fetch the git diff, comments, and CI jobs via `gh`
 11. For each payload in the chain, extract the full RPM database from RHCOS images via `podman`
-12. Generate summary.json with comprehensive triage data, plus AGENTS.md/CLAUDE.md for agent orientation
+12. For packages changed between the target and its baseline, extract the relevant RPM changelog via `rpm --changelog`, diffed exactly against the baseline's own RPMDB when available
+13. Generate summary.json with comprehensive triage data, plus AGENTS.md/CLAUDE.md for agent orientation
 
 ### Step 2: Navigate the Snapshot
 
@@ -121,6 +125,8 @@ payload/
         rpmdb/                             # RPMDB from RHCOS images
           rhel-coreos/                     # queryable with rpm --dbpath
             rpmdb.sqlite
+            changelogs/                    # RPM changelogs vs. baseline
+              <package>.txt
           rhel-coreos-10/
             rpmdb.sqlite
 ```
@@ -157,6 +163,12 @@ jq '.[].name' payload/<version>/<stream>/<tag>/jobs/blocking/<job-name>/junit/re
 rpm -qa --dbpath $(pwd)/payload/<version>/<stream>/<tag>/rpmdb/rhel-coreos
 ```
 
+**Read the changelog for a package that changed vs. baseline:**
+```bash
+jq '.rpm_changelogs[] | {variant, package, old, new, changelog}' payload/<version>/<stream>/summary.json
+cat payload/<version>/<stream>/<tag>/rpmdb/<variant>/changelogs/<package>.txt
+```
+
 ## CLI Reference
 
 ```text
@@ -171,6 +183,8 @@ Options:
   --workers N          Parallel workers for API calls (default: 8)
   --no-junit           Skip JUnit download and regression tracking
   --no-rpmdb           Skip RHCOS RPMDB extraction
+  --no-rpm-changelogs  Skip RPM changelog extraction for packages changed
+                       vs. baseline
   --sippy              Force Sippy for all payload metadata instead of using
                        the automatic release-controller-first fallback
   --fail-on-incomplete Exit 1 if any requested data could not be collected
@@ -193,6 +207,7 @@ Comprehensive stream-level triage data — start here. Contains:
 - `test_failures.informing[]` / `test_failures.flakes[]` — `test_name`, `jobs`. Neither can fail a job. No onset is tracked for them, because an onset implies there is a culprit to find.
 - `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments paths, and `rhcos_changes[]` with RPM diffs per RHCOS variant
 - `rhcos_rpms[]` — RPMDB metadata for the target payload's RHCOS variants: `tag`, `name`, `pullspec`, `rpmdb` (relative path to rpmdb.sqlite)
+- `rpm_changelogs[]` — RPM changelogs for packages changed between the target and its baseline (reconstructed from the chain's per-hop `rhcos_changes`, not a dedicated API call): `variant`, `package`, `old`, `new`, `changelog` (relative path to the extracted, trimmed `rpm --changelog` output), `boundary_found`, `trim_method` (`rpmdb_diff` / `version_match` / `full_dump`)
 - `data_complete` — `true` when all requested data was ultimately collected, including via a fallback after an initial read failed. `false` means some requested data could not be read at all.
 - `collection_errors[]` — every read failure encountered. Each entry has `reason`, `command`, and optionally `detail`, `stage`, `job`, `payload_tag`, `recovered`. Reasons: `auth`, `timeout`, `gcloud_missing`, `command_failed`, `junit_unavailable` (nothing readable), `junit_missing` (nothing discovered), `junit_unparseable` (corrupt XML), `junit_partial` (some files unread), `build_log_unavailable`.
   - `recovered: true` means a fallback subsequently obtained the data. These entries are diagnostic only (useful for spotting a timeout that needs tuning) and do **not** make `data_complete` false.
@@ -305,6 +320,17 @@ Only variants with non-empty `rpmDiff` are included. When the snapshot is create
 The `rpmdb.sqlite` file extracted from RHCOS images via `podman`. One directory per RHCOS variant (e.g., `rpmdb/rhel-coreos/`, `rpmdb/rhel-coreos-10/`), each containing `rpmdb.sqlite`. Queryable with `rpm -qa --dbpath <absolute-path-to-variant-dir>` or directly with `sqlite3`.
 
 Extracted for every payload in the chain. Skipped when `podman` is unavailable or `--no-rpmdb` is passed.
+
+### `rpmdb/<variant>/changelogs/<package>.txt`
+
+The `rpm --changelog` output for a package that changed somewhere between the target payload and its baseline, extracted from the target's already-downloaded `rpmdb.sqlite` (no extra image pull). The target-vs-baseline diff is reconstructed by folding the per-hop `rhcos_changes` already present in each chain payload's `changelog.json` — not a dedicated API call.
+
+Each file starts with a small header (`old`, `new`, `boundary_found`, `trim_method`) followed by the changelog text, trimmed to just the entries newer than `old`. Three trim strategies are tried in order, recorded in `trim_method`:
+- `rpmdb_diff` — exact: the baseline payload's RPMDB is also extracted (every payload in the chain gets one), so its `rpm --changelog` output for the same package is diffed against the target's — the baseline's entries should appear verbatim as the target's oldest entries, and whatever's above that is exactly what changed. No version-string guessing.
+- `version_match` — used when the exact diff isn't available (baseline RPMDB missing, or its changelog didn't line up as a clean prefix of the target's): a substring match on the conventional `- <version>` suffix in changelog headers, since RPM changelog entries have no structured version field.
+- `full_dump` — neither approach found a boundary; the full untrimmed changelog is kept instead of guessing wrong. `boundary_found: false` only in this case.
+
+Referenced from `summary.json`'s `rpm_changelogs[]`. Skipped when `rpm` is unavailable, `--no-rpm-changelogs` is passed, RPMDB extraction itself was skipped, or the chain has no baseline (`chain_length < 2`).
 
 ### `regressions.json`
 

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -1578,13 +1578,15 @@ class SummaryGenerator:
 
     def __init__(self, base_dir: str, chain: list[str], target_tag: str,
                  tag: "PayloadTag", streaks: Optional[dict] = None,
-                 rpmdb_data: Optional[dict[str, list[dict]]] = None):
+                 rpmdb_data: Optional[dict[str, list[dict]]] = None,
+                 rpm_changelogs: Optional[list[dict]] = None):
         self.base_dir = base_dir
         self.chain = chain
         self.target_tag = target_tag
         self.tag = tag
         self.streaks = streaks or {}
         self.rpmdb_data = rpmdb_data or {}
+        self.rpm_changelogs = rpm_changelogs or []
 
     def generate(self) -> None:
         target_dir = os.path.join(self.base_dir, self.target_tag)
@@ -1664,6 +1666,9 @@ class SummaryGenerator:
                 {**entry, "rpmdb": f"{self.target_tag}/rpmdb/{entry['tag']}/rpmdb.sqlite"}
                 for entry in target_rpms
             ]
+
+        if self.rpm_changelogs:
+            summary["rpm_changelogs"] = self.rpm_changelogs
 
         # Surface any data that could not be collected.  An empty snapshot
         # section must never be silently indistinguishable from a clean one.
@@ -1782,6 +1787,8 @@ class SummaryGenerator:
             "    rpmdb/                    # RPMDB from RHCOS images",
             "      rhel-coreos/           # queryable with rpm --dbpath",
             "        rpmdb.sqlite",
+            "        changelogs/          # RPM changelogs vs. baseline",
+            "          <package>.txt",
             "      rhel-coreos-10/",
             "        rpmdb.sqlite",
             "  <older-payload-tag>/      # Each prior payload in the chain",
@@ -1828,6 +1835,13 @@ class SummaryGenerator:
             "- `rhcos_rpms[]` — RPMDB per RHCOS variant for the target",
             "  payload: `tag`, `name`, `pullspec`, `rpmdb` (relative path",
             "  to rpmdb.sqlite — queryable with rpm --dbpath <dir> or sqlite3)",
+            "- `rpm_changelogs[]` — RPM changelogs for packages changed",
+            "  vs. the baseline: `variant`, `package`, `old`, `new`,",
+            "  `changelog` (relative path to the extracted, trimmed",
+            "  `rpm --changelog` output), `boundary_found`, `trim_method`",
+            "  (`rpmdb_diff` — exact, diffed against the baseline's own",
+            "  rpmdb; `version_match` — heuristic version-string cut;",
+            "  `full_dump` — untrimmed, neither approach found a boundary)",
             "",
         ])
 
@@ -2095,7 +2109,8 @@ class Snapshotter:
     def __init__(self, tag: PayloadTag, output_dir: str = "payload",
                  max_chain: int = 20, workers: int = 8,
                  collect_junit: bool = True, use_sippy: bool = False,
-                 collect_rpmdb: bool = True):
+                 collect_rpmdb: bool = True,
+                 collect_rpm_changelogs: bool = True):
         self.tag = tag
         self.output_dir = output_dir
         self.max_chain = max_chain
@@ -2103,6 +2118,7 @@ class Snapshotter:
         self.collect_junit = collect_junit
         self.use_sippy = use_sippy
         self.collect_rpmdb = collect_rpmdb
+        self.collect_rpm_changelogs = collect_rpm_changelogs
         self.rc = ReleaseController(tag.architecture, stream=tag.stream)
         self.sippy = SippyClient(
             tag.version, architecture=tag.architecture, stream=tag.stream
@@ -2148,8 +2164,13 @@ class Snapshotter:
 
         rpmdb_data = self._collect_rpmdb(base_dir, chain)
 
+        rpm_changelogs = self._collect_rpm_changelogs(
+            base_dir, chain, rpmdb_data
+        )
+
         self._generate_summary(base_dir, chain, streaks,
-                               rpmdb_data=rpmdb_data)
+                               rpmdb_data=rpmdb_data,
+                               rpm_changelogs=rpm_changelogs)
 
         _log(f"\nSnapshot complete: {base_dir}/")
 
@@ -2543,10 +2564,189 @@ class Snapshotter:
 
         return rpmdb_data
 
+    def _collect_rpm_changelogs(
+        self, base_dir: str, chain: list[str],
+        rpmdb_data: dict[str, list[dict]],
+    ) -> list[dict]:
+        """Extract RPM changelogs for packages changed vs. the baseline.
+
+        Reuses the per-hop changelog.json files already fetched by
+        _collect_payloads (each diffs chain[i] against chain[i+1]) instead
+        of making a dedicated target-vs-baseline API call: walking the
+        chain oldest-to-newest and folding each hop's rpmDiff.changed into
+        a running per-variant {package: {old, new}} reconstructs the same
+        diff the release page shows for target vs. baseline.
+        """
+        if not self.collect_rpm_changelogs or not self.collect_rpmdb:
+            return []
+        if self.use_sippy or len(chain) < 2:
+            return []
+
+        target_tag = chain[0]
+        baseline_tag = chain[-1]
+        target_rpms = rpmdb_data.get(target_tag)
+        if not target_rpms:
+            return []
+        extracted_variants = {entry["tag"] for entry in target_rpms}
+        baseline_variants = {
+            entry["tag"] for entry in rpmdb_data.get(baseline_tag, [])
+        }
+
+        cumulative: dict[str, dict[str, dict]] = {}
+        for i in range(len(chain) - 2, -1, -1):
+            hop_tag = chain[i]
+            changelog = _read_json(
+                os.path.join(base_dir, hop_tag, "changelog.json")
+            )
+            if changelog is None:
+                # Unreadable, not just empty - the fold below assumes every
+                # hop was seen, so continuing would risk misattributing a
+                # later hop's "old" version as the true baseline version.
+                _log(f"\nSkipping RPM changelogs: could not read "
+                     f"changelog.json for {hop_tag}")
+                return []
+            if not changelog:
+                continue
+            for stream in _extract_rhcos_changes(changelog):
+                variant = stream.get("tag", "")
+                if variant not in extracted_variants:
+                    continue
+                variant_changes = cumulative.setdefault(variant, {})
+                for pkg, versions in (stream.get("changed") or {}).items():
+                    if pkg in variant_changes:
+                        variant_changes[pkg]["new"] = versions.get("new", "")
+                    else:
+                        variant_changes[pkg] = dict(versions)
+
+        if not cumulative:
+            return []
+
+        packages = [
+            (variant, pkg, versions.get("old", ""), versions.get("new", ""))
+            for variant, changes in cumulative.items()
+            for pkg, versions in changes.items()
+            if versions.get("old", "") != versions.get("new", "")
+        ]
+        if not packages:
+            return []
+
+        workers = min(self.workers, 4)
+        _log(f"\nExtracting RPM changelogs for {target_tag} vs. baseline "
+             f"{chain[-1]} ({len(packages)} packages, {workers} workers)...")
+        results = []
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(
+                    self._extract_one_changelog, target_tag, variant,
+                    os.path.join(base_dir, target_tag, "rpmdb", variant),
+                    pkg, old, new,
+                    os.path.join(base_dir, baseline_tag, "rpmdb", variant)
+                        if variant in baseline_variants else None,
+                ): (variant, pkg)
+                for variant, pkg, old, new in packages
+            }
+            for future in as_completed(futures):
+                variant, pkg = futures[future]
+                try:
+                    entry = future.result()
+                    if entry:
+                        results.append(entry)
+                except Exception as e:
+                    _log(f"    {variant}/{pkg}: error: {e}")
+        return results
+
+    def _extract_one_changelog(
+        self, target_tag: str, variant: str, variant_dir: str,
+        pkg: str, old: str, new: str,
+        baseline_variant_dir: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Extract and trim one package's changelog from the target rpmdb."""
+        if not re.match(r"^[A-Za-z0-9._+-]+$", pkg):
+            _log(f"    {variant}: skipping suspicious package name: {pkg!r}")
+            return None
+
+        rel_path = f"{target_tag}/rpmdb/{variant}/changelogs/{pkg}.txt"
+        output_path = os.path.join(variant_dir, "changelogs", f"{pkg}.txt")
+        if os.path.exists(output_path):
+            cached = _read_changelog_cache_header(output_path)
+            if cached and cached["old"] == old and cached["new"] == new:
+                _log(f"    {variant}/{pkg}: skip (exists)")
+                return {
+                    "variant": variant, "package": pkg, "old": old, "new": new,
+                    "changelog": rel_path,
+                    "boundary_found": cached["boundary_found"],
+                    "trim_method": cached["trim_method"],
+                }
+            _log(f"    {variant}/{pkg}: cached boundary stale, re-extracting")
+
+        target_stdout = self._run_rpm_changelog(variant, pkg, variant_dir)
+        if target_stdout is None:
+            return None
+
+        trimmed = None
+        method = "full_dump"
+        if baseline_variant_dir:
+            baseline_stdout = self._run_rpm_changelog(
+                variant, pkg, baseline_variant_dir, quiet=True
+            )
+            if baseline_stdout is not None:
+                trimmed = _diff_changelog_against_baseline(
+                    target_stdout, baseline_stdout
+                )
+                if trimmed is not None:
+                    method = "rpmdb_diff"
+
+        if trimmed is None:
+            trimmed, found = _trim_changelog_to_new_entries(target_stdout, old)
+            method = "version_match" if found else "full_dump"
+
+        boundary_found = method != "full_dump"
+        header = (f"# {pkg}: {old} -> {new}\n"
+                  f"# boundary_found: {boundary_found}\n"
+                  f"# trim_method: {method}\n\n")
+        _write_text(output_path, header + trimmed + "\n")
+        _log(f"    {variant}/{pkg}: changelog extracted "
+             f"({old} -> {new}, {method})")
+        return {
+            "variant": variant, "package": pkg, "old": old, "new": new,
+            "changelog": rel_path, "boundary_found": boundary_found,
+            "trim_method": method,
+        }
+
+    @staticmethod
+    def _run_rpm_changelog(
+        variant: str, pkg: str, dbpath: str, quiet: bool = False,
+    ) -> Optional[str]:
+        """Run `rpm -q --changelog` against one rpmdb dir.
+
+        quiet=True suppresses failure logging for probes where "unavailable"
+        is expected and not an error (e.g. querying the baseline's rpmdb,
+        which may not have this package extracted at all).
+        """
+        try:
+            result = subprocess.run(
+                ["rpm", "-q", "--changelog", "--dbpath", dbpath, pkg],
+                capture_output=True, text=True, timeout=30,
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            if not quiet:
+                _log(f"    {variant}/{pkg}: rpm --changelog failed: {e}")
+            return None
+        if result.returncode != 0:
+            if not quiet:
+                _log(f"    {variant}/{pkg}: rpm --changelog failed "
+                     f"(exit {result.returncode})")
+                stderr = result.stderr.strip()
+                if stderr:
+                    _log(f"    stderr: {stderr}")
+            return None
+        return result.stdout
+
     def _generate_summary(
         self, base_dir: str, chain: list[str],
         streaks: Optional[dict] = None,
         rpmdb_data: Optional[dict[str, list[dict]]] = None,
+        rpm_changelogs: Optional[list[dict]] = None,
     ) -> None:
         """Generate the stream-level summary."""
         _log("\nGenerating summary...")
@@ -2556,7 +2756,7 @@ class Snapshotter:
 
         generator = SummaryGenerator(
             base_dir, chain, chain[0], self.tag, streaks=streaks,
-            rpmdb_data=rpmdb_data,
+            rpmdb_data=rpmdb_data, rpm_changelogs=rpm_changelogs,
         )
         generator.generate()
 
@@ -2674,6 +2874,94 @@ def _extract_rhcos_changes(changelog: dict) -> list[dict]:
             "removed": rpm_diff.get("removed", {}),
         })
     return results
+
+
+def _split_changelog_entries(changelog_text: str) -> list[str]:
+    """Split `rpm --changelog` output into individual entries, each
+    starting with a "* <date> <name>" header line."""
+    return [
+        e for e in re.split(r"(?=^\* )", changelog_text, flags=re.MULTILINE)
+        if e.strip()
+    ]
+
+
+def _diff_changelog_against_baseline(
+    target_text: str, baseline_text: str
+) -> Optional[str]:
+    """Exact diff of two `rpm --changelog` outputs for the same package,
+    read from the target and baseline RPMDBs.
+
+    RPM changelogs only grow (newest entries prepended), so the baseline's
+    entries should appear verbatim as the oldest contiguous suffix of the
+    target's entries. When that holds, the entries above that suffix are
+    exactly what changed between baseline and target — no version-string
+    guessing needed. Returns None if the invariant doesn't hold (diverged
+    history, or the package wasn't in the baseline at all), so the caller
+    can fall back to a looser heuristic instead of trusting a bogus diff.
+    """
+    baseline_entries = _split_changelog_entries(baseline_text)
+    if not baseline_entries:
+        return None
+    target_entries = _split_changelog_entries(target_text)
+    n = len(baseline_entries)
+    if len(target_entries) < n or target_entries[-n:] != baseline_entries:
+        return None
+    return "".join(target_entries[:-n]).strip("\n")
+
+
+def _trim_changelog_to_new_entries(
+    changelog_text: str, old_version: str
+) -> tuple[str, bool]:
+    """Best-effort trim of `rpm --changelog` output to entries newer than
+    old_version.
+
+    RPM changelog entries have no structured version field — packagers
+    conventionally end each entry's header line with "- <version>". Cut
+    there if found; otherwise return the full changelog unchanged, since a
+    wrong guess is worse than showing extra history.
+    """
+    bare_old = old_version.split(":", 1)[-1]  # strip epoch prefix, if any
+    # Anchor to the trailing version token (preceded by whitespace/"-", and
+    # at end of line) so e.g. old="1.2" doesn't match inside a newer "1.20.3-1".
+    boundary_re = (
+        re.compile(rf"(?:^|[\s-]){re.escape(bare_old)}\s*$")
+        if bare_old else None
+    )
+    kept = []
+    for entry in _split_changelog_entries(changelog_text):
+        first_line = entry.splitlines()[0]
+        if boundary_re and boundary_re.search(first_line):
+            return "".join(kept).strip("\n"), True
+        kept.append(entry)
+    return changelog_text.strip("\n"), False
+
+
+_CHANGELOG_HEADER_RE = re.compile(
+    r"^# .+: (?P<old>\S+) -> (?P<new>\S+)\n"
+    r"# boundary_found: (?P<boundary>True|False)\n"
+    r"# trim_method: (?P<method>\S+)\n"
+)
+
+
+def _read_changelog_cache_header(path: str) -> Optional[dict]:
+    """Parse the (old, new, boundary_found, trim_method) header
+    _extract_one_changelog writes to a changelog file, to check a cached
+    file is still valid for the currently computed old/new before reusing
+    it."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            head = f.read(4096)
+    except OSError:
+        return None
+    m = _CHANGELOG_HEADER_RE.match(head)
+    if not m:
+        return None
+    return {
+        "old": m.group("old"),
+        "new": m.group("new"),
+        "boundary_found": m.group("boundary") == "True",
+        "trim_method": m.group("method"),
+    }
 
 
 def _parse_pr_url(url: str) -> Optional[tuple[str, str, int]]:
@@ -3131,6 +3419,18 @@ def _check_podman() -> bool:
         return False
 
 
+def _check_rpm() -> bool:
+    """Verify that the rpm CLI is available."""
+    try:
+        result = subprocess.run(
+            ["rpm", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _run_podman(
     args: list[str], timeout: int = 300
 ) -> Optional[subprocess.CompletedProcess]:
@@ -3480,6 +3780,10 @@ def main() -> None:
         help="Skip RHCOS RPMDB extraction",
     )
     parser.add_argument(
+        "--no-rpm-changelogs", action="store_true",
+        help="Skip RPM changelog extraction for packages changed vs. baseline",
+    )
+    parser.add_argument(
         "--sippy", action="store_true",
         help=(
             "Force Sippy for all payload metadata (default: prefer release "
@@ -3531,6 +3835,12 @@ def main() -> None:
         _log("RHCOS RPMDB data will not be extracted.\n")
         collect_rpmdb = False
 
+    collect_rpm_changelogs = not args.no_rpm_changelogs
+    if collect_rpmdb and collect_rpm_changelogs and not _check_rpm():
+        _log("Warning: rpm CLI not available. RPM changelog extraction "
+             "will be skipped.\n")
+        collect_rpm_changelogs = False
+
     if args.sippy:
         _log("Forcing Sippy APIs for all release payload data.\n")
 
@@ -3543,6 +3853,7 @@ def main() -> None:
             collect_junit=collect_junit,
             use_sippy=args.sippy,
             collect_rpmdb=collect_rpmdb,
+            collect_rpm_changelogs=collect_rpm_changelogs,
         )
         snapshotter.run()
 

--- a/plugins/ci/skills/payload-snapshot/scripts/test_rpm_changelogs.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/test_rpm_changelogs.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Tests for RPM changelog extraction (packages changed vs. baseline).
+
+Run with: pytest test_rpm_changelogs.py
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "payload_snapshot_rpm_changelogs", os.path.join(_HERE, "payload_snapshot.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ps = _load_module()
+
+
+def _snapshotter(**kwargs):
+    tag = ps.PayloadTag.parse("5.0.0-0.nightly-2026-08-03-000000")
+    return ps.Snapshotter(tag, **kwargs)
+
+
+def _fake_result(returncode=0, stdout="", stderr=""):
+    return type("R", (), {
+        "returncode": returncode, "stdout": stdout, "stderr": stderr,
+    })()
+
+
+# ---------------------------------------------------------------------------
+# _trim_changelog_to_new_entries — version-string heuristic
+# ---------------------------------------------------------------------------
+
+CHANGELOG = """\
+* Fri Aug 01 2026 Some Body <a@b.com> - 5.14.0-687.33.1.el9_8
+- newest entry
+
+* Wed Jul 30 2026 Some Body <a@b.com> - 5.14.0-687.32.1.el9_8
+- boundary entry (old version)
+
+* Mon Jul 20 2026 Some Body <a@b.com> - 5.14.0-687.30.1.el9_8
+- older entry
+"""
+
+
+def test_trim_finds_boundary_and_keeps_only_newer_entries():
+    trimmed, found = ps._trim_changelog_to_new_entries(
+        CHANGELOG, "5.14.0-687.32.1.el9_8"
+    )
+    assert found is True
+    assert "newest entry" in trimmed
+    assert "boundary entry" not in trimmed
+    assert "older entry" not in trimmed
+
+
+def test_trim_strips_epoch_prefix_before_matching():
+    trimmed, found = ps._trim_changelog_to_new_entries(
+        CHANGELOG, "2:5.14.0-687.32.1.el9_8"
+    )
+    assert found is True
+    assert "newest entry" in trimmed
+
+
+def test_trim_falls_back_to_full_changelog_when_no_match():
+    trimmed, found = ps._trim_changelog_to_new_entries(CHANGELOG, "9.9.9-nomatch")
+    assert found is False
+    assert trimmed.strip() == CHANGELOG.strip()
+
+
+def test_trim_does_not_false_positive_on_substring_version():
+    """A short old version must not match inside a longer newer one.
+
+    Regression test: old="1.2" used to match anywhere inside "1.20.3-1"
+    (a plain substring test), silently discarding the real newest entry
+    while reporting boundary_found=True.
+    """
+    changelog = (
+        "* Mon Aug 03 2026 Someone <a@b.com> - 1.20.3-1\n"
+        "- newest fix\n\n"
+        "* Mon Jan 01 2026 Someone <a@b.com> - 1.2-1\n"
+        "- old baseline\n"
+    )
+    trimmed, found = ps._trim_changelog_to_new_entries(changelog, "1.2")
+    assert found is False
+    assert "newest fix" in trimmed
+    assert "old baseline" in trimmed
+
+
+# ---------------------------------------------------------------------------
+# _diff_changelog_against_baseline — exact rpmdb-vs-rpmdb diff
+# ---------------------------------------------------------------------------
+
+def test_diff_against_baseline_returns_only_new_entries():
+    baseline = (
+        "* Wed Jul 30 2026 Some Body <a@b.com> - 1.1-1\n"
+        "- boundary entry\n\n"
+        "* Mon Jul 20 2026 Some Body <a@b.com> - 1.0-1\n"
+        "- older entry\n"
+    )
+    target = (
+        "* Fri Aug 01 2026 Some Body <a@b.com> - 1.2-1\n"
+        "- newest entry\n\n"
+    ) + baseline
+    diff = ps._diff_changelog_against_baseline(target, baseline)
+    assert diff is not None
+    assert "newest entry" in diff
+    assert "boundary entry" not in diff
+    assert "older entry" not in diff
+
+
+def test_diff_against_baseline_returns_none_when_not_a_clean_suffix():
+    """Baseline entries must appear verbatim as target's oldest suffix.
+
+    If they don't (diverged history, or the package wasn't in the
+    baseline), the caller must fall back rather than trust a bogus diff.
+    """
+    baseline = "* Wed Jul 30 2026 Some Body <a@b.com> - 1.1-1\n- boundary entry\n"
+    target = "* Fri Aug 01 2026 Some Body <a@b.com> - 1.2-1\n- newest entry\n"
+    assert ps._diff_changelog_against_baseline(target, baseline) is None
+
+
+def test_diff_against_baseline_returns_none_for_empty_baseline():
+    assert ps._diff_changelog_against_baseline("anything", "") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_changelog_cache_header — round-trips the header _extract_one_changelog writes
+# ---------------------------------------------------------------------------
+
+def test_cache_header_round_trips(tmp_path):
+    path = tmp_path / "pkg.txt"
+    ps._write_text(
+        str(path),
+        "# pkg: 1.0-1 -> 1.1-1\n# boundary_found: True\n# trim_method: rpmdb_diff\n\nbody",
+    )
+    header = ps._read_changelog_cache_header(str(path))
+    assert header == {
+        "old": "1.0-1", "new": "1.1-1",
+        "boundary_found": True, "trim_method": "rpmdb_diff",
+    }
+
+
+def test_cache_header_returns_none_for_malformed_file(tmp_path):
+    path = tmp_path / "pkg.txt"
+    ps._write_text(str(path), "not a changelog header\n")
+    assert ps._read_changelog_cache_header(str(path)) is None
+
+
+def test_cache_header_returns_none_for_missing_file(tmp_path):
+    assert ps._read_changelog_cache_header(str(tmp_path / "missing.txt")) is None
+
+
+# ---------------------------------------------------------------------------
+# Snapshotter._extract_one_changelog
+# ---------------------------------------------------------------------------
+
+def test_extract_prefers_exact_rpmdb_diff_over_baseline(tmp_path, monkeypatch):
+    target_dir = str(tmp_path / "target")
+    baseline_dir = str(tmp_path / "baseline")
+    baseline_text = "* Wed Jul 30 2026 A <a@b.com> - 1.1-1\n- boundary\n"
+    target_text = (
+        "* Fri Aug 01 2026 A <a@b.com> - 1.2-1\n- newest\n\n"
+    ) + baseline_text
+
+    def fake_run(args, **kwargs):
+        dbpath = args[args.index("--dbpath") + 1]
+        if dbpath == target_dir:
+            return _fake_result(stdout=target_text)
+        return _fake_result(stdout=baseline_text)
+
+    monkeypatch.setattr(ps.subprocess, "run", fake_run)
+    snap = _snapshotter()
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", target_dir, "openshift-clients",
+        "1.1-1", "1.2-1", baseline_variant_dir=baseline_dir,
+    )
+    assert entry["trim_method"] == "rpmdb_diff"
+    assert entry["boundary_found"] is True
+    with open(os.path.join(target_dir, "changelogs", "openshift-clients.txt")) as f:
+        content = f.read()
+    assert "newest" in content
+    assert "- boundary\n" not in content
+
+
+def test_extract_falls_back_to_version_match_when_baseline_diverged(tmp_path, monkeypatch):
+    target_dir = str(tmp_path / "target")
+    baseline_dir = str(tmp_path / "baseline")
+    target_text = (
+        "* Fri Aug 01 2026 A <a@b.com> - 1.2-1\n- newest\n\n"
+        "* Wed Jul 30 2026 A <a@b.com> - 1.1-1\n- boundary\n"
+    )
+    # Baseline changelog doesn't match target's suffix at all (diverged/unrelated).
+    baseline_text = "* Thu Jan 01 2026 A <a@b.com> - 0.1-1\n- unrelated\n"
+
+    def fake_run(args, **kwargs):
+        dbpath = args[args.index("--dbpath") + 1]
+        if dbpath == target_dir:
+            return _fake_result(stdout=target_text)
+        return _fake_result(stdout=baseline_text)
+
+    monkeypatch.setattr(ps.subprocess, "run", fake_run)
+    snap = _snapshotter()
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", target_dir, "openshift-clients",
+        "1.1-1", "1.2-1", baseline_variant_dir=baseline_dir,
+    )
+    assert entry["trim_method"] == "version_match"
+    assert entry["boundary_found"] is True
+
+
+def test_extract_falls_back_to_full_dump_with_no_baseline(tmp_path, monkeypatch):
+    target_dir = str(tmp_path / "target")
+    target_text = "* Fri Aug 01 2026 A <a@b.com> - 1.2-1\n- newest\n"
+
+    monkeypatch.setattr(
+        ps.subprocess, "run",
+        lambda args, **kwargs: _fake_result(stdout=target_text),
+    )
+    snap = _snapshotter()
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", target_dir, "openshift-clients",
+        "9.9.9-nomatch", "1.2-1", baseline_variant_dir=None,
+    )
+    assert entry["trim_method"] == "full_dump"
+    assert entry["boundary_found"] is False
+
+
+def test_extract_rejects_path_traversal_package_names(tmp_path, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        ps.subprocess, "run",
+        lambda *a, **k: called.append(1) or _fake_result(),
+    )
+    snap = _snapshotter()
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", str(tmp_path),
+        "../../etc/passwd", "1.0", "1.1",
+    )
+    assert entry is None
+    assert not called, "must not shell out for a suspicious package name"
+    assert not (tmp_path / "changelogs").exists()
+
+
+def test_extract_revalidates_stale_cache(tmp_path, monkeypatch):
+    target_dir = str(tmp_path / "target")
+    changelog_dir = os.path.join(target_dir, "changelogs")
+    cache_path = os.path.join(changelog_dir, "pkg.txt")
+    ps._write_text(
+        cache_path,
+        "# pkg: 1.0-1 -> 1.1-1\n# boundary_found: True\n# trim_method: version_match\n\nold cached body",
+    )
+
+    fresh_text = "* Fri Aug 01 2026 A <a@b.com> - 1.3-1\n- fresh\n"
+    monkeypatch.setattr(
+        ps.subprocess, "run",
+        lambda args, **kwargs: _fake_result(stdout=fresh_text),
+    )
+    snap = _snapshotter()
+    # old/new differ from what's cached (1.0-1 -> 1.1-1) - must re-extract.
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", target_dir, "pkg", "1.1-1", "1.3-1",
+    )
+    assert entry["old"] == "1.1-1" and entry["new"] == "1.3-1"
+    with open(cache_path) as f:
+        assert "fresh" in f.read()
+
+
+def test_extract_reuses_matching_cache_without_shelling_out(tmp_path, monkeypatch):
+    target_dir = str(tmp_path / "target")
+    cache_path = os.path.join(target_dir, "changelogs", "pkg.txt")
+    ps._write_text(
+        cache_path,
+        "# pkg: 1.0-1 -> 1.1-1\n# boundary_found: True\n# trim_method: rpmdb_diff\n\ncached body",
+    )
+
+    def fail_run(*a, **k):
+        raise AssertionError("must not shell out on a valid cache hit")
+
+    monkeypatch.setattr(ps.subprocess, "run", fail_run)
+    snap = _snapshotter()
+    entry = snap._extract_one_changelog(
+        "target-tag", "rhel-coreos-10", target_dir, "pkg", "1.0-1", "1.1-1",
+    )
+    assert entry == {
+        "variant": "rhel-coreos-10", "package": "pkg",
+        "old": "1.0-1", "new": "1.1-1",
+        "changelog": "target-tag/rpmdb/rhel-coreos-10/changelogs/pkg.txt",
+        "boundary_found": True, "trim_method": "rpmdb_diff",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshotter._collect_rpm_changelogs — cumulative fold across chain hops
+# ---------------------------------------------------------------------------
+
+def _write_changelog(base_dir, tag, changed_by_variant):
+    streams = [
+        {"name": variant, "tag": variant, "rpmDiff": {"changed": changed}}
+        for variant, changed in changed_by_variant.items()
+    ]
+    ps._write_json(
+        os.path.join(base_dir, tag, "changelog.json"),
+        {"nodeImageStreams": streams},
+    )
+
+
+def test_fold_reconstructs_cumulative_diff_across_hops(tmp_path, monkeypatch):
+    base_dir = str(tmp_path)
+    chain = ["p0", "p1", "p2"]  # p0=target, p2=baseline
+    _write_changelog(base_dir, "p0", {
+        "rhel-coreos-10": {"openshift-clients": {"old": "1.1-1", "new": "1.2-1"}},
+    })
+    _write_changelog(base_dir, "p1", {
+        "rhel-coreos-10": {
+            "kernel": {"old": "5.0-1", "new": "5.0-2"},
+            "openshift-clients": {"old": "1.0-1", "new": "1.1-1"},
+        },
+    })
+    rpmdb_data = {"p0": [{"tag": "rhel-coreos-10", "name": "x", "pullspec": "y"}]}
+
+    captured = []
+    monkeypatch.setattr(
+        ps.Snapshotter, "_extract_one_changelog",
+        lambda self, target_tag, variant, variant_dir, pkg, old, new,
+               baseline_variant_dir=None: captured.append(
+            (variant, pkg, old, new)
+        ) or None,
+    )
+    snap = _snapshotter()
+    snap._collect_rpm_changelogs(base_dir, chain, rpmdb_data)
+
+    # openshift-clients changed in both hops: cumulative old=1.0 (first seen),
+    # new=1.2 (last seen) - not just the most recent hop's 1.1->1.2.
+    assert ("rhel-coreos-10", "openshift-clients", "1.0-1", "1.2-1") in captured
+    assert ("rhel-coreos-10", "kernel", "5.0-1", "5.0-2") in captured
+
+
+def test_fold_skips_packages_that_revert_to_no_net_change(tmp_path, monkeypatch):
+    """A package bumped then reverted across hops nets to old == new and
+    must not be queued for extraction (or reported as "changed" at all)."""
+    base_dir = str(tmp_path)
+    chain = ["p0", "p1", "p2"]  # p0=target, p2=baseline
+    _write_changelog(base_dir, "p1", {  # p1 vs p2 (baseline): bump
+        "rhel-coreos-10": {"kernel": {"old": "5.0-1", "new": "5.0-2"}},
+    })
+    _write_changelog(base_dir, "p0", {  # p0 vs p1 (target): revert back
+        "rhel-coreos-10": {"kernel": {"old": "5.0-2", "new": "5.0-1"}},
+    })
+    rpmdb_data = {"p0": [{"tag": "rhel-coreos-10", "name": "x", "pullspec": "y"}]}
+
+    captured = []
+    monkeypatch.setattr(
+        ps.Snapshotter, "_extract_one_changelog",
+        lambda self, *a, **k: captured.append(a) or None,
+    )
+    snap = _snapshotter()
+    result = snap._collect_rpm_changelogs(base_dir, chain, rpmdb_data)
+    assert captured == []
+    assert result == []
+
+
+def test_fold_aborts_on_unreadable_hop_changelog(tmp_path, monkeypatch):
+    """An unreadable hop must not be silently treated as 'no changes' -
+    that could misattribute a later hop's old version as the baseline."""
+    base_dir = str(tmp_path)
+    chain = ["p0", "p1", "p2"]
+    _write_changelog(base_dir, "p0", {
+        "rhel-coreos-10": {"openshift-clients": {"old": "1.1-1", "new": "1.2-1"}},
+    })
+    # p1's changelog.json is corrupt/unreadable.
+    os.makedirs(os.path.join(base_dir, "p1"), exist_ok=True)
+    with open(os.path.join(base_dir, "p1", "changelog.json"), "w") as f:
+        f.write("{not valid json")
+
+    rpmdb_data = {"p0": [{"tag": "rhel-coreos-10", "name": "x", "pullspec": "y"}]}
+    called = []
+    monkeypatch.setattr(
+        ps.Snapshotter, "_extract_one_changelog",
+        lambda self, *a, **k: called.append(a) or None,
+    )
+    snap = _snapshotter()
+    result = snap._collect_rpm_changelogs(base_dir, chain, rpmdb_data)
+    assert result == []
+    assert called == []
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"use_sippy": True},
+    {"collect_rpmdb": False},
+    {"collect_rpm_changelogs": False},
+])
+def test_fold_gates_are_respected(tmp_path, kwargs):
+    base_dir = str(tmp_path)
+    chain = ["p0", "p1"]
+    _write_changelog(base_dir, "p0", {
+        "rhel-coreos-10": {"kernel": {"old": "1.0", "new": "1.1"}},
+    })
+    rpmdb_data = {"p0": [{"tag": "rhel-coreos-10", "name": "x", "pullspec": "y"}]}
+    snap = _snapshotter(**kwargs)
+    assert snap._collect_rpm_changelogs(base_dir, chain, rpmdb_data) == []
+
+
+def test_fold_requires_a_baseline_and_target_rpmdb():
+    snap = _snapshotter()
+    assert snap._collect_rpm_changelogs("base", ["only-one-tag"], {}) == []
+    assert snap._collect_rpm_changelogs("base", ["t", "b"], {}) == []


### PR DESCRIPTION
Reconstructs the target-vs-baseline RPM version diff by aggregating the per-hop rhcos_changes already fetched for every payload in the chain (no dedicated API call), then extracts each changed package's `rpm --changelog` from the already-downloaded target RPMDB, trimmed to entries newer than the old version on a best-effort basis. Results are referenced from summary.json as rpm_changelogs[], and the whole step is gated behind a new --no-rpm-changelogs flag plus an rpm CLI preflight check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payload snapshots can optionally include RPM package changelogs for packages changed between baseline and target versions.
  * Snapshot summaries include changelog file paths and metadata, with automatic handling when RPM data is unavailable.
  * Added an option to disable RPM changelog collection.

* **Documentation**
  * Documented changelog extraction, trimming, generated files, summary fields, and skip conditions.

* **Chores**
  * Updated the CI plugin version to 0.0.80.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->