### PR TITLE
fix(jira): harden GitHub PR URL check against substring bypass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "category": "productivity",
       "keywords": [
         "jira",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1490,7 +1490,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "has_readme": true,
       "commands": [
         {
@@ -1645,8 +1645,8 @@ footer a { color: var(--primary); }
         },
         {
           "name": "create",
-          "description": "Create Jira issues — story, bug, epic, feature, initiative, task, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates",
-          "description_html": "Create Jira issues — story, bug, epic, feature, initiative, task, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates",
+          "description": "Create Jira issues — story, bug, epic, feature, initiative, task, risk, spike, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates",
+          "description_html": "Create Jira issues — story, bug, epic, feature, initiative, task, risk, spike, or feature-request — with CNTRLPLANE, OCPBUGS, GCP, HyperShift, ARO, ROSA conventions and type-specific templates",
           "meta": ""
         },
         {
@@ -1863,7 +1863,7 @@ footer a { color: var(--primary); }
     {
       "name": "nid-team",
       "description": "NI&D team PR triage and review workflow tools",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "has_readme": true,
       "commands": [
         {
@@ -1872,7 +1872,7 @@ footer a { color: var(--primary); }
           "description": "Send reminder comments on stale high-priority assigned PRs",
           "description_html": "Send reminder comments on stale high-priority assigned PRs",
           "synopsis": "/nid-team:nudge-prs [--dryrun] [--days 7] [--priority High,Urgent]",
-          "body_html": "Sends automated reminder comments on PRs that are assigned (Status=Assigned), high priority (PR Priority=High or Urgent), and have had no human activity for a configurable number of days. Determines whether the author or reviewer is blocking and @-mentions them in the comment."
+          "body_html": "Sends automated reminder comments on PRs that are assigned (Status=Assigned), high priority (PR Priority=High or Urgent), and have had no human activity for a configurable number of days."
         },
         {
           "name": "sync-pr-dashboard",

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/skills/status-analysis/scripts/gather_status_data.py
+++ b/plugins/jira/skills/status-analysis/scripts/gather_status_data.py
@@ -1071,7 +1071,7 @@ class StatusDataGatherer:
                 obj = link.get("object", {})
                 url = obj.get("url", "")
                 title = obj.get("title", "")
-                if url and "github.com" in url and "/pull" in url:
+                if url and self.PR_PATTERN.fullmatch(url):
                     # Check if the PR title references a descendant issue
                     references_descendant = any(desc_key in title for desc_key in desc_keys)
                     if references_descendant:


### PR DESCRIPTION
## What this PR does / why we need it:

Resolves the open CodeQL alert `py/incomplete-url-substring-sanitization` (CWE-20) in `plugins/jira/skills/status-analysis/scripts/gather_status_data.py`.

The GitHub PR URL check used substring tests (`"github.com" in url and "/pull" in url`), which CodeQL flags because the host is not pinned — a URL like `https://evil.net/github.com/o/r/pull/1` would pass. The fix reuses the class's existing **anchored** `PR_PATTERN` regex (`https?://github\.com/[^/]+/[^/]+/pull[s]?/\d+`), which pins the host immediately after the scheme. This is the same pattern `PRRef.from_url` already relies on, so behavior is unchanged for legitimate URLs while the bypass is closed.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

- One-line change; verified the anchored pattern matches valid PR URLs (`https://github.com/o/r/pull/1`, `.../pulls/12`) and rejects bypass forms (`https://evil.net/github.com/o/r/pull/1`, `https://evil-github.com/o/r/pull/1`).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Jira issue creation guidance now supports `risk` and `spike` issue types.
  - Marketplace metadata reflects Jira version 0.9.4 and NI&D version 0.1.2.

- **Bug Fixes**
  - Improved linked pull request detection by recognizing only valid pull request URLs.
  - Updated NI&D reminder messaging to accurately describe author and reviewer identification behavior.
  - Synchronized Jira version information across marketplace and plugin listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->