### PR TITLE
nid-team: make PR dashboard scripts work on bash 3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -563,7 +563,7 @@
       "name": "nid-team",
       "source": "./plugins/nid-team",
       "description": "Development and workflow tools for the Network Ingress & DNS team",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "category": "development",
       "keywords": [
         "nid",

--- a/plugins/nid-team/.claude-plugin/plugin.json
+++ b/plugins/nid-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nid-team",
   "description": "NI&D team PR triage and review workflow tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/nid-team/scripts/pr-dashboard/config.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/config.sh
@@ -5,45 +5,47 @@
 # =============================================================================
 
 # =============================================================================
-# TEAM CONFIGURATION
-# Update these when team membership changes.
+# BASH COMPATIBILITY
+# Associative arrays (declare -A) require bash 4+, but macOS ships bash 3.2.
+# We define team/area data once as pipe-delimited tables (below) and expose it
+# through accessor functions. When bash 4+ is available we build associative
+# arrays for O(1) lookups; on bash 3.2 the accessors fall back to scanning the
+# tables. Either way the sourcing scripts call the same functions.
 # =============================================================================
+if [ "${BASH_VERSINFO:-0}" -ge 4 ]; then
+    HAVE_ASSOC=1
+else
+    HAVE_ASSOC=0
+fi
 
-TEAM_USERNAMES=("candita" "gcs278" "Miciah" "rfredette" "Thealisyed" "grzpiotrowski" "rikatz" "davidesalerno" "bentito" "jcmoraisjr" "aswinsuryan" "melvinjoseph86" "rhamini3")
+# =============================================================================
+# TEAM CONFIGURATION
+# Single source of truth: one row per member as  login|display|fullname
+#   login    — GitHub login
+#   display  — short display name (PR Author column)
+#   fullname — Primary/Secondary Reviewer dropdown label
+# Update this table when team membership changes.
+# =============================================================================
+TEAM_DATA="\
+candita|Candace H.|Candace Holman
+gcs278|Grant S.|Grant Spence
+Miciah|Miciah M.|Miciah Masters
+rfredette|Ryan F.|Ryan Fredette
+Thealisyed|Ali S.|Ali Syed
+grzpiotrowski|Grzegorz P.|Grzegorz Piotrowski
+rikatz|Ricardo K.|Ricardo Katz
+davidesalerno|Davide S.|Davide Salerno
+bentito|Brett T.|Brett Tofel
+jcmoraisjr|Joao M.|Joao Morais
+aswinsuryan|Aswin S.|Aswin Suryanarayanan
+melvinjoseph86|Melvin J.|Melvin Joseph
+rhamini3|Ishmam A.|Ishmam Amin"
 
-# GitHub login → short display name (used for PR Author column)
-declare -A USERNAME_TO_DISPLAY=(
-    ["candita"]="Candace H."
-    ["gcs278"]="Grant S."
-    ["Miciah"]="Miciah M."
-    ["rfredette"]="Ryan F."
-    ["Thealisyed"]="Ali S."
-    ["grzpiotrowski"]="Grzegorz P."
-    ["rikatz"]="Ricardo K."
-    ["davidesalerno"]="Davide S."
-    ["bentito"]="Brett T."
-    ["jcmoraisjr"]="Joao M."
-    ["aswinsuryan"]="Aswin S."
-    ["melvinjoseph86"]="Melvin J."
-    ["rhamini3"]="Ishmam A."
-)
-
-# Full name → GitHub login (used to match Primary/Secondary Reviewer dropdown)
-declare -A FULLNAME_TO_USERNAME=(
-    ["Candace Holman"]="candita"
-    ["Grant Spence"]="gcs278"
-    ["Miciah Masters"]="Miciah"
-    ["Ryan Fredette"]="rfredette"
-    ["Ali Syed"]="Thealisyed"
-    ["Grzegorz Piotrowski"]="grzpiotrowski"
-    ["Ricardo Katz"]="rikatz"
-    ["Davide Salerno"]="davidesalerno"
-    ["Brett Tofel"]="bentito"
-    ["Joao Morais"]="jcmoraisjr"
-    ["Aswin Suryanarayanan"]="aswinsuryan"
-    ["Melvin Joseph"]="melvinjoseph86"
-    ["Ishmam Amin"]="rhamini3"
-)
+# Derive the plain login list (indexed arrays work on all bash versions).
+TEAM_USERNAMES=()
+while IFS='|' read -r _login _disp _full; do
+    [ -n "$_login" ] && TEAM_USERNAMES+=("$_login")
+done <<< "$TEAM_DATA"
 
 BOT_USERNAMES="openshift-bot openshift-cherrypick-robot"
 
@@ -102,21 +104,88 @@ AREA_ALBO="a6184328"
 AREA_ROUTER="667048b1"
 AREA_AI="9f9c29ab"
 
-# Repo → Area mapping (deterministic cases only)
-# Any repo NOT in this map is considered ambiguous and needs AI classification.
-declare -A REPO_TO_AREA=(
-    ["openshift/external-dns"]="$AREA_EXTERNAL_DNS"
-    ["openshift/external-dns-operator"]="$AREA_EXTERNAL_DNS"
-    ["openshift/aws-load-balancer-operator"]="$AREA_ALBO"
-    ["openshift/aws-load-balancer-controller"]="$AREA_ALBO"
-    ["openshift/cluster-dns-operator"]="$AREA_DNS"
-    ["openshift/coredns"]="$AREA_DNS"
-    ["openshift/coredns-ocp-dnsnameresolver"]="$AREA_DNS"
-    ["openshift-eng/ai-helpers"]="$AREA_AI"
-    ["openshift/openshift-mcp-server"]="$AREA_AI"
-)
+# Repo → Area mapping (deterministic cases only), as  repo|area_option_id
+# Any repo NOT in this table is considered ambiguous and needs AI classification.
+REPO_AREA_DATA="\
+openshift/external-dns|$AREA_EXTERNAL_DNS
+openshift/external-dns-operator|$AREA_EXTERNAL_DNS
+openshift/aws-load-balancer-operator|$AREA_ALBO
+openshift/aws-load-balancer-controller|$AREA_ALBO
+openshift/cluster-dns-operator|$AREA_DNS
+openshift/coredns|$AREA_DNS
+openshift/coredns-ocp-dnsnameresolver|$AREA_DNS
+openshift-eng/ai-helpers|$AREA_AI
+openshift/openshift-mcp-server|$AREA_AI"
 
-# Helper: check if a repo is ambiguous (not in REPO_TO_AREA)
-is_ambiguous_repo() {
-    [ -z "${REPO_TO_AREA[$1]+x}" ]
-}
+# =============================================================================
+# LOOKUP ACCESSORS
+# On bash 4+ these use associative arrays; on bash 3.2 they scan the tables.
+# =============================================================================
+if [ "$HAVE_ASSOC" = 1 ]; then
+    declare -A _DISPLAY_BY_LOGIN _LOGIN_BY_DISPLAY _LOGIN_BY_FULLNAME _AREA_BY_REPO
+    while IFS='|' read -r _login _disp _full; do
+        [ -n "$_login" ] || continue
+        _DISPLAY_BY_LOGIN["$_login"]="$_disp"
+        _LOGIN_BY_DISPLAY["$_disp"]="$_login"
+        _LOGIN_BY_FULLNAME["$_full"]="$_login"
+    done <<< "$TEAM_DATA"
+    while IFS='|' read -r _repo _area; do
+        [ -n "$_repo" ] || continue
+        _AREA_BY_REPO["$_repo"]="$_area"
+    done <<< "$REPO_AREA_DATA"
+
+    display_name()         { echo "${_DISPLAY_BY_LOGIN[$1]:-$1}"; }
+    login_for_display()    { echo "${_LOGIN_BY_DISPLAY[$1]:-}"; }
+    login_for_fullname()   { echo "${_LOGIN_BY_FULLNAME[$1]:-}"; }
+    area_for_repo()        { echo "${_AREA_BY_REPO[$1]:-}"; }
+    is_ambiguous_repo()    { [ -z "${_AREA_BY_REPO[$1]+x}" ]; }
+    deterministic_repos()  { printf '%s\n' "${!_AREA_BY_REPO[@]}"; }
+else
+    # login → display name (falls back to the login when not a team member)
+    display_name() {
+        local login disp full
+        while IFS='|' read -r login disp full; do
+            [ "$login" = "$1" ] && { echo "$disp"; return; }
+        done <<< "$TEAM_DATA"
+        echo "$1"
+    }
+    # display name → login ("" if not found)
+    login_for_display() {
+        local login disp full
+        while IFS='|' read -r login disp full; do
+            [ "$disp" = "$1" ] && { echo "$login"; return; }
+        done <<< "$TEAM_DATA"
+        echo ""
+    }
+    # full name → login ("" if not found)
+    login_for_fullname() {
+        local login disp full
+        while IFS='|' read -r login disp full; do
+            [ "$full" = "$1" ] && { echo "$login"; return; }
+        done <<< "$TEAM_DATA"
+        echo ""
+    }
+    # repo → area option id ("" if not deterministic)
+    area_for_repo() {
+        local repo area
+        while IFS='|' read -r repo area; do
+            [ "$repo" = "$1" ] && { echo "$area"; return; }
+        done <<< "$REPO_AREA_DATA"
+        echo ""
+    }
+    # true (0) when the repo is not in the deterministic table
+    is_ambiguous_repo() {
+        local repo area
+        while IFS='|' read -r repo area; do
+            [ "$repo" = "$1" ] && return 1
+        done <<< "$REPO_AREA_DATA"
+        return 0
+    }
+    # print each deterministic repo, one per line
+    deterministic_repos() {
+        local repo area
+        while IFS='|' read -r repo area; do
+            [ -n "$repo" ] && echo "$repo"
+        done <<< "$REPO_AREA_DATA"
+    }
+fi

--- a/plugins/nid-team/scripts/pr-dashboard/list-unclassified-areas.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/list-unclassified-areas.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 
 # Build a space-separated string of deterministic repos for Python to parse
-DETERMINISTIC_REPOS=$(printf '%s ' "${!REPO_TO_AREA[@]}")
+DETERMINISTIC_REPOS=$(deterministic_repos | tr '\n' ' ')
 
 echo "Fetching project items..." >&2
 ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 500)

