### PR TITLE
payload-snapshot: diff RHCOS RPM changelogs against older payloads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.80",
+      "version": "0.0.81",
       "category": "ci",
       "keywords": [
         "prow",

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -38,7 +38,11 @@ Use this skill when you need to:
    - Requires access to the release image registry (e.g., `registry.ci.openshift.org`)
    - Without `podman`, RPMDB data is skipped; all other data is still collected
 
-5. **Network access** to:
+5. **`rpm` CLI** — for the RPM changelog diffs between payloads
+   - Queries the already-extracted RPMDBs locally; no network, no root
+   - Without `rpm`, changelog diffs are skipped; the RPMDBs themselves are still extracted
+
+6. **Network access** to:
    - `*.ocp.releases.ci.openshift.org` (release controller)
    - `sippy.dptools.openshift.org` (historical payload fallback)
    - `api.github.com` (via `gh` CLI)
@@ -66,6 +70,9 @@ python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-junit
 # Skip RPMDB extraction
 python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-rpmdb
 
+# Skip the RPM changelog diffs (RPMDBs are still extracted)
+python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --no-rpm-changelogs
+
 # Force Sippy for all payload metadata (normally fallback is automatic)
 python3 "$script_path" 4.22.0-0.nightly-2026-02-25-152806 --sippy
 ```
@@ -82,7 +89,8 @@ The script will:
 9. Track per-job failure streaks — consecutive failures, originating payload, failure pattern
 10. For each unique PR across all changelogs, fetch the git diff, comments, and CI jobs via `gh`
 11. For each payload in the chain, extract the full RPM database from RHCOS images via `podman`
-12. Generate summary.json with comprehensive triage data, plus AGENTS.md/CLAUDE.md for agent orientation
+12. Diff the target payload's RPM changelogs against every older payload in the chain, using the extracted RPMDBs
+13. Generate summary.json with comprehensive triage data, plus AGENTS.md/CLAUDE.md for agent orientation
 
 ### Step 2: Navigate the Snapshot
 
@@ -123,6 +131,9 @@ payload/
             rpmdb.sqlite
           rhel-coreos-10/
             rpmdb.sqlite
+        rpm-changelogs/                    # Target payload only
+          rhel-coreos-10/                  # One diff per older payload
+            <older-payload-tag>.md
 ```
 
 ### Step 3: Use the Data
@@ -157,6 +168,16 @@ jq '.[].name' payload/<version>/<stream>/<tag>/jobs/blocking/<job-name>/junit/re
 rpm -qa --dbpath $(pwd)/payload/<version>/<stream>/<tag>/rpmdb/rhel-coreos
 ```
 
+**See what changed in the RHCOS RPMs since the baseline** (inline in summary.json — no file read needed):
+```bash
+jq '.rpm_changelogs[] | select(.diff) | {variant, compared_tag, diff}' payload/<version>/<stream>/summary.json
+```
+
+**Find which payload in the chain introduced a package bump:**
+```bash
+cat payload/<version>/<stream>/<target-tag>/rpm-changelogs/<variant>/<older-tag>.md
+```
+
 ## CLI Reference
 
 ```text
@@ -171,6 +192,8 @@ Options:
   --workers N          Parallel workers for API calls (default: 8)
   --no-junit           Skip JUnit download and regression tracking
   --no-rpmdb           Skip RHCOS RPMDB extraction
+  --no-rpm-changelogs  Skip the RPM changelog diffs between the target payload
+                       and the older payloads in the chain
   --sippy              Force Sippy for all payload metadata instead of using
                        the automatic release-controller-first fallback
   --fail-on-incomplete Exit 1 if any requested data could not be collected
@@ -191,8 +214,9 @@ Comprehensive stream-level triage data — start here. Contains:
 - `informing_jobs.failed_jobs[]` — job name strings
 - `test_failures.blocking[]` — **gating** failures only: `test_name`, `jobs`, `first_failed_in`, `payloads_failing`, `failure_message`, `failure_text` (full, not truncated). These are the failures that can fail a job and therefore reject the payload.
 - `test_failures.informing[]` / `test_failures.flakes[]` — `test_name`, `jobs`. Neither can fail a job. No onset is tracked for them, because an onset implies there is a culprit to find.
-- `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments paths, and `rhcos_changes[]` with RPM diffs per RHCOS variant
+- `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments paths, `rhcos_changes[]` with RPM diffs per RHCOS variant (package versions only — no changelog text), and, on every payload but the target, `rpm_changelogs[]` pointing at the report holding that text
 - `rhcos_rpms[]` — RPMDB metadata for the target payload's RHCOS variants: `tag`, `name`, `pullspec`, `rpmdb` (relative path to rpmdb.sqlite)
+- `rpm_changelogs[]` — one RPM diff per (RHCOS variant, older payload in the chain): `variant`, `compared_tag`, `is_baseline`, `changed`/`added`/`removed` counts, and `changelogs` (relative path to the full report). The oldest surviving comparison per variant — normally the chain baseline — also carries `diff` inline, so target-vs-baseline needs no file read: `diff.changed[]` with `package`, `old`, `new` and `changelog` (the entries that version added), plus `diff.added[]` / `diff.removed[]` with `package` and `version`. The intermediate hops are a subset of that diff and stay behind their `changelogs` path; read them to find which hop introduced a given package bump. If the true chain baseline's RPMDB couldn't be read for a variant, the next-oldest readable comparison takes over `is_baseline`/`diff` instead, flagged with `baseline_rpmdb_missing: true` so consumers know the diff doesn't reach all the way back to the chain's actual start.
 - `data_complete` — `true` when all requested data was ultimately collected, including via a fallback after an initial read failed. `false` means some requested data could not be read at all.
 - `collection_errors[]` — every read failure encountered. Each entry has `reason`, `command`, and optionally `detail`, `stage`, `job`, `payload_tag`, `recovered`. Reasons: `auth`, `timeout`, `gcloud_missing`, `command_failed`, `junit_unavailable` (nothing readable), `junit_missing` (nothing discovered), `junit_unparseable` (corrupt XML), `junit_partial` (some files unread), `build_log_unavailable`.
   - `recovered: true` means a fallback subsequently obtained the data. These entries are diagnostic only (useful for spotting a timeout that needs tuning) and do **not** make `data_complete` false.
@@ -287,7 +311,9 @@ Full release controller response including `blockingJobs`, `informingJobs`, and 
 
 ### `changelog.json`
 
-Release controller diff response with `changeLogJson.updatedImages` listing every PR that changed between this payload and its predecessor. Also contains `nodeImageStreams` at the top level — RPM diffs for each RHCOS variant showing which packages changed between payloads.
+Release controller diff response with `changeLogJson.updatedImages` listing every PR that changed between this payload and its predecessor. Also contains `nodeImageStreams` at the top level — RPM diffs for each RHCOS variant showing which packages changed between payloads, as package names and versions only.
+
+For the target payload, `_rpm_changelogs[]` is injected alongside `_source`: `variant`, `compared_tag` (the predecessor, the same comparison this file describes) and `changelogs`, a path relative to the payload directory pointing at the report that carries the changelog text `nodeImageStreams` lacks. `payload.json` gets the same key.
 
 ### `rhcos_changes[]` (in payloads[] within summary.json)
 
@@ -305,6 +331,24 @@ Only variants with non-empty `rpmDiff` are included. When the snapshot is create
 The `rpmdb.sqlite` file extracted from RHCOS images via `podman`. One directory per RHCOS variant (e.g., `rpmdb/rhel-coreos/`, `rpmdb/rhel-coreos-10/`), each containing `rpmdb.sqlite`. Queryable with `rpm -qa --dbpath <absolute-path-to-variant-dir>` or directly with `sqlite3`.
 
 Extracted for every payload in the chain. Skipped when `podman` is unavailable or `--no-rpmdb` is passed.
+
+### `rpm-changelogs/<variant>/<older-payload-tag>.md`
+
+Written for the target payload only, one file per (RHCOS variant, older payload in the chain) — including the baseline. Each file answers "what do this variant's RPMs have in the target that they did not have in that older payload?", by querying both already-extracted RPMDBs with `rpm` locally. No API calls and no image pulls are involved, and `rhcos_changes[]` (which the release controller computes) is not consulted.
+
+Each file has three sections:
+- **Changed packages** — `<old version> -> <new version>` plus only the changelog entries the new version added. RPM changelogs are additive and grow from the top, so the cut is at the first entry the old version already had. (Not a common-suffix subtraction: rpm trims stale entries off the bottom at build time, so two builds of the same package weeks apart routinely disagree about their oldest entries.) A version bump with no new entry is reported as a rebuild.
+- **New packages** — packages the older payload did not have at all, with their full changelog.
+- **Removed packages** — name and version only. Nothing to read a changelog from.
+
+Deliberate simplifications, because the consumer is an LLM that can read a full dump when it has to:
+- **Each older payload is compared against the target independently.** No attempt is made to follow a package's evolution hop by hop. A package removed and later re-added shows up as "no difference" against the baseline and as some difference against an intermediate payload — that is the honest answer to each of those two questions, and no further reconciliation is done.
+- **A changelog whose history was rewritten degrades to a full dump.** When the two versions share no entries, the whole changelog is emitted rather than guessing a cut point from version strings.
+- **A variant missing from the older payload is skipped**, rather than reported as several hundred new packages.
+
+Indexed by `summary.json`'s `rpm_changelogs[]`, whose baseline entry repeats the same content inline under `diff`. Read these files for the intermediate hops, or when the prose layout is easier than the JSON.
+
+Skipped when `rpm` is unavailable, `--no-rpm-changelogs` is passed, the RPMDBs were not extracted, or the chain has no older payload (`chain_length < 2`).
 
 ### `regressions.json`
 

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -1392,6 +1392,232 @@ class RpmdbCollector:
 
 
 # ---------------------------------------------------------------------------
+# RpmChangelogDiffer — diffs RHCOS RPM changelogs against older payloads
+# ---------------------------------------------------------------------------
+
+class RpmChangelogDiffer:
+    """Diffs the target payload's RPM changelogs against older payloads.
+
+    Every payload in the chain already has its RHCOS rpmdb extracted, so
+    "what changed in the RPMs" is answered locally by querying two rpmdbs
+    and subtracting — no API calls, no version-string parsing.  One diff
+    file is written per (RHCOS variant, older payload): the last one is
+    the target vs. the baseline (the full picture), the earlier ones give
+    the LLM a cheap way to see which hop introduced a package bump.
+
+    Deliberately not modelled: a package that disappears and comes back,
+    or one whose changelog history was rewritten.  Each older payload is
+    compared against the target independently, so those cases just show up
+    as the diffs they are (nothing vs. the baseline, something vs. an
+    intermediate) and the reader can draw their own conclusion.
+    """
+
+    def __init__(self, base_dir: str, target_tag: str, older_tags: list[str],
+                 variants: list[str], workers: int = 4):
+        self.base_dir = base_dir
+        self.target_tag = target_tag
+        self.older_tags = older_tags
+        self.variants = variants
+        self.workers = workers
+
+    def collect(self) -> list[dict]:
+        """Write the diff files. Returns summary.json entries."""
+        entries = []
+        for variant in self.variants:
+            # Derived, best-effort data: a variant that blows up must not
+            # take down a snapshot whose summary has not been written yet.
+            try:
+                entries.extend(self._diff_variant(variant))
+            except Exception as e:
+                _log(f"  {variant}: changelog diffs failed: {e}")
+        return entries
+
+    def _dbpath(self, tag: str, variant: str) -> str:
+        return os.path.join(self.base_dir, tag, "rpmdb", variant)
+
+    def _has_rpmdb(self, tag: str, variant: str) -> bool:
+        return os.path.isfile(
+            os.path.join(self._dbpath(tag, variant), "rpmdb.sqlite")
+        )
+
+    def _diff_variant(self, variant: str) -> list[dict]:
+        target_db = self._dbpath(self.target_tag, variant)
+        target_versions = _rpm_versions(target_db)
+        if not target_versions:
+            _log(f"  {variant}: no packages read from the target rpmdb, "
+                 f"skipping changelog diffs")
+            return []
+
+        older = [t for t in self.older_tags if self._has_rpmdb(t, variant)]
+        if not older:
+            return []
+
+        with ThreadPoolExecutor(max_workers=self.workers) as pool:
+            comparisons = [
+                c for c in pool.map(
+                    lambda tag: self._compare(variant, tag, target_versions),
+                    older,
+                ) if c is not None
+            ]
+        if not comparisons:
+            return []
+
+        # The target's changelog for a package is the same in every
+        # comparison, so query it once for the union of everything the
+        # diffs need.
+        wanted = {
+            pkg for c in comparisons for pkg in (*c["changed"], *c["added"])
+        }
+        target_changelogs = _rpm_changelogs(target_db, wanted)
+
+        true_baseline = self.older_tags[-1]
+        if comparisons[-1]["tag"] != true_baseline:
+            _log(f"  {variant}: chain baseline {true_baseline}'s rpmdb was "
+                 f"unreadable; treating {comparisons[-1]['tag']} as the "
+                 f"baseline for this variant instead")
+
+        entries = []
+        for comparison in comparisons:
+            tag = comparison["tag"]
+            is_oldest = comparison is comparisons[-1]
+            changed = self._changed_packages(comparison, target_changelogs)
+            rel_path = f"{self.target_tag}/rpm-changelogs/{variant}/{tag}.md"
+            _write_text(
+                os.path.join(self.base_dir, rel_path),
+                self._render(variant, comparison, changed, target_changelogs),
+            )
+            _log(f"  {variant} vs. {tag}: "
+                 f"{len(comparison['changed'])} changed, "
+                 f"{len(comparison['added'])} new, "
+                 f"{len(comparison['removed'])} removed")
+            entry = {
+                "variant": variant,
+                "compared_tag": tag,
+                "is_baseline": is_oldest,
+                "changed": len(comparison["changed"]),
+                "added": len(comparison["added"]),
+                "removed": len(comparison["removed"]),
+                "changelogs": rel_path,
+            }
+            # "What changed since the baseline?" is the question worth
+            # answering without opening a file, so the oldest comparison
+            # carries its diff inline.  The intermediate hops are a subset
+            # of it and stay behind their path, or summary.json would grow
+            # by the whole chain.
+            if is_oldest:
+                entry["diff"] = {
+                    "changed": changed,
+                    "added": _package_versions(comparison["added"]),
+                    "removed": _package_versions(comparison["removed"]),
+                }
+                if tag != true_baseline:
+                    entry["baseline_rpmdb_missing"] = True
+            entries.append(entry)
+        return entries
+
+    @staticmethod
+    def _changed_packages(
+        comparison: dict, target_changelogs: dict[str, str]
+    ) -> list[dict]:
+        """Per-package version bump plus the changelog entries it added."""
+        return [
+            {
+                "package": pkg,
+                "old": old_version,
+                "new": new_version,
+                "changelog": _new_changelog_entries(
+                    target_changelogs.get(pkg, ""),
+                    comparison["old_changelogs"].get(pkg, ""),
+                ),
+            }
+            for pkg, (old_version, new_version)
+            in sorted(comparison["changed"].items())
+        ]
+
+    def _compare(
+        self, variant: str, tag: str, target_versions: dict[str, str]
+    ) -> Optional[dict]:
+        """Compare one older payload's rpmdb against the target's."""
+        old_db = self._dbpath(tag, variant)
+        old_versions = _rpm_versions(old_db)
+        if not old_versions:
+            _log(f"  {variant}: no packages read from {tag}'s rpmdb, "
+                 f"skipping that comparison")
+            return None
+        changed = {
+            pkg: (old_versions[pkg], version)
+            for pkg, version in target_versions.items()
+            if pkg in old_versions and old_versions[pkg] != version
+        }
+        return {
+            "tag": tag,
+            "changed": changed,
+            "added": {
+                pkg: version for pkg, version in target_versions.items()
+                if pkg not in old_versions
+            },
+            "removed": {
+                pkg: version for pkg, version in old_versions.items()
+                if pkg not in target_versions
+            },
+            "old_changelogs": _rpm_changelogs(old_db, changed),
+        }
+
+    def _render(
+        self, variant: str, comparison: dict, changed: list[dict],
+        target_changelogs: dict[str, str],
+    ) -> str:
+        tag = comparison["tag"]
+        added = comparison["added"]
+        removed = comparison["removed"]
+        lines = [
+            f"# RPM changes in {self.target_tag} vs. {tag} ({variant})",
+            "",
+            f"What the `{variant}` RHCOS image of `{self.target_tag}` ships "
+            f"that `{tag}` did not,",
+            "obtained by diffing the two payloads' RPM databases.",
+            "",
+            f"- changed: {len(changed)} (changelog entries added on top of "
+            f"the older version)",
+            f"- new: {len(added)} (full changelog)",
+            f"- removed: {len(removed)} (name and version only)",
+            "",
+        ]
+        if changed:
+            lines += ["## Changed packages", ""]
+            for change in changed:
+                lines += [
+                    f"### {change['package']}: "
+                    f"{change['old']} -> {change['new']}",
+                    "",
+                    "```text",
+                    change["changelog"]
+                    or "(rebuilt without adding a changelog entry)",
+                    "```",
+                    "",
+                ]
+        if added:
+            lines += ["## New packages", ""]
+            for pkg, version in sorted(added.items()):
+                lines += [
+                    f"### {pkg}: {version} (not in {tag})",
+                    "",
+                    "```text",
+                    target_changelogs.get(pkg, "") or "(no changelog)",
+                    "```",
+                    "",
+                ]
+        if removed:
+            lines += ["## Removed packages", ""]
+            lines += [
+                f"- {pkg}: {version} (in {tag}, gone in {self.target_tag})"
+                for pkg, version in sorted(removed.items())
+            ]
+            lines += [""]
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # RegressionTracker — traces test failures across the payload chain
 # ---------------------------------------------------------------------------
 
@@ -1578,13 +1804,15 @@ class SummaryGenerator:
 
     def __init__(self, base_dir: str, chain: list[str], target_tag: str,
                  tag: "PayloadTag", streaks: Optional[dict] = None,
-                 rpmdb_data: Optional[dict[str, list[dict]]] = None):
+                 rpmdb_data: Optional[dict[str, list[dict]]] = None,
+                 rpm_changelogs: Optional[list[dict]] = None):
         self.base_dir = base_dir
         self.chain = chain
         self.target_tag = target_tag
         self.tag = tag
         self.streaks = streaks or {}
         self.rpmdb_data = rpmdb_data or {}
