### PR TITLE
fix(openshift-developer): handle empty OWNERS reviewer lists

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -501,7 +501,7 @@
       "name": "openshift-developer",
       "source": "./plugins/openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "category": "bundle",
       "keywords": [
         "openshift",

--- a/docs/index.html
+++ b/docs/index.html
@@ -2532,7 +2532,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift-developer",
       "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "has_readme": true,
       "commands": [],
       "skills": [

--- a/plugins/openshift-developer/.claude-plugin/plugin.json
+++ b/plugins/openshift-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift-developer",
   "description": "Bundle of curated plugins, skills, and MCP servers useful to any OpenShift engineer",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "author": {
     "name": "github.com/openshift-eng"
   },

--- a/plugins/openshift-developer/skills/address-review-pr/scripts/check_authorized.py
+++ b/plugins/openshift-developer/skills/address-review-pr/scripts/check_authorized.py
@@ -145,19 +145,19 @@ def get_authorized_users(owner: str, repo: str) -> set[str]:
         if HAS_YAML:
             data = yaml.safe_load(content)
             if data:
-                def add_entries(entries: list):
-                    for entry in entries:
+                def add_entries(entries):
+                    for entry in entries or []:
                         if entry not in aliases:
                             authorized.add(entry)
 
-                add_entries(data.get("approvers", []))
-                add_entries(data.get("reviewers", []))
+                add_entries(data.get("approvers"))
+                add_entries(data.get("reviewers"))
 
                 if "filters" in data:
                     for _, config in data["filters"].items():
                         if isinstance(config, dict):
-                            add_entries(config.get("approvers", []))
-                            add_entries(config.get("reviewers", []))
+                            add_entries(config.get("approvers"))
+                            add_entries(config.get("reviewers"))
         else:
             for entry in _parse_simple_yaml_list(content, "approvers"):
                 if entry not in aliases:


### PR DESCRIPTION
## Summary
- Empty `reviewers:` in OWNERS is `None` after PyYAML load, so `check_authorized.py` crashed with exit 2 and skipped all comments (fail-safe).
- Treat missing/empty `approvers`/`reviewers` lists as `[]` so approvers still authorize.
- Bump `openshift-developer` to 1.1.17.

## Test plan
- [ ] `OWNERS` with empty `reviewers:` and `openshift-trt` in `approvers` authorizes `openshift-trt` (exit 0)
- [ ] Gate no longer reports `owners_lookup_error: 'NoneType' object is not iterable`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review authorization checks to handle missing or empty approver and reviewer information without errors.
  * Added consistent handling for review rules that omit approval or reviewer lists.

* **Chores**
  * Updated the OpenShift Developer plugin to version 1.1.17 across the marketplace and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->