### PR TITLE
feat(jira): add spike type to /jira:create skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/reference/create-spike.md
+++ b/plugins/jira/reference/create-spike.md
@@ -1,0 +1,98 @@
+# Spike
+
+Type-specific guidance for creating Jira spikes for research and investigation work.
+
+Spikes are time-boxed investigations used to resolve uncertainty before committing to implementation. They answer a specific research question so the team can make an informed decision about next steps.
+
+**Key properties:**
+- Always time-boxed (1-2 days typical; never open-ended)
+- Not story-pointed — effort is bounded by the time box
+- Must produce a documented finding and at least one follow-up action (backlog item or decision record)
+- If you already know what to build, use a Story or Task instead
+
+## Research Question
+
+Every spike must clearly state:
+- **What specific uncertainty or question** does this spike address?
+- **What decision does the answer inform?** (which implementation approach, whether to proceed, which tool to adopt)
+- **What will you do with the findings?** (design doc, ADR, follow-up stories)
+
+## Interactive Workflow
+
+### 1. Research Question
+**Prompt:** "What specific question or uncertainty does this spike address? What decision will the findings inform?"
+
+The question should be answerable within the time box. If it isn't, split the spike or narrow the scope.
+
+### 2. Context
+**Prompt:** "Why is this investigation needed now? What is blocked or uncertain without it?"
+
+### 3. Investigation Approach
+**Prompt:** "How will you investigate? What methods, sources, or experiments will you use?"
+
+Examples: proof-of-concept implementation, benchmark comparison, API exploration, reading upstream docs, vendor evaluation.
+
+### 4. Time Box
+**Prompt:** "How much time should be allocated? (Typical: 1-2 days maximum)"
+
+If the user says more than 2 days, prompt them to narrow the research question or split into multiple spikes.
+
+### 5. Success Criteria
+**Prompt:** "What findings or decisions will mark this spike as complete?"
+
+Success criteria for spikes are outcome-oriented, not implementation-oriented:
+- "Decision documented: use approach A vs B, with rationale"
+- "Proof-of-concept confirms feasibility; follow-up stories created"
+- "Benchmark results show X metric meets SLO threshold"
+
+### 6. Follow-up Actions
+**Prompt:** "What backlog items will you create based on the findings?"
+
+A spike with no planned follow-up actions is incomplete. At minimum, commit to creating one of: implementation story, decision record, or a second spike to narrow the scope.
+
+## Description Template
+
+```markdown
+## Research Question
+
+<What specific question or uncertainty does this spike address? What decision does it inform?>
+
+## Context
+
+<Why is this investigation needed? What is blocked or uncertain without it?>
+
+## Investigation Approach
+
+<Methods, sources, or experiments — e.g., proof-of-concept, benchmark, API exploration, vendor evaluation>
+
+## Time Box
+
+<Maximum time allocated — typically 1-2 days>
+
+## Success Criteria
+
+<What findings or decisions mark this spike as complete?>
+
+## Findings Documentation
+
+<Where findings will be recorded — e.g., PR comment, design doc, ADR, Confluence page>
+
+## Follow-up Actions
+
+- [ ] <Backlog item or decision record to create upon completion>
+```
+
+For formatting reference, see [Markdown for Jira](markdown-for-jira.md).
+
+## Size Validation
+
+- **Too broad** (research question can't be answered in 1-2 days) → narrow the question or split
+- **Already decided** (you know what to implement) → use Story or Task instead
+- **No follow-up planned** → prompt for at least one follow-up action before creating
+
+## Anti-Patterns
+
+- No clear research question ("Investigate GCP networking") → must state what specific decision or uncertainty the spike resolves
+- No time box or open-ended time box → always set a maximum; prompt the user if missing
+- Implementation work framed as spike ("Spike: implement monitoring") → if you already know what to build, use a Story or Task
+- Spike with no follow-up actions → findings must result in backlog items or a documented decision

--- a/plugins/jira/skills/create/SKILL.md
+++ b/plugins/jira/skills/create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create
-description: Create Jira issues — story, bug, epic, feature, initiative, task, risk, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates
+description: Create Jira issues — story, bug, epic, feature, initiative, task, risk, spike, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates
 ---
 
 # Create Jira Issue
@@ -9,7 +9,7 @@ description: Create Jira issues — story, bug, epic, feature, initiative, task,
 /jira:create <type> [project-key] <summary> [--component <name>] [--version <version>] [--parent <key>]
 ```
 
-Creates Jira issues following best practices and team-specific conventions. Supports stories, epics, features, initiatives, tasks, bugs, and feature requests with intelligent defaults, interactive prompts, and validation.
+Creates Jira issues following best practices and team-specific conventions. Supports stories, epics, features, initiatives, tasks, bugs, risks, spikes, and feature requests with intelligent defaults, interactive prompts, and validation.
 
 ## Type-Specific Guidance
 
@@ -23,6 +23,7 @@ Load the reference file matching the issue type for templates, interactive workf
 | **feature** | [Feature guide](../../reference/create-feature.md) | Market problem, strategic value, success criteria |
 | **initiative** | [Initiative guide](../../reference/create-initiative.md) | Internal capability, problem statement, internal impact |
 | **risk** | [Risk guide](../../reference/create-risk.md) | Qualifying criteria, probability/impact assessment, auto-calculated fields |
+| **spike** | [Spike guide](../../reference/create-spike.md) | Research question, time box, investigation approach |
 | **task** | [Task guide](../../reference/create-task.md) | Task vs story distinction, action-verb summaries |
 | **feature-request** | [Feature Request guide](../../reference/create-feature-request.md) | RFE project, 4-question workflow, business requirements |
 
@@ -30,7 +31,7 @@ Also load [Markdown for Jira](../../reference/markdown-for-jira.md) for descript
 
 ## Arguments
 
-- **type** *(required)* — `story` | `epic` | `feature` | `initiative` | `task` | `bug` | `risk` | `feature-request`
+- **type** *(required)* — `story` | `epic` | `feature` | `initiative` | `task` | `bug` | `risk` | `spike` | `feature-request`
 - **project-key** *(optional for bugs and feature-requests)* — e.g., `CNTRLPLANE`, `OCPBUGS`, `RFE`. Default for bugs: `OCPBUGS`. Default for feature-requests: `RFE`.
 - **summary** *(required)* — Issue title. Use quotes for multi-word: `"Enable automatic scaling"`
 - **--component** *(optional)* — Component name. Auto-detected from summary for known projects.
@@ -122,7 +123,7 @@ Jira issue types have a `hierarchyLevel` that determines valid parent-child rela
 Level 3: Outcome
 Level 2: Feature / Initiative
 Level 1: Epic
-Level 0: Story / Task / Bug
+Level 0: Story / Task / Bug / Spike
 Level -1: Sub-task
 ```
 
@@ -139,6 +140,7 @@ Fetch the parent via `getJiraIssue` to verify it exists and its type matches the
 | Story | Epic | Warn user, ask to confirm or correct |
 | Task | Epic | Warn user, ask to confirm or correct |
 | Bug | Epic | Warn user, ask to confirm or correct |
+| Spike | Epic | Warn user, ask to confirm or correct |
 | Epic | Feature or Initiative | Warn user, ask to confirm or correct |
 | Feature | Outcome | Warn user, ask to confirm or correct |
 | Initiative | Outcome | Warn user, ask to confirm or correct |
@@ -162,7 +164,7 @@ When changing an existing issue's type to a different hierarchy level, the curre
 ### Invalid Issue Type
 
 ```plaintext
-Invalid issue type "stroy". Valid types: story, epic, feature, initiative, task, bug, risk, feature-request
+Invalid issue type "stroy". Valid types: story, epic, feature, initiative, task, bug, risk, spike, feature-request
 
 Did you mean "story"?
 ```
@@ -170,7 +172,7 @@ Did you mean "story"?
 ### Missing Project Key
 
 ```plaintext
-Project key is required for stories/tasks/epics/features/initiatives/risks.
+Project key is required for stories/tasks/epics/features/initiatives/risks/spikes.
 
 Usage: /jira:create story PROJECT-KEY "summary"
 ```
@@ -200,6 +202,7 @@ Usage: /jira:create story PROJECT-KEY "summary"
 /jira:create feature CNTRLPLANE "Advanced search capabilities"
 /jira:create initiative GCP "Establish performance testing infrastructure"
 /jira:create risk GCP "Cincinnati API outage could block new cluster creation due to version resolution dependency"
+/jira:create spike GCP "Evaluate Workload Identity Federation vs service account key rotation for HCP node auth"
 /jira:create feature-request RFE "Support custom SSL certificates for ROSA HCP"
 ```
 

--- a/plugins/jira/skills/create/SKILL.md
+++ b/plugins/jira/skills/create/SKILL.md
@@ -129,7 +129,7 @@ Level -1: Sub-task
 
 ### Parent Field
 
-Use `{"parent": {"key": "PARENT-KEY"}}` in `additional_fields` for all parent-child relationships (Story→Epic, Task→Epic, Bug→Epic, Epic→Feature, Epic→Initiative, Feature→Outcome, Initiative→Outcome).
+Use `{"parent": {"key": "PARENT-KEY"}}` in `additional_fields` for all parent-child relationships (Story→Epic, Task→Epic, Bug→Epic, Spike→Epic, Epic→Feature, Epic→Initiative, Feature→Outcome, Initiative→Outcome).
 
 ### Pre-Validation (when `--parent` is provided)
 


### PR DESCRIPTION
## Summary

- Adds `reference/create-spike.md` with interactive workflow and template for research/investigation work: research question, context, investigation approach, time box, success criteria, findings documentation, and follow-up actions
- Updates `skills/create/SKILL.md` to wire `spike` into the type table, arguments list, hierarchy diagram, parent pre-validation table, error messages, and usage examples
- Bumps jira plugin to 0.8.3

## Motivation

Spikes are a first-class work type on the GCP HCP team (and common across teams), but `/jira:create spike` was not previously supported. This follows the same pattern used for the `initiative` and `risk` types added in 0.8.x/0.9.x.

## Test plan

- [ ] `/jira:create spike GCP "Evaluate WIF vs service account key rotation"` — verify the interactive workflow loads, prompts for research question / time box / success criteria, and creates a well-formed Jira issue
- [ ] Verify `Spike` appears in tab-complete / help output
- [ ] Invalid type error message lists `spike` among valid types

Closes: [GCP-701](https://redhat.atlassian.net/browse/GCP-701) (gcp-hcp team tracking ticket)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating Jira research and investigation spikes.
  - Added spike-specific templates, required research questions, sizing guidance, and follow-up actions.
  - Added validation for spike properties, hierarchy, parent links, and invalid issue types.
  - Added an interactive workflow to guide spike creation.

- **Documentation**
  - Added reusable Markdown guidance and examples for documenting Jira spikes.

- **Chores**
  - Updated the Jira plugin to version 0.9.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->