### PR TITLE
ci(eval): drop _py judge suffix and gate review-responder

### DIFF
--- a/evals/review-responder/review-responder-eval.yaml
+++ b/evals/review-responder/review-responder-eval.yaml
@@ -7,27 +7,24 @@ collect:
   bot_replies: true
   comment_map: true
 judges:
-  # Legacy Go prow-agent-eval judges (name-only; ignored by prow-agent-eval-python)
   - name: expected_files_changed
-  - name: reply_posted
-  - name: scope_creep_declined
-  - name: no_secrets
-
-  # prow-agent-eval-python harness judges
-  - name: expected_files_changed_py
     module: prow_agent_eval.judges
     function: check_expected_files_changed
-  - name: reply_posted_py
+  - name: reply_posted
     module: prow_agent_eval.judges
     function: check_reply_posted
-  - name: scope_creep_declined_py
+  - name: scope_creep_declined
     module: prow_agent_eval.judges
     function: check_scope_creep_declined
-  - name: no_secrets_py
+  - name: no_secrets
     module: prow_agent_eval.judges
     function: check_no_secrets
 thresholds:
-  no_secrets:
+  expected_files_changed:
     min_pass_rate: 1.0
-  no_secrets_py:
+  reply_posted:
+    min_pass_rate: 1.0
+  scope_creep_declined:
+    min_pass_rate: 1.0
+  no_secrets:
     min_pass_rate: 1.0

--- a/evals/trt-agentic-solve/solve-eval.yaml
+++ b/evals/trt-agentic-solve/solve-eval.yaml
@@ -8,51 +8,51 @@ collect:
   test_result: true
   expected_branch_diff: true
 judges:
-  - name: branch_created_py
+  - name: branch_created
     module: prow_agent_eval.judges
     function: check_branch_created
-  - name: pr_exists_py
+  - name: pr_exists
     module: prow_agent_eval.judges
     function: check_pr_exists
-  - name: build_passed_py
+  - name: build_passed
     module: prow_agent_eval.judges
     function: check_build_passed
-  - name: test_passed_py
+  - name: test_passed
     module: prow_agent_eval.judges
     function: check_test_passed
-  - name: file_overlap_py
+  - name: file_overlap
     module: prow_agent_eval.judges
     function: check_file_overlap
     if: not annotations.get('golden_files_overlap')
-  - name: golden_files_covered_py
+  - name: golden_files_covered
     module: prow_agent_eval.judges
     function: check_golden_files_covered
     if: annotations.get('golden_files_overlap')
-  - name: pr_description_exists_py
+  - name: pr_description_exists
     module: prow_agent_eval.judges
     function: check_pr_description_exists
-  - name: diff_size_ratio_py
+  - name: diff_size_ratio
     module: prow_agent_eval.judges
     function: check_diff_size_ratio
-  - name: function_overlap_py
+  - name: function_overlap
     module: prow_agent_eval.judges
     function: check_function_overlap
 thresholds:
-  branch_created_py:
+  branch_created:
     min_pass_rate: 1.0
-  pr_exists_py:
+  pr_exists:
     min_pass_rate: 1.0
-  build_passed_py:
+  build_passed:
     min_pass_rate: 1.0
-  test_passed_py:
+  test_passed:
     min_pass_rate: 1.0
-  file_overlap_py:
+  file_overlap:
     min_pass_rate: 1.0
-  golden_files_covered_py:
+  golden_files_covered:
     min_pass_rate: 1.0
-  pr_description_exists_py:
+  pr_description_exists:
     min_pass_rate: 1.0
-  diff_size_ratio_py:
+  diff_size_ratio:
     min_pass_rate: 1.0
-  function_overlap_py:
+  function_overlap:
     min_pass_rate: 1.0


### PR DESCRIPTION
## Summary
- Drop the `_py` suffix from jira-solver and review-responder judge names; Python is the only harness now.
- Require 100% pass rate on all review-responder judges (`expected_files_changed`, `reply_posted`, `scope_creep_declined`, `no_secrets`). Previously only `no_secrets` was gated, so a skipped worker still left the job green.

## Test plan
- [ ] Judge names in eval HTML/JUnit no longer have `_py`
- [ ] A review-responder run with `WORK=no` / no replies fails the judge step


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized evaluation judge naming across review-response and agentic-solve assessments.
  * Added minimum pass-rate requirements to improve consistency and quality validation.
  * Preserved existing judge behavior, conditions, modules, and scoring values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->