### PR TITLE
ci: enforce docs/marketplace sync on every PR

### DIFF
--- a/.github/workflows/check-docs-sync.yml
+++ b/.github/workflows/check-docs-sync.yml
@@ -1,0 +1,50 @@
+name: Check Documentation Sync
+
+# Fails any PR that changed plugin metadata without running `make update`.
+# Replays the same generation sequence as the `update` target in the Makefile
+# (frontmatter fixer, marketplace version sync, docs regen), then requires the
+# generated output to be unchanged. This prevents docs/index.html and
+# .claude-plugin/marketplace.json from drifting out of sync with plugin
+# content (the post-merge auto-regen PRs from update-docs.yml often sit
+# unmerged, so drift accumulated on main).
+
+on:
+  pull_request:
+
+jobs:
+  check-docs-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: '.python-version'
+          pip-install: -r requirements-dev.txt
+
+      - name: Fix frontmatter quotes
+        run: python3 scripts/fix_frontmatter_quotes.py
+
+      - name: Sync marketplace versions
+        run: python3 scripts/sync_marketplace_versions.py
+
+      - name: Regenerate documentation
+        run: skillsaw docs -o docs/ --theme crimson-red
+
+      - name: Verify no drift
+        run: |
+          drift="$(git status --porcelain=v1 --untracked-files=all -- docs/ .claude-plugin/marketplace.json)"
+          if [ -n "$drift" ]; then
+            echo "$drift"
+            echo ""
+            echo "::error::docs/ or .claude-plugin/marketplace.json is out of sync with plugin metadata."
+            echo "::error::Run 'make update' locally and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Enforce docs sync on every PR (`check-docs-sync.yml`).

The repo already has post-merge self-healing (`update-docs.yml` opens auto-regen PRs), but those PRs often sit unmerged, which lets `docs/index.html` drift from plugin metadata (see e.g. #656) and forces unrelated docs catch-up into feature PRs (the `plugins-doc-up-to-date` lint rule requires full regen output, all or nothing).

The new workflow enforces at PR time instead: it runs the same generation steps as `update-docs.yml` (`scripts/sync_marketplace_versions.py` + `skillsaw docs -o docs/ --theme crimson-red`, skillsaw version pinned via `requirements-dev.txt`, same pinned action SHAs) and fails with an actionable error if `docs/` or `.claude-plugin/marketplace.json` differ:

> docs/ or .claude-plugin/marketplace.json is out of sync with plugin metadata.
> Run 'make update' locally and commit the result.

With this in place, a PR that bumps a plugin without running `make update` can never merge, drift cannot accumulate, and the post-merge bot PRs become a no-op safety net.

Note: this PR deliberately does not regenerate the currently stale `docs/index.html` itself — that regeneration is covered by the bot PR #656. This PR only adds the enforcement; the check will pass once docs are back in sync.

Verified: workflow YAML parses; the check's generation steps match `update-docs.yml`.

---
_This PR description was generated using AI. Please verify before acting on it._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull-request checks to keep marketplace versions and generated documentation synchronized.
  * Pull requests now fail when required documentation or marketplace updates are missing.
  * Documentation and marketplace metadata are automatically regenerated and verified against the committed state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->