### PR TITLE
jira(gcp-hcp): add Architect and Product Manager custom field IDs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/reference/gcp-hcp.md
+++ b/plugins/jira/reference/gcp-hcp.md
@@ -17,6 +17,8 @@ Team-specific conventions for GCP HCP (Hypershift on GKE) issues in the GCP proj
 | **Epic Name** | `customfield_10011` | Required for Epics | `"Multi-cluster metrics aggregation"` |
 | **Story Points** | `customfield_10028` | Fibonacci scale: 0, 1, 2, 3, 5, 8, 13 | `3.0` |
 | **Blocked** | `customfield_10517` | Mark issue as blocked | `{"value": "True"}` |
+| **Architect** | `customfield_10467` | Single user; technical lead for a Feature or Initiative. Named during Refinement. | `{"accountId": "..."}` |
+| **Product Manager** | `customfield_10469` | Single user; PM accountable for the product perspective. Named during Refinement. | `{"accountId": "..."}` |
 
 ## Components
 
@@ -35,8 +37,8 @@ Components are **optional** — only specify if work clearly fits. Do not reques
 |---|---|
 | Story / Task | `customfield_10028` (Story Points): float, auto-estimated per Sizing Guide; `priority`: `{"name": "Normal"}` (omit unless user specifies) |
 | Epic | `customfield_10011` (Epic Name): must match summary |
-| Feature | No type-specific custom fields required |
-| Initiative | No type-specific custom fields required |
+| Feature | `customfield_10467` (Architect): single user, named during Refinement; `customfield_10469` (Product Manager): single user, named during Refinement |
+| Initiative | `customfield_10467` (Architect): single user, named during Refinement; `customfield_10469` (Product Manager): single user, named during Refinement |
 
 **Story Points:** Auto-estimate using the Sizing Guide below. Set `customfield_10028` as float. For estimates of 8+, recommend splitting.
 


### PR DESCRIPTION
## Summary

Adds `customfield_10467` (Architect) and `customfield_10469` (Product Manager) to the GCP HCP Jira conventions reference.

Both fields are enabled on the GCP project per HP-wide ownership guidance from May 2026, which requires three named roles on all Features and Initiatives: Assignee, Architect, and Product Manager.

## Test plan

- [ ] Verify field IDs match what appears in the GCP Jira project for Feature/Initiative issues

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GCP project configuration guidance to specify that Architect and Product Manager custom fields are required for Feature and Initiative issue types.
  * Removed outdated information stating that Feature issue types had no type-specific field requirements.
* **Chores**
  * Updated the Jira plugin version to 0.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->