### PR TITLE
fix(images): handle missing ubi.repo gracefully in container builds

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS 
 ENV ART_DNF_WRAPPER_POLICY=append
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
-RUN rm /etc/yum.repos.d/ubi.repo && \
+RUN rm -f /etc/yum.repos.d/ubi.repo && \
     dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
@@ -10,7 +10,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 
 # Copy external rpm repos into the image, and tell the ART wrapper to append them
 ENV ART_DNF_WRAPPER_POLICY=append
-RUN rm /etc/yum.repos.d/ubi.repo
+RUN rm -f /etc/yum.repos.d/ubi.repo
 COPY images/repos/*.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
 

--- a/images/Dockerfile.nested-podman
+++ b/images/Dockerfile.nested-podman
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS 
 ENV ART_DNF_WRAPPER_POLICY=append
 COPY images/repos/claude-code-latest.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-claude-code /etc/pki/rpm-gpg/
-RUN rm /etc/yum.repos.d/ubi.repo && \
+RUN rm -f /etc/yum.repos.d/ubi.repo && \
     dnf install -y --disablerepo='*-ppc64le' --disablerepo='*-s390x' --disablerepo='claude-code' --enablerepo='claude-code-latest' claude-code && \
     dnf clean all
 
@@ -10,7 +10,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
 
 # Copy external rpm repos into the image, and tell the ART wrapper to append them
 ENV ART_DNF_WRAPPER_POLICY=append
-RUN rm /etc/yum.repos.d/ubi.repo
+RUN rm -f /etc/yum.repos.d/ubi.repo
 COPY images/repos/*.repo /etc/yum.repos.d/
 COPY images/repos/RPM-GPG-KEY-* /etc/pki/rpm-gpg/
 


### PR DESCRIPTION
This PR fixes a pre-existing container image build failure where both `claude-ai-helpers` and `claude-ai-helpers-no-podman` hit an error during the Dockerfile RUN step: `rm: cannot remove '/etc/yum.repos.d/ubi.repo': No such file or directory` because that file does not exist in the base image. By switching to `rm -f`, the step succeeds regardless of whether the file exists or has already been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building an image with the latest Claude Code installation.

* **Bug Fixes**
  * Improved container image builds by making repository cleanup resilient when the repository file is already absent.
  * Applied the same reliability improvement to nested Podman image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->