--- a/plugins/nid-team/scripts/pr-dashboard/nudge-prs.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/nudge-prs.sh
@@ -150,10 +150,12 @@ print(f'NUDGE|{age_days}|{created.strftime(\"%b %-d\")}|{days_inactive}|{last_in
 
     IFS='|' read -r _ age_days created_str days_inactive last_info pr_author needs_rebase has_hold has_lgtm has_approved <<< "$result"
 
-    primary_login="${FULLNAME_TO_USERNAME[$primary]:-$primary}"
+    primary_login="$(login_for_fullname "$primary")"
+    [ -z "$primary_login" ] && primary_login="$primary"
     secondary_login=""
     if [ -n "$secondary" ] && [ "$secondary" != "Other" ]; then
-        secondary_login="${FULLNAME_TO_USERNAME[$secondary]:-$secondary}"
+        secondary_login="$(login_for_fullname "$secondary")"
+        [ -z "$secondary_login" ] && secondary_login="$secondary"
     fi
 
     # Build comment

--- a/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
@@ -110,7 +110,7 @@ for item in data['items']:
         continue
     fi
 
-    login="${FULLNAME_TO_USERNAME[$reviewer]:-}"
+    login="$(login_for_fullname "$reviewer")"
     if [ -z "$login" ]; then
         echo "  SKIP: Unknown reviewer name '$reviewer' on $repo#$number"
         continue
@@ -326,7 +326,7 @@ for item in data['items']:
         echo "  SKIP: Could not get author for $repo#$number"
         continue
     fi
-    display="${USERNAME_TO_DISPLAY[$author]:-$author}"
+    display="$(display_name "$author")"
     echo "  SET: $repo#$number → $display"
     if ! gh project item-edit \
         --project-id "$PROJECT_ID" \
@@ -358,19 +358,19 @@ for item in data['items']:
         number = item['content']['number']
         print(f'{item_id}\t{repo}\t{number}')
 " | while IFS=$'\t' read -r item_id repo number; do
-    area_id="${REPO_TO_AREA[$repo]:-}"
+    area_id="$(area_for_repo "$repo")"
     if [ -z "$area_id" ]; then
         continue
     fi
-    area_name=$(case "$area_id" in
-        "$AREA_EXTERNAL_DNS") echo "ExDNS" ;;
-        "$AREA_ALBO") echo "ALBO" ;;
-        "$AREA_DNS") echo "DNS" ;;
-        "$AREA_AI") echo "AI" ;;
-        "$AREA_ROUTER") echo "Router" ;;
-        "$AREA_GWAPI") echo "GWAPI" ;;
-        *) echo "unknown" ;;
-    esac)
+    case "$area_id" in
+        "$AREA_EXTERNAL_DNS") area_name="ExDNS" ;;
+        "$AREA_ALBO") area_name="ALBO" ;;
+        "$AREA_DNS") area_name="DNS" ;;
+        "$AREA_AI") area_name="AI" ;;
+        "$AREA_ROUTER") area_name="Router" ;;
+        "$AREA_GWAPI") area_name="GWAPI" ;;
+        *) area_name="unknown" ;;
+    esac
     echo "  SET: $repo#$number → area $area_name"
     if ! gh project item-edit \
         --project-id "$PROJECT_ID" \
