### PR TITLE
TRT-2872: `ci:payload-analysis`: correlate detected infra issues with outages in SHIP Status

### DIFF
--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -31,6 +31,7 @@ rules:
       - gopls
       - atlassian
       - openshift-ci-mcp
+      - ship-status
 
   # Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) must be valid, non-empty with valid references
   instruction-file-valid:

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/.mcp.json
+++ b/plugins/ci/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ship-status": {
+      "type": "http",
+      "url": "https://mcp.ship-status.ci.openshift.org/mcp"
+    }
+  }
+}

--- a/plugins/ci/evals/cases/payload-analysis/case-005/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-005/annotations.yaml
@@ -19,3 +19,6 @@ notes: >
   (infra teardown timeout, not a code regression). One high-confidence
   revert candidate: cloud-credential-operator#978 (score 95). The hypershift
   failure should be classified as infrastructure, not product.
+  When SHIP Status read tools are present, Step 6.5 must call
+  get_outages_during over the job window (not live status) and record
+  ship_status on the infra job.

--- a/plugins/ci/evals/cases/payload-analysis/case-005/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-005/annotations.yaml
@@ -12,6 +12,9 @@ expected_candidates:
       - "aws-ovn-upgrade"
       - "gcp-ovn-upgrade"
 
+expected_infra_jobs:
+  - hypershift-e2e-aws
+
 notes: >
   Payload 4.22.0-0.ci-2026-03-31-050515 was rejected with 3 failed blocking
   jobs: aggregated-aws-ovn-upgrade (CCO Progressing invariant violation),

--- a/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
@@ -19,4 +19,6 @@ notes: >
   long as none reaches the revert threshold. Tests parallel subagent
   correlation: the agent must recognize four superficially different job
   failures (serial test failure vs. upgrade stalls) as one shared external
-  cause rather than attributing them to payload PRs.
+  cause rather than attributing them to payload PRs.   When SHIP Status read
+  tools are present, Step 6.5 must call get_outages_during over the job
+  window (not live status).

--- a/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
@@ -6,6 +6,12 @@ payload_completed_at: "2026-05-14T16:40:01Z"
 
 expected_candidates: []
 
