### PR TITLE
fix node-cve: scope triage to latest OCP version by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -333,7 +333,7 @@
       "name": "node-cve",
       "source": "./plugins/node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "category": "openshift",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1942,7 +1942,7 @@ footer a { color: var(--primary); }
           "full_name": "node-cve:triage",
           "description": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
           "description_html": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
-          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days 7]",
+          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--notify-jira] [--notify-slack] [--days 7]",
           "body_html": "\u003cp\u003eQueries all open CVE vulnerability issues in OCPBUGS for Node team components, deduplicates across version trackers, clones affected repositories, and analyzes source code for CVE reachability. Optionally posts analysis comments to Jira trackers and sends a Slack summary.\u003c/p\u003e\u003cp\u003eDesigned for both interactive use and headless execution via \u003ccode\u003eclaude --print\u003c/code\u003e.\u003c/p\u003e"
         }
       ],

--- a/docs/index.html
+++ b/docs/index.html
@@ -1934,7 +1934,7 @@ footer a { color: var(--primary); }
     {
       "name": "node-cve",
       "description": "CVE triage for OpenShift Node team components",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "has_readme": true,
       "commands": [
         {
@@ -1942,7 +1942,7 @@ footer a { color: var(--primary); }
           "full_name": "node-cve:triage",
           "description": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
           "description_html": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
-          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--notify-jira] [--notify-slack] [--days 7]",
+          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--version latest] [--notify-jira] [--notify-slack] [--days 7]",
           "body_html": "\u003cp\u003eQueries all open CVE vulnerability issues in OCPBUGS for Node team components, deduplicates across version trackers, clones affected repositories, and analyzes source code for CVE reachability. Optionally posts analysis comments to Jira trackers and sends a Slack summary.\u003c/p\u003e\u003cp\u003eDesigned for both interactive use and headless execution via \u003ccode\u003eclaude --print\u003c/code\u003e.\u003c/p\u003e"
         }
       ],

--- a/docs/index.html
+++ b/docs/index.html
@@ -1942,7 +1942,7 @@ footer a { color: var(--primary); }
           "full_name": "node-cve:triage",
           "description": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
           "description_html": "Triage all open CVEs for OpenShift Node team components with reachability analysis",
-          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--version latest] [--notify-jira] [--notify-slack] [--days 7]",
+          "synopsis": "/node-cve:triage [--component \"Node / CRI-O\"] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days 7]",
           "body_html": "\u003cp\u003eQueries all open CVE vulnerability issues in OCPBUGS for Node team components, deduplicates across version trackers, clones affected repositories, and analyzes source code for CVE reachability. Optionally posts analysis comments to Jira trackers and sends a Slack summary.\u003c/p\u003e\u003cp\u003eDesigned for both interactive use and headless execution via \u003ccode\u003eclaude --print\u003c/code\u003e.\u003c/p\u003e"
         }
       ],

--- a/plugins/node-cve/.claude-plugin/plugin.json
+++ b/plugins/node-cve/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "node-cve",
   "description": "CVE triage for OpenShift Node team components",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -27,7 +27,7 @@ Triage all open CVEs for Node team components with automated reachability analys
 
 1. Queries OCPBUGS for open Vulnerability issues across all Node team components (CRI-O, Kubelet, MCO, etc.)
 2. Deduplicates by CVE ID (each CVE has multiple version trackers)
-3. Filters to the target OCP version (default: latest — currently 5.0). Older versions are owned by the sustaining team.
+3. Filters to the target OCP version (default: latest — auto-detected as the highest numeric version from query results, e.g., `5.0`). Older versions are owned by the sustaining team.
 4. Clones affected repositories at the target version's release branch and analyzes source code for reachability
 5. Classifies each CVE: Reachable, Present but not exploitable, Present but not reachable, Unaffected, or Uncertain
 6. Generates a triage report with confidence levels and recommended actions
@@ -104,7 +104,7 @@ spec:
 
 ## Safeguards
 
-The plugin implements three layers of defense to ensure triage analysis is only posted where it belongs:
+The plugin implements two safeguards, each with query-time and posting-time validation, to ensure triage analysis is only posted where it belongs:
 
 ### Component safeguard (cross-team protection)
 

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -14,7 +14,7 @@ Requires the `node-team` plugin (installed automatically as a dependency).
 
 ## Command
 
-### `/node-cve:triage [--component <name>] [--notify-jira] [--notify-slack] [--days N]`
+### `/node-cve:triage [--component <name>] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days N]`
 
 Triage all open CVEs for Node team components with automated reachability analysis.
 
@@ -27,14 +27,16 @@ Triage all open CVEs for Node team components with automated reachability analys
 
 1. Queries OCPBUGS for open Vulnerability issues across all Node team components (CRI-O, Kubelet, MCO, etc.)
 2. Deduplicates by CVE ID (each CVE has multiple version trackers)
-3. Clones affected repositories at all version-specific release branches and analyzes source code for reachability
-4. Classifies each CVE: Reachable, Present but not exploitable, Present but not reachable, Unaffected, or Uncertain
-5. Generates a triage report with confidence levels and recommended actions
-6. Posts analysis comments to Jira tracker issues (with `--notify-jira`)
-7. Sends a threaded summary to Slack (with `--notify-slack`)
+3. Filters to the target OCP version (default: latest — currently 5.0). Older versions are owned by the sustaining team.
+4. Clones affected repositories at the target version's release branch and analyzes source code for reachability
+5. Classifies each CVE: Reachable, Present but not exploitable, Present but not reachable, Unaffected, or Uncertain
+6. Generates a triage report with confidence levels and recommended actions
+7. Posts analysis comments to Jira tracker issues (with `--notify-jira`)
+8. Sends a threaded summary to Slack (with `--notify-slack`)
 
 **Arguments:**
 - `--component <name>`: Filter to a single specific component (e.g., "Node / CRI-O"). If omitted, ALL Node team components are included — and only Node team components, never all OCPBUGS components.
+- `--version <value>`: Control which OCP versions are triaged. Default: `latest` (auto-detects the highest OCP version from query results). Use a specific version (e.g., `5.0`) or `all` for full cross-version analysis.
 - `--notify-jira`: Post analysis results as comments on Jira tracker issues (also enables cross-run caching)
 - `--notify-slack`: Send summary to Slack (API token for threading, or webhook for simple messages)
 - `--days N`: Only include CVEs updated in the last N days (default: all open)
@@ -102,12 +104,25 @@ spec:
 
 ## Safeguards
 
-Many CVEs (especially Go stdlib or vendored-dependency vulnerabilities) have tracker issues across dozens of OpenShift teams — not just Node. Posting Node-specific reachability analysis to another team's tracker is confusing and erodes trust in the automation. The plugin implements two layers of defense against this:
+The plugin implements three layers of defense to ensure triage analysis is only posted where it belongs:
+
+### Component safeguard (cross-team protection)
+
+Many CVEs (especially Go stdlib or vendored-dependency vulnerabilities) have tracker issues across dozens of OpenShift teams — not just Node. Posting Node-specific reachability analysis to another team's tracker is confusing and erodes trust in the automation.
 
 1. **Component filter at query time (Phase 1):** Every Jira query — whether or not `--component` is passed — is scoped with `component in (...)` to the Node team component list from the [shared components reference](../node-team/skills/node/references/shared/components.md). "No `--component` flag" means "all Node team components," never "no filter."
 2. **Component re-validation at posting time (Phase 3):** Immediately before posting any `--notify-jira` comment, each tracker's component is re-checked against the Node team list, independent of Phase 1's filtering. Trackers that don't match are skipped and recorded in `posting-audit.log` instead of being commented on.
 
-This two-layer design follows an incident (2026-07-15) where a CVE with 200+ multi-team trackers had Node-specific analysis posted to non-Node trackers (HyperShift, Storage, Networking, Installer, etc.) because a downstream step re-searched Jira by CVE ID alone, without a component filter. See [report-findings](skills/report-findings/SKILL.md) for the full validation logic, and never construct a CVE-ID-only Jira search as a shortcut for finding trackers to comment on — always reuse the already-filtered tracker list from Phase 1.
+This design follows an incident (2026-07-15) where a CVE with 200+ multi-team trackers had Node-specific analysis posted to non-Node trackers because a downstream step re-searched Jira by CVE ID alone without a component filter.
+
+### Version safeguard (cross-version protection)
+
+Each CVE has tracker issues for every affected OCP version (e.g., 4.12.z through 5.0). The OCP sustaining team owns triage for all versions except the latest in-development release. The Node team should only triage the latest version.
+
+1. **Version filter at query time (Phase 1):** After deduplication, trackers are filtered to the target OCP version. By default (`--version latest`), the plugin auto-detects the highest OCP version from the query results. Only trackers matching that version are retained.
+2. **Version re-validation at posting time (Phase 3):** Immediately before posting, each tracker's OCP version (from its summary) is re-checked against the active version filter. Trackers that don't match are skipped and recorded in `posting-audit.log`.
+
+See [report-findings](skills/report-findings/SKILL.md) for the full validation logic, and never construct a CVE-ID-only Jira search as a shortcut for finding trackers to comment on — always reuse the already-filtered tracker list from Phase 1.
 
 ## Node Team Components
 

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -27,8 +27,8 @@ Triage all open CVEs for Node team components with automated reachability analys
 
 1. Queries OCPBUGS for open Vulnerability issues across all Node team components (CRI-O, Kubelet, MCO, etc.)
 2. Deduplicates by CVE ID (each CVE has multiple version trackers)
-3. Filters to the target OCP version (default: latest — auto-detected as the highest numeric version from query results, e.g., `5.0`). Older versions are owned by the sustaining team.
-4. Clones affected repositories at the target version's release branch and analyzes source code for reachability
+3. Filters to the latest OCP version (auto-detected as the highest numeric version from query results, e.g., `5.0`). Older versions are owned by the sustaining team.
+4. Clones affected repositories at the latest version's release branch and analyzes source code for reachability
 5. Classifies each CVE: Reachable, Present but not exploitable, Present but not reachable, Unaffected, or Uncertain
 6. Generates a triage report with confidence levels and recommended actions
 7. Posts analysis comments to Jira tracker issues (with `--notify-jira`)

--- a/plugins/node-cve/README.md
+++ b/plugins/node-cve/README.md
@@ -14,7 +14,7 @@ Requires the `node-team` plugin (installed automatically as a dependency).
 
 ## Command
 
-### `/node-cve:triage [--component <name>] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days N]`
+### `/node-cve:triage [--component <name>] [--notify-jira] [--notify-slack] [--days N]`
 
 Triage all open CVEs for Node team components with automated reachability analysis.
 
@@ -36,7 +36,6 @@ Triage all open CVEs for Node team components with automated reachability analys
 
 **Arguments:**
 - `--component <name>`: Filter to a single specific component (e.g., "Node / CRI-O"). If omitted, ALL Node team components are included — and only Node team components, never all OCPBUGS components.
-- `--version <value>`: Control which OCP versions are triaged. Default: `latest` (auto-detects the highest OCP version from query results). Use a specific version (e.g., `5.0`) or `all` for full cross-version analysis.
 - `--notify-jira`: Post analysis results as comments on Jira tracker issues (also enables cross-run caching)
 - `--notify-slack`: Send summary to Slack (API token for threading, or webhook for simple messages)
 - `--days N`: Only include CVEs updated in the last N days (default: all open)
