### PR TITLE
fix(jira): construct ADF directly for Status Summary field updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -225,16 +225,16 @@ Using the pre-gathered data, apply the activity analysis rules from `activity-an
 
 ##### c. Generate Status Update
 
-Format using `ryg_field` template:
+Format the status content using the `ryg_field` structure. The content will be written as ADF (Atlassian Document Format) — a nested `bulletList` with three top-level items: Color Status, Status summary (with nested bullet items), and Risks (with nested bullet items).
 
-```
+**Logical structure:**
+
 - Color Status: {Red, Yellow, Green}
   - Status summary:
     - Thing 1 that happened since last week
     - Thing 2 that happened since last week
   - Risks:
     - Risk 1 (or "None at this time")
-```
 
 ##### d. Present to User for Review
 
@@ -290,7 +290,65 @@ Options:
 
 ##### e. Update the Issue
 
-Use `editJiraIssue` with `contentFormat: "markdown"` to set `customfield_10814` (Status Summary) to the formatted status text.
+Use `editJiraIssue` with `contentFormat: "adf"` to set `customfield_10814` (Status Summary). This field requires an ADF (Atlassian Document Format) JSON document — passing a plain string (even with `contentFormat: "markdown"`) will fail with `"Operation value must be an Atlassian Document"`.
+
+Construct the ADF as a `bulletList` with three top-level `listItem` nodes. The Status summary and Risks items each contain a nested `bulletList` for their sub-items.
+
+```javascript
+editJiraIssue(
+  cloudId: "redhat.atlassian.net",
+  issueIdOrKey: "{ISSUE_KEY}",
+  contentFormat: "adf",
+  fields: {
+    "customfield_10814": {
+      "type": "doc",
+      "version": 1,
+      "content": [{
+        "type": "bulletList",
+        "content": [
+          // Item 1: Color Status
+          {"type": "listItem", "content": [
+            {"type": "paragraph", "content": [
+              {"type": "text", "text": "Color Status: Green"}
+            ]}
+          ]},
+          // Item 2: Status summary with nested bullets
+          {"type": "listItem", "content": [
+            {"type": "paragraph", "content": [
+              {"type": "text", "text": "Status summary:"}
+            ]},
+            {"type": "bulletList", "content": [
+              {"type": "listItem", "content": [
+                {"type": "paragraph", "content": [
+                  {"type": "text", "text": "Achievement or progress item 1"}
+                ]}
+              ]},
+              {"type": "listItem", "content": [
+                {"type": "paragraph", "content": [
+                  {"type": "text", "text": "Achievement or progress item 2"}
+                ]}
+              ]}
+            ]}
+          ]},
+          // Item 3: Risks with nested bullets
+          {"type": "listItem", "content": [
+            {"type": "paragraph", "content": [
+              {"type": "text", "text": "Risks:"}
+            ]},
+            {"type": "bulletList", "content": [
+              {"type": "listItem", "content": [
+                {"type": "paragraph", "content": [
+                  {"type": "text", "text": "None at this time"}
+                ]}
+              ]}
+            ]}
+          ]}
+        ]
+      }]
+    }
+  }
+)
+```
 
 Display confirmation: `✓ Updated {ISSUE-KEY}`
 
@@ -507,7 +565,7 @@ The Python script (`gather_status_data.py`) handles efficient batch data collect
 
 5. **Format Validation**:
    - Validate Status Summary text format before updating
-   - Ensure markdown bullet point structure is maintained
+   - Ensure the value is a valid ADF JSON document with the correct `bulletList`/`listItem` structure
    - Check for Color Status line (Red/Yellow/Green)
    - Warn if format doesn't match expected template
 

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -287,6 +287,7 @@ Options:
 - Ask: "Please provide your updated status text (maintain the bullet format):"
 - Validate format (should start with `- Color Status:`)
 - Show modified version and ask for final confirmation
+- Convert the modified text to an ADF JSON document before updating (same `bulletList`/`listItem` structure as auto-generated updates)
 
 ##### e. Update the Issue
 

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -230,11 +230,11 @@ Format the status content using the `ryg_field` structure. The content will be w
 **Logical structure:**
 
 - Color Status: {Red, Yellow, Green}
-  - Status summary:
-    - Thing 1 that happened since last week
-    - Thing 2 that happened since last week
-  - Risks:
-    - Risk 1 (or "None at this time")
+- Status summary:
+  - Thing 1 that happened since last week
+  - Thing 2 that happened since last week
+- Risks:
+  - Risk 1 (or "None at this time")
 
 ##### d. Present to User for Review
 

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -225,7 +225,7 @@ Using the pre-gathered data, apply the activity analysis rules from `activity-an
 
 ##### c. Generate Status Update
 
