### PR TITLE
`prow-agent-eval` new eval format

### DIFF
--- a/evals/review-responder/review-responder-eval.yaml
+++ b/evals/review-responder/review-responder-eval.yaml
@@ -7,10 +7,25 @@ collect:
   bot_replies: true
   comment_map: true
 judges:
+  # Legacy Go prow-agent-eval judges (name-only; ignored by prow-agent-eval-python)
   - name: expected_files_changed
   - name: reply_posted
   - name: scope_creep_declined
   - name: no_secrets
+
+  # prow-agent-eval-python harness judges
+  - name: expected_files_changed_py
+    module: prow_agent_eval.judges
+    function: check_expected_files_changed
+  - name: reply_posted_py
+    module: prow_agent_eval.judges
+    function: check_reply_posted
+  - name: scope_creep_declined_py
+    module: prow_agent_eval.judges
+    function: check_scope_creep_declined
+  - name: no_secrets_py
+    module: prow_agent_eval.judges
+    function: check_no_secrets
 thresholds:
   no_secrets:
     min_pass_rate: 1.0

--- a/evals/review-responder/review-responder-eval.yaml
+++ b/evals/review-responder/review-responder-eval.yaml
@@ -29,3 +29,5 @@ judges:
 thresholds:
   no_secrets:
     min_pass_rate: 1.0
+  no_secrets_py:
+    min_pass_rate: 1.0

--- a/evals/trt-agentic-solve/solve-eval.yaml
+++ b/evals/trt-agentic-solve/solve-eval.yaml
@@ -8,6 +8,7 @@ collect:
   test_result: true
   expected_branch_diff: true
 judges:
+  # Legacy Go prow-agent-eval judges (name-only; ignored by prow-agent-eval-python)
   - name: branch_created
   - name: pr_exists
   - name: build_passed
@@ -16,4 +17,30 @@ judges:
   - name: pr_description_exists
   - name: diff_size_ratio
   - name: function_overlap
+
+  # prow-agent-eval-python harness judges
+  - name: branch_created_py
+    module: prow_agent_eval.judges
+    function: check_branch_created
+  - name: pr_exists_py
+    module: prow_agent_eval.judges
+    function: check_pr_exists
+  - name: build_passed_py
+    module: prow_agent_eval.judges
+    function: check_build_passed
+  - name: test_passed_py
+    module: prow_agent_eval.judges
+    function: check_test_passed
+  - name: file_overlap_py
+    module: prow_agent_eval.judges
+    function: check_file_overlap
+  - name: pr_description_exists_py
+    module: prow_agent_eval.judges
+    function: check_pr_description_exists
+  - name: diff_size_ratio_py
+    module: prow_agent_eval.judges
+    function: check_diff_size_ratio
+  - name: function_overlap_py
+    module: prow_agent_eval.judges
+    function: check_function_overlap
 thresholds: {}


### PR DESCRIPTION
Migrating `prow-agent-eval` to python so it can become a wrapper of `agent-eval-harness`. We need to migrate the config for this. Legacy stuff remains for now until the migration is complete. Config should support both modes for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded evaluation coverage with additional judging criteria for solution quality.
  * Added Python-based evaluation checks alongside existing checks for more consistent results.
  * Added a dedicated secret-detection check that requires complete compliance.
  * Clarified evaluation configuration to improve transparency and reliability of automated scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->