@@ -119,10 +118,10 @@ This design follows an incident (2026-07-15) where a CVE with 200+ multi-team tr
 
 Each CVE has tracker issues for every affected OCP version (e.g., 4.12.z through 5.0). The OCP sustaining team owns triage for all versions except the latest in-development release. The Node team should only triage the latest version.
 
-1. **Version filter at query time (Phase 1):** After deduplication, trackers are filtered to the target OCP version. By default (`--version latest`), the plugin auto-detects the highest OCP version from the query results. Only trackers matching that version are retained.
-2. **Version re-validation at posting time (Phase 3):** Immediately before posting, each tracker's OCP version (from its summary) is re-checked against the active version filter. Trackers that don't match are skipped and recorded in `posting-audit.log`.
+1. **Version filter at query time (Phase 1):** After deduplication, trackers are filtered to the auto-detected latest OCP version (the highest numeric `major.minor` from query results). Only trackers matching that version are retained.
+2. **Version re-validation at posting time (Phase 3):** Immediately before posting, each tracker's OCP version (from its summary) is re-checked against the auto-detected version. Trackers that don't match are skipped and recorded in `posting-audit.log`.
 
-See [report-findings](skills/report-findings/SKILL.md) for the full validation logic, and never construct a CVE-ID-only Jira search as a shortcut for finding trackers to comment on — always reuse the already-filtered tracker list from Phase 1.
+See [report-findings](skills/report-findings/SKILL.md) for the full validation logic (including `.z` suffix handling), and never construct a CVE-ID-only Jira search as a shortcut for finding trackers to comment on — always reuse the already-filtered tracker list from Phase 1.
 
 ## Node Team Components
 

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -209,18 +209,16 @@ Wait for all agents to complete, then collect results. Print progress for each: 
    | Overall classification | Reachable |
    | Overall confidence | High |
    | Assignee | <name or "Unassigned"> |
-   | Affected versions | 4.12.z - 4.19 |
-   | Tracker issues | OCPBUGS-XXXXX, OCPBUGS-XXXXX, ... |
+   | OCP version | 5.0 |
+   | Tracker issues | OCPBUGS-XXXXX |
 
-   **Per-branch results:**
+   **Analysis result:**
 
    | Branch | OCP Version | Classification | Confidence |
    |--------|-------------|----------------|------------|
-   | release-1.28 | 4.15 | Reachable | High |
-   | release-1.29 | 4.16 | Reachable | High |
-   | release-1.30 | 4.17 | Unaffected | High |
+   | release-1.36 | 5.0 | Reachable | High |
 
-   **Evidence (worst-case branch):** <source code analysis summary>
+   **Evidence:** <source code analysis summary>
    **Recommended action:** <update dependency / apply patch / monitor / investigate>
    ```
 
@@ -228,7 +226,7 @@ Wait for all agents to complete, then collect results. Print progress for each: 
 
    **Before posting anything, re-validate every tracker against both the auto-detected version and the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard", "OCP Version Safeguard", and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component or whose OCP version does not match the auto-detected latest version, and record it in the posting audit log.
 
-   Use Atlassian wiki markup (not Markdown), matching the format in [report-findings](../skills/report-findings/SKILL.md) Step 2. The comment includes per-branch results across all analyzed versions so reviewers can see the full picture.
+   Use Atlassian wiki markup (not Markdown), matching the format in [report-findings](../skills/report-findings/SKILL.md) Step 2. The comment includes the analysis result for the latest OCP version.
 
    Before posting, check for existing `node-cve:triage` comments on the issue. If a prior comment exists with the same classification, skip it. If the classification changed, edit the existing comment instead of adding a new one. See [report-findings](../skills/report-findings/SKILL.md) Step 2 for the deduplication logic.
 

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -1,6 +1,6 @@
 ---
 description: Triage all open CVEs for OpenShift Node team components with reachability analysis
-argument-hint: "[--component <name>] [--notify-jira] [--notify-slack] [--days N]"
+argument-hint: "[--component <name>] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days N]"
 ---
 
 ## Name
@@ -8,7 +8,7 @@ node-cve:triage
 
 ## Synopsis
 ```text
-/node-cve:triage [--component "Node / CRI-O"] [--notify-jira] [--notify-slack] [--days 7]
+/node-cve:triage [--component "Node / CRI-O"] [--version latest] [--notify-jira] [--notify-slack] [--days 7]
 ```
 
 ## Description
@@ -30,9 +30,15 @@ Designed for both interactive use and headless execution via `claude --print`.
 
 1. **Parse Arguments**
    - `--component <name>`: Filter to a single specific OCPBUGS component (e.g., "Node / CRI-O"). Optional. **If omitted, the command includes ALL Node team components — and only Node team components. It never queries or posts to components outside the Node team.** See the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md) for the canonical list.
+   - `--version <value>`: Control which OCP versions are triaged. Default: `latest`. Accepted values:
+     - `latest` (default): auto-detect the highest OCP version from the query results and triage only trackers for that version. Older versions are owned by the sustaining team and should not receive Node team triage comments.
+     - A specific version (e.g., `5.0`, `4.19`): triage only trackers matching that exact OCP version.
+     - `all`: triage trackers for all OCP versions (legacy behavior, use with caution — see rationale below).
    - `--notify-jira`: Post analysis results as comments on Jira tracker issues. Default: off.
    - `--notify-slack`: Send summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (simpler, no threading). Default: off.
    - `--days N`: Only include CVEs created or updated in the last N days. Default: all open.
+
+   **Why `--version latest` is the default:** Each CVE typically has tracker issues across many OCP versions (e.g., 4.12.z through 5.0). The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work. By defaulting to `latest`, the command triages only the version the Node team is actively responsible for.
 
 2. **Validate Tools**
 
@@ -52,8 +58,8 @@ Designed for both interactive use and headless execution via `claude --print`.
 ### Phase 1: Query Open CVEs
 
 - **Skill**: [query-open-cves](../skills/query-open-cves/SKILL.md)
-- **Input**: Optional `--component` filter, optional `--days` filter
-- **Output**: Deduplicated list of CVEs with metadata
+- **Input**: Optional `--component` filter, `--version` filter (default: `latest`), optional `--days` filter
+- **Output**: Deduplicated, version-filtered list of CVEs with metadata
 
 **CRITICAL SAFEGUARD:** The `component in (...)` filter below is mandatory and must never be omitted, regardless of whether `--component` was passed. This is the first of two layers of defense against cross-team contamination — the second is the posting-time re-validation in [report-findings](../skills/report-findings/SKILL.md) Phase 3, Step 2. Both layers exist because a prior incident (2026-07-15) showed that CVE analysis can otherwise be posted to 200+ trackers belonging to other OpenShift teams.
 
@@ -77,10 +83,17 @@ Designed for both interactive use and headless execution via `claude --print`.
    - Assignee (from the highest version tracker)
    - Status
 
-4. Print intermediate summary: "Found N unique CVEs across M tracker issues."
+4. **Filter by OCP version** (see [query-open-cves](../skills/query-open-cves/SKILL.md) Step 5 for full logic):
+   - If `--version latest` (or omitted): auto-detect the highest OCP version across all tracker summaries, then keep only tracker issues matching that version. CVEs that have no tracker for the latest version are excluded entirely.
+   - If `--version <specific>`: keep only tracker issues matching the specified version.
+   - If `--version all`: skip filtering (keep all versions).
+
+   Print the version scope: "Version filter: <version> (auto-detected)" or "Version filter: <version> (user-specified)" or "Version filter: all (all versions included)".
+
+5. Print intermediate summary: "Found N unique CVEs across M tracker issues (version: <version>)."
 
 **Decision Point:**
-- IF 0 CVEs found -> Print "No open CVEs for Node team components." -> Exit
+- IF 0 CVEs found -> Print "No open CVEs for Node team components at version <version>." -> Exit
 - IF CVEs found -> Continue to Phase 2
 
 ---
@@ -122,12 +135,12 @@ Print which CVEs are skipped or partially cached: "CVE-XXXX-XXXXX: reusing prior
 ### Phase 2: Clone Repos and Analyze CVEs in Parallel
 
 - **Skill**: [analyze-cve-repos](../skills/analyze-cve-repos/SKILL.md)
-- **Input**: List of unique CVEs from Phase 1
+- **Input**: Version-filtered list of unique CVEs from Phase 1
 - **Output**: Reachability results per CVE
 
 #### Step 1: Determine affected repos, branches, and clone
 
-Analysis must target the release branch that corresponds to each affected OpenShift version. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in older release branches. Analysis targets downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
+Analysis targets only the release branches for OCP versions that survived the Phase 1 version filter. When `--version latest` is in effect (the default), this means a single release branch per repo per CVE. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in shipped releases. Analysis targets downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
 
 **Component to repository mapping:** Read from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md). Use the "Component to Repository Mapping" table for downstream forks and branch patterns, and the "pscomponent Label Mapping" table for label-based repo resolution.
 
@@ -135,7 +148,7 @@ Analysis must target the release branch that corresponds to each affected OpenSh
 
 **Clone strategy:**
 
-For each CVE, determine ALL affected OCP versions from its tracker summaries (e.g., `[openshift-4.16]`, `[openshift-4.18]`). Clone the repo at each corresponding release branch. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another. Analyzing only the oldest branch would miss these differences.
+For each CVE, use the OCP versions that survived the Phase 1 version filter. When `--version latest` is in effect, each CVE has a single version (the auto-detected latest); when `--version all` is used, all affected versions from the tracker summaries are included. Clone the repo at each corresponding release branch. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another.
 
 For each affected version's release branch, clone the downstream fork:
 
@@ -149,7 +162,7 @@ Use `--depth 1` for speed. Multiple CVEs sharing the same repo and branch reuse 
 
 #### Step 2: Analyze CVEs across all affected branches in parallel
 
-Spawn a concurrent analysis agent for each unique CVE and release branch combination. For example, if CVE-2026-32281 affects OCP 4.15 through 4.19, spawn separate agents for release-1.28, release-1.29, release-1.30, release-1.31, and release-1.32. Each agent runs the [analyze-cve-repos](../skills/analyze-cve-repos/SKILL.md) skill independently:
+Spawn a concurrent analysis agent for each unique CVE and release branch combination. With `--version latest` (default), each CVE typically has one branch to analyze (e.g., CVE-2026-32281 at release-1.36 for OCP 5.0). With `--version all`, a CVE spanning OCP 4.15 through 5.0 would spawn separate agents for each release branch. Each agent runs the [analyze-cve-repos](../skills/analyze-cve-repos/SKILL.md) skill independently:
 
 1. **Gather CVE intelligence**: fetch vulnerability details from public sources (NVD, advisories, Jira issue description/comments) to identify the affected package, vulnerable functions, and attack vector. This step is shared across branches for the same CVE (gather once, reuse).
 
@@ -220,9 +233,9 @@ The per-branch results are preserved in the report so reviewers can see which ve
    **Recommended action:** <update dependency / apply patch / monitor / investigate>
    ```
 
-2. **If `--notify-jira`**: For each CVE, post a comment on ALL its **Node-team-validated** tracker issues. Each tracker receives the analysis result specific to its OCP version/branch.
+2. **If `--notify-jira`**: For each CVE, post a comment on its **version-filtered, Node-team-validated** tracker issues. Each tracker receives the analysis result specific to its OCP version/branch.
 
