### PR TITLE
Use golden file coverage for `case-002` instead of Jaccard overlap and remove legacy configs

### DIFF
--- a/evals/trt-agentic-solve/README.md
+++ b/evals/trt-agentic-solve/README.md
@@ -87,7 +87,8 @@ The eval-judge step produces:
 - `pr_description_exists` — PR description file is non-empty
 
 **Diff-based scoring (0.0-1.0):**
-- `file_overlap` — Jaccard similarity of files changed
+- `file_overlap` — Jaccard similarity of files changed (default cases)
+- `golden_files_covered` — golden-branch file coverage (`case-002` only; extra test files OK)
 - `diff_size_ratio` — ratio of Claude's diff size to expected
 - `function_overlap` — overlap of modified functions/methods
 

--- a/evals/trt-agentic-solve/cases/case-002/annotations.yaml
+++ b/evals/trt-agentic-solve/cases/case-002/annotations.yaml
@@ -4,6 +4,7 @@ original_base_sha: ee2761fdf296c5f0799f7c45dd49e7978464505d
 original_expected_sha: d022605b7d424434817b0df63ec0022da1c0f2b0
 expected_files_changed:
   - pkg/sippyserver/server.go
+golden_files_overlap: true
 description: >
   Fix Sippy UI failing to render when /sippy-ng URL lacks trailing
   slash. Widen PathPrefix match and add a 301 redirect from /sippy-ng

--- a/evals/trt-agentic-solve/solve-eval.yaml
+++ b/evals/trt-agentic-solve/solve-eval.yaml
@@ -8,17 +8,6 @@ collect:
   test_result: true
   expected_branch_diff: true
 judges:
-  # Legacy Go prow-agent-eval judges (name-only; ignored by prow-agent-eval-python)
-  - name: branch_created
-  - name: pr_exists
-  - name: build_passed
-  - name: test_passed
-  - name: file_overlap
-  - name: pr_description_exists
-  - name: diff_size_ratio
-  - name: function_overlap
-
-  # prow-agent-eval-python harness judges
   - name: branch_created_py
     module: prow_agent_eval.judges
     function: check_branch_created
@@ -34,6 +23,11 @@ judges:
   - name: file_overlap_py
     module: prow_agent_eval.judges
     function: check_file_overlap
+    if: not annotations.get('golden_files_overlap')
+  - name: golden_files_covered_py
+    module: prow_agent_eval.judges
+    function: check_golden_files_covered
+    if: annotations.get('golden_files_overlap')
   - name: pr_description_exists_py
     module: prow_agent_eval.judges
     function: check_pr_description_exists

--- a/evals/trt-agentic-solve/solve-eval.yaml
+++ b/evals/trt-agentic-solve/solve-eval.yaml
@@ -37,4 +37,22 @@ judges:
   - name: function_overlap_py
     module: prow_agent_eval.judges
     function: check_function_overlap
-thresholds: {}
+thresholds:
+  branch_created_py:
+    min_pass_rate: 1.0
+  pr_exists_py:
+    min_pass_rate: 1.0
+  build_passed_py:
+    min_pass_rate: 1.0
+  test_passed_py:
+    min_pass_rate: 1.0
+  file_overlap_py:
+    min_pass_rate: 1.0
+  golden_files_covered_py:
+    min_pass_rate: 1.0
+  pr_description_exists_py:
+    min_pass_rate: 1.0
+  diff_size_ratio_py:
+    min_pass_rate: 1.0
+  function_overlap_py:
+    min_pass_rate: 1.0


### PR DESCRIPTION
The expected diff for [case-002](https://redhat.atlassian.net/browse/case-002) doesn't contain tests. Later changes to the workflow make it more likely (and soon, always) add tests. This makes the Jaccard overlap fail due to all the extra files. The golden file check is a simpler way to handle cases like this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified evaluation metrics, including default file overlap and golden-file coverage.
* **Evaluation Improvements**
  * Added support for allowing extra test files in the second evaluation case.
  * Updated judge selection to use the appropriate file-overlap metric based on case configuration.
  * Removed legacy name-only evaluation judges.
  * Added explicit pass-rate requirements for Python-based evaluation judges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->