-Format the status content using the `ryg_field` structure. The content will be written as ADF (Atlassian Document Format) — a nested `bulletList` with three top-level items: Color Status, Status summary (with nested bullet items), and Risks (with nested bullet items).
+Format the status content using the `ryg_field` structure. The content will be written as ADF (Atlassian Document Format) — a nested `bulletList` with three top-level items: Color Status, Status summary (with nested bullet items), and Risks (with nested bullet items). The gathered `issue.current_status_summary` value is the raw ADF document, not Markdown; use the summary script's rendered text only for review, and retain the raw document when project-specific guidance requires history preservation.
 
 **Logical structure:**
 
@@ -291,7 +291,7 @@ Options:
 
 ##### e. Update the Issue
 
-Use `editJiraIssue` with `contentFormat: "adf"` to set `customfield_10814` (Status Summary). This field requires an ADF (Atlassian Document Format) JSON document — passing a plain string (even with `contentFormat: "markdown"`) will fail with `"Operation value must be an Atlassian Document"`.
+Use `editJiraIssue` with `contentFormat: "adf"` to set `customfield_10814` (Status Summary). This field requires an ADF (Atlassian Document Format) JSON document — passing a plain string (even with `contentFormat: "markdown"`) will fail with `"Operation value must be an Atlassian Document"`. For ARO, follow the loaded project guidance: prepend the new ADF entry nodes to `issue.current_status_summary.content`; do not replace history with the rendered display text.
 
 Construct the ADF as a `bulletList` with three top-level `listItem` nodes. The Status summary and Risks items each contain a nested `bulletList` for their sub-items.
 
@@ -419,7 +419,7 @@ The Python script (`gather_status_data.py`) handles efficient batch data collect
     "summary": "string",
     "status": "string",
     "assignee": {"email": "string", "name": "string"},
