### PR TITLE
chore(deps): bump actions/setup-python from 6.3.0 to 7.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: '.python-version'
-          pip-install: -r requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
 
       - name: Run tests
         run: make test

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,10 +21,12 @@ jobs:
           persist-credentials: true
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: '.python-version'
-          pip-install: -r requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
 
       - name: Sync marketplace versions
         run: python3 scripts/sync_marketplace_versions.py


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-python` from v6.3.0 to v7.0.0
- Replaces the removed `pip-install` input with an explicit `pip install` step in both workflows

v7.0.0 [removed the `pip-install` input](https://github.com/actions/setup-python/pull/1336), which broke the Dependabot PR #638. This PR applies the same version bump with the breaking change fixed.

Supersedes #638.

## Test plan

- [ ] CI `test` job passes (previously failed on #638)
- [ ] CI `lint` job passes
- [ ] `update-docs` workflow is syntactically valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated testing and documentation workflows to use the latest Python setup action.
  - Improved development dependency installation steps for more consistent workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->