-   **Before posting anything, re-validate every tracker's component against the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard" and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component, and record it in the posting audit log.
+   **Before posting anything, re-validate every tracker against both the version filter and the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard", "OCP Version Safeguard", and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component or whose OCP version does not match the active version filter, and record it in the posting audit log.
 
    Use Atlassian wiki markup (not Markdown), matching the format in [report-findings](../skills/report-findings/SKILL.md) Step 2. The comment includes per-branch results across all analyzed versions so reviewers can see the full picture.
 
@@ -238,10 +251,10 @@ The per-branch results are preserved in the report so reviewers can see which ve
 
 ### Phase 4: Summary Output
 
-Print a final summary grouped by classification with bold section headings. This makes it easy to scan and jump to the section that matters:
+Print a final summary grouped by classification with bold section headings. This makes it easy to scan and jump to the section that matters. Include the version scope in the headline:
 
 ```text
-Node CVE Triage (N CVEs analyzed)
+Node CVE Triage (N CVEs analyzed, OCP <version>)
 🔴 Reachable: N (M unassigned)
 🟡 Present: N (M unassigned)
 🟢 Unaffected: N (M unassigned)
@@ -269,22 +282,26 @@ See report-findings skill.)
 Report: .work/node-cve/triage-YYYY-MM-DD/report.md
 ```
 
-If any trackers were skipped during posting because their component was not a Node team component (see [report-findings](../skills/report-findings/SKILL.md) Step 2), print a warning line before the report path, e.g. "⚠️ Skipped N non-Node-component trackers during posting — see posting-audit.log". Omit this line entirely when the skip count is 0.
+If any trackers were skipped during posting because their component was not a Node team component or their OCP version did not match the active version filter (see [report-findings](../skills/report-findings/SKILL.md) Step 2), print a warning line before the report path, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". Omit this line entirely when the skip count is 0.
 
 Omit empty sections (e.g., if there are no Uncertain CVEs, skip that heading). Each section heading must be bold or visually distinct from the CVE entries beneath it. The "Present" section groups both "Present but not exploitable" and "Present but not reachable" analysis results together, since both mean no urgent action is needed. The detailed classification is preserved in the per-CVE report and Jira comments. Only show the "(M unassigned)" count when M > 0.
 
-The headline format depends on whether cached results were used. On first run (all CVEs are new): "Node CVE Triage (N CVEs analyzed)". On subsequent runs with cached results: "Node CVE Triage (N CVEs, M new)" where M is the number of CVEs without a prior `node-cve:triage` Jira comment. If classifications changed since the last run, also show "K updated": "Node CVE Triage (N CVEs, M new, K updated)".
+The headline format depends on the version scope and whether cached results were used. On first run (all CVEs are new): "Node CVE Triage (N CVEs analyzed, OCP 5.0)". On subsequent runs with cached results: "Node CVE Triage (N CVEs, M new, OCP 5.0)". If classifications changed since the last run, also show "K updated". If `--version all` was used, replace the version with "all versions".
 
 ## Arguments
 
 - `--component <name>`: Filter to a single specific OCPBUGS component. Must match a Node team component name exactly (e.g., "Node / CRI-O"). Optional. **If omitted, ALL Node team components are included, and only Node team components — never all OCPBUGS components.**
+- `--version <value>`: Control which OCP versions are triaged. Default: `latest`. Accepted values:
+  - `latest` (default): auto-detect the highest OCP version from the query results and triage only that version. The sustaining team handles older versions.
+  - A specific version (e.g., `5.0`, `4.19`): triage only trackers matching that exact OCP version.
+  - `all`: triage trackers for all OCP versions. Use when you need a full cross-version analysis (e.g., for a critical CVE where you want to see which older branches are also affected).
 - `--notify-jira`: Post analysis as a comment on each Jira tracker issue. Requires `JIRA_API_TOKEN`. Also enables cross-run caching via Jira comments.
 - `--notify-slack`: Send a summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (no threading).
 - `--days N`: Only include CVEs created or updated in the last N days. Default: all open CVEs.
 
 ## Examples
 
-1. **List all open Node CVEs with reachability analysis**:
+1. **Triage latest OCP version (default)**:
    ```text
    /node-cve:triage
    ```
@@ -299,7 +316,17 @@ The headline format depends on whether cached results were used. On first run (a
    claude --print "/node-cve:triage --notify-jira --notify-slack"
    ```
 
-4. **Recent CVEs only (last 7 days)**:
+4. **Triage a specific OCP version**:
+   ```text
+   /node-cve:triage --version 5.0 --notify-jira
+   ```
+
+5. **Full cross-version analysis (all OCP versions)**:
+   ```text
+   /node-cve:triage --version all
+   ```
+
+6. **Recent CVEs only (last 7 days)**:
    ```text
    /node-cve:triage --days 7 --notify-slack
    ```
@@ -307,10 +334,11 @@ The headline format depends on whether cached results were used. On first run (a
 ## Notes
 
 - The Jira query uses OCPBUGS component names from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md).
-- **Cross-team safeguard:** The command filters to Node team components at query time (Phase 1) AND re-validates each tracker's component immediately before posting any Jira comment (Phase 3). Never write or run an ad-hoc Jira search scoped only by CVE ID to find trackers to comment on — a CVE can span 200+ trackers across dozens of unrelated OpenShift teams, and a CVE-ID-only search will return all of them. Always reuse the already-filtered `tracker_keys` from Phase 1. Any tracker that fails the component re-validation is skipped and logged in `posting-audit.log`, never posted to.
-- Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and analyzes ALL affected release branches. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another.
+- **Version scope:** By default (`--version latest`), the command only triages CVE trackers for the latest OCP version (currently 5.0). The sustaining team owns triage for all earlier versions. Use `--version all` only when you need a full cross-version analysis. The latest version is auto-detected from the query results (highest OCP version number), so the default stays correct as new OCP releases ship without requiring changes to this plugin.
+- **Cross-team safeguard:** The command filters to Node team components at query time (Phase 1) AND re-validates each tracker's component immediately before posting any Jira comment (Phase 3). Never write or run an ad-hoc Jira search scoped only by CVE ID to find trackers to comment on — a CVE can span 200+ trackers across dozens of unrelated OpenShift teams, and a CVE-ID-only search will return all of them. Always reuse the already-filtered `tracker_keys` from Phase 1. Any tracker that fails the component or version re-validation is skipped and logged in `posting-audit.log`, never posted to.
+- Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and, unless `--version all` is used, filters to the target version's trackers before analysis.
 - Analysis targets downstream forks only (e.g., openshift/cri-o). If the downstream fork or branch does not exist, the CVE is classified as Uncertain. Dependency versions and Go toolchain versions differ across releases, so version-specific branches are used.
-- Each version tracker receives the analysis result specific to its release branch. The overall classification for a CVE is the most severe result across all analyzed branches.
+- Each version tracker receives the analysis result specific to its release branch. When multiple branches are analyzed (`--version all`), the overall classification for a CVE is the most severe result across all analyzed branches.
 - Large repos like openshift/kubernetes may take longer to analyze. The command uses `--depth 1` clones for speed.
 - Reachability analysis is performed by Claude reading the source code directly, not by external tools. This works across Go, Rust, and C codebases.
 - Jira comments use Atlassian wiki markup (not Markdown).

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -8,7 +8,7 @@ node-cve:triage
 
 ## Synopsis
 ```text
-/node-cve:triage [--component "Node / CRI-O"] [--version latest] [--notify-jira] [--notify-slack] [--days 7]
+/node-cve:triage [--component "Node / CRI-O"] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days 7]
 ```
 
 ## Description
@@ -334,7 +334,7 @@ The headline format depends on the version scope and whether cached results were
 ## Notes
 
 - The Jira query uses OCPBUGS component names from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md).
-- **Version scope:** By default (`--version latest`), the command only triages CVE trackers for the latest OCP version (currently 5.0). The sustaining team owns triage for all earlier versions. Use `--version all` only when you need a full cross-version analysis. The latest version is auto-detected from the query results (highest OCP version number), so the default stays correct as new OCP releases ship without requiring changes to this plugin.
+- **Version scope:** By default (`--version latest`), the command only triages CVE trackers for the latest OCP version (auto-detected from query results as the highest numeric `major.minor` version). The sustaining team owns triage for all earlier versions. Use `--version all` only when you need a full cross-version analysis. The latest version is determined at runtime, so the default stays correct as new OCP releases ship without requiring changes to this plugin.
 - **Cross-team safeguard:** The command filters to Node team components at query time (Phase 1) AND re-validates each tracker's component immediately before posting any Jira comment (Phase 3). Never write or run an ad-hoc Jira search scoped only by CVE ID to find trackers to comment on — a CVE can span 200+ trackers across dozens of unrelated OpenShift teams, and a CVE-ID-only search will return all of them. Always reuse the already-filtered `tracker_keys` from Phase 1. Any tracker that fails the component or version re-validation is skipped and logged in `posting-audit.log`, never posted to.
 - Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and, unless `--version all` is used, filters to the target version's trackers before analysis.
 - Analysis targets downstream forks only (e.g., openshift/cri-o). If the downstream fork or branch does not exist, the CVE is classified as Uncertain. Dependency versions and Go toolchain versions differ across releases, so version-specific branches are used.

--- a/plugins/node-cve/commands/triage.md
+++ b/plugins/node-cve/commands/triage.md
@@ -1,6 +1,6 @@
 ---
 description: Triage all open CVEs for OpenShift Node team components with reachability analysis
-argument-hint: "[--component <name>] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days N]"
+argument-hint: "[--component <name>] [--notify-jira] [--notify-slack] [--days N]"
 ---
 
 ## Name
@@ -8,7 +8,7 @@ node-cve:triage
 
 ## Synopsis
 ```text