+        self.rpm_changelogs = rpm_changelogs or []
 
     def generate(self) -> None:
         target_dir = os.path.join(self.base_dir, self.target_tag)
@@ -1664,6 +1892,9 @@ class SummaryGenerator:
                 {**entry, "rpmdb": f"{self.target_tag}/rpmdb/{entry['tag']}/rpmdb.sqlite"}
                 for entry in target_rpms
             ]
+
+        if self.rpm_changelogs:
+            summary["rpm_changelogs"] = self.rpm_changelogs
 
         # Surface any data that could not be collected.  An empty snapshot
         # section must never be silently indistinguishable from a clean one.
@@ -1784,6 +2015,9 @@ class SummaryGenerator:
             "        rpmdb.sqlite",
             "      rhel-coreos-10/",
             "        rpmdb.sqlite",
+            "    rpm-changelogs/           # Target only: RPM diffs vs. every",
+            "      rhel-coreos-10/         # older payload in the chain",
+            "        <older-payload-tag>.md",
             "  <older-payload-tag>/      # Each prior payload in the chain",
             "    ...                     # Same structure",
             "```",
@@ -1823,11 +2057,28 @@ class SummaryGenerator:
             "- `payloads[]` — per-payload entries with `tag`, `phase`,",
             "  `source`, `changelog_source`, relative paths, `prs[]` with",
             "  component/diff/comments paths,",
