### PR TITLE
Add Codex payload analysis eval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.83",
+      "version": "0.0.84",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,7 +541,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.83",
+      "version": "0.0.84",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/evals/cases/payload-analysis/case-011-5.0-ci-infra-only-no-candidates/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-011-5.0-ci-infra-only-no-candidates/annotations.yaml
@@ -1,5 +1,5 @@
 expected_phase: Rejected
-expected_failed_job_count: 1
+expected_failed_job_count: 2
 has_revert_candidates: false
 force_accept_expected: false
 

--- a/plugins/ci/evals/eval-payload-analysis-codex.yaml
+++ b/plugins/ci/evals/eval-payload-analysis-codex.yaml
@@ -1,0 +1,455 @@
+name: ci-payload-analysis-eval
+description: Evaluate payload-analysis and its dependent skills with Codex through Harbor
+
+execution:
+  mode: case
+  skill: ci:payload-analysis
+  arguments: "{payload_tag} --snapshot-dir $EVAL_SNAPSHOT_DIR/{payload_tag}"
+  timeout: 3600
+  # Codex currently reports usage, but its CLI does not enforce this cap.
+  max_budget_usd: 25.0
+  env:
+    # Harbor: mount the host archive root at this container path with --mount.
+    EVAL_SNAPSHOT_DIR: /historical-payload-data
+    # Keep the canonical root-level artifacts, and also copy them here so the
+    # harness can collect them after the ephemeral Harbor container exits.
+    AGENT_EVAL_OUTPUT_DIR: output
+
+runner:
+  type: codex
+  effort: xhigh
+  # Pass the entire plugin so payload-analysis can load payload-results-yaml,
+  # payload-autodl-json, prow-job-analysis, and other transitive dependencies.
+  plugin_dirs:
+    - plugins/ci
+  system_prompt: |
+    You are a diligent senior OpenShift release engineer triaging failures.
+
+    **CRITICAL**: You have many ci, must-gather, and jira skills at your
+    disposal. You MUST load the relevant skills BEFORE you begin any work.
+    Do NOT improvise or guess. This applies equally to subagents: instruct
+    every subagent to review its available skills and load the appropriate
+    ones before beginning its investigation. A subagent that does not load
+    a skill will produce shallow, unreliable analysis.
+
+    After completing your analysis, you MUST invoke the
+    ci:payload-results-yaml and ci:payload-autodl-json skills to generate
+    the structured output files. NEVER write these files directly — the
+    skills enforce the canonical schema.
+
+    When searching external sources (GitHub, Prow, GCS) for CI configuration
+    changes or PRs not found in the snapshot changelog, constrain searches to
+    changes merged before the payload creation timestamp. The payload tag
+    encodes its creation date (e.g., 4.22.0-0.nightly-2026-03-26-231124 was
+    created on 2026-03-26).
+
+models:
+  skill: gpt-5.6-luna
+  judge: claude-opus-4-6
+
+permissions:
+  allow:
+    - "Skill"
+    - "Bash"
+    - "Agent"
+    - "WebFetch"
+    - "Write"
+    - "Read"
+  deny: []
+
+mlflow:
+  experiment: ci-payload-analysis-eval
+
+dataset:
+  path: cases/payload-analysis
+  schema: |
+    Each case directory contains:
+    - input.yaml: YAML file with fields:
+      - 'payload_tag' — a real payload tag from amd64.ocp.releases.ci.openshift.org
+        (e.g., '5.0.0-0.nightly-2026-05-30-072431')
+    - annotations.yaml: Expected outcomes and metadata for scoring:
+      - 'expected_phase': Rejected|Ready|Accepted
+      - 'expected_failed_job_count': integer
+      - 'has_revert_candidates': boolean
+      - 'force_accept_expected': boolean
+      - 'expected_candidates': list of expected revert candidates with pr_url,
+        component, min_confidence, expected_confidence, description,
+        expected_failing_jobs
+      - 'notes': free text context
+
+    Snapshots are stored as tar.gz archives in
+    plugins/ci/evals/snapshots/payload-analysis/ and must be extracted before
+    running evals. Run:
+      export EVAL_SNAPSHOT_DIR=$(plugins/ci/evals/scripts/extract-payload-analysis-snapshots.sh <tag>)
+
+outputs:
+  - path: "output"
+    schema: |
+      The skill writes three canonical files to the workspace root and copies
+      them to output/ for Harbor artifact collection:
+      1. payload-analysis-{sanitized_tag}-summary.html — self-contained HTML report
+         with executive summary, blocking jobs summary table, recommended reverts
+         (or no-revert verdict), optional force-accept recommendation, and per-job
+         collapsible failure details. Uses GitHub dark mode styling with embedded CSS.
+      2. payload-results-{sanitized_tag}.yaml — structured YAML with:
+         - metadata: payload_tag, version, stream, architecture, release_controller_url,
+           analyzed_at, force_accept_recommended
+         - failing_jobs[]: job_name, prow_url, is_aggregated, underlying_job_name,
+           failure_type, root_cause_summary, streak_length, originating_payload_tag,
+           failure_pattern
+         - candidates[]: pr_url, pr_number, component, title, confidence_score,
+           rationale, failing_jobs[], actions[]
+      3. payload-analysis-{sanitized_tag}-autodl.json — flat denormalized JSON object
+         with table_name, schema, and rows array. One row per (failed blocking job,
+         candidate PR) pair. All row values are strings. Fields include payload_tag,
+         version, stream, architecture, phase, job_name, prow_url, failure_type,
+         root_cause_summary, candidate_pr_url, candidate_confidence_score.
+
+      Judges should check outputs["files"] and outputs["modified_files"] for files
+      matching these naming patterns.
+
+traces:
+  stdout: true
+  stderr: true
+  events: true
+  metrics: true
+
+judges:
+  - name: output_files_exist
+    description: |
+      Verify all three required output files are produced: HTML report,
+      payload results YAML, and autodl JSON.
+    check: |
+      import os
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      html = [k for k in all_f if k.endswith("-summary.html")]
+      yaml_f = [k for k in all_f if os.path.basename(k).startswith("payload-results-") and k.endswith(".yaml")]
+      json_f = [k for k in all_f if k.endswith("-autodl.json")]
+      missing = []
+      if not html:
+          missing.append("HTML report (*-summary.html)")
+      if not yaml_f:
+          missing.append("payload results YAML (payload-results-*.yaml)")
+      if not json_f:
+          missing.append("autodl JSON (*-autodl.json)")
+      if missing:
+          return (False, f"Missing: {', '.join(missing)}")
+      return (True, f"All 3 files found: {html[0]}, {yaml_f[0]}, {json_f[0]}")
+
+  - name: yaml_results_valid
+    description: |
+      Verify the payload results YAML has the required schema: metadata block
+      with payload_tag, version, stream, architecture; failing_jobs array;
+      and candidates array with properly structured entries.
+    check: |
+      import yaml, os
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      yaml_files = {k: v for k, v in all_f.items() if os.path.basename(k).startswith("payload-results-") and k.endswith(".yaml")}
+      if not yaml_files:
+          return (False, "No payload results YAML found")
+      content = list(yaml_files.values())[0]
+      try:
+          data = yaml.safe_load(content)
+      except Exception as e:
+          return (False, f"Invalid YAML: {e}")
+      if not isinstance(data, dict):
+          return (False, "YAML root is not a dict")
+      meta = data.get("metadata", {})
+      required_meta = ["payload_tag", "version", "stream", "architecture"]
+      missing = [f for f in required_meta if f not in meta]
+      if missing:
+          return (False, f"Missing metadata: {', '.join(missing)}")
+      if "failing_jobs" not in data:
+          return (False, "Missing failing_jobs array")
+      if "candidates" not in data:
+          return (False, "Missing candidates array")
+      jobs = data.get("failing_jobs", [])
+      cands = data.get("candidates", [])
+      if jobs:
+          required_job_fields = ["job_name", "failure_type", "root_cause_summary"]
+          j0 = jobs[0]
+          jmissing = [f for f in required_job_fields if f not in j0]
+          if jmissing:
+              return (False, f"failing_jobs[0] missing: {', '.join(jmissing)}")
+      if cands:
+          required_cand_fields = ["pr_url", "confidence_score", "failing_jobs"]
+          c0 = cands[0]
+          cmissing = [f for f in required_cand_fields if f not in c0]
+          if cmissing:
+              return (False, f"candidates[0] missing: {', '.join(cmissing)}")
+      return (True, f"Valid: {len(jobs)} failing jobs, {len(cands)} candidates")
+
+  - name: json_data_valid
+    description: |
+      Verify the autodl JSON has the expected structure: table_name, schema dict,
+      rows array with required fields, and all row values are strings.
+    check: |
+      import json
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      json_files = {k: v for k, v in all_f.items() if k.endswith("-autodl.json")}
+      if not json_files:
+          return (False, "No autodl JSON found")
+      content = list(json_files.values())[0]
+      try:
+          data = json.loads(content)
+      except Exception as e:
+          return (False, f"Invalid JSON: {e}")
+      if not isinstance(data, dict):
+          return (False, "JSON root is not a dict (expected object with table_name, schema, rows)")
+      if "table_name" not in data:
+          return (False, "Missing 'table_name' field")
+      if "schema" not in data or not isinstance(data["schema"], dict):
+          return (False, "Missing or invalid 'schema' field")
+      rows = data.get("rows", [])
+      if not isinstance(rows, list):
+          return (False, "'rows' is not an array")
+      if len(rows) == 0:
+          return (False, "rows array is empty")
+      required = ["payload_tag", "job_name", "failure_type", "root_cause_summary"]
+      row = rows[0]
+      missing = [f for f in required if f not in row]
+      if missing:
+          return (False, f"Missing fields in rows[0]: {', '.join(missing)}")
+      non_string = [f for f in row if not isinstance(row[f], str)]
+      if non_string:
+          return (False, f"Non-string values in rows[0]: {', '.join(non_string)} (all values must be strings)")
+      return (True, f"Valid JSON: {len(rows)} rows, table_name={data['table_name']}, all values are strings")
+
+  - name: html_report_structure
+    description: |
+      Verify the HTML report contains required sections: executive summary,
+      blocking jobs table, revert/no-revert verdict, embedded CSS, and
+      per-job details.
+    check: |
+      files = outputs.get("files", {})
+      modified = outputs.get("modified_files", {})
+      all_f = {**files, **modified}
+      html_files = {k: v for k, v in all_f.items() if k.endswith("-summary.html")}
+      if not html_files:
+          return (False, "No HTML report found")
+      html = list(html_files.values())[0]
+      checks = {
+          "executive summary": "executive" in html.lower() or "summary" in html.lower(),
+          "blocking jobs table": "<table" in html,
+          "revert verdict": "revert" in html.lower() or "verdict" in html.lower(),
+          "embedded CSS": "<style>" in html,
+      }
+      failed = [k for k, v in checks.items() if not v]
+      if failed:
+          return (False, f"Missing: {', '.join(failed)}")
+      return (True, f"All {len(checks)} structural checks passed")
+
+  - name: required_skill_invocations
+    description: |
+      Verify that payload-results-yaml and payload-autodl-json skill
+      content was loaded during execution. Detects loading regardless of
+      method (Skill tool, Read tool, Bash cat/sed, etc.) by searching
+      for the skill's heading line in stdout — these headings only appear
+      when the actual skill content is returned, not when the skill is
+      merely referenced by name.
+    check: |
+      stdout = outputs.get("stdout", "")
+      required = {
+          "payload-results-yaml": "# Payload Results YAML",
+          "payload-autodl-json": "# Payload Autodl JSON",
+      }
+      found = {}
+      missing = []
+      for skill, heading in required.items():
+          if heading in stdout:
+              found[skill] = True
+          else:
+              missing.append(skill)
+      if missing:
+          return (False, f"Skill content not loaded: {', '.join(missing)}")
+      return (True, f"Both skill contents loaded: {', '.join(sorted(found))}")
+
+  - name: expected_outcomes
+    description: |
+      Compare structured output with deterministic case annotations so schema-
+      valid but semantically incorrect results cannot receive a perfect score.
+    check: |
+      import json, os, yaml
+      files = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
+      expected = outputs.get("annotations", {}) or {}
+      yaml_files = [v for k, v in files.items()
+                    if os.path.basename(k).startswith("payload-results-")
+                    and k.endswith(".yaml")]
+      json_files = [v for k, v in files.items() if k.endswith("-autodl.json")]
+      if not yaml_files or not json_files:
+          return (False, "Structured YAML or JSON output is missing")
+      try:
+          results = yaml.safe_load(yaml_files[0]) or {}
+          autodl = json.loads(json_files[0])
+      except Exception as e:
+          return (False, f"Could not parse structured output: {e}")
+      failures = []
+      expected_count = expected.get("expected_failed_job_count")
+      actual_count = len(results.get("failing_jobs") or [])
+      if expected_count is not None and actual_count != int(expected_count):
+          failures.append(f"failed jobs: expected {expected_count}, got {actual_count}")
+      expected_candidates = bool(expected.get("has_revert_candidates"))
+      actual_candidates = bool(results.get("candidates"))
+      if actual_candidates != expected_candidates:
+          failures.append(
+              f"revert candidates: expected {expected_candidates}, got {actual_candidates}")
+      expected_force = bool(expected.get("force_accept_expected"))
+      actual_force = bool((results.get("metadata") or {}).get(
+          "force_accept_recommended"))
+      if actual_force != expected_force:
+          failures.append(
+              f"force accept: expected {expected_force}, got {actual_force}")
+      expected_phase = expected.get("expected_phase")
+      rows = autodl.get("rows") or []
+      actual_phase = rows[0].get("phase") if rows else None
+      if expected_phase and actual_phase != expected_phase:
+          failures.append(f"phase: expected {expected_phase}, got {actual_phase}")
+      if failures:
+          return (False, "; ".join(failures))
+      return (True, f"Expected outcomes matched: {actual_count} failed jobs, "
+                    f"candidates={actual_candidates}, force_accept={actual_force}, "
+                    f"phase={actual_phase}")
+
+  - name: analysis_quality
+    description: |
+      LLM judge to assess root cause analysis depth, PR correlation accuracy,
+      and overall report quality. Uses only YAML results and HTML report, not
+      the full output tree (which includes the snapshot and exceeds context).
+    prompt: |
+      You are evaluating the output of an OCP payload analysis skill. The skill
+      analyzes failed blocking jobs in an OpenShift CI payload using a local
+      snapshot, traces root causes by examining Prow job logs and artifacts,
+      correlates failures with candidate PRs using a weighted scoring rubric,
+      and produces a comprehensive HTML report with revert recommendations.
+
+      Review the skill's YAML results file:
+
+      {% for path, content in outputs.files.items() if path.endswith('.yaml') and 'payload-results' in path %}
+      ### {{ path }}
+
+      {{ content }}
+      {% endfor %}
+
+      Review the skill's HTML report:
+
+      {% for path, content in outputs.files.items() if path.endswith('-summary.html') %}
+      ### {{ path }}
+
+      {{ content }}
+      {% endfor %}
+
+      Expected outcomes for this test case:
+
+      {{ annotations }}
+
+      Evaluate the YAML results file and HTML report on a 1-5 scale:
+
+      Score 1: Analysis is missing or completely wrong — no root causes identified,
+               no PR correlation, report is empty or broken.
+      Score 2: Superficial analysis — root causes restate symptoms without explanation
+               (e.g., "node not ready" without tracing WHY), PR correlations are
+               absent or random, report structure is incomplete.
+      Score 3: Adequate analysis — root causes go one level deeper than symptoms,
+               some PR correlations are plausible, report has required sections
+               but may have gaps in coverage or depth.
+      Score 4: Good analysis — root causes cite specific error messages from logs,
+               PR correlations reference actual code/components changed, revert
+               recommendations have clear rationale, report is well-structured.
+      Score 5: Excellent analysis — root causes traced to specific code paths with
+               log excerpts, PR correlations demonstrate causal reasoning (not just
+               temporal coincidence), rubric scores are itemized, report is
+               comprehensive and immediately actionable.
+
+      Key evaluation criteria:
+      - Does the number of failing jobs approximately match expected_failed_job_count?
+      - Are the root cause summaries specific (citing error messages, code paths)
+        rather than generic (just restating test names)?
+      - If expected_candidates are listed in annotations, are they identified with
+        evidence-based rationale?
+      - Does the HTML report contain actionable information?
+
+  - name: revert_scoring_accuracy
+    description: |
+      LLM judge to assess whether the confidence scoring rubric was correctly
+      applied and expected revert candidates identified. Uses only YAML results
+      and autodl JSON, not the full output tree.
+    prompt: |
+      You are evaluating whether the payload analysis skill correctly identified
+      revert candidates and applied its confidence scoring rubric.
+
+      The rubric awards points for:
+      - New failure mode: +30 (this specific failure wasn't present in prior payloads)
+      - Component exclusivity: +10 to +30 (fewer PRs touching same component = higher)
+      - Error message match: +40 (errors directly reference code changed by the PR)
+      - Multi-job correlation: +10 (same PR is candidate for multiple failed jobs)
+      - Presubmit coverage gap: +10 (failing scenario not in PR's presubmit tests)
+      - Single candidate: +10 (only one PR touches the affected component)
+      Maximum: 130 (capped at 100). Revert threshold: >= 85.
+
+      Review the YAML results file:
+
+      {% for path, content in outputs.files.items() if path.endswith('.yaml') and 'payload-results' in path %}
+      ### {{ path }}
+
+      {{ content }}
+      {% endfor %}
+
+      Review the autodl JSON file:
+
+      {% for path, content in outputs.files.items() if path.endswith('-autodl.json') %}
+      ### {{ path }}
+
+      {{ content }}
+      {% endfor %}
+
+      Expected outcomes for this test case:
+
+      {{ annotations }}
+
+      If expected_candidates are listed in annotations, those PRs should be
+      identified with confidence >= min_confidence and linked to the
+      expected_failing_jobs. If expected_candidates is empty, no false positive
+      revert recommendations should appear.
+
+      Evaluate on a 1-5 scale:
+
+      Score 1: No scoring applied, or scores are arbitrary. Expected revert
+               candidates (from annotations) are completely missed.
+      Score 2: Some expected candidates identified but confidence scores are way
+               off (>20 points from expected) or key failing job linkages are
+               missing.
+      Score 3: All expected high-confidence candidates (min_confidence >= 85) are
+               identified above threshold, but scores may be off by 10-20 points
+               or rubric components not itemized.
+      Score 4: All expected candidates identified with scores within 10 points of
+               expected_confidence. Rubric correctly applied with itemized
+               breakdown. Most expected failing jobs correctly linked.
+               Infrastructure failures correctly distinguished from product
+               failures.
+      Score 5: All expected candidates identified with scores within 5 points of
+               expected_confidence. Rubric meticulously applied — each component
+               score justified with specific evidence. All expected failing jobs
+               correctly linked. No false positive revert recommendations for
+               unrelated PRs. Cross-job correlation signal clearly documented.
+
+thresholds:
+  output_files_exist:
+    min_pass_rate: 1.0
+  yaml_results_valid:
+    min_pass_rate: 1.0
+  json_data_valid:
+    min_pass_rate: 1.0
+  html_report_structure:
+    min_pass_rate: 1.0
+  analysis_quality:
+    min_mean: 3.5
+  revert_scoring_accuracy:
+    min_mean: 3.0
+  required_skill_invocations:
+    min_pass_rate: 1.0

--- a/plugins/ci/evals/eval-payload-analysis-codex.yaml
+++ b/plugins/ci/evals/eval-payload-analysis-codex.yaml
@@ -453,3 +453,5 @@ thresholds:
     min_mean: 3.0
   required_skill_invocations:
     min_pass_rate: 1.0
+  expected_outcomes:
+    min_pass_rate: 1.0

--- a/plugins/ci/evals/scripts/extract-payload-analysis-snapshots.sh
+++ b/plugins/ci/evals/scripts/extract-payload-analysis-snapshots.sh
@@ -11,11 +11,16 @@ set -euo pipefail
 
 REPO_URL="https://github.com/stbenjam/historical-payload-data.git"
 REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
-BASE_DIR="$REPO_ROOT/.work/eval-payload-snapshots"
+BASE_DIR="${HISTORICAL_PAYLOAD_DATA_DIR:-$REPO_ROOT/.work/eval-payload-snapshots}"
 
 tag="${1:-}"
 
-if [[ -d "$BASE_DIR/.git" ]]; then
+if [[ -n "${HISTORICAL_PAYLOAD_DATA_DIR:-}" ]]; then
+    if [[ ! -d "$BASE_DIR" ]]; then
+        echo "Historical payload data directory not found: $BASE_DIR" >&2
+        exit 1
+    fi
+elif [[ -d "$BASE_DIR/.git" ]]; then
     echo "Snapshot repo already cloned at $BASE_DIR" >&2
     git -C "$BASE_DIR" pull --ff-only >&2 2>/dev/null || true
 else
@@ -24,10 +29,27 @@ else
 fi
 
 if [[ -n "$tag" ]]; then
-    if [[ -d "$BASE_DIR/$tag" ]]; then
-        echo "$BASE_DIR/$tag"
-    else
+    tag_dir="$BASE_DIR/$tag"
+    if [[ ! -d "$tag_dir" ]]; then
         echo "Snapshot not found for tag: $tag" >&2
+        exit 1
+    fi
+
+    if [[ -f "$tag_dir/summary.json" ]]; then
+        echo "$tag_dir"
+        exit 0
+    fi
+
+    mapfile -t summaries < <(find "$tag_dir" -mindepth 2 -maxdepth 4 \
+        -type f -name summary.json -print | sort)
+    if [[ ${#summaries[@]} -eq 1 ]]; then
+        dirname "${summaries[0]}"
+    elif [[ ${#summaries[@]} -eq 0 ]]; then
+        echo "Snapshot has no summary.json: $tag_dir" >&2
+        exit 1
+    else
+        echo "Snapshot is ambiguous; multiple summary.json files found under $tag_dir:" >&2
+        printf '  %s\n' "${summaries[@]}" >&2
         exit 1
     fi
 else

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -77,7 +77,12 @@ The first argument is a **full payload tag** (e.g., `4.22.0-0.nightly-2026-02-25
 
 The analysis requires a local snapshot produced by the `payload-snapshot` skill. Search for an existing snapshot in this order:
 
-1. **Explicit `--snapshot-dir DIR`**: If provided, look for `DIR/summary.json`. If not found, exit with an error.
+1. **Explicit `--snapshot-dir DIR`**: First look for `DIR/summary.json`. Historical
+   archives may wrap a snapshot as `<tag>/<version>/<stream>/summary.json`; when
+   the direct file is absent, search below `DIR` for `summary.json`. If exactly
+   one match exists, use its parent as `SNAPSHOT_DIR`. If there are no matches,
+   exit with a missing-snapshot error. If there is more than one, exit with an
+   ambiguity error and list the matches rather than choosing one silently.
 2. **Current directory**: Check if `./summary.json` exists and its `payload_tag` field matches the requested tag.
 3. **Standard relative path**: Check if `payload/<version>/<stream>/summary.json` exists and matches the tag.
 
@@ -781,6 +786,13 @@ Before presenting, confirm that **all Step 4 investigation subagents and the Ste
 4. **Every affirmative root cause appears as a scored `candidates[]` entry** — including causal CI-infrastructure changes, even when `failure_type: infra`.
 
 If any check fails, fix it before presenting.
+
+When `AGENT_EVAL_OUTPUT_DIR` is set, copy the three verified canonical files
+there **after** the self-check so an external evaluation harness can collect
+them. Resolve a relative value beneath `$OUTPUT_DIR`; use an absolute value as
+given. Create the destination directory if needed, and leave the canonical
+files at `$OUTPUT_DIR` in place. Copy only the three exact filenames checked
+above, never a glob.
 
 Then tell the user:
    - Path to each saved file


### PR DESCRIPTION
## What changed

- add a Codex/Luna `xhigh` payload-analysis eval configuration with deterministic and Opus judges
- expose the full CI plugin so Codex can load payload-analysis's dependent skills
- support existing historical payload archives and their wrapped snapshot layout
- copy verified canonical artifacts to an optional harness collection directory
- correct case 011's expected failed-job count from one to two

## Why

This makes the existing payload-analysis eval runnable with Codex both locally and through Harbor. Historical payload data remains external and can be mounted read-only rather than copied into each trial.

The Harbor execution path depends on opendatahub-io/agent-eval-harness#183,
including the follow-up image fix in `c63bab5`.

## Validation

- agent-eval config validation: valid, 8 judges
- archive resolver against case 011 historical data: passed
- `bash -n plugins/ci/evals/scripts/extract-payload-analysis-snapshots.sh`
- `git diff --check`
- `make lint`: A+, 0 errors, 0 warnings
- native Codex, Luna `xhigh`, case 011: execution passed; 5/6 deterministic
  judges passed; Opus scored analysis quality 2/5 and revert accuracy 1/5. The
  outcome judge correctly caught a model false positive: `openshift/release#78936`
  was recommended although the frozen case expects no revert candidate. Three
  configured regressions were reported.
- Harbor/Podman Codex, Luna `xhigh`, case 011: all 6 deterministic judges passed;
  Opus judges scored 4/5 and 4/5; all configured thresholds passed; no infra or
  trial errors. Runtime was 10m45s with a 4 GiB cap and read-only historical
  payload mount.
