### PR TITLE
TRT-2887: multi-value Grafana params and new filter mappings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.82",
+      "version": "0.0.83",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.82",
+      "version": "0.0.83",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
@@ -31,6 +31,14 @@ GRAFANA_TO_VARIANT = {
     "topologies": "Topology",
     "networks": "Network",
     "upgrade_type": "Upgrade",
+    "featureset": "FeatureSet",
+    "ipmode": "NetworkStack",
+    "os": "OS",
+}
+
+GRAFANA_DISPLAY_ONLY = {
+    "master_nodes_updated", "percentile", "lookback", "min_disruption_regression",
+    "min_disruption_job_list", "min_relevance", "orgId",
 }
 
 
@@ -530,6 +538,11 @@ def main(argv=None):
         val = cli_overrides.get(gkey) or grafana_params.get(gkey)
         if val:
             variants[variant_key] = val
+
+    known_keys = set(GRAFANA_TO_VARIANT) | GRAFANA_DISPLAY_ONLY | {"releases", "backend", "_dashboard_name"}
+    for gkey in grafana_params:
+        if gkey not in known_keys:
+            print("Warning: Grafana parameter '%s' not mapped to a Sippy filter, ignoring" % gkey, file=sys.stderr)
 
     since_ms = int((time.time() - args.since_hours * 3600) * 1000)
 