-/node-cve:triage [--component "Node / CRI-O"] [--version latest|<ver>|all] [--notify-jira] [--notify-slack] [--days 7]
+/node-cve:triage [--component "Node / CRI-O"] [--notify-jira] [--notify-slack] [--days 7]
 ```
 
 ## Description
@@ -30,15 +30,11 @@ Designed for both interactive use and headless execution via `claude --print`.
 
 1. **Parse Arguments**
    - `--component <name>`: Filter to a single specific OCPBUGS component (e.g., "Node / CRI-O"). Optional. **If omitted, the command includes ALL Node team components — and only Node team components. It never queries or posts to components outside the Node team.** See the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md) for the canonical list.
-   - `--version <value>`: Control which OCP versions are triaged. Default: `latest`. Accepted values:
-     - `latest` (default): auto-detect the highest OCP version from the query results and triage only trackers for that version. Older versions are owned by the sustaining team and should not receive Node team triage comments.
-     - A specific version (e.g., `5.0`, `4.19`): triage only trackers matching that exact OCP version.
-     - `all`: triage trackers for all OCP versions (legacy behavior, use with caution — see rationale below).
    - `--notify-jira`: Post analysis results as comments on Jira tracker issues. Default: off.
    - `--notify-slack`: Send summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (simpler, no threading). Default: off.
    - `--days N`: Only include CVEs created or updated in the last N days. Default: all open.
 
-   **Why `--version latest` is the default:** Each CVE typically has tracker issues across many OCP versions (e.g., 4.12.z through 5.0). The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work. By defaulting to `latest`, the command triages only the version the Node team is actively responsible for.
+   **Version scope:** The command always triages only the latest OCP version, auto-detected from the query results as the highest numeric `major.minor` version. Each CVE typically has tracker issues across many OCP versions (e.g., 4.12.z through 5.0). The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work.
 
 2. **Validate Tools**
 
@@ -58,8 +54,8 @@ Designed for both interactive use and headless execution via `claude --print`.
 ### Phase 1: Query Open CVEs
 
 - **Skill**: [query-open-cves](../skills/query-open-cves/SKILL.md)
-- **Input**: Optional `--component` filter, `--version` filter (default: `latest`), optional `--days` filter
-- **Output**: Deduplicated, version-filtered list of CVEs with metadata
+- **Input**: Optional `--component` filter, optional `--days` filter
+- **Output**: Deduplicated, version-filtered list of CVEs with metadata (latest OCP version only)
 
 **CRITICAL SAFEGUARD:** The `component in (...)` filter below is mandatory and must never be omitted, regardless of whether `--component` was passed. This is the first of two layers of defense against cross-team contamination — the second is the posting-time re-validation in [report-findings](../skills/report-findings/SKILL.md) Phase 3, Step 2. Both layers exist because a prior incident (2026-07-15) showed that CVE analysis can otherwise be posted to 200+ trackers belonging to other OpenShift teams.
 
@@ -83,12 +79,9 @@ Designed for both interactive use and headless execution via `claude --print`.
    - Assignee (from the highest version tracker)
    - Status
 
-4. **Filter by OCP version** (see [query-open-cves](../skills/query-open-cves/SKILL.md) Step 5 for full logic):
-   - If `--version latest` (or omitted): auto-detect the highest OCP version across all tracker summaries, then keep only tracker issues matching that version. CVEs that have no tracker for the latest version are excluded entirely.
-   - If `--version <specific>`: keep only tracker issues matching the specified version.
-   - If `--version all`: skip filtering (keep all versions).
+4. **Filter to latest OCP version** (see [query-open-cves](../skills/query-open-cves/SKILL.md) Step 5 for full logic): auto-detect the highest OCP version across all tracker summaries, then keep only tracker issues matching that version. CVEs that have no tracker for the latest version are excluded entirely — they are the sustaining team's responsibility.
 
-   Print the version scope: "Version filter: <version> (auto-detected)" or "Version filter: <version> (user-specified)" or "Version filter: all (all versions included)".
+   Print the version scope: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
 
 5. Print intermediate summary: "Found N unique CVEs across M tracker issues (version: <version>)."
 
@@ -140,7 +133,7 @@ Print which CVEs are skipped or partially cached: "CVE-XXXX-XXXXX: reusing prior
 
 #### Step 1: Determine affected repos, branches, and clone
 
-Analysis targets only the release branches for OCP versions that survived the Phase 1 version filter. When `--version latest` is in effect (the default), this means a single release branch per repo per CVE. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in shipped releases. Analysis targets downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
+Analysis targets only the release branch for the latest OCP version (as detected in Phase 1), meaning a single release branch per repo per CVE. The `main` branch may have newer dependencies or Go versions that mask vulnerabilities present in shipped releases. Analysis targets downstream forks only. If the downstream fork or branch does not exist, classify as Uncertain with note "downstream fork/branch not found" and skip analysis.
 
 **Component to repository mapping:** Read from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md). Use the "Component to Repository Mapping" table for downstream forks and branch patterns, and the "pscomponent Label Mapping" table for label-based repo resolution.
 
@@ -148,7 +141,7 @@ Analysis targets only the release branches for OCP versions that survived the Ph
 
 **Clone strategy:**
 
-For each CVE, use the OCP versions that survived the Phase 1 version filter. When `--version latest` is in effect, each CVE has a single version (the auto-detected latest); when `--version all` is used, all affected versions from the tracker summaries are included. Clone the repo at each corresponding release branch. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another.
+Each CVE has a single version after Phase 1 filtering (the auto-detected latest). Clone the repo at the corresponding release branch.
 
 For each affected version's release branch, clone the downstream fork:
 
@@ -162,7 +155,7 @@ Use `--depth 1` for speed. Multiple CVEs sharing the same repo and branch reuse 
 
 #### Step 2: Analyze CVEs across all affected branches in parallel
 
-Spawn a concurrent analysis agent for each unique CVE and release branch combination. With `--version latest` (default), each CVE typically has one branch to analyze (e.g., CVE-2026-32281 at release-1.36 for OCP 5.0). With `--version all`, a CVE spanning OCP 4.15 through 5.0 would spawn separate agents for each release branch. Each agent runs the [analyze-cve-repos](../skills/analyze-cve-repos/SKILL.md) skill independently:
+Spawn a concurrent analysis agent for each unique CVE. Each CVE has one branch to analyze (e.g., CVE-2026-32281 at release-1.36 for OCP 5.0). Each agent runs the [analyze-cve-repos](../skills/analyze-cve-repos/SKILL.md) skill independently:
 
 1. **Gather CVE intelligence**: fetch vulnerability details from public sources (NVD, advisories, Jira issue description/comments) to identify the affected package, vulnerable functions, and attack vector. This step is shared across branches for the same CVE (gather once, reuse).
 
@@ -180,9 +173,7 @@ Spawn a concurrent analysis agent for each unique CVE and release branch combina
 
 5. **Save analysis** to `.work/node-cve/triage-$(date +%Y-%m-%d)/<CVE-ID>-<branch>-analysis.md` with file paths, call sites, and evidence.
 
-Wait for all agents to complete, then collect results. A CVE's overall classification is the most severe across all analyzed branches (e.g., if Reachable on release-1.28 but Unaffected on release-1.32, the overall result is Reachable). Print progress for each: "Analyzed CVE-XXXX-XXXXX against <repo> (<branch>): <result>"
-
-The per-branch results are preserved in the report so reviewers can see which versions are affected. Post the version-specific result to each version's Jira tracker (e.g., the 4.18 tracker gets the release-1.31 analysis result).
+Wait for all agents to complete, then collect results. Print progress for each: "Analyzed CVE-XXXX-XXXXX against <repo> (<branch>): <result>"
 
 ---
 
@@ -233,9 +224,9 @@ The per-branch results are preserved in the report so reviewers can see which ve
    **Recommended action:** <update dependency / apply patch / monitor / investigate>
    ```
 
-2. **If `--notify-jira`**: For each CVE, post a comment on its **version-filtered, Node-team-validated** tracker issues. Each tracker receives the analysis result specific to its OCP version/branch.
+2. **If `--notify-jira`**: For each CVE, post a comment on its **version-filtered, Node-team-validated** tracker issues.
 
-   **Before posting anything, re-validate every tracker against both the version filter and the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard", "OCP Version Safeguard", and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component or whose OCP version does not match the active version filter, and record it in the posting audit log.
+   **Before posting anything, re-validate every tracker against both the auto-detected version and the Node team component list — do not rely solely on Phase 1's filtering.** See [report-findings](../skills/report-findings/SKILL.md) "Node Team Component Safeguard", "OCP Version Safeguard", and Step 2 for the mandatory validation logic and audit logging. Skip (never post to) any tracker whose component is not a Node team component or whose OCP version does not match the auto-detected latest version, and record it in the posting audit log.
 
    Use Atlassian wiki markup (not Markdown), matching the format in [report-findings](../skills/report-findings/SKILL.md) Step 2. The comment includes per-branch results across all analyzed versions so reviewers can see the full picture.
 
@@ -282,19 +273,15 @@ See report-findings skill.)
 Report: .work/node-cve/triage-YYYY-MM-DD/report.md
 ```
 
-If any trackers were skipped during posting because their component was not a Node team component or their OCP version did not match the active version filter (see [report-findings](../skills/report-findings/SKILL.md) Step 2), print a warning line before the report path, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". Omit this line entirely when the skip count is 0.
+If any trackers were skipped during posting because their component was not a Node team component or their OCP version did not match the auto-detected latest version (see [report-findings](../skills/report-findings/SKILL.md) Step 2), print a warning line before the report path, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". Omit this line entirely when the skip count is 0.
 
 Omit empty sections (e.g., if there are no Uncertain CVEs, skip that heading). Each section heading must be bold or visually distinct from the CVE entries beneath it. The "Present" section groups both "Present but not exploitable" and "Present but not reachable" analysis results together, since both mean no urgent action is needed. The detailed classification is preserved in the per-CVE report and Jira comments. Only show the "(M unassigned)" count when M > 0.
 
-The headline format depends on the version scope and whether cached results were used. On first run (all CVEs are new): "Node CVE Triage (N CVEs analyzed, OCP 5.0)". On subsequent runs with cached results: "Node CVE Triage (N CVEs, M new, OCP 5.0)". If classifications changed since the last run, also show "K updated". If `--version all` was used, replace the version with "all versions".
+The headline format depends on whether cached results were used. On first run (all CVEs are new): "Node CVE Triage (N CVEs analyzed, OCP 5.0)". On subsequent runs with cached results: "Node CVE Triage (N CVEs, M new, OCP 5.0)". If classifications changed since the last run, also show "K updated".
 
 ## Arguments
 
 - `--component <name>`: Filter to a single specific OCPBUGS component. Must match a Node team component name exactly (e.g., "Node / CRI-O"). Optional. **If omitted, ALL Node team components are included, and only Node team components — never all OCPBUGS components.**
-- `--version <value>`: Control which OCP versions are triaged. Default: `latest`. Accepted values:
-  - `latest` (default): auto-detect the highest OCP version from the query results and triage only that version. The sustaining team handles older versions.
-  - A specific version (e.g., `5.0`, `4.19`): triage only trackers matching that exact OCP version.
-  - `all`: triage trackers for all OCP versions. Use when you need a full cross-version analysis (e.g., for a critical CVE where you want to see which older branches are also affected).
 - `--notify-jira`: Post analysis as a comment on each Jira tracker issue. Requires `JIRA_API_TOKEN`. Also enables cross-run caching via Jira comments.
 - `--notify-slack`: Send a summary to Slack. Requires either `$SLACK_API_TOKEN` + `$SLACK_CHANNEL` (enables threading) or `$SLACK_WEBHOOK` (no threading).
 - `--days N`: Only include CVEs created or updated in the last N days. Default: all open CVEs.
@@ -316,17 +303,7 @@ The headline format depends on the version scope and whether cached results were
    claude --print "/node-cve:triage --notify-jira --notify-slack"
    ```
 
-4. **Triage a specific OCP version**:
-   ```text
-   /node-cve:triage --version 5.0 --notify-jira
-   ```
-
-5. **Full cross-version analysis (all OCP versions)**:
-   ```text
-   /node-cve:triage --version all
-   ```
-
-6. **Recent CVEs only (last 7 days)**:
+4. **Recent CVEs only (last 7 days)**:
    ```text
    /node-cve:triage --days 7 --notify-slack
    ```
@@ -334,11 +311,10 @@ The headline format depends on the version scope and whether cached results were
 ## Notes
 
 - The Jira query uses OCPBUGS component names from the [node-team shared components reference](../../node-team/skills/node/references/shared/components.md).