@@ -415,12 +415,7 @@ while IFS='|' read -r item_id repo number pr_author title; do
     # Determine author login - if PR Author is empty, fetch from GitHub
     author_login=""
     if [ -n "$pr_author" ]; then
-        for login in "${!USERNAME_TO_DISPLAY[@]}"; do
-            if [ "${USERNAME_TO_DISPLAY[$login]}" = "$pr_author" ]; then
-                author_login="$login"
-                break
-            fi
-        done
+        author_login="$(login_for_display "$pr_author")"
         # If no match in display names, pr_author might be the raw login
         if [ -z "$author_login" ]; then
             author_login="$pr_author"
@@ -703,7 +698,7 @@ echo "  Bug PRs added (non-team): $BUGPR_ADDED"
 echo "  Docs PRs added: $DOCS_ADDED"
 echo "$ITEMS_JSON" | python3 -c "
 import json, sys
-deterministic = {$(printf '"%s",' "${!REPO_TO_AREA[@]}")}
+deterministic = set('''$(deterministic_repos)'''.split())
 data = json.load(sys.stdin)
 area_count = 0
 for item in data['items']:


### PR DESCRIPTION
## Problem

Running `/nid-team:sync-pr-dashboard` on macOS fails before it does any work:

```
config.sh: line 15: candita: unbound variable
```