+expected_infra_jobs:
+  - e2e-aws-ovn-serial
+  - e2e-aws-upgrade-ovn-single-node
+  - e2e-aws-ovn-upgrade
+  - upgrade-from-stable-4.17-e2e-gcp-ovn-rt-upgrade
+
 notes: >
   External-service infrastructure incident affecting multiple job families.
   All 4 failed blocking jobs (e2e-aws-ovn-serial, e2e-aws-upgrade-ovn-single-node,

--- a/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-010/annotations.yaml
@@ -20,5 +20,6 @@ notes: >
   correlation: the agent must recognize four superficially different job
   failures (serial test failure vs. upgrade stalls) as one shared external
   cause rather than attributing them to payload PRs.   When SHIP Status read
-  tools are present, Step 6.5 must call get_outages_during over the job
-  window (not live status).
+  tools are present, Insights/console.redhat.com is unmapped: call
+  list_components, then record ship_status with action: skipped (reason
+  unmapped plus candidates). Do not call get_outages_during.

--- a/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
@@ -6,6 +6,10 @@ payload_completed_at: "2026-05-15T00:00:06Z"
 
 expected_candidates: []
 
+expected_infra_jobs:
+  - aggregated-aws-ovn-upgrade-5.0-major
+  - aggregated-gcp-ovn-upgrade-5.0-micro
+
 notes: >
   Infrastructure-only failure test case. This payload was rejected with two
   failed blocking jobs (aggregated-aws-ovn-upgrade-5.0-major and

--- a/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
@@ -14,4 +14,6 @@ notes: >
   which is an infrastructure issue unrelated to any code change. The correct
   outcome is zero revert candidates. This case tests the agent's ability to
   classify and dismiss infrastructure issues without producing false positive
-  revert recommendations.
+  revert recommendations.   When SHIP Status read tools are present, Step 6.5
+  must call get_outages_during over the job window (not live status) and
+  record ship_status on the infra jobs.

--- a/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-011/annotations.yaml
@@ -14,6 +14,6 @@ notes: >
   which is an infrastructure issue unrelated to any code change. The correct
   outcome is zero revert candidates. This case tests the agent's ability to
   classify and dismiss infrastructure issues without producing false positive
-  revert recommendations.   When SHIP Status read tools are present, Step 6.5
-  must call get_outages_during over the job window (not live status) and
-  record ship_status on the infra jobs.
+  revert recommendations.   When SHIP Status read tools are present, Insights
+  is unmapped: call list_components, then record ship_status with
+  action: skipped (reason unmapped plus candidates), not a mapped observation.

--- a/plugins/ci/evals/cases/payload-analysis/case-020/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-020/annotations.yaml
@@ -6,6 +6,10 @@ payload_completed_at: "2026-07-29T13:32:49Z"
 
 expected_candidates: []
 
+expected_infra_jobs:
+  - aggregated-gcp-ovn-rt-upgrade-5.0-major
+  - aggregated-hypershift-aks-conformance-5.0
+
 notes: >
   Compound infrastructure and resilience case. The Payload Agent recommended
   openshift/ovn-kubernetes#3298 and openshift/cloud-provider-azure#164 at 90.

--- a/plugins/ci/evals/cases/payload-analysis/case-020/annotations.yaml
+++ b/plugins/ci/evals/cases/payload-analysis/case-020/annotations.yaml
@@ -24,5 +24,8 @@ notes: >
   correlation, not a payload regression), no more than 2 blocking jobs failed,
   and the stream has had no accepted payload for 48.4h (>= the 18h threshold),
   force-accept is the correct recommendation per Step 6.4: force_accept_expected
-  is true. Source Payload Agent analysis:
+  is true.   When SHIP Status read tools are present, Step 6.5 must call
+  get_outages_during over the job window (not live status) against the
+  mapped cloud/Boskos slugs and record ship_status on the infra jobs. Source
+  Payload Agent analysis:
   https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-claude-payload-agent/2082347184044380160/artifacts/claude-payload-agent/openshift-claude-payload-agent/artifacts/payload-analysis-5.0.0-0.nightly-2026-07-29-055948-summary.html

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -205,12 +205,15 @@ judges:
   - name: ship_status_infra_read
     description: |
       Correlation must use get_outages_during over each job's Prow window,
-      not live get_infrastructure_status. Detect the tool from structured
-      tool-call events (not serialized-text search). When it was used,
-      every failure_type: infra job must carry a ship_status dict, and
-      each non-skipped job's window_start/window_end must match a call's
-      start/end. If get_outages_during was not invoked (evals without the
-      public MCP), omitting ship_status is correct. Recording ship_status
+      not live get_infrastructure_status. Detect tools from structured
+      tool-call events (not serialized-text search). When SHIP read tools
+      were used, every failure_type: infra job must carry a ship_status
+      dict. Each non-skipped job must match a get_outages_during call on
+      component_slug, sub_component_slug, window_start, and window_end.
+      Skipped jobs must use action skipped with reason unmapped, include
+      list_components candidates in reason, and have a list_components
+      call. If SHIP read tools were not invoked (evals without the public
+      MCP), omitting ship_status is correct. Recording mapped ship_status
       after only a current-status query is a fail.
     check: |
       import yaml, os, json
@@ -251,36 +254,73 @@ judges:
                   calls.append((str(name), inp if isinstance(inp, dict) else {}))
           return calls
 
+      def _during_key(inp):
+          return (
+              str(inp.get("component_name") or inp.get("component_slug") or "").strip(),
+              str(inp.get("sub_component_name") or inp.get("sub_component_slug") or "").strip(),
+              str(inp.get("start") or "").strip(),
+              str(inp.get("end") or "").strip(),
+          )
+
+      def _ship(job):
+          st = job.get("ship_status")
+          return st if isinstance(st, dict) else {}
+
       calls = _tool_calls()
-      during_windows = set()
+      during_keys = set()
       during_seen = False
+      list_seen = False
       current_seen = False
       for name, inp in calls:
           if name.endswith("get_outages_during"):
               during_seen = True
-              during_windows.add((str(inp.get("start") or "").strip(), str(inp.get("end") or "").strip()))
+              during_keys.add(_during_key(inp))
+          if name.endswith("list_components"):
+              list_seen = True
           if name.endswith("get_infrastructure_status"):
               current_seen = True
       with_ship_status = [j for j in infra if isinstance(j.get("ship_status"), dict)]
-      if with_ship_status and not during_seen:
+      mapped = [j for j in infra if str(_ship(j).get("action") or "") != "skipped"]
+      skipped = [j for j in infra if str(_ship(j).get("action") or "") == "skipped"]
+      mapped_with_ss = [j for j in mapped if isinstance(j.get("ship_status"), dict)]
+      if mapped_with_ss and not during_seen:
           why = "get_infrastructure_status (live now)" if current_seen else "no get_outages_during"
           return (False, f"ship_status recorded without a job-window query ({why})")
-      if during_seen and len(with_ship_status) != len(infra):
+      ship_tools_seen = during_seen or list_seen
+      if ship_tools_seen and len(with_ship_status) != len(infra):
           missing = [str(j.get("job_name") or "?") for j in infra if not isinstance(j.get("ship_status"), dict)]
-          return (False, "get_outages_during was used but infra jobs missing ship_status: " + ", ".join(missing))
+          return (False, "SHIP Status tools were used but infra jobs missing ship_status: " + ", ".join(missing))
       if during_seen:
           mismatched = []
-          for job in infra:
-              st = job.get("ship_status") if isinstance(job.get("ship_status"), dict) else {}
-              if str(st.get("action") or "") == "skipped":
-                  continue
-              window = (str(st.get("window_start") or "").strip(), str(st.get("window_end") or "").strip())
-              if window not in during_windows:
+          for job in mapped:
+              st = _ship(job)
+              key = (
+                  str(st.get("component_slug") or "").strip(),
+                  str(st.get("sub_component_slug") or "").strip(),
+                  str(st.get("window_start") or "").strip(),
+                  str(st.get("window_end") or "").strip(),
+              )
+              if key not in during_keys:
                   mismatched.append(str(job.get("job_name") or "?"))
           if mismatched:
-              return (False, "get_outages_during start/end did not match job window for: " + ", ".join(mismatched))
-          return (True, f"{len(with_ship_status)}/{len(infra)} infra jobs have ship_status from get_outages_during")
-      return (True, "get_outages_during not evidenced; ship_status omitted")
+              return (False, "get_outages_during slug/window did not match for: " + ", ".join(mismatched))
+      if skipped:
+          bad_skip = []
+          for job in skipped:
+              st = _ship(job)
+              reason = str(st.get("reason") or "")
+              if str(st.get("action") or "") != "skipped" or "unmapped" not in reason:
+                  bad_skip.append(str(job.get("job_name") or "?"))
+                  continue
+              if not reason.replace("unmapped", "", 1).strip(" :-,"):
+                  bad_skip.append(str(job.get("job_name") or "?"))
+          if bad_skip:
+              return (False, "skipped infra jobs must have action=skipped, reason=unmapped plus list_components candidates: " + ", ".join(bad_skip))
+          if ship_tools_seen and not list_seen:
+              return (False, "skipped unmapped jobs require a list_components call")
+      if ship_tools_seen:
+          return (True, f"{len(with_ship_status)}/{len(infra)} infra jobs have ship_status ({len(skipped)} skipped)")
+      return (True, "SHIP Status read tools not evidenced; ship_status omitted")
 
   - name: json_data_valid
     description: |

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -204,12 +204,14 @@ judges:
 
   - name: ship_status_infra_read
     description: |
-      Correlation must use get_outages_during over the job window, not live
-      get_infrastructure_status. When that tool was used, every
-      failure_type: infra job must carry a ship_status observation. If
-      get_outages_during was not invoked (evals without the public MCP),
-      omitting ship_status is correct. Recording ship_status after only a
-      current-status query is a fail.
+      Correlation must use get_outages_during over each job's Prow window,
+      not live get_infrastructure_status. Detect the tool from structured
+      tool-call events (not serialized-text search). When it was used,
+      every failure_type: infra job must carry a ship_status dict, and
+      each non-skipped job's window_start/window_end must match a call's
+      start/end. If get_outages_during was not invoked (evals without the
+      public MCP), omitting ship_status is correct. Recording ship_status
+      after only a current-status query is a fail.
     check: |
       import yaml, os, json
       all_f = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
@@ -220,17 +222,63 @@ judges:
       infra = [j for j in (data.get("failing_jobs") or []) if isinstance(j, dict) and j.get("failure_type") == "infra"]
       if not infra:
           return (True, "No infra jobs")
-      events = outputs.get("events") or []
-      corpus = json.dumps(events) if events else (outputs.get("stdout") or "")
-      during_seen = "get_outages_during" in corpus
-      current_seen = "get_infrastructure_status" in corpus
+
+      def _tool_calls():
+          calls = []
+          for entry in outputs.get("events") or []:
+              if not isinstance(entry, dict):
+                  continue
+              for tool in entry.get("tools") or []:
+                  if isinstance(tool, dict) and tool.get("name"):
+                      inp = tool.get("input") or tool.get("arguments") or {}
+                      calls.append((str(tool.get("name")), inp if isinstance(inp, dict) else {}))
+          if calls:
+              return calls
+          for line in (outputs.get("stdout") or "").splitlines():
+              try:
+                  entry = json.loads(line)
+              except (json.JSONDecodeError, ValueError):
+                  continue
+              if not isinstance(entry, dict) or entry.get("type") != "assistant":
+                  continue
+              for block in (entry.get("message") or {}).get("content") or []:
+                  if not isinstance(block, dict) or block.get("type") != "tool_use":
+                      continue
+                  name = block.get("name")
+                  if not name:
+                      continue
+                  inp = block.get("input") or {}
+                  calls.append((str(name), inp if isinstance(inp, dict) else {}))
+          return calls
+
+      calls = _tool_calls()
+      during_windows = set()
+      during_seen = False
+      current_seen = False
+      for name, inp in calls:
+          if name.endswith("get_outages_during"):
+              during_seen = True
+              during_windows.add((str(inp.get("start") or "").strip(), str(inp.get("end") or "").strip()))
+          if name.endswith("get_infrastructure_status"):
+              current_seen = True
       with_ship_status = [j for j in infra if isinstance(j.get("ship_status"), dict)]
       if with_ship_status and not during_seen:
           why = "get_infrastructure_status (live now)" if current_seen else "no get_outages_during"
           return (False, f"ship_status recorded without a job-window query ({why})")
-      if during_seen and not with_ship_status:
-          return (False, "get_outages_during was used but no failing_jobs[].ship_status on infra jobs")
-      if with_ship_status:
+      if during_seen and len(with_ship_status) != len(infra):
+          missing = [str(j.get("job_name") or "?") for j in infra if not isinstance(j.get("ship_status"), dict)]
+          return (False, "get_outages_during was used but infra jobs missing ship_status: " + ", ".join(missing))
+      if during_seen:
+          mismatched = []
+          for job in infra:
+              st = job.get("ship_status") if isinstance(job.get("ship_status"), dict) else {}
+              if str(st.get("action") or "") == "skipped":
+                  continue
+              window = (str(st.get("window_start") or "").strip(), str(st.get("window_end") or "").strip())
+              if window not in during_windows:
+                  mismatched.append(str(job.get("job_name") or "?"))
+          if mismatched:
+              return (False, "get_outages_during start/end did not match job window for: " + ", ".join(mismatched))
           return (True, f"{len(with_ship_status)}/{len(infra)} infra jobs have ship_status from get_outages_during")
       return (True, "get_outages_during not evidenced; ship_status omitted")
 

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -112,7 +112,7 @@ outputs:
            analyzed_at, force_accept_recommended
          - failing_jobs[]: job_name, prow_url, is_aggregated, underlying_job_name,
            failure_type, root_cause_summary, streak_length, originating_payload_tag,
-           failure_pattern
+           failure_pattern, optional ship_status observation on infra jobs
          - candidates[]: type ("pr" or "rhcos_rpm"), component, confidence_score,
            rationale, failing_jobs[], actions[]; type "pr" entries also carry
            pr_url, pr_number, title
@@ -201,6 +201,38 @@ judges:
           if cmissing:
               return (False, f"candidates[0] missing: {', '.join(cmissing)}")
       return (True, f"Valid: {len(jobs)} failing jobs, {len(cands)} candidates")
+
+  - name: ship_status_infra_read
+    description: |
+      Correlation must use get_outages_during over the job window, not live
+      get_infrastructure_status. When that tool was used, every
+      failure_type: infra job must carry a ship_status observation. If
+      get_outages_during was not invoked (evals without the public MCP),
+      omitting ship_status is correct. Recording ship_status after only a
+      current-status query is a fail.
+    check: |
+      import yaml, os, json
+      all_f = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
+      yf = [v for k, v in all_f.items() if os.path.basename(k).startswith("payload-results-") and k.endswith(".yaml")]
+      if not yf:
+          return (False, "No payload results YAML found")
+      data = yaml.safe_load(yf[0]) or {}
+      infra = [j for j in (data.get("failing_jobs") or []) if isinstance(j, dict) and j.get("failure_type") == "infra"]
+      if not infra:
+          return (True, "No infra jobs")
+      events = outputs.get("events") or []
+      corpus = json.dumps(events) if events else (outputs.get("stdout") or "")
+      during_seen = "get_outages_during" in corpus
+      current_seen = "get_infrastructure_status" in corpus
+      with_ship_status = [j for j in infra if isinstance(j.get("ship_status"), dict)]
+      if with_ship_status and not during_seen:
+          why = "get_infrastructure_status (live now)" if current_seen else "no get_outages_during"
+          return (False, f"ship_status recorded without a job-window query ({why})")
+      if during_seen and not with_ship_status:
+          return (False, "get_outages_during was used but no failing_jobs[].ship_status on infra jobs")
+      if with_ship_status:
+          return (True, f"{len(with_ship_status)}/{len(infra)} infra jobs have ship_status from get_outages_during")
+      return (True, "get_outages_during not evidenced; ship_status omitted")
 
   - name: json_data_valid
     description: |
@@ -791,6 +823,8 @@ thresholds:
   output_files_exist:
     min_pass_rate: 1.0
   yaml_results_valid:
+    min_pass_rate: 1.0
+  ship_status_infra_read:
     min_pass_rate: 1.0
   json_data_valid:
     min_pass_rate: 1.0

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -280,8 +280,23 @@ judges:
           if name.endswith("get_infrastructure_status"):
               current_seen = True
       with_ship_status = [j for j in infra if isinstance(j.get("ship_status"), dict)]
-      mapped = [j for j in infra if str(_ship(j).get("action") or "") != "skipped"]
-      skipped = [j for j in infra if str(_ship(j).get("action") or "") == "skipped"]
+      allowed_actions = ("pending", "created", "linked", "skipped")
+      bad_action = []
+      for job in infra:
+          st = _ship(job)
+          if not st:
+              continue
+          action = st.get("action")
+          if not isinstance(action, str) or action not in allowed_actions:
+              bad_action.append(f"{job.get('job_name') or '?'}: {action!r}")
+      if bad_action:
+          return (
+              False,
+              "ship_status.action must be pending, created, linked, or skipped: "
+              + ", ".join(bad_action),
+          )
+      mapped = [j for j in infra if _ship(j).get("action") in ("pending", "created", "linked")]
+      skipped = [j for j in infra if _ship(j).get("action") == "skipped"]
       mapped_with_ss = [j for j in mapped if isinstance(j.get("ship_status"), dict)]
       if mapped_with_ss and not during_seen:
           why = "get_infrastructure_status (live now)" if current_seen else "no get_outages_during"

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -50,6 +50,12 @@ models:
   judge: claude-opus-4-8
 
 permissions:
+  # Allow only the public SHIP Status MCP. Do not use mcp__* — that would
+  # also permit unrelated plugin/user MCP servers if they are present.
+  # Claude names plugin MCP tools mcp__plugin_<plugin>_<server>__<tool>; the
+  # unprefixed mcp__<server>__* form is the project-local .mcp.json name.
+  # Deny writes even though the public endpoint is read-only — defense in
+  # depth if an authenticated server is also configured in the eval env.
   allow:
     - "Skill"
     - "Bash"
@@ -57,7 +63,30 @@ permissions:
     - "WebFetch"
     - "Write"
     - "Read"
-  deny: []
+    - "Edit"
+    - "mcp__ship-status__*"
+    - "mcp__plugin_ci_ship-status__*"
+  deny:
+    - "mcp__ship-status__create_outage"
+    - "mcp__ship-status__update_outage"
+    - "mcp__ship-status__delete_outage"
+    - "mcp__ship-status__add_triage_note"
+    - "mcp__ship-status__update_triage_note"
+    - "mcp__ship-status__delete_triage_note"
+    - "mcp__ship-status__add_outage_link"
+    - "mcp__ship-status__update_outage_link"
+    - "mcp__ship-status__delete_outage_link"
+    - "mcp__ship-status__record_payload_infra_outage"
+    - "mcp__plugin_ci_ship-status__create_outage"
+    - "mcp__plugin_ci_ship-status__update_outage"
+    - "mcp__plugin_ci_ship-status__delete_outage"
+    - "mcp__plugin_ci_ship-status__add_triage_note"
+    - "mcp__plugin_ci_ship-status__update_triage_note"
+    - "mcp__plugin_ci_ship-status__delete_triage_note"
+    - "mcp__plugin_ci_ship-status__add_outage_link"
+    - "mcp__plugin_ci_ship-status__update_outage_link"
+    - "mcp__plugin_ci_ship-status__delete_outage_link"
+    - "mcp__plugin_ci_ship-status__record_payload_infra_outage"
 
 mlflow:
   experiment: ci-payload-analysis-eval
@@ -146,7 +175,12 @@ judges:
       json_f = [k for k in all_f if k.endswith("-autodl.json")]
       missing = []
       if not html:
-          missing.append("HTML report (*-summary.html)")
+          wrong = [
+              k for k in all_f
+              if k.endswith(".html") and "payload-analysis" in os.path.basename(k)
+          ]
+          hint = f" (found {os.path.basename(wrong[0])} — must end with -summary.html)" if wrong else ""
+          missing.append("HTML report (*-summary.html)" + hint)
       if not yaml_f:
           missing.append("payload results YAML (payload-results-*.yaml)")
       if not json_f:
@@ -212,9 +246,10 @@ judges:
       component_slug, sub_component_slug, window_start, and window_end.
       Skipped jobs must use action skipped with reason unmapped, include
       list_components candidates in reason, and have a list_components
-      call. If SHIP read tools were not invoked (evals without the public
-      MCP), omitting ship_status is correct. Recording mapped ship_status
-      after only a current-status query is a fail.
+      call. This eval (and the Prow payload-agent job) provide the public
+      SHIP Status MCP — infra jobs without get_outages_during or
+      list_components are a fail, not an omit. Recording mapped
+      ship_status after only a current-status query is a fail.
     check: |
       import yaml, os, json
       all_f = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
@@ -228,15 +263,27 @@ judges:
 
       def _tool_calls():
           calls = []
+          seen = set()
+
+          def _add(name, inp):
+              inp = inp if isinstance(inp, dict) else {}
+              key = (name, json.dumps(inp, sort_keys=True, default=str))
+              if key in seen:
+                  return
+              seen.add(key)
+              calls.append((name, inp))
+
           for entry in outputs.get("events") or []:
               if not isinstance(entry, dict):
                   continue
               for tool in entry.get("tools") or []:
                   if isinstance(tool, dict) and tool.get("name"):
-                      inp = tool.get("input") or tool.get("arguments") or {}
-                      calls.append((str(tool.get("name")), inp if isinstance(inp, dict) else {}))
-          if calls:
-              return calls
+                      _add(
+                          str(tool.get("name")),
+                          tool.get("input") or tool.get("arguments") or {},
+                      )
+          # Events often list only host tools (Bash/Read/…). Merge stdout
+          # JSONL so MCP calls are not dropped when events is non-empty.
           for line in (outputs.get("stdout") or "").splitlines():
               try:
                   entry = json.loads(line)
@@ -248,10 +295,8 @@ judges:
                   if not isinstance(block, dict) or block.get("type") != "tool_use":
                       continue
                   name = block.get("name")
-                  if not name:
-                      continue
-                  inp = block.get("input") or {}
-                  calls.append((str(name), inp if isinstance(inp, dict) else {}))
+                  if name:
+                      _add(str(name), block.get("input") or {})
           return calls
 
       def _during_key(inp):
@@ -311,6 +356,12 @@ judges:
           why = "get_infrastructure_status (live now)" if current_seen else "no get_outages_during"
           return (False, f"ship_status recorded without a job-window query ({why})")
       ship_tools_seen = during_seen or list_seen
+      if not ship_tools_seen:
+          return (
+              False,
+              "infra jobs present but SHIP Status MCP was not used "
+              "(need get_outages_during, or list_components when unmapped)",
+          )
       if ship_tools_seen and len(with_ship_status) != len(infra):
           missing = [str(j.get("job_name") or "?") for j in infra if not isinstance(j.get("ship_status"), dict)]
           return (False, "SHIP Status tools were used but infra jobs missing ship_status: " + ", ".join(missing))
@@ -344,7 +395,7 @@ judges:
               return (False, "skipped unmapped jobs require a list_components call")
       if ship_tools_seen:
           return (True, f"{len(with_ship_status)}/{len(infra)} infra jobs have ship_status ({len(skipped)} skipped)")
-      return (True, "SHIP Status read tools not evidenced; ship_status omitted")
+      return (False, "infra jobs present but SHIP Status MCP was not used")
 
   - name: json_data_valid
     description: |
@@ -395,7 +446,13 @@ judges:
       all_f = {**files, **modified}
       html_files = {k: v for k, v in all_f.items() if k.endswith("-summary.html")}
       if not html_files:
-          return (False, "No HTML report found")
+          import os
+          wrong = [
+              k for k in all_f
+              if k.endswith(".html") and "payload-analysis" in os.path.basename(k)
+          ]
+          hint = f" (found {os.path.basename(wrong[0])} — must end with -summary.html)" if wrong else ""
+          return (False, "No HTML report found" + hint)
       html = list(html_files.values())[0]
       checks = {
           "executive summary": "executive" in html.lower() or "summary" in html.lower(),

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -50,12 +50,12 @@ models:
   judge: claude-opus-4-8
 
 permissions:
-  # Allow only the public SHIP Status MCP. Do not use mcp__* — that would
-  # also permit unrelated plugin/user MCP servers if they are present.
+  # Allow only the public SHIP Status MCP (reads). Do not use mcp__* — that
+  # would also permit unrelated plugin/user MCP servers if they are present.
   # Claude names plugin MCP tools mcp__plugin_<plugin>_<server>__<tool>; the
   # unprefixed mcp__<server>__* form is the project-local .mcp.json name.
-  # Deny writes even though the public endpoint is read-only — defense in
-  # depth if an authenticated server is also configured in the eval env.
+  # The public endpoint has no write tools; the authenticated MCP is not
+  # configured in this eval.
   allow:
     - "Skill"
     - "Bash"
@@ -66,27 +66,7 @@ permissions:
     - "Edit"
     - "mcp__ship-status__*"
     - "mcp__plugin_ci_ship-status__*"
-  deny:
-    - "mcp__ship-status__create_outage"
-    - "mcp__ship-status__update_outage"
-    - "mcp__ship-status__delete_outage"
-    - "mcp__ship-status__add_triage_note"
-    - "mcp__ship-status__update_triage_note"
-    - "mcp__ship-status__delete_triage_note"
-    - "mcp__ship-status__add_outage_link"
-    - "mcp__ship-status__update_outage_link"
-    - "mcp__ship-status__delete_outage_link"
-    - "mcp__ship-status__record_payload_infra_outage"
-    - "mcp__plugin_ci_ship-status__create_outage"
-    - "mcp__plugin_ci_ship-status__update_outage"
-    - "mcp__plugin_ci_ship-status__delete_outage"
-    - "mcp__plugin_ci_ship-status__add_triage_note"
-    - "mcp__plugin_ci_ship-status__update_triage_note"
-    - "mcp__plugin_ci_ship-status__delete_triage_note"
-    - "mcp__plugin_ci_ship-status__add_outage_link"
-    - "mcp__plugin_ci_ship-status__update_outage_link"
-    - "mcp__plugin_ci_ship-status__delete_outage_link"
-    - "mcp__plugin_ci_ship-status__record_payload_infra_outage"
+  deny: []
 
 mlflow:
   experiment: ci-payload-analysis-eval

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -155,12 +155,7 @@ judges:
       json_f = [k for k in all_f if k.endswith("-autodl.json")]
       missing = []
       if not html:
-          wrong = [
-              k for k in all_f
-              if k.endswith(".html") and "payload-analysis" in os.path.basename(k)
-          ]
-          hint = f" (found {os.path.basename(wrong[0])} — must end with -summary.html)" if wrong else ""
-          missing.append("HTML report (*-summary.html)" + hint)
+          missing.append("HTML report (*-summary.html)")
       if not yaml_f:
           missing.append("payload results YAML (payload-results-*.yaml)")
       if not json_f:
@@ -426,13 +421,7 @@ judges:
       all_f = {**files, **modified}
       html_files = {k: v for k, v in all_f.items() if k.endswith("-summary.html")}
       if not html_files:
-          import os
-          wrong = [
-              k for k in all_f
-              if k.endswith(".html") and "payload-analysis" in os.path.basename(k)
-          ]
-          hint = f" (found {os.path.basename(wrong[0])} — must end with -summary.html)" if wrong else ""
-          return (False, "No HTML report found" + hint)
+          return (False, "No HTML report found")
       html = list(html_files.values())[0]
       checks = {
           "executive summary": "executive" in html.lower() or "summary" in html.lower(),

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -282,13 +282,22 @@ judges:
       with_ship_status = [j for j in infra if isinstance(j.get("ship_status"), dict)]
       allowed_actions = ("pending", "created", "linked", "skipped")
       bad_action = []
+      bad_type = []
       for job in infra:
           st = job.get("ship_status")
+          if st is None:
+              continue
           if not isinstance(st, dict):
+              bad_type.append(f"{job.get('job_name') or '?'}: {type(st).__name__}")
               continue
           action = st.get("action")
           if not isinstance(action, str) or action not in allowed_actions:
               bad_action.append(f"{job.get('job_name') or '?'}: {action!r}")
+      if bad_type:
+          return (
+              False,
+              "ship_status must be an object: " + ", ".join(bad_type),
+          )
       if bad_action:
           return (
               False,

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -100,6 +100,9 @@ dataset:
         expected_failing_jobs. An explicit empty list means the correct
         analysis recommends NO revert — any candidate at or above the
         revert threshold is a false positive.
+      - 'expected_infra_jobs': optional list of job-name stems that must be
+        failure_type: infra. When set, classifying them as test/product is a
+        ship_status_infra_read fail (not a vacuous "No infra jobs" pass).
       - 'notes': free text context
 
     Snapshots are stored as tar.gz archives in
@@ -213,18 +216,20 @@ judges:
 
   - name: ship_status_infra_read
     description: |
-      Correlation must use get_outages_during over each job's Prow window,
-      not live get_infrastructure_status. Detect tools from structured
-      tool-call events (not serialized-text search). When SHIP read tools
-      were used, every failure_type: infra job must carry a ship_status
+      This eval provides the public SHIP Status MCP. Fail if those tools are
+      missing from the session catalog. Cases with expected_infra_jobs fail
+      when those jobs are not failure_type: infra (a vacuous "No infra jobs"
+      pass is not allowed). Correlation must use get_outages_during over each
+      job's Prow window, not live get_infrastructure_status. Detect tools from
+      structured tool-call events (not serialized-text search). When SHIP read
+      tools were used, every failure_type: infra job must carry a ship_status
       dict. Each non-skipped job must match a get_outages_during call on
       component_slug, sub_component_slug, window_start, and window_end.
       Skipped jobs must use action skipped with reason unmapped, include
       list_components candidates in reason, and have a list_components
-      call. This eval (and the Prow payload-agent job) provide the public
-      SHIP Status MCP — infra jobs without get_outages_during or
-      list_components are a fail, not an omit. Recording mapped
-      ship_status after only a current-status query is a fail.
+      call. Infra jobs without get_outages_during or list_components are a
+      fail, not an omit. Recording mapped ship_status after only a
+      current-status query is a fail.
     check: |
       import yaml, os, json
       all_f = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
@@ -232,7 +237,56 @@ judges:
       if not yf:
           return (False, "No payload results YAML found")
       data = yaml.safe_load(yf[0]) or {}
-      infra = [j for j in (data.get("failing_jobs") or []) if isinstance(j, dict) and j.get("failure_type") == "infra"]
+
+      def _ship_mcp_in_catalog():
+          for line in (outputs.get("stdout") or "").splitlines():
+              try:
+                  entry = json.loads(line)
+              except (json.JSONDecodeError, ValueError):
+                  continue
+              if not isinstance(entry, dict):
+                  continue
+              if entry.get("type") != "system" or entry.get("subtype") != "init":
+                  continue
+              for t in entry.get("tools") or []:
+                  name = t if isinstance(t, str) else str((t or {}).get("name") or "")
+                  if name.startswith("mcp__") and "ship-status" in name:
+                      return True
+              for srv in entry.get("mcp_servers") or []:
+                  if isinstance(srv, dict) and "ship-status" in str(srv.get("name") or ""):
+                      return True
+          return False
+
+      if not _ship_mcp_in_catalog():
+          return (
+              False,
+              "SHIP Status MCP not in tool catalog "
+              "(need mcp__ship-status__* or mcp__plugin_ci_ship-status__*)",
+          )
+
+      def _name_match(exp, got):
+          exp, got = str(exp or ""), str(got or "")
+          return bool(exp and got and (exp in got or got in exp))
+
+      jobs = [j for j in (data.get("failing_jobs") or []) if isinstance(j, dict)]
+      expected_infra = outputs.get("annotations", {}).get("expected_infra_jobs") or []
+      if expected_infra:
+          missing = []
+          for exp in expected_infra:
+              classified = "absent"
+              for j in jobs:
+                  if _name_match(exp, j.get("job_name")):
+                      classified = str(j.get("failure_type") or "unset")
+                      break
+              if classified != "infra":
+                  missing.append(f"{exp} (failure_type={classified})")
+          if missing:
+              return (
+                  False,
+                  "expected infra jobs not classified as infra: " + "; ".join(missing),
+              )
+
+      infra = [j for j in jobs if j.get("failure_type") == "infra"]
       if not infra:
           return (True, "No infra jobs")
 

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -283,8 +283,8 @@ judges:
       allowed_actions = ("pending", "created", "linked", "skipped")
       bad_action = []
       for job in infra:
-          st = _ship(job)
-          if not st:
+          st = job.get("ship_status")
+          if not isinstance(st, dict):
               continue
           action = st.get("action")
           if not isinstance(action, str) or action not in allowed_actions:

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -477,6 +477,17 @@ Otherwise, recommend force-accepting when **all** of the following are true:
 
 Instead, recommend the correct action: **wait for the RHCOS with the rebuilt kubelet to land** (i.e., for the transient build lag from Step 6.2 to resolve). Once the updated kubelet is delivered, the skew clears and the payload passes on its own.
 
+#### Failure type
+
+Set `failure_type` from the **root cause**, not the job family (an `e2e-*-upgrade` job can still be `infra`).
+
+- **`infra`**: affirmative infrastructure — Boskos/lease/quota, cloud-provider API throttling or 429s, VIP/DNS reachability loss, Insights/console.redhat.com API 500s, Prow/build-farm outages, hypershift or cluster **teardown** timeouts after tests completed.
+- **`install`**: installer/provisioning failed before the cluster was up.
+- **`upgrade`**: the upgrade path itself failed (CVO/operators/MCP), not an external API or teardown blip.
+- **`test`**: in-cluster product test failure.
+
+Do not use `test` or `upgrade` merely because the job name contains those words.
+
 #### 6.5: Read SHIP Status (required when SHIP read tools exist)
 
 After classification — and as a check when infrastructure is suspected but not yet committed — correlate each `failure_type: infra` job with the SHIP Status dashboard.
@@ -487,10 +498,10 @@ This analysis often runs **hours after** the payload jobs finished. Current dash
 2. If SHIP Status read tools exist, call **`get_outages_during`** for the mapped component/sub-component with RFC3339 UTC `start`/`end` covering the **job's Prow run window** (start slightly before job start if uncertain; end at job completion, or `--as-of` / `payload_completed_at` if completion is missing). An outage overlapping that window is **affirmative infra evidence**.
 3. Do **not** use `get_infrastructure_status` for this step — that is live "now" health. Do **not** substitute `get_component_outages`; it has no overlap filter. Use `list_components` only when mapping is ambiguous.
 4. Record a `ship_status` observation on each infra job (see the `payload-results-yaml` schema): slugs, `window_start` / `window_end` (the same bounds passed to `get_outages_during`), `observed_health` from the overlap result (`healthy` if none), `existing_outage_id`, `queried_at`, `action: pending`. Empty overlap is still a recorded observation, not a skip. Chai `payload_check` reuses these windows on the write path.
-5. If mapping is ambiguous, skip that job (`action: skipped`, `reason: unmapped`) and include `list_components` candidates in `reason`. Do not invent slugs.
-6. If SHIP read tools are **not** available, omit `ship_status` entirely and continue.
+5. If mapping is ambiguous, skip that job (`action: skipped`, `reason: unmapped`) and include `list_components` candidates in `reason`. Do not invent slugs. External Red Hat SaaS (Insights, console.redhat.com) is unmapped — skip after `list_components`, do not map it to boskos/prow.
+6. Detect SHIP read tools by their presence in the tool list (`get_outages_during`, `list_components`), not by a `ship-status` CLI. If those tools are **not** in the tool list, **omit** the `ship_status` key entirely. Do not write `action: skipped` / `reason: unmapped` as a stand-in for missing tools.
 
-The Prow job uses the public SHIP Status MCP (reads only). This step must still run there.
+The Prow job and this eval use the public SHIP Status MCP (reads only). This step must still run there.
 
 #### 6.6: Record SHIP Status outage (only if `record_payload_infra_outage` exists)
 
@@ -508,7 +519,7 @@ This file contains ALL scored candidates across all confidence tiers (HIGH, MEDI
 
 ### Step 7: Generate HTML Report
 
-Create a self-contained HTML file named `payload-analysis-<sanitized_tag>-summary.html` in `$OUTPUT_DIR` (the directory captured in Step 1).
+Create a self-contained HTML file named **exactly** `payload-analysis-<sanitized_tag>-summary.html` in `$OUTPUT_DIR` (the directory captured in Step 1). The filename MUST end with `-summary.html`. `payload-analysis-<tag>.html` is a defect.
 
 Produce it by filling the bundled template — do NOT write the HTML structure or CSS from scratch; the template is the single source of truth for section order, markup, and styling, which keeps reports consistent across runs:
 
@@ -523,7 +534,7 @@ Produce it by filling the bundled template — do NOT write the HTML structure o
 
 2. Read `references/report-guide.md` (in this skill's directory) for the per-section content rules: how to derive each `{placeholder}` value and when to include, drop, or repeat the marked `BEGIN`/`END` blocks.
 
-3. Copy the template to the output path and fill it: replace every placeholder, expand repeatable blocks once per item, remove blocks whose condition is false, and strip the marker comments. No unfilled `{placeholder}` or `BEGIN`/`END` marker may remain (verified in Step 10).
+3. Copy the template to `$OUTPUT_DIR/payload-analysis-<sanitized_tag>-summary.html` (same `<sanitized_tag>` as the YAML and autodl JSON) and fill it: replace every placeholder, expand repeatable blocks once per item, remove blocks whose condition is false, and strip the marker comments. No unfilled `{placeholder}` or `BEGIN`/`END` marker may remain (verified in Step 10). Do not save a second copy as `payload-analysis-<tag>.html`.
 
 ### Step 8: Generate JSON Data File
 
@@ -553,6 +564,8 @@ Before presenting, confirm that **all Step 4 investigation subagents and the Ste
 2. **The HTML contains every required section** from the Step 7 template: header + executive summary (including the payload-chain context), the revert verdict (or the "No Recommended Reverts" verdict), the force-accept verdict when applicable, the blocking-jobs summary table, a collapsible details block for **every** failed job, the RHCOS Changes section when any payload has RHCOS changes, the informing-tests section when such tests exist, and the Adversarial Review section. No unfilled `{placeholder}` and no `BEGIN`/`END` marker comments remain.
 3. **Cross-output consistency**: phase, failure counts, per-job root causes (including any adjudicated in Step 5b), and scored candidates agree across the HTML, YAML, and JSON.
 4. **Every affirmative root cause appears as a scored `candidates[]` entry** — including causal CI-infrastructure changes, even when `failure_type: infra`.
+5. **HTML filename** ends with `-summary.html`. If a `payload-analysis-*.html` file exists without that suffix, rename it — do not leave the short name as the report.
+6. **SHIP Status**: every `failure_type: infra` job has a `ship_status` observation if `get_outages_during` / `list_components` are in the tool list. Omit the key only when those tools are absent.
 
 If any check fails, fix it before presenting.
 

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -53,8 +53,9 @@ Load these only at the step that needs them — not up front:
 - **`references/report-guide.md`** — per-section content rules for the HTML report (Step 7)
 - **`references/completeness-review.md`** — the completeness-reviewer prompt and response handling (Step 9)
 - **`assets/report-template.html`** — the fill-in-the-blanks HTML report template (Step 7)
+- **`references/ship-status-component-map.md`** — SHIP Status slug mapping (Step 6.5)
 
-The `payload-results-yaml` and `payload-autodl-json` skills define the structured output schemas; load each via the Skill tool at its point of use (Steps 6.5 and 8).
+The `payload-results-yaml` and `payload-autodl-json` skills define the structured output schemas; load each via the Skill tool at its point of use (Steps 6.7 and 8).
 
 ## Implementation Steps
 
@@ -66,7 +67,7 @@ The `payload-results-yaml` and `payload-autodl-json` skills define the structure
 OUTPUT_DIR="$(pwd)"
 ```
 
-All three output files — the payload results YAML (Step 6.5), the HTML report (Step 7), and the autodl JSON (Step 8) — MUST be written under `$OUTPUT_DIR`, never into a snapshot subdirectory or a path a later `cd` may have changed. The Step 10 self-check verifies them at `$OUTPUT_DIR`.
+All three output files — the payload results YAML (Step 6.7), the HTML report (Step 7), and the autodl JSON (Step 8) — MUST be written under `$OUTPUT_DIR`, never into a snapshot subdirectory or a path a later `cd` may have changed. The Step 10 self-check verifies them at `$OUTPUT_DIR`.
 
 The first argument is a **full payload tag** (e.g., `4.22.0-0.nightly-2026-02-25-152806`). Parse from it:
 - `tag`: The specific payload tag to analyze
@@ -476,7 +477,28 @@ Otherwise, recommend force-accepting when **all** of the following are true:
 
 Instead, recommend the correct action: **wait for the RHCOS with the rebuilt kubelet to land** (i.e., for the transient build lag from Step 6.2 to resolve). Once the updated kubelet is delivered, the skew clears and the payload passes on its own.
 
-#### 6.5: Write Payload Results YAML
+#### 6.5: Read SHIP Status (required when SHIP read tools exist)
+
+After classification — and as a check when infrastructure is suspected but not yet committed — correlate each `failure_type: infra` job with the SHIP Status dashboard.
+
+This analysis often runs **hours after** the payload jobs finished. Current dashboard health is the wrong window.
+
+1. Read `references/ship-status-component-map.md` in this skill's directory. Map `component_slug` / `sub_component_slug` from `prowjob.json` `spec.cluster`, Boskos/lease/cloud signals, or Prow control-plane symptoms. First match wins.
+2. If SHIP Status read tools exist, call **`get_outages_during`** for the mapped component/sub-component with RFC3339 UTC `start`/`end` covering the **job's Prow run window** (start slightly before job start if uncertain; end at job completion, or `--as-of` / `payload_completed_at` if completion is missing). An outage overlapping that window is **affirmative infra evidence**.
+3. Do **not** use `get_infrastructure_status` for this step — that is live "now" health. Do **not** substitute `get_component_outages`; it has no overlap filter. Use `list_components` only when mapping is ambiguous.
+4. Record a `ship_status` observation on each infra job (see the `payload-results-yaml` schema): slugs, `window_start` / `window_end` (the same bounds passed to `get_outages_during`), `observed_health` from the overlap result (`healthy` if none), `existing_outage_id`, `queried_at`, `action: pending`. Empty overlap is still a recorded observation, not a skip. Chai `payload_check` reuses these windows on the write path.
+5. If mapping is ambiguous, skip that job (`action: skipped`, `reason: unmapped`) and include `list_components` candidates in `reason`. Do not invent slugs.
+6. If SHIP read tools are **not** available, omit `ship_status` entirely and continue.
+
+The Prow job uses the public SHIP Status MCP (reads only). This step must still run there.
+
+#### 6.6: Record SHIP Status outage (only if `record_payload_infra_outage` exists)
+
+If the `record_payload_infra_outage` tool is available (Chai RWS), pass **all** infra jobs in **one** call (`jobs_json` array with `job_name`, `prow_url`, `root_cause_summary`, slugs, and the same `window_start` / `window_end` used in Step 6.5). Do not call it once per job. Do not call raw `create_outage`.
+
+Stamp `action` / `outage_id` / `dashboard_url` onto each job from the tool result. The Prow job does not have this tool and skips this step — Chai `payload_check` performs the write later from the YAML snapshot.
+
+#### 6.7: Write Payload Results YAML
 
 Load the `payload-results-yaml` skill now (via the Skill tool) — this is its point of use — and follow it to create `$OUTPUT_DIR/payload-results-{tag}.yaml` (the `$OUTPUT_DIR` captured in Step 1).
 

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -494,7 +494,7 @@ The Prow job uses the public SHIP Status MCP (reads only). This step must still 
 
 #### 6.6: Record SHIP Status outage (only if `record_payload_infra_outage` exists)
 
-If the `record_payload_infra_outage` tool is available (Chai RWS), pass **all** infra jobs in **one** call (`jobs_json` array with `job_name`, `prow_url`, `root_cause_summary`, slugs, and the same `window_start` / `window_end` used in Step 6.5). Do not call it once per job. Do not call raw `create_outage`.
+If the `record_payload_infra_outage` tool is available (Chai RWS), pass **mapped** infra jobs in **one** call (`jobs_json` array with `job_name`, `prow_url`, `root_cause_summary`, slugs, and the same `window_start` / `window_end` used in Step 6.5). Include only jobs whose Step 6.5 `ship_status.action` is not `skipped`. Exclude unmapped jobs (`action: skipped`, `reason: unmapped`) — they have no slugs and the wrapper cannot place them. Do not call it once per job. Do not call raw `create_outage`.
 
 Stamp `action` / `outage_id` / `dashboard_url` onto each job from the tool result. The Prow job does not have this tool and skips this step — Chai `payload_check` performs the write later from the YAML snapshot.
 

--- a/plugins/ci/skills/payload-analysis/assets/report-template.html
+++ b/plugins/ci/skills/payload-analysis/assets/report-template.html
@@ -189,6 +189,11 @@ code { font-family: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace; fo
     <h4>Failure Analysis</h4>
     <div class="analysis">{analysis_from_subagent}</div>
 
+    <!-- BEGIN: ship-status — include on failure_type infra when a SHIP Status observation exists -->
+    <h4>SHIP Status</h4>
+    <p>{ship_status_line}</p>
+    <!-- END: ship-status -->
+
     <!-- BEGIN: known-symptoms — include only when symptoms are not "none" -->
     <h4>Known Symptoms Seen</h4>
     <p>{comma_separated_symptom_summaries}</p>

--- a/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
+++ b/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
@@ -18,9 +18,11 @@ Use the following prompt **verbatim** (substituting the placeholder values) when
 >
 > **IMPORTANT** — Trace every failure to its specific root cause by examining actual logs. Never stop at high-level symptoms like "0 nodes ready", "operator degraded", or "containers are crash-looping". Download and read the actual log bundles, pod logs, and container previous logs. Cite specific error messages. The root cause must be actionable, not a restatement of the symptom.
 >
-> **Do NOT classify a failure as "infrastructure flake" or "transient" unless you have affirmative evidence** of an infrastructure problem (cloud API errors, quota exceeded, network timeouts from the cloud provider, Boskos lease failures, CI platform outages). The absence of an obvious code-level explanation does NOT make something infrastructure — it means you need to investigate deeper. Default to treating failures as potential product regressions until evidence proves otherwise.
+> **Do NOT classify a failure as "infrastructure flake" or "transient" unless you have affirmative evidence** of an infrastructure problem (cloud API errors, quota exceeded, network timeouts from the cloud provider, Boskos lease failures, CI platform outages, Insights/console.redhat.com API 500s, hypershift/cluster teardown timeouts after tests completed). The absence of an obvious code-level explanation does NOT make something infrastructure — it means you need to investigate deeper. Default to treating failures as potential product regressions until evidence proves otherwise.
 >
-> Return a concise summary including: failure type (install vs test), root cause, key error messages, and any relevant log excerpts. Do not ask user questions. Keep the output concise for inclusion in a summary report.
+> Set `failure_type` from the **root cause**, not the job family. An upgrade or e2e job whose trigger is an Insights API 500, cloud-provider 429/throttling, VIP reachability loss, Boskos lease failure, or teardown timeout is `infra`. `upgrade`/`test`/`install` are for product or install-path failures in that phase.
+>
+> Return a concise summary including: failure type (`install` | `test` | `upgrade` | `infra`), root cause, key error messages, and any relevant log excerpts. Do not ask user questions. Keep the output concise for inclusion in a summary report.
 >
 > If the job is an aggregated job (has `aggregated-` prefix in the name or an `aggregator` container/step), also return the **underlying job name** (e.g., `periodic-ci-openshift-release-main-ci-4.22-e2e-aws-upgrade-ovn-single-node`). This is found in the junit-aggregated.xml artifacts — each `<testcase>` has `<system-out>` YAML data with a `humanurl` field linking to individual runs whose URL path contains the underlying job name. The underlying job name cannot be derived from the aggregated job name — it must be extracted from the artifacts.
 
@@ -34,7 +36,7 @@ Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed 
 
 `<summary_json_path>` is the absolute path to the snapshot's `summary.json` file, and `<originating_payload_tag>` is the failure mode's `first_failed_in` value (Step 3.3/Step 5) — not the job-level `streak.originating_payload`, which can predate the regression when a job has multiple failure modes.
 
-Under `--as-of` (Step 1), append the cutoff timestamp to the prompt and instruct the subagent to discard post-cutoff artifacts and discussion.
+Under `--as-of` (Step 1), append the cutoff timestamp to the prompt and instruct the subagent to discard post-cutoff artifacts and discussion. Do not treat a later revert, its merge, or a subsequent payload outcome as evidence that a PR caused (or did not cause) the failure.
 
 ## Structured Return Format
 

--- a/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
+++ b/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
@@ -36,7 +36,7 @@ Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed 
 
 `<summary_json_path>` is the absolute path to the snapshot's `summary.json` file, and `<originating_payload_tag>` is the failure mode's `first_failed_in` value (Step 3.3/Step 5) — not the job-level `streak.originating_payload`, which can predate the regression when a job has multiple failure modes.
 
-Under `--as-of` (Step 1), append the cutoff timestamp to the prompt and instruct the subagent to discard post-cutoff artifacts and discussion. Do not treat a later revert, its merge, or a subsequent payload outcome as evidence that a PR caused (or did not cause) the failure.
+Under `--as-of` (Step 1), append the cutoff timestamp to the prompt and instruct the subagent to discard post-cutoff artifacts and discussion.
 
 ## Structured Return Format
 

--- a/plugins/ci/skills/payload-analysis/references/report-guide.md
+++ b/plugins/ci/skills/payload-analysis/references/report-guide.md
@@ -47,6 +47,7 @@ One `failed-job` collapsible block per failed blocking job:
 - Prow line: Prow and GCS Artifacts links; for aggregated jobs, append the underlying job name.
 - `variant-callout` — include only when the failure is variant-isolated; fill in which variant is affected.
 - `analysis_from_subagent` — the subagent's failure analysis (Step 4), adjudicated where Step 5b applied. Preserve its structure (failure type, root cause, key errors with `<code>`, retry comparison).
+- `ship-status` — include only for `failure_type: infra` jobs that have a `ship_status` observation. `{ship_status_line}` is one sentence: health overlapping the **job run window** (from `get_outages_during`, not live now) plus either an existing outage link, "pending Chai create", or the created/linked dashboard URL after a Chai-hosted write. Omit the block when `ship_status` was not recorded (read tools missing).
 - `known-symptoms` — include only when the subagent reported symptoms other than "none".
 - Candidates: use `candidates-table` (one `candidate-row` per scored candidate with its tiered score class) when candidates exist; otherwise use `candidates-none`, whose prose must state **why** no candidate explains the failure (Step 6.1) — never leave it blank or generic.
 

--- a/plugins/ci/skills/payload-analysis/references/report-guide.md
+++ b/plugins/ci/skills/payload-analysis/references/report-guide.md
@@ -47,7 +47,9 @@ One `failed-job` collapsible block per failed blocking job:
 - Prow line: Prow and GCS Artifacts links; for aggregated jobs, append the underlying job name.
 - `variant-callout` — include only when the failure is variant-isolated; fill in which variant is affected.
 - `analysis_from_subagent` — the subagent's failure analysis (Step 4), adjudicated where Step 5b applied. Preserve its structure (failure type, root cause, key errors with `<code>`, retry comparison).
-- `ship-status` — include only for `failure_type: infra` jobs that have a `ship_status` observation. `{ship_status_line}` is one sentence: health overlapping the **job run window** (from `get_outages_during`, not live now) plus either an existing outage link, "pending Chai create", or the created/linked dashboard URL after a Chai-hosted write. Omit the block when `ship_status` was not recorded (read tools missing).
+- `ship-status` — include for `failure_type: infra` jobs that have a `ship_status` observation, including `action: skipped`. Never leave `{ship_status_line}` empty.
+  - Mapped jobs: one sentence of health overlapping the **job run window** (from `get_outages_during`, not live now) plus either an existing outage link, "pending Chai create", or the created/linked dashboard URL after a Chai-hosted write.
+  - `action: skipped` (unmapped): use exactly `SHIP Status skipped: component unmapped. No component_slug, sub_component_slug, outage_id, or dashboard_url.` Do not invent slugs or outage URLs. Omit the block only when `ship_status` was not recorded (read tools missing).
 - `known-symptoms` — include only when the subagent reported symptoms other than "none".
 - Candidates: use `candidates-table` (one `candidate-row` per scored candidate with its tiered score class) when candidates exist; otherwise use `candidates-none`, whose prose must state **why** no candidate explains the failure (Step 6.1) — never leave it blank or generic.
 

--- a/plugins/ci/skills/payload-analysis/references/ship-status-component-map.md
+++ b/plugins/ci/skills/payload-analysis/references/ship-status-component-map.md
@@ -1,0 +1,15 @@
+# SHIP Status component mapping
+
+Use this table when correlating payload-analysis infrastructure failures with the [SHIP Status dashboard](https://ship-status.ci.openshift.org/). First match wins. Live slugs: https://ship-status.ci.openshift.org/api/components
+
+| Signal | Component | Sub-component |
+|--------|-----------|----------------|
+| ProwJob `spec.cluster` = `buildNN` or `hosted-mgmt` | `build-farm` | `build01`…`build13`, `hosted-mgmt` |
+| Boskos / lease / quota exhaustion | `boskos` | `leasing-server`, or `aws` / `gcp` / `azure-2` / `azure4` from the job-name platform |
+| Cloud API / throttling / quota (no Boskos) | `boskos` | same cloud account slugs |
+| Prow control plane (pod pending, plank, hook) | `prow` | `prow-controller-manager` (default) unless a more specific sub-component is named |
+| Unmapped | skip | call `list_components` and record candidates; do not invent slugs |
+
+**Build cluster** comes from `prowjob.json` `spec.cluster` (already read during investigation). Job-name substrings pick the Boskos cloud account: `aws` → `aws`, `gcp` → `gcp`, `azure4` / `azure-4` → `azure4`, `aks` / `azure-2` / `azure` → `azure-2`.
+
+Mapping misses are `skipped`, not silent creates.

--- a/plugins/ci/skills/payload-analysis/references/ship-status-component-map.md
+++ b/plugins/ci/skills/payload-analysis/references/ship-status-component-map.md
@@ -8,6 +8,7 @@ Use this table when correlating payload-analysis infrastructure failures with th
 | Boskos / lease / quota exhaustion | `boskos` | `leasing-server`, or `aws` / `gcp` / `azure-2` / `azure4` from the job-name platform |
 | Cloud API / throttling / quota (no Boskos) | `boskos` | same cloud account slugs |
 | Prow control plane (pod pending, plank, hook) | `prow` | `prow-controller-manager` (default) unless a more specific sub-component is named |
+| Insights / console.redhat.com / other Red Hat SaaS API errors | skip | not a SHIP Status component; `list_components` then `action: skipped` |
 | Unmapped | skip | call `list_components` and record candidates; do not invent slugs |
 
 **Build cluster** comes from `prowjob.json` `spec.cluster` (already read during investigation). Job-name substrings pick the Boskos cloud account: `aws` → `aws`, `gcp` → `gcp`, `azure4` / `azure-4` → `azure4`, `aks` / `azure-2` / `azure` → `azure-2`.

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -149,7 +149,7 @@ Recorded by `payload-analysis` steps 6.5 (read) and 6.6 (write, only when `recor
 | `observed_health` | string | Health overlapping the **job run window** from `get_outages_during` (`healthy` if none; otherwise the overlapping outage severity). Never live "now" status from `get_infrastructure_status`. |
 | `existing_outage_id` | int or `null` | Outage id overlapping the job window, or `null` if none |
 | `queried_at` | string | RFC3339 UTC timestamp of the read |
-| `action` | string | `pending` \| `created` \| `linked` \| `skipped` |
+| `action` | string | Required when `ship_status` is present. `pending` \| `created` \| `linked` \| `skipped` |
 | `outage_id` | int or `null` | Filled after a Chai-hosted write |
 | `dashboard_url` | string or `null` | Outage URL after create/link |
 | `reason` | string | Skip/error detail (`unmapped`, `already_recorded`, …) |

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -134,7 +134,7 @@ All failed blocking jobs in the payload. Written once by `payload-analysis`. Nev
 | `streak_length` | int | Consecutive payloads this job has been failing |
 | `originating_payload_tag` | string | The payload where this job first started failing in the current streak |
 | `failure_pattern` | string | Pass/fail history across the lookback window, most recent first (e.g., `"F F F S F F"`) |
-| `ship_status` | object | Optional. SHIP Status observation for `failure_type: infra` jobs (and when infra is suspected). Omit entirely when SHIP read tools are unavailable. |
+| `ship_status` | object | Optional. SHIP Status observation for `failure_type: infra` jobs (and when infra is suspected). Omit the key entirely when SHIP read tools (`get_outages_during` / `list_components`) are not in the tool list. Do not write `action: skipped` as a stand-in for missing tools. |
 
 #### `failing_jobs[].ship_status` (optional)
 

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -56,6 +56,18 @@ failing_jobs:
     streak_length: 1
     originating_payload_tag: "4.22.0-0.nightly-2026-02-25-152806"
     failure_pattern: "F"
+    ship_status:
+      component_slug: build-farm
+      sub_component_slug: build04
+      window_start: "2026-02-25T14:00:00Z"
+      window_end: "2026-02-25T15:30:00Z"
+      observed_health: healthy
+      existing_outage_id: null
+      queried_at: "2026-02-25T16:00:00Z"
+      action: pending
+      outage_id: null
+      dashboard_url: null
+      reason: ""
 
 candidates:
   - type: "pr"
@@ -122,6 +134,25 @@ All failed blocking jobs in the payload. Written once by `payload-analysis`. Nev
 | `streak_length` | int | Consecutive payloads this job has been failing |
 | `originating_payload_tag` | string | The payload where this job first started failing in the current streak |
 | `failure_pattern` | string | Pass/fail history across the lookback window, most recent first (e.g., `"F F F S F F"`) |
+| `ship_status` | object | Optional. SHIP Status observation for `failure_type: infra` jobs (and when infra is suspected). Omit entirely when SHIP read tools are unavailable. |
+
+#### `failing_jobs[].ship_status` (optional)
+
+Recorded by `payload-analysis` steps 6.5 (read) and 6.6 (write, only when `record_payload_infra_outage` exists). Downstream skills must not invent slugs.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `component_slug` | string | SHIP Status component (e.g. `build-farm`, `boskos`, `prow`) |
+| `sub_component_slug` | string | SHIP Status sub-component (e.g. `build04`, `aws`) |
+| `window_start` | string | RFC3339 UTC start of the job's Prow run (same bound passed to `get_outages_during`) |
+| `window_end` | string | RFC3339 UTC end of the job's Prow run (job completion, or `--as-of` if missing) |
+| `observed_health` | string | Health overlapping the **job run window** from `get_outages_during` (`healthy` if none; otherwise the overlapping outage severity). Never live "now" status from `get_infrastructure_status`. |
+| `existing_outage_id` | int or `null` | Outage id overlapping the job window, or `null` if none |
+| `queried_at` | string | RFC3339 UTC timestamp of the read |
+| `action` | string | `pending` \| `created` \| `linked` \| `skipped` |
+| `outage_id` | int or `null` | Filled after a Chai-hosted write |
+| `dashboard_url` | string or `null` | Outage URL after create/link |
+| `reason` | string | Skip/error detail (`unmapped`, `already_recorded`, …) |
 
 ### `candidates[]`
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
         ("invalid candidate type not a string", f"{TESTDATA}/invalid_candidate_type_not_string.yaml", 1),
         ("invalid ship_status action", f"{TESTDATA}/invalid_ship_status_action.yaml", 1),
         ("invalid ship_status action missing or null", f"{TESTDATA}/invalid_ship_status_action_missing.yaml", 1),
+        ("invalid ship_status null", f"{TESTDATA}/invalid_ship_status_null.yaml", 1),
         ("file not found", f"{TESTDATA}/nonexistent.yaml", 1),
     ]
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
@@ -36,6 +36,7 @@ if __name__ == "__main__":
         ("invalid rhcos rpm candidate missing fields", f"{TESTDATA}/invalid_rhcos_rpm_candidate.yaml", 1),
         ("invalid candidate type not a string", f"{TESTDATA}/invalid_candidate_type_not_string.yaml", 1),
         ("invalid ship_status action", f"{TESTDATA}/invalid_ship_status_action.yaml", 1),
+        ("invalid ship_status action missing or null", f"{TESTDATA}/invalid_ship_status_action_missing.yaml", 1),
         ("file not found", f"{TESTDATA}/nonexistent.yaml", 1),
     ]
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
@@ -28,12 +28,14 @@ if __name__ == "__main__":
     cases = [
         ("valid full schema", f"{TESTDATA}/valid.yaml", 0),
         ("valid no candidates", f"{TESTDATA}/valid_no_candidates.yaml", 0),
+        ("valid with ship_status", f"{TESTDATA}/valid_with_ship_status.yaml", 0),
         ("valid with rhcos rpm candidate", f"{TESTDATA}/valid_with_rhcos_rpm_candidate.yaml", 0),
         ("invalid flat schema (no metadata wrapper)", f"{TESTDATA}/invalid_flat_schema.yaml", 1),
         ("invalid metadata is string", f"{TESTDATA}/invalid_metadata_string.yaml", 1),
         ("invalid missing job/candidate fields", f"{TESTDATA}/invalid_missing_job_fields.yaml", 1),
         ("invalid rhcos rpm candidate missing fields", f"{TESTDATA}/invalid_rhcos_rpm_candidate.yaml", 1),
         ("invalid candidate type not a string", f"{TESTDATA}/invalid_candidate_type_not_string.yaml", 1),
+        ("invalid ship_status action", f"{TESTDATA}/invalid_ship_status_action.yaml", 1),
         ("file not found", f"{TESTDATA}/nonexistent.yaml", 1),
     ]
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_action.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_action.yaml
@@ -1,0 +1,14 @@
+metadata:
+  payload_tag: "5.0.0-0.ci-2026-05-01-212308"
+  version: "5.0"
+  stream: "ci"
+  architecture: "amd64"
+
+failing_jobs:
+  - job_name: "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp"
+    failure_type: "infra"
+    root_cause_summary: "GCP quota exceeded"
+    ship_status:
+      action: invented
+
+candidates: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_action_missing.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_action_missing.yaml
@@ -1,0 +1,20 @@
+metadata:
+  payload_tag: "5.0.0-0.ci-2026-05-01-212308"
+  version: "5.0"
+  stream: "ci"
+  architecture: "amd64"
+
+failing_jobs:
+  - job_name: "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp"
+    failure_type: "infra"
+    root_cause_summary: "GCP quota exceeded"
+    ship_status:
+      component_slug: boskos
+      sub_component_slug: gcp
+  - job_name: "periodic-ci-openshift-release-main-ci-5.0-e2e-aws"
+    failure_type: "infra"
+    root_cause_summary: "AWS quota exceeded"
+    ship_status:
+      action: null
+
+candidates: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_null.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_ship_status_null.yaml
@@ -1,0 +1,13 @@
+metadata:
+  payload_tag: "5.0.0-0.ci-2026-05-01-212308"
+  version: "5.0"
+  stream: "ci"
+  architecture: "amd64"
+
+failing_jobs:
+  - job_name: "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp"
+    failure_type: "infra"
+    root_cause_summary: "GCP quota exceeded"
+    ship_status: null
+
+candidates: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid_with_ship_status.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid_with_ship_status.yaml
@@ -1,0 +1,24 @@
+metadata:
+  payload_tag: "5.0.0-0.ci-2026-05-01-212308"
+  version: "5.0"
+  stream: "ci"
+  architecture: "amd64"
+
+failing_jobs:
+  - job_name: "periodic-ci-openshift-release-main-ci-5.0-e2e-gcp"
+    failure_type: "infra"
+    root_cause_summary: "GCP quota exceeded"
+    ship_status:
+      component_slug: boskos
+      sub_component_slug: gcp
+      window_start: "2026-05-01T20:00:00Z"
+      window_end: "2026-05-01T21:30:00Z"
+      observed_health: healthy
+      existing_outage_id: null
+      queried_at: "2026-05-01T22:00:00Z"
+      action: pending
+      outage_id: null
+      dashboard_url: null
+      reason: ""
+
+candidates: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/validate.py
@@ -51,8 +51,14 @@ def validate(path):
             for field in REQUIRED_JOB_FIELDS:
                 if field not in job:
                     errors.append(f"failing_jobs[{i}] missing '{field}'")
-            ship_status = job.get("ship_status")
+            if "ship_status" not in job:
+                continue
+            ship_status = job["ship_status"]
             if ship_status is None:
+                errors.append(
+                    f"failing_jobs[{i}].ship_status must be an object "
+                    f"(omit the key if unavailable, do not set null)"
+                )
                 continue
             if not isinstance(ship_status, dict):
                 errors.append(f"failing_jobs[{i}].ship_status is not an object")

--- a/plugins/ci/skills/payload-results-yaml/scripts/validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/validate.py
@@ -58,7 +58,12 @@ def validate(path):
                 errors.append(f"failing_jobs[{i}].ship_status is not an object")
                 continue
             action = ship_status.get("action")
-            if action is not None and action not in SHIP_STATUS_ACTIONS:
+            if not isinstance(action, str) or not action:
+                errors.append(
+                    f"failing_jobs[{i}].ship_status.action must be a non-empty "
+                    f"string one of {sorted(SHIP_STATUS_ACTIONS)}, got {action!r}"
+                )
+            elif action not in SHIP_STATUS_ACTIONS:
                 errors.append(
                     f"failing_jobs[{i}].ship_status.action must be one of "
                     f"{sorted(SHIP_STATUS_ACTIONS)}, got {action!r}"

--- a/plugins/ci/skills/payload-results-yaml/scripts/validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/validate.py
@@ -11,6 +11,7 @@ REQUIRED_CANDIDATE_FIELDS_BY_TYPE = {
     "pr": ["pr_url"],
     "rhcos_rpm": ["package", "rhcos_tag", "changelog_evidence"],
 }
+SHIP_STATUS_ACTIONS = {"pending", "created", "linked", "skipped"}
 
 
 def validate(path):
@@ -50,6 +51,18 @@ def validate(path):
             for field in REQUIRED_JOB_FIELDS:
                 if field not in job:
                     errors.append(f"failing_jobs[{i}] missing '{field}'")
+            ship_status = job.get("ship_status")
+            if ship_status is None:
+                continue
+            if not isinstance(ship_status, dict):
+                errors.append(f"failing_jobs[{i}].ship_status is not an object")
+                continue
+            action = ship_status.get("action")
+            if action is not None and action not in SHIP_STATUS_ACTIONS:
+                errors.append(
+                    f"failing_jobs[{i}].ship_status.action must be one of "
+                    f"{sorted(SHIP_STATUS_ACTIONS)}, got {action!r}"
+                )
 
     if "candidates" not in data:
         errors.append("missing 'candidates' key")

--- a/plugins/ci/skills/prow-job-analysis/SKILL.md
+++ b/plugins/ci/skills/prow-job-analysis/SKILL.md
@@ -144,6 +144,8 @@ Never clear the OS layer from end-of-run snapshots alone.
 | Lease/quota, ci-operator, Prow infra | [CI Infrastructure](references/ci-infrastructure-changes.md) | Distinguish "product broke" from "CI config changed"; ci-operator, step registry, leases |
 | Need a specific artifact file | [Artifacts](references/artifacts.md) | Artifact directory structure, paths, and gcloud fetch commands |
 
+Job-name routing (Step 3) picks which reference to read. Failure classification (`install` | `test` | `upgrade` | `infra`) follows the root cause, not the job name.
+
 ## Common Artifact Paths
 
 These are the most frequently needed artifacts. See [artifacts reference](references/artifacts.md) for the complete directory structure.

--- a/plugins/ci/skills/prow-job-analysis/references/cloud-provider-errors.md
+++ b/plugins/ci/skills/prow-job-analysis/references/cloud-provider-errors.md
@@ -12,6 +12,9 @@ creation — typically environment issues rather than product bugs;
 - `junit_install.xml` failure mode is `infrastructure` (see
   [Install — General](install/general.md#infrastructure-failures))
 - Installer log shows cloud API errors (quota, throttling, auth, capacity)
+- Cloud API 429/throttling or external VIP/DNS reachability loss **during**
+  test or upgrade — still `failure_type: infra`, even when the job name says
+  `upgrade` or `e2e`
 - Many jobs on **one** cloud fail simultaneously while other clouds pass
 
 **Use a different reference for:**

--- a/plugins/ci/skills/prow-job-analysis/references/hypershift.md
+++ b/plugins/ci/skills/prow-job-analysis/references/hypershift.md
@@ -172,6 +172,7 @@ never provisioned — check the CAPI provider pods (`capi-provider`, `cluster-ap
 | Hosted API 5xx / timeouts | HCP etcd or kube-apiserver | `etcd-*`/`kube-apiserver-*` in `clusters-<name>` |
 | `*.apps.<hosted>` unreachable | Router / konnectivity tunnel | `router`, `konnectivity-*`, [networking.md](networking.md) |
 | Only management must-gather present | Standard-only pattern or hosted collection failed | confirm no `hostedcluster-*` dir; note in report |
+| Tests passed; destroy / dump / deprovision / teardown timed out | **Infrastructure** — cluster under test succeeded; CI cleanup did not | post-step `build-log.txt`, `ipi-deprovision-*`, hypershift destroy logs. Report `failure_type: infra`, not `test` |
 
 ## See Also
 


### PR DESCRIPTION
Read dashboard health during analysis, record optional ship_status on failing jobs, and wire the public SHIP Status MCP into the ci plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SHIP Status integration to correlate historical outages with infrastructure job windows.
  * Included optional outage details, status actions, dashboard links, and skipped mappings in failed-job reports and payload results.
  * Added component mapping guidance for infrastructure failure signals.
  * Improved failure classification guidance for cloud, teardown, and upgrade-related issues.

* **Bug Fixes**
  * Validation now accepts only supported SHIP Status actions and rejects missing or invalid values.
  * Clarified report filename requirements.

* **Tests**
  * Added valid and invalid payload coverage.
  * Expanded evaluations for outage correlation and skipped-job handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->