-- **Version scope:** By default (`--version latest`), the command only triages CVE trackers for the latest OCP version (auto-detected from query results as the highest numeric `major.minor` version). The sustaining team owns triage for all earlier versions. Use `--version all` only when you need a full cross-version analysis. The latest version is determined at runtime, so the default stays correct as new OCP releases ship without requiring changes to this plugin.
+- **Version scope:** The command always triages only the latest OCP version, auto-detected from query results as the highest numeric `major.minor` version. The sustaining team owns triage for all earlier versions. The latest version is determined at runtime, so it stays correct as new OCP releases ship without requiring changes to this plugin.
 - **Cross-team safeguard:** The command filters to Node team components at query time (Phase 1) AND re-validates each tracker's component immediately before posting any Jira comment (Phase 3). Never write or run an ad-hoc Jira search scoped only by CVE ID to find trackers to comment on — a CVE can span 200+ trackers across dozens of unrelated OpenShift teams, and a CVE-ID-only search will return all of them. Always reuse the already-filtered `tracker_keys` from Phase 1. Any tracker that fails the component or version re-validation is skipped and logged in `posting-audit.log`, never posted to.
-- Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and, unless `--version all` is used, filters to the target version's trackers before analysis.
+- Each CVE typically has multiple tracker issues (one per OCP version). The command deduplicates by CVE ID and filters to the latest version's trackers before analysis.
 - Analysis targets downstream forks only (e.g., openshift/cri-o). If the downstream fork or branch does not exist, the CVE is classified as Uncertain. Dependency versions and Go toolchain versions differ across releases, so version-specific branches are used.
-- Each version tracker receives the analysis result specific to its release branch. When multiple branches are analyzed (`--version all`), the overall classification for a CVE is the most severe result across all analyzed branches.
 - Large repos like openshift/kubernetes may take longer to analyze. The command uses `--depth 1` clones for speed.
 - Reachability analysis is performed by Claude reading the source code directly, not by external tools. This works across Go, Rust, and C codebases.
 - Jira comments use Atlassian wiki markup (not Markdown).

--- a/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
+++ b/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze CVE reachability against downstream repository forks at ver
 
 ## When to Use
 
-Use this skill when Phase 2 of the `node-cve:triage` command needs to determine whether a CVE's vulnerable code path is actually reachable in a Node team repository. Each CVE is analyzed against ALL affected release branches in parallel (one agent per CVE-branch combination). Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another. Analysis targets downstream forks only; if the downstream fork or branch is not found, the CVE is classified as Uncertain.
+Use this skill when Phase 2 of the `node-cve:triage` command needs to determine whether a CVE's vulnerable code path is actually reachable in a Node team repository. Each CVE is analyzed against its version-filtered release branches in parallel (one agent per CVE-branch combination). When `--version latest` is in effect (the default), each CVE has a single branch to analyze — the one corresponding to the latest OCP version. When `--version all` is used, all affected branches are analyzed. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another. Analysis targets downstream forks only; if the downstream fork or branch is not found, the CVE is classified as Uncertain.
 
 ## Prerequisites
 

--- a/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
+++ b/plugins/node-cve/skills/analyze-cve-repos/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze CVE reachability against downstream repository forks at ver
 
 ## When to Use
 