`config.sh` uses bash 4+ associative arrays (`declare -A`), but macOS ships `/bin/bash` 3.2. Under 3.2, `["candita"]=...` is parsed as an *arithmetic* subscript, and with `set -u` the bare word `candita` becomes an "unbound variable", aborting the sync.

## Fix

Make the scripts function regardless of which bash they run under:

- **Single source of truth.** Team identity (`login|display|fullname`) and repo→area mappings are now defined once as pipe-delimited tables in `config.sh`.
- **Conditional branching on `BASH_VERSINFO`.** Bash 4+ builds associative arrays for O(1) lookups; bash 3.2 scans the tables. Both paths expose the same accessor functions (`display_name`, `login_for_display`, `login_for_fullname`, `area_for_repo`, `is_ambiguous_repo`, `deterministic_repos`).
- **Callers use accessors.** `sync-dashboard.sh`, `list-unclassified-areas.sh`, and `nudge-prs.sh` call the functions instead of indexing arrays directly.
- **Separate 3.2 parser fix.** Rewrote a `case` inside `$(...)` in `sync-dashboard.sh` as a direct-assignment `case` (bash 3.2 can't parse the former).
- Bumped plugin `0.1.1 → 0.1.2` and synced `marketplace.json`.

## Testing

- `bash -n` passes for all four scripts under bash 3.2.
- Accessors verified under bash 3.2 (`HAVE_ASSOC=0` path): display names, reverse lookups, area mapping, ambiguity check, and deterministic-repo listing all correct.
- Full `sync-dashboard.sh` run completed end-to-end under bash 3.2 (390→393 items, authors/areas/author-types/priorities populated, status update posted).

`make lint` and docs regeneration require Podman, which wasn't available in the dev environment; `make update` synced `marketplace.json` before the Podman-backed docs step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running the PR dashboard with both Bash 3.2 and Bash 4+.
  - Improved team, reviewer, repository, and area lookups across dashboard workflows.
  - Added more consistent handling for deterministic repositories and reviewer assignments.

- **Bug Fixes**
  - Improved compatibility and reliability for environments using older Bash versions.

- **Chores**
  - Updated the plugin version from 0.1.1 to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->