--- a/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
@@ -35,14 +35,18 @@ GRAFANA_TO_VARIANT = {
 
 
 def parse_grafana_url(url):
-    """Extract var-* parameters from a Grafana dashboard URL."""
+    """Extract var-* parameters from a Grafana dashboard URL.
+
+    Multi-value params (e.g. var-platform=azure&var-platform=gcp) are stored
+    as comma-joined strings so downstream code stays simple.
+    """
     parsed = urllib.parse.urlparse(url)
     params = urllib.parse.parse_qs(parsed.query)
     result = {}
     for key, values in params.items():
         if key.startswith("var-"):
             name = key[4:]
-            result[name] = values[0]
+            result[name] = ",".join(values) if len(values) > 1 else values[0]
 
     dashboard_name = ""
     path_parts = parsed.path.rstrip("/").split("/")
@@ -528,8 +532,28 @@ def main(argv=None):
             variants[variant_key] = val
 
     since_ms = int((time.time() - args.since_hours * 3600) * 1000)
-    filter_dict = build_sippy_filter(variants, since_ms)
-    rows = fetch_runs(release, filter_dict, args.limit)
+
+    multi_keys = [(k, v.split(",")) for k, v in variants.items() if "," in v]
+    if multi_keys:
+        seen_prow_ids = set()
+        rows = []
+        variant_combos = [{}]
+        for mk, mv in multi_keys:
+            variant_combos = [
+                dict(combo, **{mk: val}) for combo in variant_combos for val in mv
+            ]
+        for combo in variant_combos:
+            query_variants = dict(variants, **combo)
+            filter_dict = build_sippy_filter(query_variants, since_ms)
+            batch = fetch_runs(release, filter_dict, args.limit)
+            for r in batch:
+                pid = str(r.get("prow_id", ""))
+                if pid not in seen_prow_ids:
+                    seen_prow_ids.add(pid)
+                    rows.append(r)
+    else:
+        filter_dict = build_sippy_filter(variants, since_ms)
+        rows = fetch_runs(release, filter_dict, args.limit)
 
     if not rows:
         filters_desc = ", ".join("%s:%s" % (k, v) for k, v in variants.items())

--- a/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
@@ -542,6 +542,11 @@ def main(argv=None):
             variant_combos = [
                 dict(combo, **{mk: val}) for combo in variant_combos for val in mv
             ]
+        max_combos = 20
+        if len(variant_combos) > max_combos:
+            print("Error: %d variant combinations exceeds limit of %d" % (
+                len(variant_combos), max_combos), file=sys.stderr)
+            sys.exit(1)
         for combo in variant_combos:
             query_variants = dict(variants, **combo)
             filter_dict = build_sippy_filter(query_variants, since_ms)
@@ -551,6 +556,8 @@ def main(argv=None):
                 if pid not in seen_prow_ids:
                     seen_prow_ids.add(pid)
                     rows.append(r)
+        rows.sort(key=lambda r: r.get("timestamp", 0), reverse=True)
+        rows = rows[:args.limit]
     else:
         filter_dict = build_sippy_filter(variants, since_ms)
         rows = fetch_runs(release, filter_dict, args.limit)

--- a/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/find_disruption_runs.py
@@ -13,6 +13,7 @@ Output formats:
     --format json    Machine-readable JSON array
 """
 import argparse
+import itertools
 import json
 import math
 import re
@@ -522,6 +523,12 @@ def main(argv=None):
     if not backend:
         print("Error: --backend is required (or provide --grafana-url with var-backend)", file=sys.stderr)
         sys.exit(1)
+    if "," in release:
+        print("Error: multiple releases not supported (got '%s'). Use a single release." % release, file=sys.stderr)
+        sys.exit(1)
+    if "," in backend:
+        print("Error: multiple backends not supported (got '%s'). Use a single backend." % backend, file=sys.stderr)
+        sys.exit(1)
 
     base_backend, _conn_type = parse_backend(backend)
 
@@ -550,11 +557,9 @@ def main(argv=None):
     if multi_keys:
         seen_prow_ids = set()
         rows = []
-        variant_combos = [{}]
-        for mk, mv in multi_keys:
-            variant_combos = [
-                dict(combo, **{mk: val}) for combo in variant_combos for val in mv
-            ]
+        keys = [k for k, _ in multi_keys]
+        vals = [v for _, v in multi_keys]
+        variant_combos = [dict(zip(keys, combo)) for combo in itertools.product(*vals)]
         max_combos = 20
         if len(variant_combos) > max_combos:
             print("Error: %d variant combinations exceeds limit of %d" % (

--- a/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
@@ -119,6 +119,19 @@ def test_parse_grafana_url_all_variants():
     assert result["backend"] == "kube-api-reused-connections"
 
 
+def test_parse_grafana_url_featureset_ipmode_os():
+    url = (
+        "https://grafana-loki.ci.openshift.org/d/abc/dash"
+        "?var-platform=aws&var-backend=kube-api-new-connections"
+        "&var-releases=5.0&var-featureset=techpreview"
+        "&var-ipmode=ipv6&var-os=rhcos10"
+    )
+    result = parse_grafana_url(url)
+    assert result["featureset"] == "techpreview"
+    assert result["ipmode"] == "ipv6"
+    assert result["os"] == "rhcos10"
+
+
 def test_parse_backend_new_connections():
     base, conn = parse_backend("host-to-host-new-connections")
     assert base == "host-to-host"

--- a/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
@@ -101,6 +101,50 @@ def test_multi_value_queries_and_dedup(mock_fetch_runs, _mock_disruption):
     assert timestamps[0] > timestamps[-1]
 
 
+@patch("find_disruption_runs.fetch_disruption_data", return_value={})
+@patch("find_disruption_runs.fetch_runs", return_value=[])
+def test_multi_value_backend_rejected(_mock_fetch, _mock_disruption):
+    """Multi-value var-backend should error, not silently produce garbage."""
+    import io
+    from contextlib import redirect_stderr
+
+    buf = io.StringIO()
+    try:
+        with redirect_stderr(buf):
+            main([
+                "--grafana-url",
+                "https://grafana-loki.ci.openshift.org/d/abc/dash"
+                "?var-backend=host-to-host-new-connections&var-backend=kube-api-new-connections"
+                "&var-releases=5.0",
+            ])
+        assert False, "should have exited"
+    except SystemExit as e:
+        assert e.code == 1
+    assert "multiple backends not supported" in buf.getvalue()
+
+
+@patch("find_disruption_runs.fetch_disruption_data", return_value={})
+@patch("find_disruption_runs.fetch_runs", return_value=[])
+def test_multi_value_release_rejected(_mock_fetch, _mock_disruption):
+    """Multi-value var-releases should error, not silently query nonsense."""
+    import io
+    from contextlib import redirect_stderr
+
+    buf = io.StringIO()
+    try:
+        with redirect_stderr(buf):
+            main([
+                "--grafana-url",
+                "https://grafana-loki.ci.openshift.org/d/abc/dash"
+                "?var-releases=5.0&var-releases=5.1"
+                "&var-backend=kube-api-new-connections",
+            ])
+        assert False, "should have exited"
+    except SystemExit as e:
+        assert e.code == 1
+    assert "multiple releases not supported" in buf.getvalue()
+
+
 def test_parse_grafana_url_all_variants():
     url = (
         "https://grafana-loki.ci.openshift.org/d/abc/dash"

--- a/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
@@ -31,6 +31,22 @@ def test_parse_grafana_url_extracts_vars():
     assert "orgId" not in result
 
 
+def test_parse_grafana_url_multi_value():
+    url = (
+        "https://grafana-loki.ci.openshift.org/d/abc/dash"
+        "?var-platform=azure&var-platform=gcp"
+        "&var-backend=host-to-host-new-connections"
+        "&var-releases=5.0&var-ipmode=ipv6&var-ipmode=ipv4"
+        "&var-os=rhcos10&var-os=rhcos9"
+    )
+    result = parse_grafana_url(url)
+    assert result["platform"] == "azure,gcp"
+    assert result["backend"] == "host-to-host-new-connections"
+    assert result["ipmode"] == "ipv6,ipv4"
+    assert result["os"] == "rhcos10,rhcos9"
+    assert result["releases"] == "5.0"
+
+
 def test_parse_grafana_url_all_variants():
     url = (
         "https://grafana-loki.ci.openshift.org/d/abc/dash"

--- a/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
+++ b/plugins/ci/skills/analyze-disruption/test_find_disruption_runs.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from find_disruption_runs import (
     extract_disruption_failures,
     fetch_disruption_data,
+    main,
     max_disruption_for_backend,
     parse_backend,
     parse_grafana_url,
@@ -45,6 +46,59 @@ def test_parse_grafana_url_multi_value():
     assert result["ipmode"] == "ipv6,ipv4"
     assert result["os"] == "rhcos10,rhcos9"
     assert result["releases"] == "5.0"
+
+
+@patch("find_disruption_runs.fetch_disruption_data", return_value={})
+@patch("find_disruption_runs.fetch_runs")
+def test_multi_value_queries_and_dedup(mock_fetch_runs, _mock_disruption):
+    """Multi-value params expand into separate queries, dedup by prow_id, sort by timestamp, and cap at --limit."""
+    import io
+    from contextlib import redirect_stdout
+
+    base_ts = 1722988800000  # epoch ms
+    azure_rows = [
+        {"prow_id": "A1", "timestamp": base_ts + 50000, "job": "azure-job"},
+        {"prow_id": "A2", "timestamp": base_ts + 30000, "job": "azure-job"},
+        {"prow_id": "SHARED", "timestamp": base_ts + 10000, "job": "shared-job"},
+    ]
+    gcp_rows = [
+        {"prow_id": "G1", "timestamp": base_ts + 40000, "job": "gcp-job"},
+        {"prow_id": "SHARED", "timestamp": base_ts + 10000, "job": "shared-job"},
+        {"prow_id": "G2", "timestamp": base_ts + 5000, "job": "gcp-job"},
+    ]
+    mock_fetch_runs.side_effect = [azure_rows, gcp_rows]
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main([
+            "--grafana-url",
+            "https://grafana-loki.ci.openshift.org/d/abc/dash"
+            "?var-platform=azure&var-platform=gcp"
+            "&var-backend=kube-api-new-connections&var-releases=5.0",
+            "--format", "json", "--limit", "4",
+        ])
+    output = json.loads(buf.getvalue())
+
+    # Both platform values were queried
+    assert mock_fetch_runs.call_count == 2
+    platforms_queried = set()
+    for call in mock_fetch_runs.call_args_list:
+        filter_dict = call[0][1]  # positional: (release, filter_dict, limit)
+        for item in filter_dict["items"]:
+            if "Platform:" in item["value"]:
+                platforms_queried.add(item["value"])
+    assert platforms_queried == {"Platform:azure", "Platform:gcp"}
+
+    # Dedup: SHARED appears once; limit enforced (5 unique -> capped to 4)
+    prow_ids = [r["build_id"] for r in output]
+    assert len(prow_ids) == 4
+    assert len(set(prow_ids)) == 4
+    assert "SHARED" in prow_ids
+
+    # Sorted by timestamp descending (epoch ms numbers)
+    timestamps = [r["timestamp"] for r in output]
+    assert timestamps == sorted(timestamps, reverse=True)
+    assert timestamps[0] > timestamps[-1]
 
 
 def test_parse_grafana_url_all_variants():


### PR DESCRIPTION
## Changes
### Support multi-value Grafana URL params
Grafana dashboards can have repeated `var-` params (e.g. `var-platform=azure&var-platform=gcp`). Previously only the first value was used. Now multi-value params are detected and separate Sippy queries are issued per combination, with results merged, deduped by prow_id, sorted by timestamp descending, and capped at the global `--limit`. Cartesian expansion is bounded at 20 combinations.

### Map FeatureSet, NetworkStack, and OS Grafana filters
Added `featureset` → `FeatureSet`, `ipmode` → `NetworkStack`, and `os` → `OS` to `GRAFANA_TO_VARIANT`. Without these, Grafana URLs with `var-featureset=techpreview` would return runs from all feature sets instead of just techpreview jobs. Display-only Grafana params (`master_nodes_updated`, `percentile`, `lookback`, etc.) are silently ignored; unknown params emit a stderr warning.

### Fix symmetric cache-ness matching
`_backend_matches` previously excluded cache backends unconditionally. When the target itself was a cache backend (e.g. `cache-kube-api`), all matching entries returned 0 disruption. Now matching respects whether both sides are cache or non-cache.

## Test plan
- [x] All 34 tests pass in `test_find_disruption_runs.py`
- [x] `make lint` passes clean (A+)
- [x] Tested `/ci:analyze-disruption` with Grafana URL — skill loads and follows SKILL.md steps correctly
- [x] Multi-platform URL (`var-platform=azure&var-platform=gcp`) queries both platforms and merges results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disruption-run analysis for dashboards with repeated filter parameters.
  * Results are gathered across selected filter values, deduplicated, sorted by newest timestamp, and limited appropriately.
  * Searches support up to 20 filter combinations while preserving existing single-value behavior.
  * Added warnings for unsupported dashboard parameters and validation for conflicting selections.

* **Tests**
  * Added coverage for repeated filters, platform expansion, deduplication, sorting, limits, validation, and additional filter types.

* **Chores**
  * Updated the CI plugin version to 0.0.83.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->