-Use this skill when Phase 2 of the `node-cve:triage` command needs to determine whether a CVE's vulnerable code path is actually reachable in a Node team repository. Each CVE is analyzed against its version-filtered release branches in parallel (one agent per CVE-branch combination). When `--version latest` is in effect (the default), each CVE has a single branch to analyze — the one corresponding to the latest OCP version. When `--version all` is used, all affected branches are analyzed. Features can be added, removed, or refactored across releases, so a CVE may be reachable on one version but not affected on another. Analysis targets downstream forks only; if the downstream fork or branch is not found, the CVE is classified as Uncertain.
+Use this skill when Phase 2 of the `node-cve:triage` command needs to determine whether a CVE's vulnerable code path is actually reachable in a Node team repository. Each CVE is analyzed against the release branch corresponding to the auto-detected latest OCP version (one agent per CVE). Analysis targets downstream forks only; if the downstream fork or branch is not found, the CVE is classified as Uncertain.
 
 ## Prerequisites
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -72,7 +72,33 @@ A single CVE may span multiple components (e.g., both "Node / CRI-O" and "Machin
 
 Use the highest version tracker for the "primary" assignee and status (issues on newer versions are typically more actively managed).
 
-### Step 5: Identify unassigned CVEs
+### Step 5: Filter by OCP version
+
+Apply the `--version` filter to scope trackers to the target OCP version. This prevents the Node team from triaging versions owned by the sustaining team.
+
+**If `--version latest` (default when omitted):**
+
+1. Collect all OCP versions extracted from tracker summaries in Step 3 (e.g., `4.12.z`, `4.14.z`, `4.17`, `4.18`, `4.19`, `5.0`).
+2. Determine the latest version by sorting numerically:
+   - Strip trailing `.z` suffixes for comparison purposes (`.z` indicates a z-stream release, which is always an older maintenance stream).
+   - Parse each version as `(major, minor)` — e.g., `5.0` → `(5, 0)`, `4.19` → `(4, 19)`, `4.12.z` → `(4, 12)`.
+   - Sort descending by major, then by minor. The first entry is the latest version.
+   - Example: given `[4.12.z, 4.14.z, 4.17, 4.18, 4.19, 5.0]`, the latest is `5.0`.
+3. For each CVE record from Step 4, remove tracker issues whose OCP version does not match the latest version:
+   - Remove non-matching entries from `tracker_keys` and `affected_versions`.
+   - If a CVE has no remaining trackers after filtering, exclude it entirely — it has no tracker for the latest version and is therefore a sustaining-team concern only.
+4. Print: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
+
+**If `--version <specific>` (e.g., `--version 5.0`):**
+
+Same filtering logic as above, but use the user-specified version instead of auto-detecting. If no trackers match the specified version, print: "No open CVEs for Node team components at version <version>."
+
+**If `--version all`:**
+
+Skip filtering. All versions are retained (legacy behavior).
+Print: "Version filter: all (all versions included)."
+
+### Step 6: Identify unassigned CVEs
 
 Flag CVEs where:
 - Assignee is a bot account (e.g., "ocp-sustaining-blocked-trackers") or empty
@@ -85,7 +111,10 @@ Flag CVEs where:
 {
   "skill": "query-open-cves",
   "status": "success",
-  "total_trackers": 45,
+  "version_filter": "5.0",
+  "version_filter_mode": "latest",
+  "total_trackers": 8,
+  "total_trackers_before_version_filter": 45,
   "unique_cves": 6,
   "cves": [
     {
@@ -95,13 +124,15 @@ Flag CVEs where:
       "status": "New",
       "assignee": "ocp-sustaining-blocked-trackers",
       "is_unassigned": true,
-      "tracker_keys": ["OCPBUGS-85948", "..."],
-      "affected_versions": ["4.12.z", "..."],
+      "tracker_keys": ["OCPBUGS-85948"],
+      "affected_versions": ["5.0"],
       "labels": ["pscomponent:cri-o"]
     }
   ]
 }
 ```
+
+When `--version all` is used, `version_filter` is `"all"`, `version_filter_mode` is `"all"`, and `total_trackers_before_version_filter` equals `total_trackers` (no filtering applied).
 
 ## Error Handling
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -72,34 +72,23 @@ A single CVE may span multiple components (e.g., both "Node / CRI-O" and "Machin
 
 Use the highest version tracker for the "primary" assignee and status (issues on newer versions are typically more actively managed).
 
-### Step 5: Filter by OCP version
+### Step 5: Filter to latest OCP version
 
-Apply the `--version` filter to scope trackers to the target OCP version. This prevents the Node team from triaging versions owned by the sustaining team.
+Auto-detect the latest OCP version from the query results and filter to it. This prevents the Node team from triaging versions owned by the sustaining team.
 
-**If `--version latest` (default when omitted):**
-
-1. If Step 2 returned zero Jira rows, skip version filtering — there are no trackers to filter. Return an empty CVE list with `version_filter: null`, `version_filter_mode: "latest"`, and `version_detected: false`. Print: "No open CVEs found; version auto-detection skipped."
+1. If Step 2 returned zero Jira rows, skip version filtering — there are no trackers to filter. Return an empty CVE list with `version_filter: null`. Print: "No open CVEs found; version auto-detection skipped."
 2. Collect all OCP versions extracted from tracker summaries in Step 3 (e.g., `4.12.z`, `4.14.z`, `4.17`, `4.18`, `4.19`, `5.0`).
-3. **Discard non-numeric versions:** Any version string that cannot be parsed as a numeric `major.minor` pair (e.g., `latest`, `nightly`, or other non-version labels) must be discarded with a warning — do not treat it as a valid OCP version. Only versions matching the pattern `<digits>.<digits>` (optionally followed by `.z`) are valid. If ALL extracted versions are discarded (no valid numeric versions remain), treat this the same as zero Jira rows: return an empty CVE list with `version_filter: null`, `version_filter_mode: "latest"`, and `version_detected: false`. Print: "No valid numeric OCP versions found in tracker summaries; version auto-detection failed."
+3. **Discard non-numeric versions:** Any version string that cannot be parsed as a numeric `major.minor` pair (e.g., `latest`, `nightly`, or other non-version labels) must be discarded with a warning — do not treat it as a valid OCP version. Only versions matching the pattern `<digits>.<digits>` (optionally followed by `.z`) are valid. If ALL extracted versions are discarded (no valid numeric versions remain), treat this the same as zero Jira rows: return an empty CVE list with `version_filter: null`. Print: "No valid numeric OCP versions found in tracker summaries; version auto-detection failed."
 4. Determine the latest version by sorting the remaining valid versions numerically:
    - Strip trailing `.z` suffixes for comparison purposes (`.z` indicates a z-stream release, which is always an older maintenance stream).
    - Parse each version as `(major, minor)` — e.g., `5.0` → `(5, 0)`, `4.19` → `(4, 19)`, `4.12.z` → `(4, 12)`.
    - Sort descending by major, then by minor. The first entry is the latest version.
-   - Example: given `[4.12.z, 4.14.z, 4.17, 4.18, 4.19, 5.0]`, the latest is `5.0`.
-5. For each CVE record from Step 4, remove tracker issues whose OCP version does not match the latest version:
+   - **`version_filter` always stores the stripped `major.minor` form** (no `.z` suffix), since `.z` is a release-stream qualifier, not a distinct version. Example: given `[4.12.z, 4.14.z, 4.17, 4.18, 4.19, 5.0]`, the latest is `5.0` and `version_filter` is `"5.0"`.
+5. For each CVE record from Step 4, filter trackers to the latest version. Compare each tracker's OCP version against `version_filter` after stripping any `.z` suffix from the tracker version (so `4.14.z` matches filter `4.14`):
    - Remove non-matching entries from `tracker_keys`, `affected_versions`, `components`, and `labels` — keep only values associated with retained trackers.
    - If a CVE has no remaining trackers after filtering, exclude it entirely — it has no tracker for the latest version and is therefore a sustaining-team concern only.
 6. After filtering, rebuild each CVE record's metadata entirely from the retained tracker set. Per-tracker associations (component, labels, assignee, status) must be preserved during Step 4 deduplication so they can be used here. Recompute: `tracker_keys`, `affected_versions`, `components`, `labels`, `assignee`, `status`, and `is_unassigned`. This ensures no stale metadata from removed trackers leaks into Phase 2 (repo selection) or Phase 3 (reporting).
 7. Print: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
-
-**If `--version <specific>` (e.g., `--version 5.0`):**
-
-Same filtering logic as above, but use the user-specified version instead of auto-detecting. If no trackers match the specified version, print: "No open CVEs for Node team components at version <version>."
-
-**If `--version all`:**
-
-Skip filtering. All versions are retained (legacy behavior).
-Print: "Version filter: all (all versions included)."
 
 ### Step 6: Identify unassigned CVEs
 
@@ -115,8 +104,6 @@ Flag CVEs where:
   "skill": "query-open-cves",
   "status": "success",
   "version_filter": "5.0",
-  "version_filter_mode": "latest",
-  "version_detected": true,
   "total_trackers": 8,
   "total_trackers_before_version_filter": 45,
   "unique_cves": 6,
@@ -136,10 +123,7 @@ Flag CVEs where:
 }
 ```
 
-**Field semantics for `version_filter`:**
-- When a version is resolved (auto-detected or user-specified): `version_filter` is the resolved version string (e.g., `"5.0"`), `version_detected` is `true`.
-- When `--version latest` is used but no numeric version could be detected (zero Jira rows or all extracted versions were non-numeric): `version_filter` is `null`, `version_detected` is `false`, `version_filter_mode` is `"latest"`, and `cves` is an empty array. Downstream consumers must check `version_detected` before using `version_filter` as a version string.
-- When `--version all` is used: `version_filter` is `"all"`, `version_filter_mode` is `"all"`, `version_detected` is not applicable, and `total_trackers_before_version_filter` equals `total_trackers` (no filtering applied).
+`version_filter` is the auto-detected latest OCP version in stripped `major.minor` form (e.g., `"5.0"`). It is `null` when no version could be detected (zero Jira rows or all extracted versions were non-numeric) — in that case `cves` is an empty array. Downstream consumers must check for `null` before using `version_filter` as a version string.
 
 ## Error Handling
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -78,18 +78,18 @@ Apply the `--version` filter to scope trackers to the target OCP version. This p
 
 **If `--version latest` (default when omitted):**
 
-1. If Step 2 returned zero Jira rows, skip version filtering — there are no trackers to filter. Return an empty CVE list with `version_filter: "latest"` and `version_filter_mode: "latest"`.
+1. If Step 2 returned zero Jira rows, skip version filtering — there are no trackers to filter. Return an empty CVE list with `version_filter: null`, `version_filter_mode: "latest"`, and `version_detected: false`. Print: "No open CVEs found; version auto-detection skipped."
 2. Collect all OCP versions extracted from tracker summaries in Step 3 (e.g., `4.12.z`, `4.14.z`, `4.17`, `4.18`, `4.19`, `5.0`).
-3. **Discard non-numeric versions:** Any version string that cannot be parsed as a numeric `major.minor` pair (e.g., `latest`, `nightly`, or other non-version labels) must be discarded with a warning — do not treat it as a valid OCP version. Only versions matching the pattern `<digits>.<digits>` (optionally followed by `.z`) are valid.
+3. **Discard non-numeric versions:** Any version string that cannot be parsed as a numeric `major.minor` pair (e.g., `latest`, `nightly`, or other non-version labels) must be discarded with a warning — do not treat it as a valid OCP version. Only versions matching the pattern `<digits>.<digits>` (optionally followed by `.z`) are valid. If ALL extracted versions are discarded (no valid numeric versions remain), treat this the same as zero Jira rows: return an empty CVE list with `version_filter: null`, `version_filter_mode: "latest"`, and `version_detected: false`. Print: "No valid numeric OCP versions found in tracker summaries; version auto-detection failed."
 4. Determine the latest version by sorting the remaining valid versions numerically:
    - Strip trailing `.z` suffixes for comparison purposes (`.z` indicates a z-stream release, which is always an older maintenance stream).
    - Parse each version as `(major, minor)` — e.g., `5.0` → `(5, 0)`, `4.19` → `(4, 19)`, `4.12.z` → `(4, 12)`.
    - Sort descending by major, then by minor. The first entry is the latest version.
    - Example: given `[4.12.z, 4.14.z, 4.17, 4.18, 4.19, 5.0]`, the latest is `5.0`.
 5. For each CVE record from Step 4, remove tracker issues whose OCP version does not match the latest version:
-   - Remove non-matching entries from `tracker_keys` and `affected_versions`.
+   - Remove non-matching entries from `tracker_keys`, `affected_versions`, `components`, and `labels` — keep only values associated with retained trackers.
    - If a CVE has no remaining trackers after filtering, exclude it entirely — it has no tracker for the latest version and is therefore a sustaining-team concern only.
-6. After filtering, recompute each CVE record's `assignee`, `status`, and `is_unassigned` from the highest-version tracker that remains in the filtered set, since the pre-filter values may have come from a tracker that was removed.
+6. After filtering, rebuild each CVE record's metadata entirely from the retained tracker set. Per-tracker associations (component, labels, assignee, status) must be preserved during Step 4 deduplication so they can be used here. Recompute: `tracker_keys`, `affected_versions`, `components`, `labels`, `assignee`, `status`, and `is_unassigned`. This ensures no stale metadata from removed trackers leaks into Phase 2 (repo selection) or Phase 3 (reporting).
 7. Print: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
 
 **If `--version <specific>` (e.g., `--version 5.0`):**
@@ -116,6 +116,7 @@ Flag CVEs where:
   "status": "success",
   "version_filter": "5.0",
   "version_filter_mode": "latest",
+  "version_detected": true,
   "total_trackers": 8,
   "total_trackers_before_version_filter": 45,
   "unique_cves": 6,
@@ -135,7 +136,10 @@ Flag CVEs where:
 }
 ```
 
-When `--version all` is used, `version_filter` is `"all"`, `version_filter_mode` is `"all"`, and `total_trackers_before_version_filter` equals `total_trackers` (no filtering applied).
+**Field semantics for `version_filter`:**
+- When a version is resolved (auto-detected or user-specified): `version_filter` is the resolved version string (e.g., `"5.0"`), `version_detected` is `true`.
+- When `--version latest` is used but no numeric version could be detected (zero Jira rows or all extracted versions were non-numeric): `version_filter` is `null`, `version_detected` is `false`, `version_filter_mode` is `"latest"`, and `cves` is an empty array. Downstream consumers must check `version_detected` before using `version_filter` as a version string.
+- When `--version all` is used: `version_filter` is `"all"`, `version_filter_mode` is `"all"`, `version_detected` is not applicable, and `total_trackers_before_version_filter` equals `total_trackers` (no filtering applied).
 
 ## Error Handling
 

--- a/plugins/node-cve/skills/query-open-cves/SKILL.md
+++ b/plugins/node-cve/skills/query-open-cves/SKILL.md
@@ -78,16 +78,19 @@ Apply the `--version` filter to scope trackers to the target OCP version. This p
 
 **If `--version latest` (default when omitted):**
 
-1. Collect all OCP versions extracted from tracker summaries in Step 3 (e.g., `4.12.z`, `4.14.z`, `4.17`, `4.18`, `4.19`, `5.0`).
-2. Determine the latest version by sorting numerically:
+1. If Step 2 returned zero Jira rows, skip version filtering — there are no trackers to filter. Return an empty CVE list with `version_filter: "latest"` and `version_filter_mode: "latest"`.
+2. Collect all OCP versions extracted from tracker summaries in Step 3 (e.g., `4.12.z`, `4.14.z`, `4.17`, `4.18`, `4.19`, `5.0`).
+3. **Discard non-numeric versions:** Any version string that cannot be parsed as a numeric `major.minor` pair (e.g., `latest`, `nightly`, or other non-version labels) must be discarded with a warning — do not treat it as a valid OCP version. Only versions matching the pattern `<digits>.<digits>` (optionally followed by `.z`) are valid.
+4. Determine the latest version by sorting the remaining valid versions numerically:
    - Strip trailing `.z` suffixes for comparison purposes (`.z` indicates a z-stream release, which is always an older maintenance stream).
    - Parse each version as `(major, minor)` — e.g., `5.0` → `(5, 0)`, `4.19` → `(4, 19)`, `4.12.z` → `(4, 12)`.
    - Sort descending by major, then by minor. The first entry is the latest version.
    - Example: given `[4.12.z, 4.14.z, 4.17, 4.18, 4.19, 5.0]`, the latest is `5.0`.
-3. For each CVE record from Step 4, remove tracker issues whose OCP version does not match the latest version:
+5. For each CVE record from Step 4, remove tracker issues whose OCP version does not match the latest version:
    - Remove non-matching entries from `tracker_keys` and `affected_versions`.
    - If a CVE has no remaining trackers after filtering, exclude it entirely — it has no tracker for the latest version and is therefore a sustaining-team concern only.
-4. Print: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
+6. After filtering, recompute each CVE record's `assignee`, `status`, and `is_unassigned` from the highest-version tracker that remains in the filtered set, since the pre-filter values may have come from a tracker that was removed.
+7. Print: "Version filter: <version> (auto-detected). Older versions are triaged by the sustaining team."
 
 **If `--version <specific>` (e.g., `--version 5.0`):**
 

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -32,11 +32,11 @@ The canonical Node team component list lives in the [node-team shared components
 
 ## OCP Version Safeguard
 
-**This skill may ONLY post comments to trackers whose OCP version matches the active version filter.** The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work.
+**This skill may ONLY post comments to trackers whose OCP version matches the auto-detected latest version.** The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work.
 
-The `--version` flag (default: `latest`) controls which version is in scope. The `query-open-cves` skill (Phase 1) applies this filter during query processing, but this skill re-validates at posting time as defense-in-depth — the same principle as the component safeguard above. The version filter value and the auto-detected latest version are passed through from Phase 1 via the `version_filter` and `version_filter_mode` fields in the CVE query results.
+The `query-open-cves` skill (Phase 1) auto-detects the latest OCP version and filters trackers to it, but this skill re-validates at posting time as defense-in-depth — the same principle as the component safeguard above. The auto-detected version is passed through from Phase 1 via the `version_filter` field in the CVE query results.
 
-**At posting time, re-validate each tracker's OCP version** (extracted from the tracker summary via regex `\[openshift-([^\]]+)\]`) against the active version filter. If the tracker's version does not match, skip it and log the reason in the posting audit log. When `--version all` is active, this check is a no-op (all versions pass).
+**At posting time, re-validate each tracker's OCP version** (extracted from the tracker summary via regex `\[openshift-([^\]]+)\]`) against `version_filter`. If the tracker's version does not match (after stripping `.z` suffixes from both sides for comparison), skip it and log the reason in the posting audit log.
 
 If you ever find yourself constructing a new JQL query or Jira search specifically to find trackers to comment on, STOP — that is the anti-pattern that caused this incident. Reuse the already-filtered tracker list from Phase 1 instead.
 
@@ -49,7 +49,7 @@ Write the report to `.work/node-cve/triage-YYYY-MM-DD/report.md`:
 ```markdown
 # Node CVE Triage Report - YYYY-MM-DD
 
-**Version scope:** OCP <version> (<mode>)
+**Version scope:** OCP <version> (auto-detected)
 
 ## Summary
 
@@ -107,7 +107,7 @@ List CVEs that are Reachable or Uncertain with unassigned owners. These need imm
 # canonical Node team component list from the shared components reference
 # (link above), NOT a hardcoded list.
 # version_matches_filter() checks the tracker's OCP version (from its summary)
-# against the active version filter from Phase 1.
+# against version_filter from Phase 1, after stripping .z suffixes from both.
 for tracker_key in $TRACKER_KEYS; do
   # Single API call per tracker to minimize rate-limiting risk
   output=$(jira issue view "$tracker_key" --plain --no-headers --columns COMPONENT,SUMMARY | tail -1)