-            "  `rhcos_changes[]` with RPM diffs per RHCOS variant, and",
-            "  `rhcos_rpms[]` with rpmdb.sqlite per variant",
+            "  `rhcos_changes[]` with RPM diffs per RHCOS variant",
+            "  (versions only — no changelog text),",
+            "  `rhcos_rpms[]` with rpmdb.sqlite per variant, and, on every",
+            "  payload but the target, `rpm_changelogs[]` pointing at the",
+            "  report that does carry the changelog text",
             "- `rhcos_rpms[]` — RPMDB per RHCOS variant for the target",
             "  payload: `tag`, `name`, `pullspec`, `rpmdb` (relative path",
             "  to rpmdb.sqlite — queryable with rpm --dbpath <dir> or sqlite3)",
+            "- `rpm_changelogs[]` — one RPM diff per (RHCOS variant, older",
+            "  payload): `variant`, `compared_tag`, `is_baseline`, counts of",
+            "  `changed`/`added`/`removed`, and `changelogs` (relative path",
+            "  to the full report). The oldest surviving comparison per",
+            "  variant (normally the chain baseline) also carries `diff`",
+            "  inline: `diff.changed[]` with `package`, `old`, `new`,",
+            "  `changelog` (the entries that version added), plus",
+            "  `diff.added[]` / `diff.removed[]` with `package`, `version`.",
+            "  So target-vs-baseline needs no file read; open the other",
+            "  entries' `changelogs` only to find which hop introduced a",
+            "  given package bump. If the true chain baseline's RPMDB was",
+            "  unreadable, the next-oldest readable comparison takes over",
+            "  `is_baseline`/`diff` instead, flagged with",
+            "  `baseline_rpmdb_missing: true`.",
             "",
         ])
 
@@ -2036,6 +2287,18 @@ class SummaryGenerator:
                     for e in rpmdb_entries
                 ]
 
