### PR TITLE
Post project status update after dashboard sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -563,7 +563,7 @@
       "name": "nid-team",
       "source": "./plugins/nid-team",
       "description": "Development and workflow tools for the Network Ingress & DNS team",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "development",
       "keywords": [
         "nid",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1863,7 +1863,7 @@ footer a { color: var(--primary); }
     {
       "name": "nid-team",
       "description": "NI&D team PR triage and review workflow tools",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/nid-team/.claude-plugin/plugin.json
+++ b/plugins/nid-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nid-team",
   "description": "NI&D team PR triage and review workflow tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
@@ -706,7 +706,6 @@ import json, sys
 deterministic = {$(printf '"%s",' "${!REPO_TO_AREA[@]}")}
 data = json.load(sys.stdin)
 area_count = 0
-priority_count = 0
 for item in data['items']:
     if item.get('content', {}).get('type') != 'PullRequest':
         continue
@@ -716,3 +715,28 @@ for item in data['items']:
         area_count += 1
 print(f'  Items without Area (need AI classification): {area_count}')
 "
+
+# --- Post project status update ---
+echo ""
+echo "--- Posting project status update ---"
+
+TOTAL_ADDED=$((SHARED_ADDED + BUGPR_ADDED + DOCS_ADDED))
+STATUS_BODY="**Dashboard synced** ($(date '+%b %-d, %Y %H:%M %Z'))"
+if [ "$TOTAL_ADDED" -gt 0 ]; then
+    STATUS_BODY="$STATUS_BODY\n- $TOTAL_ADDED PRs added ($SHARED_ADDED shared, $BUGPR_ADDED bug, $DOCS_ADDED docs)"
+fi
+STATUS_BODY="$STATUS_BODY\n- $ITEM_COUNT total items on board"
+
+ESCAPED_BODY=$(printf "$STATUS_BODY" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+
+gh api graphql -f query="
+  mutation {
+    createProjectV2StatusUpdate(input: {
+      projectId: \"$PROJECT_ID\"
+      status: ON_TRACK
+      body: $ESCAPED_BODY
+    }) {
+      statusUpdate { id }
+    }
+  }
+" > /dev/null 2>&1 && echo "  Status update posted" || echo "  WARNING: Failed to post status update"

--- a/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
@@ -727,7 +727,7 @@ if [ "$TOTAL_ADDED" -gt 0 ]; then
 fi
 STATUS_BODY="$STATUS_BODY\n- $ITEM_COUNT total items on board"
 
-ESCAPED_BODY=$(printf "$STATUS_BODY" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+ESCAPED_BODY=$(printf "%b\n" "$STATUS_BODY" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
 
 gh api graphql -f query="
   mutation {


### PR DESCRIPTION
## Summary

- Adds a GitHub Project status update at the end of each `sync-dashboard.sh` run
- Uses the `createProjectV2StatusUpdate` GraphQL mutation with `ON_TRACK` status
- Status body includes timestamp, PRs added breakdown, and total board item count

## Test plan

- [x] Verified the GraphQL mutation works against the project (created and deleted a test update)
- [ ] Run `/nid-team:sync-pr-dashboard` and verify the status update appears on the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-sync status reporting with the synchronization time, newly added pull request count, and total board items.
  * Added clear success or warning messages based on the dashboard update result.
  * Dashboard syncs now report an `ON_TRACK` project status when completed successfully.

* **Bug Fixes**
  * Removed an unused reporting value from the final area-count summary.

* **Chores**
  * Updated the plugin version to 0.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->