@@ -134,9 +134,9 @@ done
 
 **Component validation:** A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) in the shared components reference. **Check the COMPONENT field only — do not treat a `pscomponent:` label as an alternative pass condition.** `pscomponent:` labels are used in Phase 1/Phase 2 for CVE discovery and repo mapping, not for determining tracker ownership; a non-Node tracker (e.g. component "Security") could incidentally carry a `pscomponent:cri-o` label, and accepting that as a pass would silently reintroduce the exact cross-team contamination this safeguard exists to prevent.
 
-**Version validation:** A tracker's OCP version is extracted from its summary using regex `\[openshift-([^\]]+)\]`. The version must match the active version filter (`version_filter` from Phase 1). When the filter mode is `latest` or a specific version, only trackers whose extracted OCP version matches (after stripping `.z` suffixes for comparison) pass validation. When the filter mode is `all`, this check is a no-op — all versions pass.
+**Version validation:** A tracker's OCP version is extracted from its summary using regex `\[openshift-([^\]]+)\]`. The version must match `version_filter` from Phase 1, after stripping `.z` suffixes from both sides for comparison (so tracker version `4.14.z` matches filter `4.14`, and `version_filter` itself is already stored in stripped `major.minor` form).
 
-If a tracker fails either check, **skip it and log the reason** — never post "just in case." Both checks must run even when `--component` or `--version` was explicitly passed, and even if Phase 1 already filtered, since this is the last line of defense before an irreversible write. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
+If a tracker fails either check, **skip it and log the reason** — never post "just in case." Both checks must run even when `--component` was explicitly passed, and even if Phase 1 already filtered, since this is the last line of defense before an irreversible write. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
 
 For each unique CVE, post a comment on every **validated** tracker issue. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
 
@@ -193,7 +193,7 @@ Search the output for comments containing `[node-cve:triage|`. This pattern anch
 ```bash
 {
   echo "=== Node CVE Triage Posting Audit — $(date +%Y-%m-%d) ==="
-  echo "Version filter: $VERSION_FILTER ($VERSION_FILTER_MODE)"
+  echo "Version filter: $VERSION_FILTER (auto-detected)"
   echo "CVEs processed: $CVE_COUNT"
   echo "Trackers commented: $POSTED_COUNT"
   echo "Trackers skipped (non-Node component): $SKIPPED_COMPONENT_COUNT"
@@ -346,7 +346,6 @@ Write `cves.json` to `.work/node-cve/triage-YYYY-MM-DD/cves.json` containing the
 {
   "date": "YYYY-MM-DD",
   "version_filter": "5.0",
-  "version_filter_mode": "latest",
   "total_cves": 6,
   "cves": [
     {
@@ -396,7 +395,6 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
   "skill": "report-findings",
   "status": "success",
   "version_filter": "5.0",
-  "version_filter_mode": "latest",
   "report_path": ".work/node-cve/triage-2026-05-20/report.md",
   "jira_comments_posted": 6,
   "jira_comments_failed": 0,
@@ -416,7 +414,7 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
 ## Error Handling
 
 - Non-Node-team component detected on a tracker: skip that tracker and log it in the audit log (see Step 2). Never post to it. Do not fail the entire command — other trackers for the same CVE may still be valid Node team trackers.
-- OCP version mismatch detected on a tracker: skip that tracker and log it in the audit log (see Step 2). The sustaining team owns older versions. Do not fail the entire command — this is expected behavior when `--version latest` filters out older trackers.
+- OCP version mismatch detected on a tracker: skip that tracker and log it in the audit log (see Step 2). The sustaining team owns older versions. Do not fail the entire command — this is expected behavior when the auto-detected latest version filters out older trackers.
 - Jira comment failures: log and continue. Do not fail the entire command because one tracker issue is inaccessible.
 - Slack failure: log warning. Common causes: invalid token/webhook URL, missing channel permissions, network issues, payload too large (Slack limit: 3000 chars per text block).
 - If the Slack payload exceeds the character limit, truncate the CVE list and add "... and N more. See full report."

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -27,7 +27,16 @@ The canonical Node team component list lives in the [node-team shared components
 
 **Only post to tracker keys that are:**
 1. Present in the `tracker_keys` list of the CVE record produced by `query-open-cves` (Phase 1), AND
-2. Re-validated against the Node team component list immediately before posting (see Step 2 below).
+2. Re-validated against the Node team component list immediately before posting (see Step 2 below), AND
+3. Re-validated against the active OCP version filter (see "OCP Version Safeguard" below and Step 2).
+
+## OCP Version Safeguard
+
+**This skill may ONLY post comments to trackers whose OCP version matches the active version filter.** The OCP sustaining team owns triage and remediation for all versions except the latest in-development release. Posting Node-team reachability analysis to older-version trackers creates noise for the sustaining team and duplicates their work.
+
+The `--version` flag (default: `latest`) controls which version is in scope. The `query-open-cves` skill (Phase 1) applies this filter during query processing, but this skill re-validates at posting time as defense-in-depth — the same principle as the component safeguard above. The version filter value and the auto-detected latest version are passed through from Phase 1 via the `version_filter` and `version_filter_mode` fields in the CVE query results.
+
+**At posting time, re-validate each tracker's OCP version** (extracted from the tracker summary via regex `\[openshift-([^\]]+)\]`) against the active version filter. If the tracker's version does not match, skip it and log the reason in the posting audit log. When `--version all` is active, this check is a no-op (all versions pass).
 
 If you ever find yourself constructing a new JQL query or Jira search specifically to find trackers to comment on, STOP — that is the anti-pattern that caused this incident. Reuse the already-filtered tracker list from Phase 1 instead.
 
@@ -39,6 +48,8 @@ Write the report to `.work/node-cve/triage-YYYY-MM-DD/report.md`:
 
 ```markdown
 # Node CVE Triage Report - YYYY-MM-DD
+
+**Version scope:** OCP <version> (<mode>)
 
 ## Summary
 
@@ -89,14 +100,20 @@ List CVEs that are Reachable or Uncertain with unassigned owners. These need imm
 
 ### Step 2: Post Jira comments (if --notify-jira)
 
-**VALIDATION (MANDATORY, before posting anything):** For each unique CVE, take its `tracker_keys` list from Phase 1 (`query-open-cves`) and re-validate every tracker's component immediately before posting — do not trust cached or upstream filtering alone:
+**VALIDATION (MANDATORY, before posting anything):** For each unique CVE, take its `tracker_keys` list from Phase 1 (`query-open-cves`) and re-validate every tracker against both the component list and the version filter immediately before posting — do not trust cached or upstream filtering alone:
 
 ```bash
 # component_is_node_team() checks the tracker's COMPONENT field against the
 # canonical Node team component list from the shared components reference
 # (link above), NOT a hardcoded list.
+# version_matches_filter() checks the tracker's OCP version (from its summary)
+# against the active version filter from Phase 1.
 for tracker_key in $TRACKER_KEYS; do
-  component=$(jira issue view "$tracker_key" --plain --no-headers --columns COMPONENT | tail -1)
+  # Single API call per tracker to minimize rate-limiting risk
+  output=$(jira issue view "$tracker_key" --plain --no-headers --columns COMPONENT,SUMMARY | tail -1)
+  component=$(echo "$output" | awk -F'\t' '{print $1}')
+  summary=$(echo "$output" | awk -F'\t' '{print $2}')
+  ocp_version=$(echo "$summary" | grep -oP '\[openshift-\K[^\]]+')
 
   if ! component_is_node_team "$component"; then
     echo "⚠️  SKIPPING $tracker_key: component '$component' is not a Node team component" | tee -a "$SKIPPED_LOG"
@@ -104,12 +121,22 @@ for tracker_key in $TRACKER_KEYS; do
     continue
   fi
 
-  # Component validated — proceed with posting for $tracker_key
+  if ! version_matches_filter "$ocp_version" "$VERSION_FILTER"; then
+    echo "⚠️  SKIPPING $tracker_key: OCP version '$ocp_version' does not match version filter '$VERSION_FILTER'" | tee -a "$SKIPPED_LOG"
+    sleep 1
+    continue
+  fi
+
+  # Component and version validated — proceed with posting for $tracker_key
   sleep 1
 done
 ```
 
-A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) in the shared components reference. **Check the COMPONENT field only — do not treat a `pscomponent:` label as an alternative pass condition.** `pscomponent:` labels are used in Phase 1/Phase 2 for CVE discovery and repo mapping, not for determining tracker ownership; a non-Node tracker (e.g. component "Security") could incidentally carry a `pscomponent:cri-o` label, and accepting that as a pass would silently reintroduce the exact cross-team contamination this safeguard exists to prevent. If a tracker's component cannot be confidently classified as Node team, **skip it and log the reason** — never post "just in case." This check must run even when `--component` was passed, and even if Phase 1 already filtered by component, since this is the last line of defense before an irreversible write to another team's tracker. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
+**Component validation:** A component is considered a Node team component only if it matches an entry in the "Jira Components (OCPBUGS)" list (plus Driver Toolkit, Machine Config Operator) in the shared components reference. **Check the COMPONENT field only — do not treat a `pscomponent:` label as an alternative pass condition.** `pscomponent:` labels are used in Phase 1/Phase 2 for CVE discovery and repo mapping, not for determining tracker ownership; a non-Node tracker (e.g. component "Security") could incidentally carry a `pscomponent:cri-o` label, and accepting that as a pass would silently reintroduce the exact cross-team contamination this safeguard exists to prevent.
+
+**Version validation:** A tracker's OCP version is extracted from its summary using regex `\[openshift-([^\]]+)\]`. The version must match the active version filter (`version_filter` from Phase 1). When the filter mode is `latest` or a specific version, only trackers whose extracted OCP version matches (after stripping `.z` suffixes for comparison) pass validation. When the filter mode is `all`, this check is a no-op — all versions pass.
+
+If a tracker fails either check, **skip it and log the reason** — never post "just in case." Both checks must run even when `--component` or `--version` was explicitly passed, and even if Phase 1 already filtered, since this is the last line of defense before an irreversible write. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
 
 For each unique CVE, post a comment on every **validated** tracker issue. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
 
@@ -161,21 +188,23 @@ Search the output for comments containing `[node-cve:triage|`. This pattern anch
 - Post to ALL **validated** tracker issues for a CVE (all version trackers), each with its version-specific result
 - If commenting fails on a specific issue (e.g., permissions), log a warning and continue
 
-**POST-POSTING AUDIT (MANDATORY when --notify-jira is used):** Write an audit log to `.work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log` summarizing what was posted and what was skipped, so cross-team contamination is caught immediately instead of discovered days later:
+**POST-POSTING AUDIT (MANDATORY when --notify-jira is used):** Write an audit log to `.work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log` summarizing what was posted and what was skipped, so cross-team or cross-version contamination is caught immediately instead of discovered days later:
 
 ```bash
 {
   echo "=== Node CVE Triage Posting Audit — $(date +%Y-%m-%d) ==="
+  echo "Version filter: $VERSION_FILTER ($VERSION_FILTER_MODE)"
   echo "CVEs processed: $CVE_COUNT"
   echo "Trackers commented: $POSTED_COUNT"
-  echo "Trackers skipped (non-Node component): $SKIPPED_COUNT"
+  echo "Trackers skipped (non-Node component): $SKIPPED_COMPONENT_COUNT"
+  echo "Trackers skipped (version mismatch): $SKIPPED_VERSION_COUNT"
   echo ""
-  echo "Skipped trackers (tracker, component, reason):"
+  echo "Skipped trackers (tracker, component/version, reason):"
   cat "$SKIPPED_LOG"
 } > ".work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log"
 ```
 