+            # rhcos_changes above names the packages this payload changed
+            # but carries no changelog text.  Point at the report that has
+            # it — the path spells out the direction (what the target has
+            # that this payload did not).
+            changelog_links = [
+                {"variant": e["variant"], "changelogs": e["changelogs"]}
+                for e in self.rpm_changelogs
+                if e["compared_tag"] == tag_name
+            ]
+            if changelog_links:
+                entry["rpm_changelogs"] = changelog_links
+
             payloads.append(entry)
         return payloads
 
@@ -2095,7 +2358,8 @@ class Snapshotter:
     def __init__(self, tag: PayloadTag, output_dir: str = "payload",
                  max_chain: int = 20, workers: int = 8,
                  collect_junit: bool = True, use_sippy: bool = False,
-                 collect_rpmdb: bool = True):
+                 collect_rpmdb: bool = True,
+                 collect_rpm_changelogs: bool = True):
         self.tag = tag
         self.output_dir = output_dir
         self.max_chain = max_chain
@@ -2103,6 +2367,7 @@ class Snapshotter:
         self.collect_junit = collect_junit
         self.use_sippy = use_sippy
         self.collect_rpmdb = collect_rpmdb
+        self.collect_rpm_changelogs = collect_rpm_changelogs
         self.rc = ReleaseController(tag.architecture, stream=tag.stream)
         self.sippy = SippyClient(
             tag.version, architecture=tag.architecture, stream=tag.stream
@@ -2148,8 +2413,15 @@ class Snapshotter:
 
         rpmdb_data = self._collect_rpmdb(base_dir, chain)
 
+        rpm_changelogs = self._collect_rpm_changelogs(
+            base_dir, chain, rpmdb_data
+        )
+
+        self._link_rpm_changelogs(base_dir, chain, rpm_changelogs)
+
         self._generate_summary(base_dir, chain, streaks,
-                               rpmdb_data=rpmdb_data)
+                               rpmdb_data=rpmdb_data,
+                               rpm_changelogs=rpm_changelogs)
 
         _log(f"\nSnapshot complete: {base_dir}/")
 
@@ -2543,10 +2815,68 @@ class Snapshotter:
 
         return rpmdb_data
 
+    def _collect_rpm_changelogs(
+        self, base_dir: str, chain: list[str],
+        rpmdb_data: dict[str, list[dict]],
+    ) -> list[dict]:
+        """Diff the target's RPM changelogs against every older payload."""
+        if not self.collect_rpm_changelogs or len(chain) < 2:
+            return []
+        target_rpms = rpmdb_data.get(chain[0])
+        if not target_rpms:
+            return []
+
+        _log(f"\nDiffing RPM changelogs of {chain[0]} against "
+             f"{len(chain) - 1} older payload(s)...")
+        differ = RpmChangelogDiffer(
+            base_dir, chain[0], chain[1:],
+            [entry["tag"] for entry in target_rpms],
+            workers=min(self.workers, 4),
+        )
+        return differ.collect()
+
+    def _link_rpm_changelogs(
+        self, base_dir: str, chain: list[str], rpm_changelogs: list[dict],
+    ) -> None:
+        """Point the target payload's raw JSONs at the matching reports.
+
+        Both files carry the release controller's own RPM diff of the
+        target against its predecessor (nodeImageStreams[].rpmDiff) —
+        package names and versions, no changelog text.  A reader who
+        lands there has no way to know the changelogs sit in a sibling
+        directory, so say so in the file itself, the way _source and
+        _release_url are already injected.
+        """
+        if len(chain) < 2:
+            return
+        target_tag, predecessor = chain[0], chain[1]
+        links = [
+            {
+                "variant": entry["variant"],
+                "compared_tag": predecessor,
+                # Relative to the payload directory these files live in.
+                "changelogs": os.path.relpath(
+                    entry["changelogs"], target_tag
+                ),
+            }
+            for entry in rpm_changelogs
+            if entry["compared_tag"] == predecessor
+        ]
+        if not links:
+            return
+        for name in ("payload.json", "changelog.json"):
+            path = os.path.join(base_dir, target_tag, name)
+            data = _read_json(path)
+            if data is None:
+                continue
+            data["_rpm_changelogs"] = links
+            _write_json(path, data)
+
     def _generate_summary(
         self, base_dir: str, chain: list[str],
         streaks: Optional[dict] = None,
         rpmdb_data: Optional[dict[str, list[dict]]] = None,
+        rpm_changelogs: Optional[list[dict]] = None,
     ) -> None:
         """Generate the stream-level summary."""
         _log("\nGenerating summary...")
@@ -2556,7 +2886,7 @@ class Snapshotter:
 
         generator = SummaryGenerator(
             base_dir, chain, chain[0], self.tag, streaks=streaks,
-            rpmdb_data=rpmdb_data,
+            rpmdb_data=rpmdb_data, rpm_changelogs=rpm_changelogs,
         )
         generator.generate()
 
