### PR TITLE
chore: coordinate skillsaw dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,25 @@
 version: 2
+multi-ecosystem-groups:
+  skillsaw:
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "stbenjam/skillsaw*"
+    multi-ecosystem-group: "skillsaw"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    patterns:
+      - "skillsaw"
+    multi-ecosystem-group: "skillsaw"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -7,7 +27,11 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
-    groups:
-      skillsaw:
-        patterns:
-          - "stbenjam/skillsaw*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@
 # Container runtime (podman or docker)
 CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || echo docker)
 
-# skillsaw image
-SKILLSAW_IMAGE = ghcr.io/stbenjam/skillsaw:0.14.1
+# skillsaw image (version shared with the Python development dependency)
+SKILLSAW_VERSION := $(shell awk -F '==' '/^skillsaw==[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$$/ { version = $$2; count++ } END { if (count == 1) print version }' requirements-dev.txt)
+ifeq ($(strip $(SKILLSAW_VERSION)),)
+$(error requirements-dev.txt must contain exactly one skillsaw==X.Y.Z requirement)
+endif
+SKILLSAW_IMAGE ?= ghcr.io/stbenjam/skillsaw:$(SKILLSAW_VERSION)
 
 # Detect if SELinux is enforcing and add security option
 SELINUX_OPT := $(shell if command -v getenforce >/dev/null 2>&1 && [ "$$(getenforce 2>/dev/null)" = "Enforcing" ]; then echo "--security-opt label=disable"; fi)
@@ -35,7 +39,7 @@ lint: ## Run plugin linter (verbose, strict mode)
 	$(CONTAINER_RUNTIME) run --rm --platform linux/amd64 $(SELINUX_OPT) -v $(PWD):/workspace:Z $(SKILLSAW_IMAGE) .
 
 .PHONY: lint-pull
-lint-pull: ## Pull the latest skillsaw image
+lint-pull: ## Pull the configured skillsaw image
 	$(CONTAINER_RUNTIME) pull $(SKILLSAW_IMAGE)
 
 .PHONY: update

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pyyaml
 pytest
-skillsaw==0.14.1
+skillsaw==0.17.0

--- a/tests/test_skillsaw_versions.py
+++ b/tests/test_skillsaw_versions.py
@@ -1,0 +1,29 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+VERSION_PATTERN = r"([0-9]+\.[0-9]+\.[0-9]+)"
+
+
+def action_pin(workflow, action):
+    content = (ROOT / workflow).read_text()
+    matches = re.findall(
+        rf"^[ \t]*uses:[ \t]+{re.escape(action)}@([0-9a-f]{{40}})[ \t]+# v{VERSION_PATTERN}$",
+        content,
+        re.MULTILINE,
+    )
+    assert len(matches) == 1, f"expected one full-SHA {action} pin with a version comment"
+    return matches[0]
+
+
+def test_skillsaw_versions_are_synchronized():
+    requirements = (ROOT / "requirements-dev.txt").read_text()
+    python_versions = re.findall(rf"^skillsaw=={VERSION_PATTERN}$", requirements, re.MULTILINE)
+    assert len(python_versions) == 1, "expected exactly one skillsaw==X.Y.Z requirement"
+
+    lint_pin = action_pin(".github/workflows/lint-plugins.yml", "stbenjam/skillsaw")
+    review_pin = action_pin(".github/workflows/lint-review.yml", "stbenjam/skillsaw/review")
+
+    assert lint_pin == review_pin, "skillsaw lint and review action pins differ"
+    assert lint_pin[1] == python_versions[0], "skillsaw action and Python versions differ"


### PR DESCRIPTION
## Summary

- derive the local Skillsaw container tag from the pinned Python development dependency
- coordinate Skillsaw GitHub Actions and pip updates through Dependabot
- add a test ensuring the Python and action versions remain synchronized

## Testing

- uv run --with-requirements requirements-dev.txt make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Skillsaw to version 0.17.0.
  * Added configurable Skillsaw image versioning based on the pinned development dependency.
  * Improved dependency update grouping and labeling.

* **Bug Fixes**
  * Added checks to ensure Skillsaw versions remain consistent across development requirements and automation workflows.

* **Documentation**
  * Updated pull-lint help text to clarify that it uses the configured Skillsaw image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->