-If `$SKIPPED_COUNT` is greater than zero, print a visible warning in the command summary output (Phase 4) so the operator notices immediately, e.g. "⚠️ Skipped N non-Node-component trackers — see posting-audit.log". A non-zero skip count is expected and healthy for multi-team CVEs; it means the safeguard is working. A skip count that is unexpectedly large relative to Phase 1's tracker count may indicate a bug and should be investigated before re-running.
+If any trackers were skipped, print a visible warning in the command summary output (Phase 4) so the operator notices immediately, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". A non-zero skip count is expected and healthy — for component skips it means the cross-team safeguard is working, and for version skips it means older-version trackers are correctly being left to the sustaining team.
 
 ### Step 3: Send Slack notification (if --notify-slack)
 
@@ -316,6 +345,8 @@ Write `cves.json` to `.work/node-cve/triage-YYYY-MM-DD/cves.json` containing the
 ```json
 {
   "date": "YYYY-MM-DD",
+  "version_filter": "5.0",
+  "version_filter_mode": "latest",
   "total_cves": 6,
   "cves": [
     {
@@ -364,10 +395,13 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
 {
   "skill": "report-findings",
   "status": "success",
+  "version_filter": "5.0",
+  "version_filter_mode": "latest",
   "report_path": ".work/node-cve/triage-2026-05-20/report.md",
-  "jira_comments_posted": 45,
+  "jira_comments_posted": 6,
   "jira_comments_failed": 0,
   "jira_trackers_skipped_non_node_component": 0,
+  "jira_trackers_skipped_version_mismatch": 0,
   "slack_notified": true,
   "artifacts": [
     ".work/node-cve/triage-2026-05-20/report.md",
@@ -381,6 +415,7 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
 ## Error Handling
 
 - Non-Node-team component detected on a tracker: skip that tracker and log it in the audit log (see Step 2). Never post to it. Do not fail the entire command — other trackers for the same CVE may still be valid Node team trackers.
+- OCP version mismatch detected on a tracker: skip that tracker and log it in the audit log (see Step 2). The sustaining team owns older versions. Do not fail the entire command — this is expected behavior when `--version latest` filters out older trackers.
 - Jira comment failures: log and continue. Do not fail the entire command because one tracker issue is inaccessible.
 - Slack failure: log warning. Common causes: invalid token/webhook URL, missing channel permissions, network issues, payload too large (Slack limit: 3000 chars per text block).
 - If the Slack payload exceeds the character limit, truncate the CVE list and add "... and N more. See full report."

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -76,19 +76,16 @@ List CVEs that are Reachable or Uncertain with unassigned owners. These need imm
 | Overall classification | Reachable / Present but not exploitable / Present but not reachable / Unaffected / Uncertain |
 | Overall confidence | High / Medium / Low |
 | Assignee | <name or Unassigned> |
-| Affected versions | 4.12.z - 4.19 |
-| Tracker issues | [OCPBUGS-XXXXX](https://redhat.atlassian.net/browse/OCPBUGS-XXXXX), [OCPBUGS-XXXXX](https://redhat.atlassian.net/browse/OCPBUGS-XXXXX), ... |
+| OCP version | 5.0 |
+| Tracker issues | [OCPBUGS-XXXXX](https://redhat.atlassian.net/browse/OCPBUGS-XXXXX) |
 
-**Per-branch results:**
+**Analysis result:**
 
 | Branch | OCP Version | Classification | Confidence |
 |--------|-------------|----------------|------------|
-| release-1.28 | 4.15 | Reachable | High |
-| release-1.29 | 4.16 | Reachable | High |
-| release-1.30 | 4.17 | Unaffected | High |
-| ... | ... | ... | ... |
+| release-1.36 | 5.0 | Reachable | High |
 
-**Evidence (worst-case branch):**
+**Evidence:**
 <source code analysis summary>
 <call path if found>
 
@@ -138,7 +135,7 @@ done
 
 If a tracker fails either check, **skip it and log the reason** — never post "just in case." Both checks must run even when `--component` was explicitly passed, and even if Phase 1 already filtered, since this is the last line of defense before an irreversible write. Rate limit: sleep 1 second between validation calls, same as the posting calls below, since a CVE with N trackers makes N validation calls before posting even starts.
 
-For each unique CVE, post a comment on every **validated** tracker issue. Each tracker issue receives the analysis result for its specific OCP version/branch (not a blanket result). Use Atlassian wiki markup (not Markdown):
+For each unique CVE, post a comment on every **validated** tracker issue. Each tracker receives the analysis result for the latest OCP version. Use Atlassian wiki markup (not Markdown):
 
 ```bash
 jira issue comment add OCPBUGS-XXXXX "$(cat <<'COMMENT'
@@ -147,19 +144,14 @@ h3. Automated CVE Reachability Analysis
 ||Field||Value||
 |CVE|CVE-XXXX-XXXXX|
 |Repository|[openshift/cri-o|https://github.com/openshift/cri-o]|
-|Branch|release-1.31|
+|Branch|release-1.36|
+|OCP Version|5.0|
 |Classification|Reachable / Present but not exploitable / Present but not reachable / Unaffected / Uncertain|
 |Confidence|High / Medium / Low|
 
-h4. Results across all analyzed branches
-||Branch||OCP Version||Classification||Confidence||
-|release-1.28|4.15|Reachable|High|
-|release-1.29|4.16|Reachable|High|
-|release-1.30|4.17|Unaffected|High|
-
 h4. Evidence
 {noformat}
-<source code analysis summary for this tracker's specific branch>
+<source code analysis summary>
 {noformat}
 
 h4. Recommended Action
@@ -185,7 +177,7 @@ Search the output for comments containing `[node-cve:triage|`. This pattern anch
 
 **Important:**
 - Rate limit: sleep 1 second between Jira API calls to avoid HTTP 429 throttling
-- Post to ALL **validated** tracker issues for a CVE (all version trackers), each with its version-specific result
+- Post to every **validated** tracker issue for a CVE
 - If commenting fails on a specific issue (e.g., permissions), log a warning and continue
 
 **POST-POSTING AUDIT (MANDATORY when --notify-jira is used):** Write an audit log to `.work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log` summarizing what was posted and what was skipped, so cross-team or cross-version contamination is caught immediately instead of discovered days later:
@@ -357,23 +349,10 @@ Write `cves.json` to `.work/node-cve/triage-YYYY-MM-DD/cves.json` containing the
       "overall_confidence": "HIGH",
       "assignee": "...",
       "tracker_keys": ["OCPBUGS-XXXXX"],
-      "affected_versions": ["4.12.z", "4.19"],
-      "per_branch_results": [
-        {
-          "branch": "release-1.28",
-          "ocp_version": "4.15",
-          "classification": "REACHABLE",
-          "confidence": "HIGH",
-          "evidence_summary": "..."
-        },
-        {
-          "branch": "release-1.30",
-          "ocp_version": "4.17",
-          "classification": "NOT_AFFECTED",
-          "confidence": "HIGH",
-          "evidence_summary": "..."
-        }
-      ],
+      "affected_versions": ["5.0"],
+      "branch": "release-1.36",
+      "ocp_version": "5.0",
+      "evidence_summary": "...",
       "recommended_action": "..."
     }
   ]

--- a/plugins/node-cve/skills/report-findings/SKILL.md
+++ b/plugins/node-cve/skills/report-findings/SKILL.md
@@ -204,7 +204,7 @@ Search the output for comments containing `[node-cve:triage|`. This pattern anch
 } > ".work/node-cve/triage-$(date +%Y-%m-%d)/posting-audit.log"
 ```
 
-If any trackers were skipped, print a visible warning in the command summary output (Phase 4) so the operator notices immediately, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". A non-zero skip count is expected and healthy — for component skips it means the cross-team safeguard is working, and for version skips it means older-version trackers are correctly being left to the sustaining team.
+If any trackers were skipped, print a visible warning in the command summary output (Phase 4) so the operator notices immediately, e.g. "⚠️ Skipped N trackers during posting (K non-Node-component, J wrong version) — see posting-audit.log". A non-zero skip count is expected and healthy — for component skips it means the cross-team safeguard is working as intended, and for version skips it means older-version trackers are being left to the sustaining team as required.
 
 ### Step 3: Send Slack notification (if --notify-slack)
 
@@ -405,7 +405,8 @@ Ensure all generated files exist under `.work/node-cve/triage-YYYY-MM-DD/`:
   "slack_notified": true,
   "artifacts": [
     ".work/node-cve/triage-2026-05-20/report.md",
-    ".work/node-cve/triage-2026-05-20/cves.json"
+    ".work/node-cve/triage-2026-05-20/cves.json",
+    ".work/node-cve/triage-2026-05-20/posting-audit.log"
   ]
 }
 ```


### PR DESCRIPTION
## What this PR does / why we need it:

Add OCP version filtering to `node-cve:triage` so it only triages CVE trackers for the latest OCP version by default (currently 5.0). Older versions are owned by the OCP sustaining team and should not receive Node-team triage comments.

Previously, `/node-cve:triage --notify-jira` would triage and post analysis comments to tracker issues across **all** OCP versions (4.12.z through 5.0). The sustaining team owns triage for all versions except the latest in-development release, so this created noise and duplicated their work.

This PR adds a `--version` flag with three modes:
- **`latest` (default):** auto-detect the highest OCP version from the Jira query results and triage only that version's trackers. No version is hardcoded — the detection is dynamic and advances automatically as new OCP releases ship.
- **A specific version** (e.g., `--version 5.0`): triage only that version.
- **`all`**: triage all versions (legacy behavior, for cross-version analysis when needed).

The implementation follows the same defense-in-depth pattern established in PR #623 (component safeguard):

**`query-open-cves`:**
- Adds Step 5 (Filter by OCP version) after deduplication. Versions are parsed as `(major, minor)`, `.z` suffixes are stripped for comparison, and the highest version is auto-detected. CVEs with no tracker for the target version are excluded entirely.

**`report-findings`:**
- Adds **OCP Version Safeguard** section — a posting-time re-validation of each tracker's OCP version against the active version filter, independent of Phase 1's filtering. This is the same defense-in-depth principle as the component safeguard.
- Audit log now separately tracks version-mismatch skip counts alongside component-mismatch skips.
- Validation pseudocode uses a single `jira issue view` call per tracker (fetching COMPONENT and SUMMARY in one request) to minimize API usage and rate-limiting risk.

**`analyze-cve-repos`:**
- Notes that input is version-filtered from Phase 1, and explains behavior under both `--version latest` and `--version all`.

**`triage.md`:**
- Adds `--version` to argument parsing, Phase 1 steps, clone strategy, Phase 3 posting, Phase 4 summary output, examples, and notes.

Also bumps `node-cve` to `0.0.7` and syncs marketplace/docs metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Triage now automatically targets the latest detected OCP version and its release branch.
  - Reports and command output include version scope, filtering details, cache status, and posting audits.
  - CVE results now include version-aware tracker totals and metadata.

- **Bug Fixes**
  - Older-version trackers and branches are excluded from analysis.
  - Invalid versions, missing branches, and mismatched trackers are safely skipped and logged.
  - Added validation to prevent inappropriate Jira updates.

- **Documentation**
  - Updated plugin guidance, examples, and workflow documentation.
  - Updated the plugin version to 0.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->