@@ -3163,6 +3493,142 @@ def _run_podman(
         return None
 
 
+def _check_rpm() -> bool:
+    """Verify that the rpm CLI is available."""
+    try:
+        result = subprocess.run(
+            ["rpm", "--version"], capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+# `rpm -q --changelog` renders exactly this, but without a package
+# delimiter — with one, a single rpm call can answer for many packages.
+_CHANGELOG_QF = (
+    "===PKG %{NAME}\n"
+    "[* %{CHANGELOGTIME:day} %{CHANGELOGNAME}\n%{CHANGELOGTEXT}\n\n]"
+)
+_CHANGELOG_SPLIT_RE = re.compile(r"^===PKG (\S+)$", re.MULTILINE)
+_VERSION_QF = "%{NAME}\t%|EPOCH?{%{EPOCH}:}|%{VERSION}-%{RELEASE}\n"
+
+
+def _run_rpm(args: list[str], dbpath: str, timeout: int = 300) -> str:
+    """Run an rpm query against an extracted rpmdb directory.
+
+    Returns stdout, empty if rpm could not be run.  A nonzero exit is
+    logged but its output is still used: `rpm -q a b c` reports the
+    packages it did find and exits 1 for the one it did not, and a
+    partial answer beats no answer.  Decoding replaces undecodable bytes
+    rather than raising — changelog author names are not always UTF-8.
+    """
+    cmd = ["rpm", "--dbpath", os.path.abspath(dbpath)] + args
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+            errors="replace",
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        _log(f"    rpm query against {dbpath} failed: {e}")
+        return ""
+    if result.returncode != 0:
+        _log(f"    rpm query against {dbpath} exited "
+             f"{result.returncode}")
+        stderr = result.stderr.strip()
+        if stderr:
+            _log(f"    stderr: {stderr.splitlines()[0]}")
+    return result.stdout
+
+
+def _rpm_versions(dbpath: str) -> dict[str, str]:
+    """Map every package in an rpmdb to its version.
+
+    Packages installed in several versions at once (kernel, gpg-pubkey)
+    collapse into one comma-joined version string: the point is only to
+    detect that the package differs between two payloads.
+    """
+    stdout = _run_rpm(["-qa", "--qf", _VERSION_QF], dbpath)
+    if not stdout:
+        return {}
+    versions: dict[str, list[str]] = {}
+    for line in stdout.splitlines():
+        name, _, version = line.partition("\t")
+        if name and version:
+            versions.setdefault(name, []).append(version)
+    return {
+        name: ", ".join(sorted(found)) for name, found in versions.items()
+    }
+
+
+def _rpm_changelogs(dbpath: str, packages: Iterable[str]) -> dict[str, str]:
+    """Read the changelogs of the named packages from one rpmdb."""
+    names = sorted(packages)
+    if not names:
+        return {}
+    stdout = _run_rpm(["-q", "--qf", _CHANGELOG_QF] + names, dbpath)
+    if not stdout:
+        return {}
+    # split() yields [preamble, name, body, name, body, ...].
+    parts = _CHANGELOG_SPLIT_RE.split(stdout)
+    changelogs: dict[str, str] = {}
+    for name, body in zip(parts[1::2], parts[2::2]):
+        body = body.strip("\n")
+        # A package installed in several versions produces several records.
+        changelogs[name] = (
+            f"{changelogs[name]}\n\n{body}" if name in changelogs else body
+        )
+    return changelogs
+
+
+def _package_versions(packages: dict[str, str]) -> list[dict]:
+    """Render a {package: version} map as sorted summary.json entries."""
+    return [
+        {"package": pkg, "version": version}
+        for pkg, version in sorted(packages.items())
+    ]
+
+
+def _split_changelog_entries(changelog: str) -> list[str]:
+    """Split changelog text into entries, each starting with '* <date>'.
+
+    Assumes only entry headers start a line with '* ' — rpm does not
+    enforce this (body bullets are conventionally '- ', not '*'), so a
+    body line that happens to start with '* ' would be mis-split into a
+    spurious extra entry. Not observed in real RHCOS changelog data.
+    """
+    return [
+        entry for entry
+        in re.split(r"(?=^\* )", changelog, flags=re.MULTILINE)
+        if entry.strip()
+    ]
+
+
+def _new_changelog_entries(new_changelog: str, old_changelog: str) -> str:
+    """Return the entries `new_changelog` has that `old_changelog` lacks.
+
+    RPM changelogs are additive and grow from the top, so everything
+    above the first entry the old version already had is what the new
+    version added.  Cutting there rather than subtracting a common
+    suffix matters: rpm trims stale entries off the bottom at build
+    time, so two builds of the same package weeks apart routinely
+    disagree about their oldest entries while sharing every recent one
+    (glibc 2.34-274 kept 159 entries, 2.34-275 kept 158).  If the two
+    share no entry at all — a rewritten changelog, or an unrelated
+    package that happens to share a name — the whole new changelog is
+    returned: more to read, never wrong.
+    """
+    already_had = {
+        entry.strip() for entry in _split_changelog_entries(old_changelog)
+    }
+    kept = []
+    for entry in _split_changelog_entries(new_changelog):
+        if entry.strip() in already_had:
+            break
+        kept.append(entry)
+    return "".join(kept).strip("\n")
+
+
 def _prow_url_to_gcs_bucket_path(prow_url: str) -> Optional[str]:
     """Extract the GCS bucket path from a Prow URL.
 
@@ -3480,6 +3946,11 @@ def main() -> None:
         help="Skip RHCOS RPMDB extraction",
     )
     parser.add_argument(
+        "--no-rpm-changelogs", action="store_true",
+        help=("Skip the RPM changelog diffs between the target payload and "
+              "the older payloads in the chain"),
+    )
+    parser.add_argument(
         "--sippy", action="store_true",
         help=(
             "Force Sippy for all payload metadata (default: prefer release "
@@ -3531,6 +4002,12 @@ def main() -> None:
         _log("RHCOS RPMDB data will not be extracted.\n")
         collect_rpmdb = False
 
+    collect_rpm_changelogs = not args.no_rpm_changelogs
+    if collect_rpm_changelogs and not _check_rpm():
+        _log("Warning: the rpm CLI is not available.")
+        _log("RPM changelog diffs will not be generated.\n")
+        collect_rpm_changelogs = False
+
     if args.sippy:
         _log("Forcing Sippy APIs for all release payload data.\n")
 
@@ -3543,6 +4020,7 @@ def main() -> None:
             collect_junit=collect_junit,
             use_sippy=args.sippy,
             collect_rpmdb=collect_rpmdb,
+            collect_rpm_changelogs=collect_rpm_changelogs,
         )
         snapshotter.run()
 

--- a/plugins/ci/skills/payload-snapshot/scripts/test_rpm_changelogs.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/test_rpm_changelogs.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Tests for the RPM changelog diffs between payloads in the chain.
+
+Run with: pytest test_rpm_changelogs.py
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "payload_snapshot_rpm_changelogs",
+        os.path.join(_HERE, "payload_snapshot.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ps = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fake rpm CLI
+# ---------------------------------------------------------------------------
+
+def _result(returncode=0, stdout="", stderr=""):
+    return type("R", (), {
+        "returncode": returncode, "stdout": stdout, "stderr": stderr,
+    })()
+
+
+def _fake_rpm(dbs):
+    """A subprocess.run stand-in answering rpm queries from memory.
+
+    `dbs` maps a dbpath to {package: (version, changelog)}.  An unknown
+    dbpath answers the way rpm does for one it cannot open.
+    """
+    def run(cmd, **kwargs):
+        assert cmd[0] == "rpm", cmd
+        db = dbs.get(cmd[cmd.index("--dbpath") + 1])
+        if db is None:
+            return _result(1, "", "error: cannot open Packages database")
+        if "-qa" in cmd:
+            return _result(0, "".join(
+                f"{pkg}\t{version}\n" for pkg, (version, _) in sorted(db.items())
+            ))
+        names = cmd[cmd.index("--qf") + 2:]
+        missing = [n for n in names if n not in db]
+        return _result(
+            1 if missing else 0,
+            "".join(f"===PKG {n}\n{db[n][1]}\n" for n in names if n in db),
+            "".join(f"package {n} is not installed\n" for n in missing),
+        )
+    return run
+
+
+ENTRY_NEW = (
+    "* Fri Aug 01 2026 Some Body <a@b.com> - 1.2-1\n"
+    "- the new thing\n"
+)
+ENTRY_MID = (
+    "* Wed Jul 30 2026 Some Body <a@b.com> - 1.1-1\n"
+    "- the middle thing\n"
+)
+ENTRY_OLD = (
+    "* Mon Jul 20 2026 Some Body <a@b.com> - 1.0-1\n"
+    "- the old thing\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# _split_changelog_entries / _new_changelog_entries
+# ---------------------------------------------------------------------------
+
+def test_split_separates_entries_on_their_header_line():
+    entries = ps._split_changelog_entries(
+        f"{ENTRY_NEW}\n{ENTRY_MID}\n{ENTRY_OLD}"
+    )
+    assert len(entries) == 3
+    assert entries[0].startswith("* Fri Aug 01 2026")
+    assert "the new thing" in entries[0]
+    # A body line that merely mentions '*' does not start a new entry.
+    assert len(ps._split_changelog_entries(
+        "* Fri Aug 01 2026 A <a@b.com> - 1.2-1\n- fixed a * glob\n"
+    )) == 1
+
+
+def test_new_entries_keeps_only_what_the_old_version_lacked():
+    new = f"{ENTRY_NEW}\n{ENTRY_MID}\n{ENTRY_OLD}"
+    old = f"{ENTRY_MID}\n{ENTRY_OLD}"
+    diff = ps._new_changelog_entries(new, old)
+    assert "the new thing" in diff
+    assert "the middle thing" not in diff
+    assert "the old thing" not in diff
+
+
+def test_new_entries_tolerates_entries_trimmed_off_the_bottom():
+    """rpm trims stale changelog entries at build time, so the newer build
+    can be missing the oldest entries the older build still carries.
+
+    Regression test: requiring a common *suffix* found no overlap at all
+    for e.g. glibc 2.34-274 (159 entries) vs. 2.34-275 (158 entries) and
+    dumped the entire changelog instead of the one entry that was added.
+    """
+    new = f"{ENTRY_NEW}\n{ENTRY_MID}"
+    old = f"{ENTRY_MID}\n{ENTRY_OLD}"
+    diff = ps._new_changelog_entries(new, old)
+    assert "the new thing" in diff
+    assert "the middle thing" not in diff
+
+
+def test_new_entries_is_empty_when_nothing_was_added():
+    changelog = f"{ENTRY_NEW}\n{ENTRY_MID}"
+    assert ps._new_changelog_entries(changelog, changelog) == ""
+
+
+def test_new_entries_returns_everything_when_the_old_side_is_empty():
+    diff = ps._new_changelog_entries(f"{ENTRY_NEW}\n{ENTRY_MID}", "")
+    assert "the new thing" in diff
+    assert "the middle thing" in diff
+
+
+def test_new_entries_returns_everything_when_histories_share_nothing():
+    """A rewritten (or unrelated) history degrades to the full changelog.
+
+    Deliberate: showing more history is noise, guessing a cut point that
+    is not there would drop real entries.
+    """
+    diff = ps._new_changelog_entries(
+        f"{ENTRY_NEW}\n{ENTRY_MID}",
+        "* Thu Jan 01 2026 Other <o@b.com> - 0.1-1\n- unrelated\n",
+    )
+    assert "the new thing" in diff
+    assert "the middle thing" in diff
+
+
+def test_new_entries_is_empty_for_a_downgrade():
+    """The target having *fewer* entries is not a diff to report."""
+    assert ps._new_changelog_entries(
+        f"{ENTRY_MID}\n{ENTRY_OLD}", f"{ENTRY_NEW}\n{ENTRY_MID}\n{ENTRY_OLD}"
+    ) == ""
+
+
+# ---------------------------------------------------------------------------
+# _rpm_versions / _rpm_changelogs
+# ---------------------------------------------------------------------------
+
+def test_rpm_versions_reads_every_package(monkeypatch):
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        "/db": {"kernel": ("5.14.0-1", ""), "bash": ("5.2-3", "")},
+    }))
+    assert ps._rpm_versions("/db") == {
+        "kernel": "5.14.0-1", "bash": "5.2-3",
+    }
+
+
+def test_rpm_versions_collapses_packages_installed_several_times(monkeypatch):
+    monkeypatch.setattr(ps.subprocess, "run", lambda cmd, **kw: _result(
+        0, "kernel\t5.14.0-2\nkernel\t5.14.0-1\ngarbage-without-a-version\n"
+    ))
+    assert ps._rpm_versions("/db") == {"kernel": "5.14.0-1, 5.14.0-2"}
+
+
+def test_rpm_queries_decode_leniently(monkeypatch):
+    """Changelog author names are not always valid UTF-8, and a decode
+    error must not escape as a ValueError that sinks the whole snapshot."""
+    seen = {}
+    monkeypatch.setattr(ps.subprocess, "run", lambda cmd, **kw: (
+        seen.update(kw) or _result(0, "")
+    ))
+    ps._rpm_versions("/db")
+    assert seen["errors"] == "replace"
+
+
+def test_rpm_versions_is_empty_when_the_rpmdb_cannot_be_read(monkeypatch):
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({}))
+    assert ps._rpm_versions("/missing") == {}
+
+
+def test_rpm_changelogs_splits_the_response_per_package(monkeypatch):
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        "/db": {"kernel": ("1", ENTRY_NEW), "bash": ("1", ENTRY_OLD)},
+    }))
+    changelogs = ps._rpm_changelogs("/db", ["kernel", "bash"])
+    assert set(changelogs) == {"kernel", "bash"}
+    assert "the new thing" in changelogs["kernel"]
+    assert "the old thing" in changelogs["bash"]
+
+
+def test_rpm_changelogs_keeps_what_it_got_when_a_package_is_missing(monkeypatch):
+    """rpm exits nonzero for the package it cannot find — the rest is still
+    a valid answer and must not be thrown away."""
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        "/db": {"kernel": ("1", ENTRY_NEW)},
+    }))
+    assert set(ps._rpm_changelogs("/db", ["kernel", "gone"])) == {"kernel"}
+
+
+def test_rpm_changelogs_joins_several_records_for_one_package(monkeypatch):
+    monkeypatch.setattr(ps.subprocess, "run", lambda cmd, **kw: _result(
+        0, f"===PKG kernel\n{ENTRY_NEW}\n===PKG kernel\n{ENTRY_OLD}\n"
+    ))
+    changelog = ps._rpm_changelogs("/db", ["kernel"])["kernel"]
+    assert "the new thing" in changelog and "the old thing" in changelog
+
+
+def test_rpm_changelogs_does_not_run_rpm_for_an_empty_package_set(monkeypatch):
+    def fail(*a, **kw):
+        raise AssertionError("must not shell out with nothing to query")
+
+    monkeypatch.setattr(ps.subprocess, "run", fail)
+    assert ps._rpm_changelogs("/db", []) == {}
+
+
+# ---------------------------------------------------------------------------
+# RpmChangelogDiffer
+# ---------------------------------------------------------------------------
+
+VARIANT = "rhel-coreos-10"
+TARGET = "5.0.0-0.nightly-2026-08-03-000000"
+MIDDLE = "5.0.0-0.nightly-2026-08-02-000000"
+BASELINE = "5.0.0-0.nightly-2026-08-01-000000"
+
+
+def _dbpath(base_dir, tag, variant=VARIANT):
+    return os.path.join(base_dir, tag, "rpmdb", variant)
+
+
+def _extracted(base_dir, *tags, variant=VARIANT):
+    """Create the rpmdb.sqlite files the differ looks for."""
+    for tag in tags:
+        ps._write_text(
+            os.path.join(_dbpath(base_dir, tag, variant), "rpmdb.sqlite"), ""
+        )
+
+
+def _differ(base_dir, older=(MIDDLE, BASELINE), variants=(VARIANT,)):
+    return ps.RpmChangelogDiffer(
+        base_dir, TARGET, list(older), list(variants), workers=1
+    )
+
+
+def test_diff_reports_changed_new_and_removed_packages(tmp_path, monkeypatch):
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {
+            "kernel": ("5.14.0-2", f"{ENTRY_NEW}\n{ENTRY_MID}\n{ENTRY_OLD}"),
+            "brand-new": ("1.0-1", f"{ENTRY_NEW}\n{ENTRY_OLD}"),
+            "untouched": ("3.0-1", ENTRY_OLD),
+        },
+        _dbpath(base_dir, BASELINE): {
+            "kernel": ("5.14.0-1", f"{ENTRY_MID}\n{ENTRY_OLD}"),
+            "untouched": ("3.0-1", ENTRY_OLD),
+            "dropped": ("2.0-1", ENTRY_OLD),
+        },
+    }))
+
+    entries = _differ(base_dir, older=[BASELINE]).collect()
+
+    assert entries == [{
+        "variant": VARIANT,
+        "compared_tag": BASELINE,
+        "is_baseline": True,
+        "changed": 1,
+        "added": 1,
+        "removed": 1,
+        "changelogs": f"{TARGET}/rpm-changelogs/{VARIANT}/{BASELINE}.md",
+        # The baseline diff is inline, so summary.json answers "what
+        # changed since the baseline?" without opening the report.
+        "diff": {
+            "changed": [{
+                "package": "kernel",
+                "old": "5.14.0-1",
+                "new": "5.14.0-2",
+                "changelog": ENTRY_NEW.strip(),
+            }],
+            "added": [{"package": "brand-new", "version": "1.0-1"}],
+            "removed": [{"package": "dropped", "version": "2.0-1"}],
+        },
+    }]
+
+    with open(os.path.join(base_dir, entries[0]["changelogs"])) as f:
+        report = f.read()
+    assert "### kernel: 5.14.0-1 -> 5.14.0-2" in report
+    # Changed package: only what the new version added.
+    assert "the new thing" in report
+    assert "the middle thing" not in report
+    # New package: the whole changelog.
+    assert "### brand-new: 1.0-1" in report
+    assert report.count("the old thing") == 1  # brand-new's, not untouched's
+    # Removed package: recorded, but no changelog.
+    assert f"- dropped: 2.0-1 (in {BASELINE}" in report
+    assert "untouched" not in report
+
+
+def test_diff_notes_a_rebuild_that_added_no_changelog_entry(tmp_path, monkeypatch):
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {"kernel": ("5.14.0-2", ENTRY_OLD)},
+        _dbpath(base_dir, BASELINE): {"kernel": ("5.14.0-1", ENTRY_OLD)},
+    }))
+    entries = _differ(base_dir, older=[BASELINE]).collect()
+    assert entries[0]["changed"] == 1
+    with open(os.path.join(base_dir, entries[0]["changelogs"])) as f:
+        assert "rebuilt without adding a changelog entry" in f.read()
+
+
+def test_diff_writes_one_report_per_older_payload(tmp_path, monkeypatch):
+    """Each older payload is compared against the target on its own — the
+    chain is not folded hop by hop."""
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, MIDDLE, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {
+            "kernel": ("5.14.0-3", f"{ENTRY_NEW}\n{ENTRY_MID}\n{ENTRY_OLD}"),
+        },
+        _dbpath(base_dir, MIDDLE): {
+            "kernel": ("5.14.0-2", f"{ENTRY_MID}\n{ENTRY_OLD}"),
+        },
+        _dbpath(base_dir, BASELINE): {
+            "kernel": ("5.14.0-1", ENTRY_OLD),
+        },
+    }))
+
+    entries = _differ(base_dir).collect()
+
+    assert [(e["compared_tag"], e["is_baseline"]) for e in entries] == [
+        (MIDDLE, False), (BASELINE, True),
+    ]
+    # Only the oldest comparison inlines its diff — the intermediate hops
+    # are a subset of it and would grow summary.json by the whole chain.
+    assert "diff" not in entries[0]
+    assert entries[1]["diff"]["changed"][0]["package"] == "kernel"
+    with open(os.path.join(base_dir, entries[0]["changelogs"])) as f:
+        vs_middle = f.read()
+    with open(os.path.join(base_dir, entries[1]["changelogs"])) as f:
+        vs_baseline = f.read()
+    assert "the middle thing" not in vs_middle
+    assert "the middle thing" in vs_baseline
+
+
+def test_diff_ignores_older_payloads_without_this_variant(tmp_path, monkeypatch):
+    """A variant that only exists in the newer payload (a RHEL major bump
+    adds one) has nothing to diff against, so it is left alone rather than
+    reported as hundreds of new packages."""
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, BASELINE)
+    _extracted(base_dir, TARGET, variant="rhel-coreos-11")
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {"kernel": ("2", ENTRY_NEW)},
+        _dbpath(base_dir, TARGET, "rhel-coreos-11"): {
+            "kernel": ("2", ENTRY_NEW),
+        },
+        _dbpath(base_dir, BASELINE): {"kernel": ("1", ENTRY_OLD)},
+    }))
+
+    entries = _differ(
+        base_dir, older=[BASELINE], variants=[VARIANT, "rhel-coreos-11"]
+    ).collect()
+
+    assert [e["variant"] for e in entries] == [VARIANT]
+    assert not os.path.exists(
+        os.path.join(base_dir, TARGET, "rpm-changelogs", "rhel-coreos-11")
+    )
+
+
+def test_diff_skips_a_variant_whose_target_rpmdb_is_unreadable(tmp_path, monkeypatch):
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, BASELINE): {"kernel": ("1", ENTRY_OLD)},
+    }))
+    assert _differ(base_dir, older=[BASELINE]).collect() == []
+
+
+def test_diff_skips_an_older_payload_whose_rpmdb_is_unreadable(tmp_path, monkeypatch):
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, MIDDLE, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {"kernel": ("2", ENTRY_NEW)},
+        _dbpath(base_dir, BASELINE): {"kernel": ("1", ENTRY_OLD)},
+    }))
+    entries = _differ(base_dir).collect()
+    assert [e["compared_tag"] for e in entries] == [BASELINE]
+
+
+def test_diff_promotes_the_oldest_readable_comparison_to_baseline(
+    tmp_path, monkeypatch
+):
+    """When the chain baseline's rpmdb cannot be read, the next-oldest
+    readable comparison takes over is_baseline/diff — flagged so a
+    consumer can tell the diff does not reach the actual chain start."""
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, MIDDLE, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {"kernel": ("3", ENTRY_NEW)},
+        _dbpath(base_dir, MIDDLE): {"kernel": ("2", ENTRY_OLD)},
+    }))
+    entries = _differ(base_dir).collect()
+    assert [e["compared_tag"] for e in entries] == [MIDDLE]
+    assert entries[0]["is_baseline"] is True
+    assert "diff" in entries[0]
+    assert entries[0]["baseline_rpmdb_missing"] is True
+
+
+def test_diff_keeps_going_when_one_variant_fails(tmp_path, monkeypatch):
+    """The diffs are derived, best-effort data collected before summary.json
+    is written — one broken variant must not abort the whole snapshot."""
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, BASELINE)
+    _extracted(base_dir, TARGET, BASELINE, variant="rhel-coreos")
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, TARGET): {"kernel": ("2", ENTRY_NEW)},
+        _dbpath(base_dir, BASELINE): {"kernel": ("1", ENTRY_OLD)},
+        _dbpath(base_dir, TARGET, "rhel-coreos"): {"kernel": ("2", ENTRY_NEW)},
+        _dbpath(base_dir, BASELINE, "rhel-coreos"): {"kernel": ("1", ENTRY_OLD)},
+    }))
+    differ = _differ(base_dir, older=[BASELINE],
+                     variants=["rhel-coreos", VARIANT])
+    real_diff_variant = differ._diff_variant
+    differ._diff_variant = lambda variant: (
+        (_ for _ in ()).throw(RuntimeError("boom"))
+        if variant == "rhel-coreos" else real_diff_variant(variant)
+    )
+
+    entries = differ.collect()
+
+    assert [e["variant"] for e in entries] == [VARIANT]
+
+
+# ---------------------------------------------------------------------------
+# Cross-links from the per-payload data to the reports
+# ---------------------------------------------------------------------------
+
+def _changelog_entry(variant, compared_tag):
+    return {
+        "variant": variant, "compared_tag": compared_tag,
+        "is_baseline": compared_tag == BASELINE,
+        "changed": 1, "added": 0, "removed": 0,
+        "changelogs":
+            f"{TARGET}/rpm-changelogs/{variant}/{compared_tag}.md",
+    }
+
+
+def test_target_raw_jsons_point_at_the_predecessor_report(tmp_path):
+    """payload.json and changelog.json show the release controller's RPM
+    diff without changelog text, so they must say where the text is."""
+    base_dir = str(tmp_path)
+    for name in ("payload.json", "changelog.json"):
+        ps._write_json(os.path.join(base_dir, TARGET, name),
+                       {"nodeImageStreams": [], "_source": "rc"})
+
+    _snapshotter()._link_rpm_changelogs(
+        base_dir, [TARGET, MIDDLE, BASELINE],
+        [_changelog_entry(VARIANT, MIDDLE), _changelog_entry(VARIANT, BASELINE)],
+    )
+
+    for name in ("payload.json", "changelog.json"):
+        data = ps._read_json(os.path.join(base_dir, TARGET, name))
+        assert data["_source"] == "rc", "must not clobber the payload data"
+        # Only the pairing these files describe: target vs. predecessor,
+        # by a path relative to the payload directory they live in.
+        assert data["_rpm_changelogs"] == [{
+            "variant": VARIANT,
+            "compared_tag": MIDDLE,
+            "changelogs": f"rpm-changelogs/{VARIANT}/{MIDDLE}.md",
+        }]
+
+
+def test_raw_jsons_are_left_alone_without_a_matching_report(tmp_path):
+    base_dir = str(tmp_path)
+    path = os.path.join(base_dir, TARGET, "payload.json")
+    ps._write_json(path, {"_source": "rc"})
+    snap = _snapshotter()
+
+    snap._link_rpm_changelogs(base_dir, [TARGET], [])          # no chain
+    snap._link_rpm_changelogs(base_dir, [TARGET, MIDDLE], [])  # no reports
+    snap._link_rpm_changelogs(  # reports, but not for the predecessor
+        base_dir, [TARGET, MIDDLE, BASELINE],
+        [_changelog_entry(VARIANT, BASELINE)],
+    )
+
+    assert ps._read_json(path) == {"_source": "rc"}
+
+
+def test_payload_entries_point_at_their_report(tmp_path):
+    base_dir = str(tmp_path)
+    generator = ps.SummaryGenerator(
+        base_dir, [TARGET, BASELINE], TARGET,
+        ps.PayloadTag.parse(TARGET),
+        rpm_changelogs=[_changelog_entry(VARIANT, BASELINE)],
+    )
+
+    by_tag = {e["tag"]: e for e in generator._build_payload_entries()}
+
+    assert by_tag[BASELINE]["rpm_changelogs"] == [{
+        "variant": VARIANT,
+        "changelogs": f"{TARGET}/rpm-changelogs/{VARIANT}/{BASELINE}.md",
+    }]
+    # The target is what every report is anchored on, so it has none.
+    assert "rpm_changelogs" not in by_tag[TARGET]
+
+
+# ---------------------------------------------------------------------------
+# Snapshotter wiring
+# ---------------------------------------------------------------------------
+
+def _snapshotter(**kwargs):
+    return ps.Snapshotter(
+        ps.PayloadTag.parse("5.0.0-0.nightly-2026-08-03-000000"), **kwargs
+    )
+
+
+RPMDB_DATA = {TARGET: [{"tag": VARIANT, "name": "n", "pullspec": "p"}]}
+
+
+@pytest.mark.parametrize("kwargs,chain,rpmdb_data", [
+    ({"collect_rpm_changelogs": False}, [TARGET, BASELINE], RPMDB_DATA),
+    ({}, [TARGET], RPMDB_DATA),          # no baseline to diff against
+    ({}, [TARGET, BASELINE], {}),        # rpmdb extraction was skipped
+])
+def test_collect_is_skipped_without_anything_to_diff(kwargs, chain, rpmdb_data,
+                                                     monkeypatch):
+    def fail(*a, **kw):
+        raise AssertionError("must not shell out to rpm")
+
+    monkeypatch.setattr(ps.subprocess, "run", fail)
+    snap = _snapshotter(**kwargs)
+    assert snap._collect_rpm_changelogs("base", chain, rpmdb_data) == []
+
+
+def test_collect_diffs_the_target_against_the_rest_of_the_chain(tmp_path,
+                                                                monkeypatch):
+    base_dir = str(tmp_path)
+    _extracted(base_dir, TARGET, MIDDLE, BASELINE)
+    monkeypatch.setattr(ps.subprocess, "run", _fake_rpm({
+        _dbpath(base_dir, tag): {"kernel": (version, ENTRY_NEW)}
+        for tag, version in [(TARGET, "3"), (MIDDLE, "2"), (BASELINE, "1")]
+    }))
+    entries = _snapshotter()._collect_rpm_changelogs(
+        base_dir, [TARGET, MIDDLE, BASELINE], RPMDB_DATA
+    )
+    assert [e["compared_tag"] for e in entries] == [MIDDLE, BASELINE]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
This is an intentionally simplified, more straightforward alternative to #668.

Every payload in the chain already has its RHCOS rpmdb extracted, so "what changed in the RPMs" is answerable locally: query two rpmdbs and subtract. `RpmChangelogDiffer` writes one report per (RHCOS variant, older payload in the chain), referenced from `summary.json` as `rpm_changelogs[]`, gated behind `--no-rpm-changelogs` plus an `rpm` CLI preflight.

For a changed package, the new changelog entries are found by cutting at the first entry the old version already had (not a common-suffix match, since rpm trims stale tail entries at build time and older builds can disagree on their oldest entries). New packages get a full dump, removed ones just their name and version.

The oldest comparison per variant (the baseline) also carries its diff inline in `summary.json` under `diff`, so target-vs-baseline needs no file read. Intermediate hops stay behind their own path and are read only to find which hop introduced a given bump.

Each older payload is compared against the target independently, so nothing needs the release controller's `rhcos_changes` and no version strings need to be parsed out of changelog text.

Where this diverges from #668: that PR reconstructs the version diff from `rhcos_changes` and does a best-effort text trim of `rpm --changelog` output. This PR queries both payloads' rpmdbs directly and diffs the changelog entries exactly.

## Test plan
- [ ] `make lint`
- [ ] `python3 -m pytest plugins/ci/skills/payload-snapshot/scripts/test_rpm_changelogs.py`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Payload snapshots now include RPM changelog differences across payload variants and older versions.
  - Reports provide per-variant Markdown diffs and comparison metadata.
  - Added `--no-rpm-changelogs` to disable changelog collection while retaining RPM database extraction.
  - Changelog collection automatically skips when the required `rpm` command is unavailable.

- **Documentation**
  - Updated snapshot workflow, CLI reference, output structure, and summary schema documentation.

- **Tests**
  - Added coverage for changelog parsing, comparisons, reporting, failures, and skip conditions.

- **Chores**
  - Updated the CI plugin version to 0.0.81.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->