### PR TITLE
docs: bump plugin versions once per PR

### DIFF
--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -30,13 +30,12 @@ jobs:
           # Fetch the base branch to ensure we have it
           git fetch "$remote" "${{ github.event.pull_request.base.ref }}"
 
-          # Find the merge-base between PR head and base branch
-          base=$(git merge-base "$remote/${{ github.event.pull_request.base.ref }}" HEAD)
+          base_tip="$remote/${{ github.event.pull_request.base.ref }}"
+          merge_base=$(git merge-base "$base_tip" HEAD)
 
-          # Find plugins with changes (excluding README.md, SKILL.md, and OWNERS files)
-          changed_plugins=$(git diff --name-only "$base" HEAD -- 'plugins/' | \
+          # Plugins with PR changes vs merge-base (README.md and OWNERS do not require a bump)
+          changed_plugins=$(git diff --name-only "$merge_base" HEAD -- 'plugins/' | \
             grep -v 'README.md$' | \
-            grep -v 'SKILL.md$' | \
             grep -v 'OWNERS$' | \
             cut -d'/' -f2 | sort -u)
 
@@ -57,8 +56,8 @@ jobs:
             # Get current version
             current=$(jq -r '.version' "$plugin_json")
 
-            # Get base version
-            if git show "$base:$plugin_json" > /tmp/old_plugin.json 2>/dev/null; then
+            # Version on the base branch tip (not merge-base)
+            if git show "$base_tip:$plugin_json" > /tmp/old_plugin.json 2>/dev/null; then
               old=$(jq -r '.version' /tmp/old_plugin.json)
             else
               old="0.0.0"  # New plugin

--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -33,10 +33,9 @@ jobs:
           base_tip="$remote/${{ github.event.pull_request.base.ref }}"
           merge_base=$(git merge-base "$base_tip" HEAD)
 
-          # Plugins with PR changes vs merge-base (README.md and OWNERS do not require a bump)
+          # Commands, skills, hooks, and plugin.json vs merge-base
           changed_plugins=$(git diff --name-only "$merge_base" HEAD -- 'plugins/' | \
-            grep -v 'README.md$' | \
-            grep -v 'OWNERS$' | \
+            grep -E '^plugins/[^/]+/(commands|skills|hooks)/|^plugins/[^/]+/\.claude-plugin/plugin\.json$' | \
             cut -d'/' -f2 | sort -u)
 
           if [ -z "$changed_plugins" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Canonical example: `plugins/hello-world/`
 | Command | When |
 |---------|------|
 | `make lint` | Before every commit — validates structure, format, and marketplace registration |
-| Bump `version` in `plugin.json` | Once per PR when modifying plugin commands or skills (not README-only). Do not bump again for later commits on the same PR. |
+| Bump `version` in `plugin.json` | Once per affected plugin per PR when modifying commands, skills, hooks, or plugin.json (not README.md or OWNERS). Skip if that plugin is already higher than the base branch tip. |
 | `make update` | After version bumps — syncs marketplace.json and regenerates docs |
 
 ## Contributing Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Canonical example: `plugins/hello-world/`
 | Command | When |
 |---------|------|
 | `make lint` | Before every commit — validates structure, format, and marketplace registration |
-| Bump `version` in `plugin.json` | When modifying plugin commands or skills (not README-only changes) |
+| Bump `version` in `plugin.json` | Once per PR when modifying plugin commands or skills (not README-only). Do not bump again for later commits on the same PR. |
 | `make update` | After version bumps — syncs marketplace.json and regenerates docs |
 
 ## Contributing Rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ If your PR modifies plugin code (commands, skills, hooks, or plugin.json), you *
 
 Bump **once per affected plugin per pull request**. Compare each modified plugin's `plugin.json` to the version on the pull request's **base branch tip** (not the merge-base). If this PR already bumped that plugin relative to the base tip, do not bump it again.
 
-CI finds changed plugins from the merge-base (files that only changed on the base branch do not count), then requires each of those versions to be higher than the base branch tip.
+CI finds changed plugins from the merge-base among commands, skills, hooks, and plugin.json (files that only changed on the base branch do not count), then requires each of those versions to be higher than the base branch tip.
 
 ## Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,18 @@ All plugins use [semantic versioning](https://semver.org/):
 - **MINOR** (0.x.0): New commands, skills, hooks, or features
 - **MAJOR** (x.0.0): Breaking changes to existing commands
 
-If your PR modifies plugin code (commands, skills, hooks, or plugin.json), you **must** bump the version in `plugins/<name>/.claude-plugin/plugin.json`. CI will fail if you forget. Documentation-only changes (README.md) do not require version bumps.
+If your PR modifies plugin code (commands, skills, hooks, or plugin.json), you **must** bump the version in that plugin's `plugins/<name>/.claude-plugin/plugin.json`. CI will fail if you forget. README.md and OWNERS changes do not require version bumps.
 
-Bump **once per pull request** — one increment versus the base branch. Do not bump again for follow-up commits on the same PR. CI only checks that the version is higher than the base branch.
+Bump **once per affected plugin per pull request**. Compare each modified plugin's `plugin.json` to the version on the pull request's **base branch tip** (not the merge-base). If this PR already bumped that plugin relative to the base tip, do not bump it again.
+
+CI finds changed plugins from the merge-base (files that only changed on the base branch do not count), then requires each of those versions to be higher than the base branch tip.
 
 ## Development Workflow
 
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Bump the version in `plugin.json` once if modifying plugin code (skip if this PR already bumped it)
+4. For each plugin whose commands, skills, hooks, or plugin.json you changed, bump its version once if it is not already higher than the base branch (skip if this PR already bumped it)
 5. Run `make lint` to validate plugin structure
 6. Run `make update` to regenerate docs
 7. Submit a PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,14 @@ All plugins use [semantic versioning](https://semver.org/):
 
 If your PR modifies plugin code (commands, skills, hooks, or plugin.json), you **must** bump the version in `plugins/<name>/.claude-plugin/plugin.json`. CI will fail if you forget. Documentation-only changes (README.md) do not require version bumps.
 
+Bump **once per pull request** — one increment versus the base branch. Do not bump again for follow-up commits on the same PR. CI only checks that the version is higher than the base branch.
+
 ## Development Workflow
 
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Bump the version in `plugin.json` if modifying plugin code
+4. Bump the version in `plugin.json` once if modifying plugin code (skip if this PR already bumped it)
 5. Run `make lint` to validate plugin structure
 6. Run `make update` to regenerate docs
 7. Submit a PR


### PR DESCRIPTION
Agents were incrementing plugin.json on every skill change in a branch. CI only requires the version to be higher than the base branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded plugin version-bumping guidance to cover changes to commands, skills, hooks, and plugin metadata.
  * Clarified that each affected plugin requires one version bump per pull request.
  * Excluded README-only and OWNERS-only changes from version-bump requirements.
  * Documented validation against the latest version on the base branch.

* **Bug Fixes**
  * Improved automated detection of plugin changes and version-bump requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->