### PR TITLE
nid-team: include PR titles in ASSIGN output, fix <carry> rendering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -563,7 +563,7 @@
       "name": "nid-team",
       "source": "./plugins/nid-team",
       "description": "Development and workflow tools for the Network Ingress & DNS team",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "category": "development",
       "keywords": [
         "nid",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1872,7 +1872,7 @@ footer a { color: var(--primary); }
     {
       "name": "nid-team",
       "description": "NI&D team PR triage and review workflow tools",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/nid-team/.claude-plugin/plugin.json
+++ b/plugins/nid-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nid-team",
   "description": "NI&D team PR triage and review workflow tools",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/nid-team/commands/sync-pr-dashboard.md
+++ b/plugins/nid-team/commands/sync-pr-dashboard.md
@@ -27,7 +27,7 @@ Syncs the NI&D PR Review GitHub Project board (https://github.com/orgs/openshift
 
 ### Step 1: Run the sync script
 
-Run `~/.claude/commands/sync-pr-dashboard.sh` (or `plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh`).
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/pr-dashboard/sync-dashboard.sh`.
 
 This handles:
 - **PR Author** — Populates blank "PR Author" fields with display names
@@ -40,7 +40,7 @@ This handles:
 After the script completes, run the helper script to get structured data on unclassified items:
 
 ```bash
-~/.claude/commands/list-unclassified-areas.sh
+${CLAUDE_PLUGIN_ROOT}/scripts/pr-dashboard/list-unclassified-areas.sh
 ```
 
 This outputs each unclassified item with its item ID, repo, PR number, title, URL, and changed files.
@@ -93,36 +93,12 @@ If there were any reviewer assignments (including "Other") during this sync, als
 - [CIO#1456 — OCPBUGS-98310: Bump sail-operator install library to OSSM 3.4.0](https://github.com/openshift/cluster-ingress-operator/pull/1456) → @rikatz, @rhamini3
 - [CIO#1469 — OCPBUGS-88353: Ensure canary cert matches the default ingress controller's cert](https://github.com/openshift/cluster-ingress-operator/pull/1469) → @bentito
 
-Get the full PR title from the script output or via `gh pr view`. For "Other" assignments, show "→ Other" instead of a username.
+Get the PR title from the JSON-encoded string in each `ASSIGN:` line in the script output (e.g. `"Fix \"carry\" handling"` → `Fix "carry" handling`) — never call `gh pr view` to look up or infer titles. For "Other" assignments, show "→ Other" instead of a username.
 
 After the PR Scrub Assignments, query for PRs that merged without ever being assigned a reviewer. Run:
 
 ```bash
-gh project item-list 28 --owner openshift --format json --limit 500 | python3 -c "
-import json, sys, subprocess, datetime
-data = json.load(sys.stdin)
-one_week_ago = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)
-results = []
-for item in data['items']:
-    c = item.get('content', {})
-    if c.get('type') != 'PullRequest': continue
-    if item.get('primary Reviewer', ''): continue
-    repo = c.get('repository', '')
-    number = c.get('number', '')
-    title = c.get('title', '')
-    r = subprocess.run(['gh','pr','view',str(number),'-R',repo,'--json','state,mergedAt','-q','.state + \" \" + .mergedAt'], capture_output=True, text=True)
-    parts = r.stdout.strip().split(' ', 1)
-    if len(parts) == 2 and parts[0] == 'MERGED':
-        try:
-            merged_at = datetime.datetime.fromisoformat(parts[1].replace('Z', '+00:00'))
-            if merged_at >= one_week_ago:
-                results.append((repo, number, title, merged_at.strftime('%Y-%m-%d')))
-        except: pass
-print(len(results))
-for repo, number, title, date in results:
-    short_repo = repo.split('/')[-1]
-    print(f'{short_repo}#{number}|{repo}|{title}|{date}')
-"
+${CLAUDE_PLUGIN_ROOT}/scripts/pr-dashboard/list-merged-without-reviewer.py
 ```
 
 Output the result as a header and bulleted list with clickable links:

--- a/plugins/nid-team/scripts/pr-dashboard/list-merged-without-reviewer.py
+++ b/plugins/nid-team/scripts/pr-dashboard/list-merged-without-reviewer.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Lists PRs on the NI&D dashboard that merged in the last week without ever
+being assigned a primary reviewer.
+
+Output: first line is the count, then one line per PR:
+  short_repo#number|full_repo|title|merged_date
+
+Usage: list-merged-without-reviewer.py [days]  (default: 7)
+"""
+
+import json
+import subprocess
+import datetime
+import sys
+
+days = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+
+raw = subprocess.run(
+    ["gh", "project", "item-list", "28", "--owner", "openshift",
+     "--format", "json", "--limit", "500"],
+    capture_output=True, text=True, check=True
+)
+data = json.loads(raw.stdout)
+
+results = []
+for item in data["items"]:
+    c = item.get("content", {})
+    if c.get("type") != "PullRequest":
+        continue
+    if item.get("primary Reviewer", "") or item.get("secondary Reviewer", ""):
+        continue
+    repo = c.get("repository", "")
+    number = str(c.get("number", ""))
+    title = c.get("title", "")
+    r = subprocess.run(
+        ["gh", "pr", "view", number, "-R", repo,
+         "--json", "state,mergedAt", "-q", '.state + " " + .mergedAt'],
+        capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        print(f"WARNING: gh pr view failed for {repo}#{number}: {r.stderr.strip()}", file=sys.stderr)
+        continue
+    parts = r.stdout.strip().split(" ", 1)
+    if len(parts) == 2 and parts[0] == "MERGED":
+        try:
+            merged_at = datetime.datetime.fromisoformat(parts[1].replace("Z", "+00:00"))
+            if merged_at >= cutoff:
+                results.append((repo, number, title, merged_at.strftime("%Y-%m-%d")))
+        except Exception as e:
+            print(f"WARNING: could not parse mergedAt for {repo}#{number}: {e}", file=sys.stderr)
+
+print(len(results))
+for repo, number, title, date in results:
+    short_repo = repo.split("/")[-1]
+    print(f"{short_repo}#{number}|{repo}|{title}|{date}")

--- a/plugins/nid-team/scripts/pr-dashboard/list-unclassified-areas.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/list-unclassified-areas.sh
@@ -16,7 +16,7 @@ source "$SCRIPT_DIR/config.sh"
 DETERMINISTIC_REPOS=$(deterministic_repos | tr '\n' ' ')
 
 echo "Fetching project items..." >&2
-ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 500)
+ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 2000)
 
 echo "Fetching changed files..." >&2
 

--- a/plugins/nid-team/scripts/pr-dashboard/nudge-prs.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/nudge-prs.sh
@@ -28,7 +28,7 @@ echo ""
 
 # Fetch project items
 echo "Fetching project items..."
-ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 500)
+ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 2000)
 
 # Build nudge list
 NUDGE_FILE=$(mktemp)

--- a/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
@@ -50,7 +50,7 @@ echo ""
 
 # Fetch all project items
 echo "Fetching project items..."
-ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 500)
+ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 2000)
 ITEM_COUNT=$(echo "$ITEMS_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['items']))")
 echo "Found $ITEM_COUNT items"
 echo ""
@@ -299,7 +299,7 @@ echo ""
 # Re-fetch items if we added new ones
 if [ "$SHARED_ADDED" -gt 0 ] || [ "$BUGPR_ADDED" -gt 0 ] || [ "$DOCS_ADDED" -gt 0 ]; then
     echo "Re-fetching project items after additions..."
-    ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 500)
+    ITEMS_JSON=$(gh project item-list "$PROJECT_NUM" --owner "$OWNER" --format json --limit 2000)
     ITEM_COUNT=$(echo "$ITEMS_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['items']))")
     echo "Now $ITEM_COUNT items"
     echo ""

--- a/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/sync-dashboard.sh
@@ -65,7 +65,7 @@ echo "--- Operation B: Sync Reviewers → Assignees ---"
 # Sync Primary and Secondary Reviewer to GitHub assignees.
 # "Other" means a non-team reviewer is handling it — skip the /assign.
 echo "$ITEMS_JSON" | python3 -c "
-import json, sys
+import json, sys, re
 data = json.load(sys.stdin)
 for item in data['items']:
     if item.get('content', {}).get('type') != 'PullRequest':
@@ -80,11 +80,12 @@ for item in data['items']:
     pr_pri = item.get('pR Priority', '')
     primary = item.get('primary Reviewer', '')
     secondary = item.get('secondary Reviewer', '')
+    title = json.dumps(re.sub(r'<[^>]+>', '', item['content'].get('title', '')).strip())
     if primary:
-        print(f'{primary}|{url}|{repo}|{number}|{assignees}|{item_id}|{status}|{jira_pri}|{pr_pri}')
-    if secondary and secondary != primary and secondary != 'Other':
-        print(f'{secondary}|{url}|{repo}|{number}|{assignees}|{item_id}|{status}|{jira_pri}|{pr_pri}')
-" | while IFS='|' read -r reviewer url repo number assignees item_id status jira_pri pr_pri; do
+        print(f'{primary}|{url}|{repo}|{number}|{assignees}|{item_id}|{status}|{jira_pri}|{pr_pri}|{title}')
+    if secondary and secondary != primary:
+        print(f'{secondary}|{url}|{repo}|{number}|{assignees}|{item_id}|{status}|{jira_pri}|{pr_pri}|{title}')
+" | while IFS='|' read -r reviewer url repo number assignees item_id status jira_pri pr_pri title; do
     # "Other" means a non-team reviewer — set status to Assigned but skip /assign
     if [ "$reviewer" = "Other" ]; then
         if [ "$status" = "New" ]; then
@@ -117,7 +118,7 @@ for item in data['items']:
     fi
     if [[ ",$assignees," == *",$login,"* ]]; then
         if [ "$status" = "New" ] || [ -z "$status" ]; then
-            echo "  ASSIGN: $repo#$number → $login ($reviewer) [already assigned on GH]"
+            echo "  ASSIGN: $repo#$number $title → $login ($reviewer) [already assigned on GH]"
             gh project item-edit --project-id "$PROJECT_ID" --id "$item_id" \
                 --field-id "$FIELD_STATUS" --single-select-option-id "$STATUS_ASSIGNED" 2>/dev/null
             echo "  STATUS: $repo#$number → Assigned"
@@ -140,7 +141,7 @@ for item in data['items']:
         fi
         continue
     fi
-    echo "  ASSIGN: $repo#$number → $login ($reviewer)"
+    echo "  ASSIGN: $repo#$number $title → $login ($reviewer)"
     if ! gh pr comment "$url" --body "/assign @$login"; then
         echo "  ERROR: failed to assign $login on $repo#$number" >&2
     fi
@@ -701,6 +702,7 @@ import json, sys
 deterministic = set('''$(deterministic_repos)'''.split())
 data = json.load(sys.stdin)
 area_count = 0
+priority_count = 0
 for item in data['items']:
     if item.get('content', {}).get('type') != 'PullRequest':
         continue


### PR DESCRIPTION
## Summary

- `sync-dashboard.sh` now strips HTML-like tags (e.g. `<carry>`) from PR titles using a regex and includes the sanitized title in every `ASSIGN:` output line: `ASSIGN: openshift/repo#123 "PR title" → reviewer (Display Name)`
- The `sync-pr-dashboard.md` skill instructions are updated to read titles from those quoted strings — explicitly prohibiting `gh pr view` calls or title inference, which was causing hallucinated PR titles in the PR Scrub Assignments output
- Skill now references the plugin script path directly instead of `~/.claude/commands/sync-pr-dashboard.sh` (a local test script)

## Test plan

- [ ] Run `/nid-team:sync-pr-dashboard` and verify `ASSIGN:` lines in script output include quoted PR titles
- [ ] Verify `<carry>` and similar tags are stripped from titles (e.g. `UPSTREAM: <carry>: ...` renders cleanly)
- [ ] Verify PR Scrub Assignments section uses titles from script output, not fabricated ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard synchronization now identifies recently merged pull requests without primary or secondary reviewers.
  * Review searches support a configurable time window and report matching pull requests more clearly.
  * Reviewer-assignment output and update messages include cleaned pull request titles.

* **Bug Fixes**
  * Improved repository, reviewer, and author information resolution.
  * Updated dashboard guidance to use reliable helper paths and assignment data.

* **Chores**
  * Updated the plugin version to 0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->