-    "current_status_summary": "string|null",
+    "current_status_summary": "ADF document object|null",
     "last_status_summary_update": "string|null"
   },
   "descendants": {

--- a/plugins/jira/reference/aro-hcp.md
+++ b/plugins/jira/reference/aro-hcp.md
@@ -123,12 +123,14 @@ The ARO project uses a **prepend** model for Status Summary — new updates are 
 
 ### Updating the Status Summary Field
 
+The Status Summary field (`customfield_10814`) is a rich text field that stores content as Atlassian Document Format (ADF). The `contentFormat: "markdown"` parameter does **not** auto-convert custom field values — it only applies to standard fields like `description`. Always construct ADF JSON directly and use `contentFormat: "adf"`.
+
 When writing to `customfield_10814`:
 
 1. Read the current value first (from the pre-gathered JSON `issue.current_status_summary`)
 2. Generate the new entry (date + color + bullets)
-3. Prepend the new entry to the existing text with a blank line separator
-4. Write the combined text back via `editJiraIssue`
+3. Prepend the new entry to the existing content
+4. Construct the full ADF document and write via `editJiraIssue`
 
 If the current value is null/empty, just write the new entry.
 
@@ -137,10 +139,21 @@ If the current value is null/empty, just write the new entry.
 editJiraIssue(
   cloudId: "redhat.atlassian.net",
   issueIdOrKey: "{ISSUE_KEY}",
-  fields: {"customfield_10814": "{new_entry}\n\n{existing_text}"},
-  contentFormat: "markdown"
+  contentFormat: "adf",
+  fields: {
+    "customfield_10814": {
+      "type": "doc",
+      "version": 1,
+      "content": [
+        // New entry as bulletList nodes
+        // ... followed by existing content nodes
+      ]
+    }
+  }
 )
 ```
+
+See the [ADF template in formatting.md](../skills/status-analysis/formatting.md#adf-template-for-ryg_field) for the exact node structure.
 
 **IMPORTANT**: If `editJiraIssue` fails with "Field cannot be set" error, the issue is not a Feature or Initiative. Skip it and log a warning — do not fall back to adding a comment.
 

--- a/plugins/jira/reference/aro-hcp.md
+++ b/plugins/jira/reference/aro-hcp.md
@@ -84,7 +84,7 @@ Other active — {N} with activity this week
 
 ### Status Summary Format (ARO-specific)
 
-The ARO project uses a **prepend** model for Status Summary — new updates are added at the top, preserving the history of previous updates. This differs from the default OCPSTRAT behavior which replaces the entire field.
+The ARO project uses a **prepend** model for Status Summary — new updates are added at the top, preserving the history of previous updates. This differs from the default OCPSTRAT behavior which replaces the entire field. The field value and its history are ADF nodes, not plaintext or Markdown.
 
 **Format for each update entry:**
 
@@ -93,33 +93,45 @@ The ARO project uses a **prepend** model for Status Summary — new updates are 
 - {Current state bullet 1 — what happened this week}
 - {Current state bullet 2}
 - Risks: {risk or "None at this time"}
+```
 
+This is the logical content shown in Jira. Write each entry as the following ADF nodes (shown for a Green update on 2026-06-05):
+
+```json
+[
+  {
+    "type": "paragraph",
+    "content": [{"type": "text", "text": "2026-06-05: Color Status: Green"}]
+  },
+  {
+    "type": "bulletList",
+    "content": [
+      {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "ARO-17759 closed; ARO-26913 is in review."}]}]},
+      {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "72% complete (18/25 descendants closed)."}]}]},
+      {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Risks: None at this time"}]}]}
+    ]
+  }
+]
 ```
 
 **Rules:**
-1. **Prepend, don't replace**: New status goes at the top of the existing Status Summary text. Keep all previous entries intact.
+1. **Prepend, don't replace**: Prepend the new entry nodes to the existing ADF document's `content` array. Keep all previous nodes intact; never stringify, render-and-reparse, or nest the existing `doc` inside a new one.
 2. **Date stamp**: Each entry starts with the date in `YYYY-MM-DD` format.
 3. **No duplication**: Only include what changed since the last update. If something was reported last week and hasn't changed, don't repeat it. Focus on: what's new, what moved, what's blocked.
 4. **Concise**: 2-4 bullets per update. One sentence per bullet.
 
-**Example of a Status Summary field after 3 weeks:**
+For an existing `issue.current_status_summary` ADF document, construct the value to write as follows:
 
-```text
-2026-06-05: Color Status: Green
-- ARO-17759 (Frontend Private KAS) closed. ARO-26913 (api.listening wiring) in review.
-- 72% complete (18/25 descendants closed).
-- Risks: None at this time
-
-2026-05-29: Color Status: Yellow
-- Blocked on HyperShift PR for private KAS topology support.
-- ARO-26777 (CS changes for private KAS) started.
-- Risks: Dependency on OCPSTRAT-3193 (HyperShift upstream)
-
-2026-05-22: Color Status: Green
-- Swift networking rollout complete across all prod regions.
-- E2E tests for private KV cluster merged (PR #4674).
-- Risks: None at this time
+```javascript
+const existingNodes = issue.current_status_summary?.content ?? [];
+const nextStatusSummary = {
+  type: "doc",
+  version: 1,
+  content: [...newEntryNodes, ...existingNodes]
+};
 ```
+
+When no value exists, use `content: newEntryNodes`. `newEntryNodes` is the dated paragraph and bullet list shown above. This yields a newest-first multi-week history without losing prior entries.
 
 ### Updating the Status Summary Field
 
@@ -127,9 +139,9 @@ The Status Summary field (`customfield_10814`) is a rich text field that stores 
 
 When writing to `customfield_10814`:
 
-1. Read the current value first (from the pre-gathered JSON `issue.current_status_summary`)
+1. Read the current raw ADF value first (from the pre-gathered JSON `issue.current_status_summary`)
 2. Generate the new entry (date + color + bullets)
-3. Prepend the new entry to the existing content
+3. Prepend the new entry nodes to the existing document's `content` nodes
 4. Construct the full ADF document and write via `editJiraIssue`
 
 If the current value is null/empty, just write the new entry.
@@ -145,8 +157,8 @@ editJiraIssue(
       "type": "doc",
       "version": 1,
       "content": [
-        // New entry as bulletList nodes
-        // ... followed by existing content nodes
+        // ...newEntryNodes,
+        // ...existingStatusSummary.content
       ]
     }
   }

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -355,18 +355,20 @@ Follow `formatting.md` to generate output based on `output_format`:
 **Metrics:** X/Y issues complete (Z%)
 ```
 
-**Note**: When posting via `addCommentToJiraIssue`, always include `contentFormat: "markdown"`.
+**Note**: When posting via `addCommentToJiraIssue`, always include `contentFormat: "markdown"`. When updating the Status Summary field via `editJiraIssue`, also use `contentFormat: "markdown"` with standard markdown syntax — the tool converts it to ADF.
 
 **For `ryg_field` (update-weekly-status)**:
 
+```markdown
+- Color Status: {Red, Yellow, Green}
+  - Status summary:
+    - Thing 1 that happened since last week
+    - Thing 2 that happened since last week
+  - Risks:
+    - Risk 1 (or "None at this time")
 ```
-* Color Status: {Red, Yellow, Green}
- * Status summary:
-     ** Thing 1 that happened since last week
-     ** Thing 2 that happened since last week
- * Risks:
-     ** Risk 1 (or "None at this time")
-```
+
+**Note**: Use standard markdown bullet syntax (`-`). Do NOT use Jira wiki syntax (`*`, `**`) — it is not recognized by the markdown-to-ADF converter used by the Atlassian MCP plugin.
 
 **For `feature_markdown` (generate-feature-updates)**:
 

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -355,20 +355,20 @@ Follow `formatting.md` to generate output based on `output_format`:
 **Metrics:** X/Y issues complete (Z%)
 ```
 
-**Note**: When posting via `addCommentToJiraIssue`, always include `contentFormat: "markdown"`. When updating the Status Summary field via `editJiraIssue`, also use `contentFormat: "markdown"` with standard markdown syntax — the tool converts it to ADF.
+**Note**: When posting via `addCommentToJiraIssue`, always include `contentFormat: "markdown"`.
 
 **For `ryg_field` (update-weekly-status)**:
 
-```markdown
+The Status Summary field (`customfield_10814`) requires an ADF JSON document — `contentFormat: "markdown"` does **not** auto-convert custom field values. Always construct ADF directly and use `contentFormat: "adf"`. See the [ADF template in formatting.md](formatting.md#adf-template-for-ryg_field) for the exact structure.
+
+**Logical content structure:**
+
 - Color Status: {Red, Yellow, Green}
   - Status summary:
     - Thing 1 that happened since last week
     - Thing 2 that happened since last week
   - Risks:
     - Risk 1 (or "None at this time")
-```
-
-**Note**: Use standard markdown bullet syntax (`-`). Do NOT use Jira wiki syntax (`*`, `**`) — it is not recognized by the markdown-to-ADF converter used by the Atlassian MCP plugin.
 
 **For `feature_markdown` (generate-feature-updates)**:
 
@@ -432,7 +432,7 @@ All modules should handle these error cases:
 
 | Field Name | Field ID | Type | Purpose |
 |---|---|---|---|
-| Status Summary | `customfield_10814` | String | Stores R/Y/G status text for update-weekly-status |
+| Status Summary | `customfield_10814` | ADF (rich text) | Stores R/Y/G status as ADF JSON; requires `contentFormat: "adf"` |
 
 ## Prerequisites
 

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -364,11 +364,11 @@ The Status Summary field (`customfield_10814`) requires an ADF JSON document —
 **Logical content structure:**
 
 - Color Status: {Red, Yellow, Green}
-  - Status summary:
-    - Thing 1 that happened since last week
-    - Thing 2 that happened since last week
-  - Risks:
-    - Risk 1 (or "None at this time")
+- Status summary:
+  - Thing 1 that happened since last week
+  - Thing 2 that happened since last week
+- Risks:
+  - Risk 1 (or "None at this time")
 
 **For `feature_markdown` (generate-feature-updates)**:
 

--- a/plugins/jira/skills/status-analysis/data-collection.md
+++ b/plugins/jira/skills/status-analysis/data-collection.md
@@ -115,7 +115,7 @@ For each issue in `manifest.issues`, read its detailed data:
       "email": "user@example.com",
       "name": "User Name"
     },
-    "current_status_summary": "* Color Status: Green\n * Status summary:\n     ** Work in progress\n * Risks:\n     ** None",
+    "current_status_summary": "- Color Status: Green\n  - Status summary:\n    - Work in progress\n  - Risks:\n    - None",
     "last_status_summary_update": "2026-01-28T10:30:00Z"
   },
   "descendants": {

--- a/plugins/jira/skills/status-analysis/data-collection.md
+++ b/plugins/jira/skills/status-analysis/data-collection.md
@@ -115,7 +115,20 @@ For each issue in `manifest.issues`, read its detailed data:
       "email": "user@example.com",
       "name": "User Name"
     },
-    "current_status_summary": "- Color Status: Green\n  - Status summary:\n    - Work in progress\n  - Risks:\n    - None",
+    "current_status_summary": {
+      "type": "doc",
+      "version": 1,
+      "content": [{
+        "type": "bulletList",
+        "content": [{
+          "type": "listItem",
+          "content": [{
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "Color Status: Green"}]
+          }]
+        }]
+      }]
+    },
     "last_status_summary_update": "2026-01-28T10:30:00Z"
   },
   "descendants": {
@@ -215,7 +228,7 @@ For each issue in `manifest.issues`, read its detailed data:
 | `issue.summary` | Issue title for display |
 | `issue.status` | Current status |
 | `issue.assignee` | For attribution and display |
-| `issue.current_status_summary` | Existing status text (may need update) |
+| `issue.current_status_summary` | Existing raw ADF document or `null`; render to text only for display, and retain its `content` nodes when prepending ARO history |
 | `issue.last_status_summary_update` | For "recently updated" warnings |
 | `descendants.total` | Total child issue count |
 | `descendants.by_status` | Status breakdown for metrics |

--- a/plugins/jira/skills/status-analysis/formatting.md
+++ b/plugins/jira/skills/status-analysis/formatting.md
@@ -137,22 +137,24 @@ Used by `/jira:update-weekly-status` to update the Status Summary custom field.
 
 ### Template
 
-```
-* Color Status: {Red|Yellow|Green}
- * Status summary:
-     ** {achievement-or-progress-1}
-     ** {achievement-or-progress-2}
-     ** {achievement-or-progress-N}
- * Risks:
-     ** {risk-1-or-"None at this time"}
-```
+This field requires ADF (Atlassian Document Format) JSON. The logical structure is a three-item bullet list:
+
+- Color Status: {Red|Yellow|Green}
+  - Status summary:
+    - {achievement-or-progress-1}
+    - {achievement-or-progress-2}
+    - {achievement-or-progress-N}
+  - Risks:
+    - {risk-1-or-"None at this time"}
+
+**ADF representation:** A `bulletList` with three `listItem` nodes. The "Status summary" and "Risks" items each contain a nested `bulletList` for their sub-items. See the [ADF template](#adf-template-for-ryg_field) below for the exact JSON structure.
 
 ### Formatting Rules
 
-1. **Exact spacing matters**: The field may have specific formatting requirements
-   - Top-level bullet: `* ` (asterisk + space)
-   - Second-level: ` * ` (space + asterisk + space)
-   - Third-level: `     ** ` (5 spaces + double asterisk + space)
+1. **Always construct ADF JSON directly**: The `customfield_10814` field requires an ADF document. Passing a plain string (even with `contentFormat: "markdown"`) will fail with `"Operation value must be an Atlassian Document"`.
+   - Use `contentFormat: "adf"` on the `editJiraIssue` call
+   - Pass the field value as a JSON object with `type: "doc"`, `version: 1`, and nested `bulletList`/`listItem`/`paragraph` nodes
+   - **Do NOT** pass plain text strings, markdown, or Jira wiki syntax — the API rejects all non-ADF values
 
 2. **Color Status line**: Always first, exactly one of Red/Yellow/Green
 
@@ -191,40 +193,36 @@ Used by `/jira:update-weekly-status` to update the Status Summary custom field.
 
 ### Example Outputs
 
-**Green Status**:
-```
-* Color Status: Green
- * Status summary:
-     ** PR #456 merged adding OAuth2 token validation with comprehensive unit tests
-     ** AUTH-102 completed: token refresh mechanism implemented and tested
-     ** AUTH-103 in progress: session handling refactor, draft PR submitted for review
- * Risks:
-     ** None at this time
-```
+The examples below show the **logical content** (what the user sees in Jira). The actual value passed to `editJiraIssue` must be the ADF JSON equivalent — see the [ADF template](#adf-template-for-ryg_field).
 
-**Yellow Status**:
-```
-* Color Status: Yellow
- * Status summary:
-     ** UI-201 design review completed, implementation 60% complete
-     ** AUTH-103 draft PR open but awaiting review capacity from team
-     ** Made progress on auth integration but slower than planned
- * Risks:
-     ** Review bandwidth may delay merge to next week
-     ** Upstream API deprecation notice received - may need refactor
-```
+**Green Status** (content):
+- Color Status: Green
+  - Status summary:
+    - PR #456 merged adding OAuth2 token validation with comprehensive unit tests
+    - AUTH-102 completed: token refresh mechanism implemented and tested
+    - AUTH-103 in progress: session handling refactor, draft PR submitted for review
+  - Risks:
+    - None at this time
 
-**Red Status**:
-```
-* Color Status: Red
- * Status summary:
-     ** AUTH-104 blocked on Azure subscription approval for 2 weeks
-     ** No PRs merged this period due to blocker
-     ** Escalated to infrastructure team, awaiting response
- * Risks:
-     ** Deadline at risk if subscription not approved by Friday
-     ** May need to descope Azure AD integration from initial release
-```
+**Yellow Status** (content):
+- Color Status: Yellow
+  - Status summary:
+    - UI-201 design review completed, implementation 60% complete
+    - AUTH-103 draft PR open but awaiting review capacity from team
+    - Made progress on auth integration but slower than planned
+  - Risks:
+    - Review bandwidth may delay merge to next week
+    - Upstream API deprecation notice received - may need refactor
+
+**Red Status** (content):
+- Color Status: Red
+  - Status summary:
+    - AUTH-104 blocked on Azure subscription approval for 2 weeks
+    - No PRs merged this period due to blocker
+    - Escalated to infrastructure team, awaiting response
+  - Risks:
+    - Deadline at risk if subscription not approved by Friday
+    - May need to descope Azure AD integration from initial release
 
 ## Format: feature_markdown
 
@@ -415,33 +413,52 @@ def format_markdown_comment(issue_data, config):
 
 ### For ryg_field format
 
+Build the ADF JSON document directly. Each text item becomes a `listItem` containing a `paragraph` with a `text` node.
+
 ```python
 def format_ryg_field(issue_data, config):
-    output = []
     health = issue_data.analysis.health.capitalize()  # Green, Yellow, Red
 
-    output.append(f"* Color Status: {health}")
-    output.append(" * Status summary:")
+    # Combine achievements and in-progress items (limit to top 3+2)
+    summary_texts = []
+    for achievement in issue_data.analysis.achievements[:3]:
+        summary_texts.append(achievement.description)
+    for progress in issue_data.analysis.in_progress[:2]:
+        summary_texts.append(progress.description)
 
-    # Combine achievements and in-progress items
-    items = []
-    for achievement in issue_data.analysis.achievements[:3]:  # Limit to top 3
-        items.append(achievement.description)
-    for progress in issue_data.analysis.in_progress[:2]:  # Add up to 2 in-progress
-        items.append(progress.description)
-
-    for item in items:
-        output.append(f"     ** {item}")
-
-    # Risks section
-    output.append(" * Risks:")
+    # Risk texts
+    risk_texts = []
     if issue_data.analysis.risks:
-        for risk in issue_data.analysis.risks[:2]:  # Limit to top 2
-            output.append(f"     ** {risk.description}")
+        for risk in issue_data.analysis.risks[:2]:
+            risk_texts.append(risk.description)
     else:
-        output.append("     ** None at this time")
+        risk_texts.append("None at this time")
 
-    return "\n".join(output)
+    # Helper: create a listItem with a single text paragraph
+    def text_item(text):
+        return {"type": "listItem", "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+        ]}
+
+    # Helper: create a listItem with a label paragraph + nested bullet list
+    def section_item(label, child_texts):
+        return {"type": "listItem", "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": label}]},
+            {"type": "bulletList", "content": [text_item(t) for t in child_texts]}
+        ]}
+
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [{
+            "type": "bulletList",
+            "content": [
+                text_item(f"Color Status: {health}"),
+                section_item("Status summary:", summary_texts),
+                section_item("Risks:", risk_texts),
+            ]
+        }]
+    }
 ```
 
 ### For feature_markdown format
@@ -524,12 +541,12 @@ Before outputting, validate the formatted text:
 
 ### ryg_field validation
 
-- [ ] Starts with `* Color Status:` line
-- [ ] Color is exactly one of: Red, Yellow, Green
-- [ ] Status summary section present with at least one item
-- [ ] Risks section present (even if "None at this time")
-- [ ] Indentation matches expected format
-- [ ] No empty bullet points
+- [ ] Value is a valid ADF JSON document with `type: "doc"` and `version: 1`
+- [ ] Top-level content is a single `bulletList` with exactly 3 `listItem` nodes
+- [ ] First item text starts with `Color Status:` followed by exactly one of: Red, Yellow, Green
+- [ ] Second item has text `Status summary:` with a nested `bulletList` containing at least one item
+- [ ] Third item has text `Risks:` with a nested `bulletList` (at least "None at this time")
+- [ ] No empty text nodes
 
 ## Escaping Special Characters
 
@@ -539,7 +556,59 @@ Backslash escaping (`\*`, `\[`, etc.) is unreliable in Jira Cloud's markdown ren
 
 ### Status Summary Field
 
-The Status Summary field (`customfield_10814`) is a plain string:
-- Avoid HTML tags
-- Keep text plain and readable
-- No special escaping needed
+The Status Summary field (`customfield_10814`) is a rich text field that stores content as Atlassian Document Format (ADF). The `contentFormat: "markdown"` parameter on `editJiraIssue` does **not** auto-convert custom field values — it only applies to standard fields like `description`. Passing a plain string for this field will fail with `"Operation value must be an Atlassian Document"`.
+
+**Always construct ADF JSON directly** and use `contentFormat: "adf"`.
+
+#### ADF template for ryg_field
+
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [{
+    "type": "bulletList",
+    "content": [
+      {
+        "type": "listItem",
+        "content": [{"type": "paragraph", "content": [
+          {"type": "text", "text": "Color Status: Green"}
+        ]}]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {"type": "paragraph", "content": [
+            {"type": "text", "text": "Status summary:"}
+          ]},
+          {"type": "bulletList", "content": [
+            {"type": "listItem", "content": [{"type": "paragraph", "content": [
+              {"type": "text", "text": "Item 1 text here"}
+            ]}]},
+            {"type": "listItem", "content": [{"type": "paragraph", "content": [
+              {"type": "text", "text": "Item 2 text here"}
+            ]}]}
+          ]}
+        ]
+      },
+      {
+        "type": "listItem",
+        "content": [
+          {"type": "paragraph", "content": [
+            {"type": "text", "text": "Risks:"}
+          ]},
+          {"type": "bulletList", "content": [
+            {"type": "listItem", "content": [{"type": "paragraph", "content": [
+              {"type": "text", "text": "None at this time"}
+            ]}]}
+          ]}
+        ]
+      }
+    ]
+  }]
+}
+```
+
+Each status summary bullet and each risk bullet is a `listItem` containing a `paragraph` with a `text` node. Add or remove `listItem` entries in the nested `bulletList` arrays as needed.
+
+**Do NOT** pass plain strings, markdown, Jira wiki syntax (`*`, `**`, `h2.`, etc.), or raw HTML as the field value.

--- a/plugins/jira/skills/status-analysis/formatting.md
+++ b/plugins/jira/skills/status-analysis/formatting.md
@@ -425,6 +425,8 @@ def format_ryg_field(issue_data, config):
         summary_texts.append(achievement.description)
     for progress in issue_data.analysis.in_progress[:2]:
         summary_texts.append(progress.description)
+    if not summary_texts:
+        summary_texts.append("No status updates this period")
 
     # Risk texts
     risk_texts = []
@@ -509,8 +511,10 @@ def status_color_changed_in_range(issue_data):
     for entry in issue_data.changelog_in_range:
         for item in entry.get("items", []):
             if item.get("field") == "Status Summary":
-                old_color = parse_color_status(item.get("fromString", ""))
-                new_color = parse_color_status(item.get("toString", ""))
+                old_value = item.get("from", "")
+                new_value = item.get("to", "")
+                old_color = parse_color_status(old_value if isinstance(old_value, str) else "")
+                new_color = parse_color_status(new_value if isinstance(new_value, str) else "")
                 if old_color != new_color:
                     return True
     return False

--- a/plugins/jira/skills/status-analysis/scripts/adf.py
+++ b/plugins/jira/skills/status-analysis/scripts/adf.py
@@ -1,0 +1,36 @@
+"""Helpers for consuming Atlassian Document Format values."""
+
+from typing import Any
+
+
+def adf_to_text(node: Any) -> str:
+    """Return a readable plain-text rendering of an ADF document or text value."""
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return str(node)
+
+    parts: list[str] = []
+    node_type = node.get("type")
+    if node_type == "text":
+        text = node.get("text", "")
+        for mark in node.get("marks", []):
+            if mark.get("type") == "link":
+                href = mark.get("attrs", {}).get("href", "")
+                if href and href != text:
+                    text = f"{text} ({href})"
+        parts.append(text)
+    elif node_type in ("inlineCard", "blockCard", "embedCard"):
+        url = node.get("attrs", {}).get("url", "")
+        if url:
+            parts.append(url)
+
+    for child in node.get("content", []):
+        parts.append(adf_to_text(child))
+
+    separator = "\n" if node_type in {
+        "doc", "paragraph", "heading", "bulletList", "orderedList", "listItem", "blockquote"
+    } else ""
+    return separator.join(parts)

--- a/plugins/jira/skills/status-analysis/scripts/gather_status_data.py
+++ b/plugins/jira/skills/status-analysis/scripts/gather_status_data.py
@@ -38,40 +38,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any, Set
 from urllib.parse import urlparse
 
-
-# NOTE: _adf_to_text is duplicated from fetch_jira_issue.py and must be kept in sync.
-def _adf_to_text(node: Any) -> str:
-    """Convert an Atlassian Document Format (ADF) node to plain text.
-
-    API v3 returns description and comment bodies as ADF dicts instead of
-    plain strings.  This recursively extracts the text content.
-    """
-    if node is None:
-        return ""
-    if isinstance(node, str):
-        return node
-    if not isinstance(node, dict):
-        return str(node)
-    parts: List[str] = []
-    node_type = node.get("type")
-    if node_type == "text":
-        text = node.get("text", "")
-        for mark in node.get("marks", []):
-            if mark.get("type") == "link":
-                href = mark.get("attrs", {}).get("href", "")
-                if href and href != text:
-                    text = f"{text} ({href})"
-        parts.append(text)
-    elif node_type in ("inlineCard", "blockCard", "embedCard"):
-        # Smart Links store URL in attrs.url
-        url = node.get("attrs", {}).get("url", "")
-        if url:
-            parts.append(url)
-    for child in node.get("content", []):
-        parts.append(_adf_to_text(child))
-    sep = "\n" if node.get("type") in ("doc", "paragraph", "heading", "bulletList",
-                                        "orderedList", "listItem", "blockquote") else ""
-    return sep.join(parts)
+from adf import adf_to_text as _adf_to_text
 
 
 # Configure logging

--- a/plugins/jira/skills/status-analysis/scripts/summarize_issue.py
+++ b/plugins/jira/skills/status-analysis/scripts/summarize_issue.py
@@ -21,6 +21,8 @@ import glob
 import os
 import sys
 
+from adf import adf_to_text
+
 
 def pr_author(pr: dict) -> str:
     """Extract author name from a PR's commit or review data."""
@@ -96,7 +98,8 @@ def summarize(path: str, date_start: str | None = None) -> None:
     print(f"Status: {issue['status']}")
     assignee = issue["assignee"]
     print(f"Assignee: {assignee['name']} ({assignee['email']})")
-    print(f"Current Status Summary: {issue.get('current_status_summary') or 'None'}")
+    current_status_summary = adf_to_text(issue.get("current_status_summary"))
+    print(f"Current Status Summary: {current_status_summary or 'None'}")
     print(f"Last Status Summary Update: {issue.get('last_status_summary_update') or 'None'}")
     print()
 

--- a/plugins/jira/skills/status-analysis/scripts/test_adf.py
+++ b/plugins/jira/skills/status-analysis/scripts/test_adf.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Tests for ADF rendering used by status-analysis helper scripts."""
+
+import unittest
+
+from adf import adf_to_text
+
+
+class AdfToTextTests(unittest.TestCase):
+    def test_renders_nested_status_summary(self) -> None:
+        document = {
+            "type": "doc",
+            "version": 1,
+            "content": [{
+                "type": "bulletList",
+                "content": [{
+                    "type": "listItem",
+                    "content": [{
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Color Status: Green"}],
+                    }],
+                }],
+            }],
+        }
+
+        self.assertIn("Color Status: Green", adf_to_text(document))
+
+    def test_preserves_legacy_text_values(self) -> None:
+        self.assertEqual(adf_to_text("Color Status: Yellow"), "Color Status: Yellow")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/jira/skills/status-analysis/scripts/triage_issues.py
+++ b/plugins/jira/skills/status-analysis/scripts/triage_issues.py
@@ -15,10 +15,14 @@ import json
 import glob
 import os
 import sys
+from typing import Any
+
+from adf import adf_to_text
 
 
-def parse_color(text: str | None) -> str | None:
+def parse_color(value: Any) -> str | None:
     """Extract Red/Yellow/Green from status summary text."""
+    text = adf_to_text(value)
     if not text:
         return None
     # Handle both "* Color Status: Green" and "{color:#d04437}Red{color}"
@@ -108,7 +112,7 @@ def triage(data_dir: str) -> tuple[list[dict], list[dict]]:
             "status_changes": len(status_changes),
             "completion": desc.get("completion_pct", 0),
             "total_desc": desc.get("total", 0),
-            "status_summary_excerpt": (status_summary or "")[:200],
+            "status_summary_excerpt": adf_to_text(status_summary)[:200],
         }
 
         if has_activity:


### PR DESCRIPTION
## Summary

- The `customfield_10814` (Status Summary) field requires an Atlassian Document Format (ADF) JSON document — `contentFormat: "markdown"` on `editJiraIssue` does **not** auto-convert custom field values to ADF (it only applies to standard fields like `description`), causing the API to reject with `"Operation value must be an Atlassian Document"`
- Replace the markdown-string approach with direct ADF JSON construction using `bulletList`/`listItem`/`paragraph` nodes, and set `contentFormat: "adf"` on the `editJiraIssue` call
- Update the command template (Step c), update step (Step e), formatting rules, pseudocode, examples, validation checklist, and field documentation across both `update-weekly-status.md` and `formatting.md`

## What changed

### `plugins/jira/commands/update-weekly-status.md`
- **Step c (Generate Status Update)**: Replaced markdown code block with logical structure description noting ADF is required
- **Step e (Update the Issue)**: Changed from `contentFormat: "markdown"` with plain string to `contentFormat: "adf"` with full ADF JSON example
- **Format Validation**: Changed from "ensure markdown bullets" to "ensure valid ADF JSON document"

### `plugins/jira/skills/status-analysis/formatting.md`
- **Template section**: Replaced markdown-conversion instructions with ADF-first guidance
- **Formatting rules**: Rule #1 now says "always construct ADF JSON directly" with explanation of the `contentFormat: "markdown"` limitation
- **Example outputs**: Kept as logical content reference, removed markdown code fences
- **Pseudocode**: Rewrote `format_ryg_field()` to return an ADF JSON object instead of a markdown string
- **Validation checklist**: Updated to validate ADF structure (doc type, bulletList with 3 items, nested lists)
- **Status Summary Field section**: Replaced "preferred: markdown, fallback: ADF" with clear statement that ADF is always required, plus a complete reusable ADF template with anchor `#adf-template-for-ryg_field`

## Test plan

- [x] `make lint` passes (A+, 0 errors, 0 warnings)
- [x] Verified fix at runtime: ran `/jira:update-weekly-status OCPSTRAT rteague@redhat.com` and successfully updated 9 issues using ADF JSON — all 9 `editJiraIssue` calls succeeded
- [x] Confirmed the previous approach (`contentFormat: "markdown"` with plain string) fails with `"Operation value must be an Atlassian Document"` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Jira status updates and summaries using structured Atlassian Document Format (ADF) rich text.
  * Added nested bullet-list formatting, validation rules, fallback handling, and guidance for preserving existing status content.
  * Updated status analysis examples to use standard Markdown bullets.
  * Expanded issue creation support for risk and spike issue types.
  * Clarified pull request nudging behavior and removed outdated identification details.
* **Chores**
  * Updated the Jira plugin to version 0.9.5.
  * Updated the nid-team plugin to version 0.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->