### PR TITLE
Upgrade skillsaw to 0.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
       "name": "jira",
       "source": "./plugins/jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "category": "productivity",
       "keywords": [
         "jira",
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.91",
+      "version": "0.0.92",
       "category": "ci",
       "keywords": [
         "prow",
@@ -134,7 +134,7 @@
       "name": "teams",
       "source": "./plugins/teams",
       "description": "Team structure knowledge and health analysis commands for OpenShift teams",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "category": "productivity",
       "keywords": [
         "teams",
@@ -184,7 +184,7 @@
       "name": "olm",
       "source": "./plugins/olm",
       "description": "OLM (Operator Lifecycle Manager) plugin for operator management and debugging",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "openshift",
       "keywords": [
         "olm",
@@ -197,7 +197,7 @@
       "name": "olm-team",
       "source": "./plugins/olm-team",
       "description": "OLM team development utilities and onboarding tools",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "category": "development",
       "keywords": [
         "olm",
@@ -234,7 +234,7 @@
       "name": "openshift",
       "source": "./plugins/openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "category": "openshift",
       "keywords": [
         "openshift",
@@ -270,7 +270,7 @@
       "name": "must-gather",
       "source": "./plugins/must-gather",
       "description": "A plugin to analyze and report on must-gather data",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "category": "debugging",
       "keywords": [
         "must-gather",
@@ -282,7 +282,7 @@
       "name": "hcp",
       "source": "./plugins/hcp",
       "description": "Generate HyperShift cluster creation commands via hcp CLI from natural language descriptions",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "category": "openshift",
       "keywords": [
         "hypershift",
@@ -414,7 +414,7 @@
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Automated code quality review with language-aware analysis, pre-commit verification, and multi-specialist deep review",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "category": "development",
       "keywords": [
         "code-review",
@@ -441,7 +441,7 @@
       "name": "ote-migration",
       "source": "./plugins/ote-migration",
       "description": "Automate OpenShift Tests Extension (OTE) migration for component repositories",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "category": "development",
       "keywords": [
         "ote",

--- a/.github/workflows/lint-plugins.yml
+++ b/.github/workflows/lint-plugins.yml
@@ -19,6 +19,6 @@ jobs:
           persist-credentials: false
 
       - name: Run skillsaw
-        uses: stbenjam/skillsaw@f9819d2de4d69100f8544175d4045f34f0282b66 # v0.17.0
+        uses: stbenjam/skillsaw@8daf5329069961267553829de3064c2c352222b2 # v0.19.0
         with:
           strict: true

--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -25,4 +25,4 @@ jobs:
           persist-credentials: false
 
       - name: Post review comments
-        uses: stbenjam/skillsaw/review@f9819d2de4d69100f8544175d4045f34f0282b66 # v0.17.0
+        uses: stbenjam/skillsaw/review@8daf5329069961267553829de3064c2c352222b2 # v0.19.0

--- a/.skillsaw-baseline.json
+++ b/.skillsaw-baseline.json
@@ -1,0 +1,666 @@
+{
+  "version": "1",
+  "generated_by": "skillsaw 0.19.0",
+  "generated_at": "2026-08-27T21:37:44.078792+00:00",
+  "violations": [
+    {
+      "fingerprint": "3271f88c8e974019",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/node-cve/skills/report-findings/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "596873c5de416adc",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/node-cve/skills/analyze-cve-repos/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "2a0ab19d8ae2e19a",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/node-cve/skills/query-open-cves/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "f8cac9b5a41af5c1",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/manage-labels/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "41006101008f9675",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-job-run-summary/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "2a5566a90da6a378",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/add-jira-triage-link/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "f895c49cb1052356",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-releases/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "0677dd88bf4e7599",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/payload-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "64b28dbe277f783f",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/revert-pr/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "a9269f92900e66bb",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/oc-auth/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "23ce47f7621f7ecf",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-payloads/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "3b9d10454173e2ce",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-new-prs-in-payload/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "1b0a1b461cf63e0b",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/reevaluate-job-runs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "7363a439fe2a1a22",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/payload-snapshot/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "8a69255b7f6cce3a",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-jira-issue/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "a5f4718a196fe4d8",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-regression-details/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "35be545a9102ac5c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/manage-symptoms/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "e54587d29eb46b83",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/triage-regression/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "700dda13a91f9b67",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-prow-job-runs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "b22c911a32b53e69",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/prow-job-analyze-resource/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "037b2a4b9df741c1",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/detect-permafail/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ee5942009ff0fd21",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-prowjob-json/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "2e1131801c75173e",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/analyze-disruption/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "2629077637f45cfa",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/diagnose-job-run-symptoms/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ea3d60e133b35a1d",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-test-report/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "32dc40f6cc871ad8",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/set-release-blocker/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "bfe327bc6ee218f9",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/payload-experimental-reverts/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "a6392855aad8949e",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/list-symptoms/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "cc2c408a918dafd2",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-test-runs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "3606a81858e9029c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/fetch-related-triages/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "db965adbe93578f2",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ci/skills/stage-payload-reverts/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "7cfbca7a9ddda1cd",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/node-tuning/skills/scripts/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "6f39c5b4deb4f089",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/code-review/skills/hypershift-code-review/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "9167f000a80cbb17",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/code-review/skills/go-code-review/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "5e6665f486f7058b",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ai-operator-dashboard-generator/skills/dashboard-templates/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "f769d415ab641b17",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/ote-migration/skills/ote-migration-workflow/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "cf58f2faabcfd1c8",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/bigquery/skills/ci-data-analyst/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "3c51ee0988941248",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/bigquery/skills/analyze-usage/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "9050c9e80f3b124c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/sosreport/skills/resource-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "d825962bb1bf7a5b",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/sosreport/skills/logs-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "d8dcca7b6494a461",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/sosreport/skills/ovs-db-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ce557d2928636d07",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/sosreport/skills/network-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "99dc8b908b80336a",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/sosreport/skills/system-config-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "502f396454e8fb6d",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/compliance/skills/call-graph-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "bedb51b76af82533",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/compliance/skills/codebase-impact-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "3a5ec9660320aa25",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/compliance/skills/remediation-planning/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ea1131966bef1d68",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/compliance/skills/cve-intelligence-gathering/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "79c46dac140eafe2",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/catch-me-up/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "d4bc49701e023035",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/ready-to-solve/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "92551cc635318aa3",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/validate-bug/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "edc14eefd61aac0c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/jira-conventions/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "be16b956daa08c54",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/jira-validate-blockers/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "19fcf0ed1b3f39c5",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/extract-prs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "bf39f6c133eef71c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/status-analysis/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "7174fc1fcef97445",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/jira-issues-by-component/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "95db94cb489c6498",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/generate-enhancement/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "046740d16520876d",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/create-release-note/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "9eaa44982d11c4e4",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/create/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "85e6beb89e923a0f",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/jira/skills/jira-doc-generator/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ebd34898e214cf2c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/openshift/skills/openshift-node-kernel/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "1e74e42fd42c1eec",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/openshift/skills/generating-ovn-topology/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "3f18b7b0adaab025",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/agentic-docs/skills/review-docs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "4770f0fda1b2f046",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/agentic-docs/skills/component-docs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "b1b5c135b4c4235c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/agentic-docs/skills/update-platform-docs/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "6021721653755ced",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/coderabbit-inheritance-scanner-open-pr/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "d35abea5c0d5eff7",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/list-jiras/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "4bdf9c8fc0b410fa",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/coderabbit-rules-from-pr-reviews/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "f32d10b28947b969",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/list-regressions/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "e359de80f93bee8d",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/list-teams/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "aa5234dda60bb376",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/coderabbit-adoption/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "ea0cd1713d0472d3",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/coderabbit-inheritance-scanner-search/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "4f7997c87db9bbd6",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/list-components/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "e99e6fd36554c814",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/analyze-regressions/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "f55af26a09599c6c",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/get-release-dates/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "81c3f6ed096c3ca0",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/coderabbit-inheritance-scanner-existing-pr/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "0fb637fa2397b145",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/teams/skills/summarize-jiras/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "fd63773e7629d315",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/rds-analyzer/skills/rds-analyzer-workflow/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "9519e4cd177b2c55",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/git/skills/suggest-reviewers/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "93c56712603871b8",
+      "rule_id": "content-description-routing",
+      "file_path": "plugins/console/skills/upgrade-console-sdk/SKILL.md",
+      "line": 3,
+      "message": "Description does not say when to use this skill; include trigger phrasing such as 'Use when ...'",
+      "severity": "warning"
+    },
+    {
+      "fingerprint": "bd002ced5ac8179d",
+      "rule_id": "content-progressive-disclosure",
+      "file_path": "plugins/ci/skills/detect-permafail/SKILL.md",
+      "message": "Estimated 9,728 tokens exceeds the 6,500-token progressive-disclosure threshold for skill and the file references no other local file \u2014 split detailed material into bundled files (references/*.md, scripts) and point to them from SKILL.md so detail loads only when needed",
+      "severity": "warning",
+      "value": 9728,
+      "baseline_mode": "ceiling"
+    },
+    {
+      "fingerprint": "d0472d816a974feb",
+      "rule_id": "content-progressive-disclosure",
+      "file_path": "plugins/ote-migration/skills/ote-migration-workflow/SKILL.md",
+      "message": "Estimated 31,325 tokens exceeds the 6,500-token progressive-disclosure threshold for skill and the file references no other local file \u2014 split detailed material into bundled files (references/*.md, scripts) and point to them from SKILL.md so detail loads only when needed",
+      "severity": "warning",
+      "value": 31325,
+      "baseline_mode": "ceiling"
+    },
+    {
+      "fingerprint": "c540e208532ce033",
+      "rule_id": "content-progressive-disclosure",
+      "file_path": "plugins/jira/skills/generate-enhancement/SKILL.md",
+      "message": "Estimated 9,969 tokens exceeds the 6,500-token progressive-disclosure threshold for skill and the file references no other local file \u2014 split detailed material into bundled files (references/*.md, scripts) and point to them from SKILL.md so detail loads only when needed",
+      "severity": "warning",
+      "value": 9969,
+      "baseline_mode": "ceiling"
+    }
+  ]
+}

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -1,6 +1,6 @@
 # skillsaw configuration
 # https://github.com/stbenjam/skillsaw
-version: "0.14.1"
+version: "0.19.0"
 strict: true
 
 rules:
@@ -57,13 +57,29 @@ rules:
   content-tautological:
     enabled: true
 
+  # Detect executable dynamic context embedded in Markdown
+  security-dynamic-context:
+    enabled: true
+    severity: warning
+    allowlist:
+      - '"${CLAUDE_PLUGIN_ROOT}/scripts/setup-generate-docs.sh" $ARGUMENTS'
+      - "gh api repos/openshift/console/contents/frontend/packages/console-dynamic-plugin-sdk/release-notes --jq '.[].name'"
+
+  # Flag oversized context that should be split into linked references
+  content-progressive-disclosure:
+    enabled: true
+    severity: warning
+    limits:
+      skill: 6500
+
+  # Detect repeated inline tool invocations that should become reusable scripts
+  content-inline-tool-examples:
+    enabled: true
+    severity: warning
+
   # TODO: ai-helpers has many skills way over budget, including one with 20K tokens
   context-budget:
     enabled: false
-  # Detect critical instructions in the middle of files where LLM attention is lowest
-  content-critical-position: # unsure if actually useful here
-    enabled: false
-
   # Detect potential API keys, tokens, and passwords in instruction files
   content-embedded-secrets:
     enabled: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -464,7 +464,10 @@ footer a { color: var(--primary); }
         }
       ],
       "mcp_servers": [],
-      "rules": []
+      "rules": [],
+      "author": {
+        "name": "github.com/openshift-eng"
+      }
     },
     {
       "name": "ai-sbom",
@@ -541,7 +544,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.91",
+      "version": "0.0.92",
       "has_readme": true,
       "commands": [
         {
@@ -989,7 +992,7 @@ footer a { color: var(--primary); }
     {
       "name": "code-review",
       "description": "Automated code quality review with language-aware analysis, pre-commit verification, and multi-specialist deep review",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "has_readme": true,
       "commands": [
         {
@@ -1391,7 +1394,7 @@ footer a { color: var(--primary); }
     {
       "name": "hcp",
       "description": "Generate HyperShift cluster creation commands via hcp CLI from natural language descriptions",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "has_readme": true,
       "commands": [
         {
@@ -1496,7 +1499,7 @@ footer a { color: var(--primary); }
     {
       "name": "jira",
       "description": "A plugin to automate tasks with Jira",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "has_readme": true,
       "commands": [
         {
@@ -1816,7 +1819,7 @@ footer a { color: var(--primary); }
     {
       "name": "must-gather",
       "description": "A plugin to analyze and report on must-gather data",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "has_readme": true,
       "commands": [
         {
@@ -2203,7 +2206,7 @@ footer a { color: var(--primary); }
     {
       "name": "olm",
       "description": "OLM (Operator Lifecycle Manager) plugin for operator management and debugging",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "has_readme": true,
       "commands": [
         {
@@ -2314,7 +2317,7 @@ footer a { color: var(--primary); }
     {
       "name": "olm-team",
       "description": "OLM team development utilities and onboarding tools",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "has_readme": true,
       "commands": [
         {
@@ -2367,7 +2370,7 @@ footer a { color: var(--primary); }
     {
       "name": "openshift",
       "description": "OpenShift development utilities and helpers",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "has_readme": true,
       "commands": [
         {
@@ -2683,7 +2686,7 @@ footer a { color: var(--primary); }
     {
       "name": "ote-migration",
       "description": "Automate OpenShift Tests Extension (OTE) migration for component repositories",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "has_readme": true,
       "commands": [
         {
@@ -2887,7 +2890,7 @@ footer a { color: var(--primary); }
     {
       "name": "teams",
       "description": "Team structure knowledge and health analysis commands for OpenShift teams",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "has_readme": true,
       "commands": [
         {
@@ -3311,7 +3314,7 @@ footer a { color: var(--primary); }
     if (type === 'plugins' && IS_MARKETPLACE) {
       html += '<div class="search-results-heading">'+label+' ('+allPlugins.length+')</div>';
       allPlugins.forEach(function(p) {
-        html += '<div class="search-result-item" onclick="navigateTo(\''+escAttr(p.name)+'\')">';
+        html += '<div class="search-result-item" onclick="navigateTo(' + escJsAttr(p.name) + ')">';
         html += '<div class="search-result-icon plugin">'+esc(pName(p).charAt(0).toUpperCase())+'</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+esc(pName(p))+'</div>';
         html += '<div class="search-result-subtitle">'+esc(p.description)+'</div></div></div>';
@@ -3330,7 +3333,7 @@ footer a { color: var(--primary); }
       if (items.length) {
         html += '<div class="search-results-heading">'+label+' ('+items.length+')</div>';
         items.forEach(function(r) {
-          var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+          var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
           html += '<div class="search-result-item"'+onclick+'>';
           html += '<div class="search-result-icon '+esc(r.icon)+'">'+esc(r.iconChar)+'</div>';
           html += '<div class="search-result-content"><div class="search-result-title">'+esc(r.name)+'</div>';
@@ -3358,10 +3361,10 @@ footer a { color: var(--primary); }
     el.innerHTML = filterHtml + '<div class="plugins-grid" id="plugins-grid">' + plugins.map(function(p) {
       var counts = buildCountBadges(p);
       var ver = p.version ? '<span class="plugin-version">v'+esc(p.version)+'</span>' : '';
-      var cat = p.category ? '<span class="plugin-category" onclick="event.stopPropagation();navigateTo(\'category='+escAttr(p.category)+'\')">'+esc(p.category)+'</span>' : '';
+      var cat = p.category ? '<span class="plugin-category" onclick="event.stopPropagation();navigateTo(' + escJsAttr('category=' + p.category) + ')">'+esc(p.category)+'</span>' : '';
       var allTags = (p.tags||[]).concat(p.keywords||[]);
-      var tagsHtml = allTags.length ? '<div class="plugin-tags">'+allTags.map(function(t){return '<span class="plugin-tag" onclick="event.stopPropagation();navigateTo(\'q='+escAttr(t)+'\')">'+esc(t)+'</span>';}).join('')+'</div>' : '';
-      return '<div class="plugin-card" data-category="'+(esc(p.category)||'')+'" onclick="navigateTo(\''+escAttr(p.name)+'\')">' +
+      var tagsHtml = allTags.length ? '<div class="plugin-tags">'+allTags.map(function(t){return '<span class="plugin-tag" onclick="event.stopPropagation();navigateTo(' + escJsAttr('q=' + t) + ')">'+esc(t)+'</span>';}).join('')+'</div>' : '';
+      return '<div class="plugin-card" data-category="'+(escAttr(p.category)||'')+'" onclick="navigateTo(' + escJsAttr(p.name) + ')">' +
         '<div class="plugin-header"><div><div class="plugin-name">'+esc(pName(p))+'</div>'+ver+'</div>'+cat+'</div>' +
         '<div class="plugin-description">'+(p.description_html || esc(p.description) || '<em>No description</em>')+'</div>' +
         tagsHtml +
@@ -3378,7 +3381,7 @@ footer a { color: var(--primary); }
   function renderCategoryFilter(cats) {
     var btns = '<button class="category-btn'+(activeCategory?'':' active')+'" onclick="navigateTo(\'\')">All</button>';
     cats.forEach(function(c) {
-      btns += '<a href="#category='+encodeURIComponent(c)+'" class="category-btn'+(activeCategory===c?' active':'')+'" onclick="event.preventDefault();navigateTo(\'category='+escAttr(c)+'\')">'+esc(c)+'</a>';
+      btns += '<a href="#category='+encodeURIComponent(c)+'" class="category-btn'+(activeCategory===c?' active':'')+'" onclick="event.preventDefault();navigateTo(' + escJsAttr('category=' + c) + ')">'+esc(c)+'</a>';
     });
     return '<div class="category-filter" id="category-filter">' + btns + '</div>';
   }
@@ -3439,7 +3442,7 @@ footer a { color: var(--primary); }
   function renderPluginSections(p, forModal) {
     var h = '';
     var wrap = forModal ? function(cls, inner) { return '<div class="modal-section-items" data-filtered="false">' + inner + '</div>'; } : function(cls, inner) { return inner; };
-    var dataAttr = forModal ? function(text) { return ' data-search="'+esc(text.toLowerCase())+'"'; } : function() { return ''; };
+    var dataAttr = forModal ? function(text) { return ' data-search="'+escAttr(text.toLowerCase())+'"'; } : function() { return ''; };
     if (p.commands.length) {
       h += '<div class="section-title">Commands</div>';
       var cmds = '';
@@ -3589,7 +3592,7 @@ footer a { color: var(--primary); }
     if (results.plugins.length && IS_MARKETPLACE) {
       html += '<div class="search-results-heading">Plugins (' + results.plugins.length + ')</div>';
       results.plugins.forEach(function(p) {
-        html += '<div class="search-result-item" onclick="navigateTo(\''+escAttr(p.name)+'\')">';
+        html += '<div class="search-result-item" onclick="navigateTo(' + escJsAttr(p.name) + ')">';
         html += '<div class="search-result-icon plugin">'+esc(pName(p).charAt(0).toUpperCase())+'</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(pName(p),q)+'</div>';
         html += '<div class="search-result-subtitle">'+hi(p.description,q)+'</div></div></div>';
@@ -3599,7 +3602,7 @@ footer a { color: var(--primary); }
     if (results.commands.length) {
       html += '<div class="search-results-heading">Commands (' + results.commands.length + ')</div>';
       results.commands.forEach(function(r) {
-        var onclick = IS_MARKETPLACE ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+        var onclick = IS_MARKETPLACE ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
         html += '<div class="search-result-item"'+onclick+'>';
         html += '<div class="search-result-icon cmd">$</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(r.item.full_name || r.item.name, q)+'</div>';
@@ -3612,7 +3615,7 @@ footer a { color: var(--primary); }
     if (results.skills.length) {
       html += '<div class="search-results-heading">Skills (' + results.skills.length + ')</div>';
       results.skills.forEach(function(r) {
-        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
         html += '<div class="search-result-item"'+onclick+'>';
         html += '<div class="search-result-icon skill">S</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(r.item.name,q)+'</div>';
@@ -3625,7 +3628,7 @@ footer a { color: var(--primary); }
     if (results.agents.length) {
       html += '<div class="search-results-heading">Agents (' + results.agents.length + ')</div>';
       results.agents.forEach(function(r) {
-        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
         html += '<div class="search-result-item"'+onclick+'>';
         html += '<div class="search-result-icon agent">A</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(r.item.name,q)+'</div>';
@@ -3638,7 +3641,7 @@ footer a { color: var(--primary); }
     if (results.hooks.length) {
       html += '<div class="search-results-heading">Hooks (' + results.hooks.length + ')</div>';
       results.hooks.forEach(function(r) {
-        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
         html += '<div class="search-result-item"'+onclick+'>';
         html += '<div class="search-result-icon hook">H</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(r.item.event_type,q)+'</div>';
@@ -3651,7 +3654,7 @@ footer a { color: var(--primary); }
     if (results.rules.length) {
       html += '<div class="search-results-heading">Rules (' + results.rules.length + ')</div>';
       results.rules.forEach(function(r) {
-        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(\''+escAttr(r.plugin)+'\')"' : '';
+        var onclick = IS_MARKETPLACE && r.plugin ? ' onclick="navigateTo(' + escJsAttr(r.plugin) + ')"' : '';
         html += '<div class="search-result-item"'+onclick+'>';
         html += '<div class="search-result-icon rule">R</div>';
         html += '<div class="search-result-content"><div class="search-result-title">'+hi(r.item.name,q)+'</div>';
@@ -3684,8 +3687,8 @@ footer a { color: var(--primary); }
     html += '</div></div>';
 
     var metaLinks = [];
-    if (p.homepage) metaLinks.push('<a href="'+esc(p.homepage)+'">Homepage</a>');
-    if (p.repository) metaLinks.push('<a href="'+esc(p.repository)+'">Repository</a>');
+    if (p.homepage) metaLinks.push('<a href="'+escAttr(p.homepage)+'">Homepage</a>');
+    if (p.repository) metaLinks.push('<a href="'+escAttr(p.repository)+'">Repository</a>');
     if (p.author) {
       var authorText = typeof p.author === 'object' ? (p.author.name||'') : p.author;
       if (authorText) metaLinks.push('Author: '+esc(authorText));
@@ -3739,6 +3742,7 @@ footer a { color: var(--primary); }
     });
   }
 
+  // BEGIN_ESCAPERS
   function esc(str) {
     if (!str) return '';
     var d = document.createElement('div');
@@ -3747,8 +3751,28 @@ footer a { color: var(--primary); }
   }
 
   function escAttr(str) {
-    return esc(str).replace(/'/g, '&#39;');
+    // HTML attribute context. esc() serialises a text node, which leaves the
+    // double quote alone — fine for element text, not for an attribute
+    // value, where it closes the attribute and a second handler can follow.
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
+
+  function escJsAttr(str) {
+    // JSON.stringify is the JavaScript string-literal serializer. It handles
+    // quotes, backslashes, and ordinary line terminators; escape the two
+    // legacy Unicode line separators that it leaves literal. Then HTML-escape
+    // the complete literal for the double-quoted attribute.
+    var literal = !str ? '""' : JSON.stringify(String(str));
+    return escAttr(
+      literal.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029')
+    );
+  }
+  // END_ESCAPERS
 
   init();
 })();

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/commands/analyze-regression.md
+++ b/plugins/ci/commands/analyze-regression.md
@@ -1023,8 +1023,7 @@ This works because `oc` reads from `~/.kube/config` which is bind-mounted from t
      [Monitor:kubelet-container-restarts][sig-architecture] platform pods in ns/openshift-kube-apiserver should not exit an excessive amount of times
      {code}
      ```
-   - Test ID(s) (`test_id` — the BigQuery/Component Readiness ID, e.g., `openshift-tests:abc123`)
-   - Regression ID(s) — the Component Readiness regression ID(s) being triaged
+   - Test and regression identifiers collected in step 12
    - Release
    - Regression opened date
    - Affected variants

--- a/plugins/ci/commands/ask-sippy.md
+++ b/plugins/ci/commands/ask-sippy.md
@@ -46,12 +46,12 @@ The DPCR cluster token is used solely for authentication with the Sippy API. Thi
 1. **Validate Arguments**: Checks that a question was provided
 2. **Notify User**: Informs the user that the query is being processed (may take time)
 3. **API Request**: Sends a POST request to the Sippy API using the `oc-auth` skill's curl wrapper:
-   ```bash
-   # Use curl_with_token.sh from oc-auth skill - it automatically adds the OAuth token
-   # DPCR cluster API: https://api.cr.j7t7.p1.openshiftapps.com:6443
-   curl_with_token.sh https://api.cr.j7t7.p1.openshiftapps.com:6443 -s -X POST "https://sippy-auth.dptools.openshift.org/api/chat" \
-     -H "Content-Type: application/json" \
-     -d @- <<'EOF'
+```bash
+# Use curl_with_token.sh from oc-auth skill - it automatically adds the OAuth token
+# DPCR cluster API: https://api.cr.j7t7.p1.openshiftapps.com:6443
+curl_with_token.sh https://api.cr.j7t7.p1.openshiftapps.com:6443 -s -X POST "https://sippy-auth.dptools.openshift.org/api/chat" \
+  -H "Content-Type: application/json" \
+  -d @- <<'EOF'
 {
   "message": "$1",
   "chat_history": [],
@@ -59,7 +59,7 @@ The DPCR cluster token is used solely for authentication with the Sippy API. Thi
   "persona": "default"
 }
 EOF
-   ```
+```
 4. **Return JSON**: Returns the full JSON response for Claude to parse
 
 ## Return Value

--- a/plugins/ci/skills/payload-autodl-json/SKILL.md
+++ b/plugins/ci/skills/payload-autodl-json/SKILL.md
@@ -215,6 +215,8 @@ After staging reverts, find rows matching `candidate_pr_url` and set:
 
 ## See Also
 
+- Validator: run `python3 scripts/validate.py <payload-autodl-file>` to check generated JSON before database ingestion.
+
 - Related Skill: `payload-analysis` — creates this file in Step 8
 - Related Skill: `stage-payload-reverts` — updates revert fields after staging reverts
 - Related Skill: `payload-experimental-reverts` — updates revert fields after experiments

--- a/plugins/ci/skills/payload-autodl-json/SKILL.md
+++ b/plugins/ci/skills/payload-autodl-json/SKILL.md
@@ -215,7 +215,7 @@ After staging reverts, find rows matching `candidate_pr_url` and set:
 
 ## See Also
 
-- Validator: run `python3 scripts/validate.py <payload-autodl-file>` to check generated JSON before database ingestion.
+- Validator: run `python3 plugins/ci/skills/payload-autodl-json/scripts/validate.py <payload-autodl-file>` to check generated JSON for correctness.
 
 - Related Skill: `payload-analysis` — creates this file in Step 8
 - Related Skill: `stage-payload-reverts` — updates revert fields after staging reverts

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -224,7 +224,7 @@ Scan all candidates. If any candidate has an action with `type: "experiment"` an
 
 ## See Also
 
-- Validator: run `python3 scripts/validate.py <payload-results-file>` to check a generated YAML file against this schema.
+- Validator: run `python3 plugins/ci/skills/payload-results-yaml/scripts/validate.py <payload-results-file>` to check a generated YAML file against this schema.
 
 - Related Skill: `payload-analysis` — creates the results file
 - Related Skill: `stage-payload-reverts` — appends `type: "revert"` actions

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -224,6 +224,8 @@ Scan all candidates. If any candidate has an action with `type: "experiment"` an
 
 ## See Also
 
+- Validator: run `python3 scripts/validate.py <payload-results-file>` to check a generated YAML file against this schema.
+
 - Related Skill: `payload-analysis` — creates the results file
 - Related Skill: `stage-payload-reverts` — appends `type: "revert"` actions
 - Related Skill: `payload-experimental-reverts` — appends `type: "experiment"` actions, updates status in Phase 2

--- a/plugins/ci/skills/prow-job-analyze-resource/SCRIPTS.md
+++ b/plugins/ci/skills/prow-job-analyze-resource/SCRIPTS.md
@@ -4,6 +4,10 @@ This directory contains Python scripts to parse Prow job artifacts and generate 
 
 ## Scripts
 
+### create_inline_html_files.py
+
+Converts collected log files into self-contained HTML files for browser-based inspection. Run `python3 create_inline_html_files.py <logs_dir> <build_id>` when the raw logs need an inline viewer before report generation.
+
 ### parse_all_logs.py
 
 Parses audit logs from Prow job artifacts and outputs structured JSON.

--- a/plugins/ci/skills/prow-job-analyze-resource/SKILL.md
+++ b/plugins/ci/skills/prow-job-analyze-resource/SKILL.md
@@ -18,6 +18,8 @@ Use this skill when the user wants to:
 
 ## Prerequisites
 
+Read [SCRIPTS.md](SCRIPTS.md) for the bundled helper inventory and standalone usage examples.
+
 Before starting, verify these prerequisites:
 
 1. **gcloud CLI Installation**
@@ -139,14 +141,13 @@ Use the `fetch-prowjob-json` skill to fetch the prowjob.json for this job. See `
 1. **Construct gather-extra paths**
    - GCS path: `gs://test-platform-results/{bucket-path}/artifacts/{target}/gather-extra/`
    - Local path: `.work/prow-job-analyze-resource/{build_id}/logs/artifacts/{target}/gather-extra/`
+   - For every download, create the local directory first and pass `--no-user-output-enabled` to `gcloud storage cp`.
 
 2. **Download audit logs**
    ```bash
    mkdir -p .work/prow-job-analyze-resource/{build_id}/logs/artifacts/{target}/gather-extra/artifacts/audit_logs
    gcloud storage cp -r gs://test-platform-results/{bucket-path}/artifacts/{target}/gather-extra/artifacts/audit_logs/ .work/prow-job-analyze-resource/{build_id}/logs/artifacts/{target}/gather-extra/artifacts/audit_logs/ --no-user-output-enabled
    ```
-   - Create directory first to avoid gcloud errors
-   - Use `--no-user-output-enabled` to suppress progress output
    - If directory not found, warn: "No audit logs found. Job may not have completed or audit logging may be disabled."
 
 3. **Download pod logs**
@@ -154,8 +155,6 @@ Use the `fetch-prowjob-json` skill to fetch the prowjob.json for this job. See `
    mkdir -p .work/prow-job-analyze-resource/{build_id}/logs/artifacts/{target}/gather-extra/artifacts/pods
    gcloud storage cp -r gs://test-platform-results/{bucket-path}/artifacts/{target}/gather-extra/artifacts/pods/ .work/prow-job-analyze-resource/{build_id}/logs/artifacts/{target}/gather-extra/artifacts/pods/ --no-user-output-enabled
    ```
-   - Create directory first to avoid gcloud errors
-   - Use `--no-user-output-enabled` to suppress progress output
    - If directory not found, warn: "No pod logs found."
 
 ### Step 6: Parse Audit Logs and Pod Logs
@@ -227,7 +226,6 @@ python3 plugins/ci/skills/prow-job-analyze-resource/parse_all_logs.py <resource_
      - Example: `create pod/etcd-0 in openshift-etcd by system:serviceaccount:kube-system:deployment-controller → HTTP 201`
 
 6. **Parse pod log files (plain text format)**
-   - Read file line by line
    - Each line is plain text (not JSON)
    - Search for resource pattern in line content
 
@@ -464,13 +462,10 @@ Handle these error scenarios by displaying a clear error message and actionable 
 ## Performance Considerations
 
 1. **Avoid re-downloading**
-   - Check if `.work/prow-job-analyze-resource/{build_id}/logs/` already has content
-   - Ask user before re-downloading
+   - Follow the cache prompt in Step 3 instead of overwriting existing artifacts.
 
 2. **Efficient downloads**
-   - Use `gcloud storage cp -r` for recursive downloads
-   - Use `--no-user-output-enabled` to suppress verbose output
-   - Create target directories with `mkdir -p` before downloading to avoid gcloud errors
+   - Follow the recursive-download safeguards in Step 5.
 
 3. **Memory efficiency**
    - The `parse_all_logs.py` script processes log files incrementally (line by line)

--- a/plugins/code-review/.claude-plugin/plugin.json
+++ b/plugins/code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-review",
   "description": "Automated code quality review with language-aware analysis, pre-commit verification, and multi-specialist deep review",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/code-review/commands/pr.md
+++ b/plugins/code-review/commands/pr.md
@@ -58,7 +58,7 @@ The two layers compose: `--language go --profile hypershift` applies both Go idi
 
 ### Step 2 — Launch Parallel Review Sub-Agents
 
-After identifying changed files, launch the following reviews concurrently. Launch ALL sub-agents in parallel (single message with multiple Task tool calls) for maximum speed. Each sub-agent should be given `subagent_type: "general-purpose"`. Do NOT set the `model` parameter — let sub-agents inherit the parent model, as these analysis tasks require a capable model. Pass each sub-agent the list of changed files, the full PR diff, the loaded language skill content (if any), and the loaded profile skill content (if any) in its prompt.
+After identifying changed files, launch the following reviews concurrently. Launch ALL sub-agents in parallel (single message with multiple Task tool calls) for maximum speed. Each sub-agent should be given `subagent_type: "general-purpose"`. Do NOT set the `model` parameter — let sub-agents inherit the parent model, as these analysis tasks require a capable model. Pass each sub-agent the list of changed files, the full PR diff, the loaded language skill content (if any), and the loaded profile skill content (if any) in its prompt. Every sub-agent must return findings as structured text.
 
 #### Sub-agent: Unit Test Coverage
 Skip if `--skip-tests` is specified.
@@ -68,13 +68,11 @@ Skip if `--skip-tests` is specified.
 - Check for edge cases, error paths, and boundary conditions in tests.
 - **If a language skill is loaded**, apply its test conventions (e.g., Go: table-driven tests, `t.Run()`, `t.Parallel()`).
 - **If a profile is loaded**, apply its additional test conventions.
-- Return findings as structured text.
 
 #### Sub-agent: Idiomatic Code
 - **If a language skill is loaded**, apply its idiomatic code guidance to the changed files.
 - **If no language skill is loaded**, perform a general review: error handling, naming, clarity, complexity.
 - **If a profile is loaded**, follow the profile's instructions to discover and apply any repo-local agents or skills it references. For example, the hypershift profile points to `.claude/agents/` — read the agents, pick the relevant ones based on changed files, and use their guidance.
-- Return findings as structured text.
 
 #### Sub-agent: DRY Principle
 - Check for code duplication within and across changed files.
@@ -82,7 +80,6 @@ Skip if `--skip-tests` is specified.
 - Identify copy-paste code that introduces maintenance risk.
 - Flag magic numbers and string literals that should be constants.
 - **If a profile is loaded**, check for proper use of project-specific shared utilities (e.g., hypershift's `support/` package).
-- Return findings as structured text.
 
 #### Sub-agent: SOLID Principles
 - Apply SOLID principles proportionally to the scope of the changes:
@@ -92,7 +89,6 @@ Skip if `--skip-tests` is specified.
   - **ISP**: Are interfaces focused and minimal?
   - **DIP**: Do high-level modules depend on abstractions rather than concrete implementations?
 - **If a profile is loaded**, apply any project-specific structural patterns it defines.
-- Return findings as structured text.
 
 #### Sub-agents: Profile-Specific Reviews (only if profile is loaded)
   - Read the profile skill to discover which SME agents are required.

--- a/plugins/code-review/commands/pre-commit-review.md
+++ b/plugins/code-review/commands/pre-commit-review.md
@@ -55,7 +55,7 @@ This step is language-agnostic.
 
 ### Step 2 — Launch Parallel Review Sub-Agents
 
-After identifying changed files, launch the following reviews concurrently. Launch ALL sub-agents in parallel (single message with multiple Task tool calls) for maximum speed. Each sub-agent should be given `subagent_type: "general-purpose"`. Do NOT set the `model` parameter — let sub-agents inherit the parent model, as these analysis tasks require a capable model. Pass each sub-agent the list of changed files, the loaded language skill content (if any), and the loaded profile skill content (if any) in its prompt.
+After identifying changed files, launch the following reviews concurrently. Launch ALL sub-agents in parallel (single message with multiple Task tool calls) for maximum speed. Each sub-agent should be given `subagent_type: "general-purpose"`. Do NOT set the `model` parameter — let sub-agents inherit the parent model, as these analysis tasks require a capable model. Pass each sub-agent the list of changed files, the loaded language skill content (if any), and the loaded profile skill content (if any) in its prompt. Every sub-agent must return findings as structured text.
 
 #### Sub-agent: Unit Test Coverage
 Skip if `--skip-tests` is specified.
@@ -65,13 +65,11 @@ Skip if `--skip-tests` is specified.
 - Check for edge cases, error paths, and boundary conditions in tests.
 - **If a language skill is loaded**, apply its test conventions (e.g., Go: table-driven tests, `t.Run()`, `t.Parallel()`).
 - **If a profile is loaded**, apply its additional test conventions.
-- Return findings as structured text.
 
 #### Sub-agent: Idiomatic Code
 - **If a language skill is loaded**, apply its idiomatic code guidance to the changed files.
 - **If no language skill is loaded**, perform a general review: error handling, naming, clarity, complexity.
 - **If a profile is loaded**, follow the profile's instructions to discover and apply any repo-local agents or skills it references. For example, the hypershift profile points to `.claude/agents/` — read the agents, pick the relevant ones based on changed files, and use their guidance.
-- Return findings as structured text.
 
 #### Sub-agent: DRY Principle
 - Check for code duplication within and across changed files.
@@ -79,7 +77,6 @@ Skip if `--skip-tests` is specified.
 - Identify copy-paste code that introduces maintenance risk.
 - Flag magic numbers and string literals that should be constants.
 - **If a profile is loaded**, check for proper use of project-specific shared utilities (e.g., hypershift's `support/` package).
-- Return findings as structured text.
 
 #### Sub-agent: SOLID Principles
 - Apply SOLID principles proportionally to the scope of the changes:
@@ -89,7 +86,6 @@ Skip if `--skip-tests` is specified.
   - **ISP**: Are interfaces focused and minimal?
   - **DIP**: Do high-level modules depend on abstractions rather than concrete implementations?
 - **If a profile is loaded**, apply any project-specific structural patterns it defines.
-- Return findings as structured text.
 
 #### Sub-agents: Profile-Specific Reviews (only if profile is loaded)
   - Read the profile skill to discover which SME agents are required.

--- a/plugins/hcp/.claude-plugin/plugin.json
+++ b/plugins/hcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hcp",
   "description": "Generate HyperShift cluster creation commands via hcp CLI from natural language descriptions",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/hcp/skills/hcp-create-agent/SKILL.md
+++ b/plugins/hcp/skills/hcp-create-agent/SKILL.md
@@ -275,7 +275,7 @@ hypershift create cluster agent \
 
 Provide additional configuration needed after cluster creation:
 
-```
+````
 ## Post-Creation Configuration (Disconnected)
 
 After running the command above (with --render), you'll need to modify the generated manifests:
@@ -307,7 +307,7 @@ spec:
 ```bash
 kubectl apply -f <rendered-manifest-files>
 ```
-```
+````
 
 **For All Environments:**
 

--- a/plugins/hcp/skills/hcp-create-agent/SKILL.md
+++ b/plugins/hcp/skills/hcp-create-agent/SKILL.md
@@ -275,7 +275,7 @@ hypershift create cluster agent \
 
 Provide additional configuration needed after cluster creation:
 
-````
+````markdown
 ## Post-Creation Configuration (Disconnected)
 
 After running the command above (with --render), you'll need to modify the generated manifests:

--- a/plugins/jira/.claude-plugin/plugin.json
+++ b/plugins/jira/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jira",
   "description": "A plugin to automate tasks with Jira",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/jira/commands/generate-feature-updates.md
+++ b/plugins/jira/commands/generate-feature-updates.md
@@ -69,7 +69,7 @@ The command executes in two phases:
 
 2. **If `--component` is NOT provided:**
    - Use `mcp__atlassian-mcp__jira_search_fields` with keyword "component" to find the component field ID
-   - Use `mcp__atlassian-mcp__jira_search` with JQL: `project = "{project-key}" AND status != Closed` and `fields=components`
+   - Query component values through `mcp__atlassian-mcp__jira_search` with `fields=components` and JQL `project = "{project-key}" AND status != Closed`
    - Extract all unique component names from the search results
    - Present components in a numbered list
    - Ask: "Please enter the number(s) of the component(s) you want to generate updates for (space-separated), or press Enter to skip:"

--- a/plugins/jira/commands/update-weekly-status.md
+++ b/plugins/jira/commands/update-weekly-status.md
@@ -96,7 +96,7 @@ After determining the project key, check if project-specific conventions exist t
    - Use the component name directly
 
 2. **If `--component` is NOT provided:**
-   - Use `searchJiraIssuesUsingJql` with JQL: `project = "{project-key}" AND status != Closed` and `fields=components`
+   - Query component values through `searchJiraIssuesUsingJql` with `fields=components` and JQL `project = "{project-key}" AND status != Closed`
    - Extract all unique component names from the search results
    - Present components in a numbered list
    - Ask: "Please enter the number(s) of the component(s) you want to update (space-separated), or press Enter to skip:"

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -102,6 +102,9 @@ This skill is composed of four sub-modules. Read each when executing the analysi
 | External Links | `external-links.md` | GitHub PR and GitLab MR integration |
 | Formatting | `formatting.md` | Output templates for different modes |
 | Data Gatherer | `scripts/gather_status_data.py` | Async batch data collection (update-weekly-status) |
+| Issue Summarizer | `scripts/summarize_issue.py` | Compact summaries of pre-gathered issue JSON |
+| Issue Triage | `scripts/triage_issues.py` | Batch triage of pre-gathered issue directories |
+| Feature Update Validator | `scripts/validate_feature_updates.py` | Validate generated feature-update markdown |
 
 ## Configuration Parameters
 

--- a/plugins/jira/skills/status-analysis/SKILL.md
+++ b/plugins/jira/skills/status-analysis/SKILL.md
@@ -93,7 +93,7 @@ Do NOT invoke this skill directly. Use the commands above.
 
 ## Sub-Modules
 
-This skill is composed of four sub-modules. Read each when executing the analysis:
+Read the modules listed below when executing the analysis:
 
 | Module | File | Purpose |
 |--------|------|---------|

--- a/plugins/must-gather/.claude-plugin/plugin.json
+++ b/plugins/must-gather/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "must-gather",
   "description": "A plugin to analyze and report on must-gather data",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "openshift"
   }

--- a/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
+++ b/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
@@ -253,7 +253,7 @@ Output: PV and PVC status tables
 Parses OVN Northbound and Southbound database dumps and supports targeted OVSDB queries.
 
 ### scripts/analyze_windows_logs.py
-Parses Windows node, HNS, containerd, and hybrid-overlay logs from must-gather archives.
+Parses Windows node component logs for kube-proxy, hybrid-overlay, kubelet, containerd, WICD, and CSI proxy.
 
 ## Tips for Analysis
 

--- a/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
+++ b/plugins/must-gather/skills/must-gather-analyzer/SKILL.md
@@ -249,6 +249,12 @@ Output: etcd cluster health and member status
 Parses: `cluster-scoped-resources/core/persistentvolumes/`, `namespaces/*/core/persistentvolumeclaims.yaml`
 Output: PV and PVC status tables
 
+### scripts/analyze_ovn_dbs.py
+Parses OVN Northbound and Southbound database dumps and supports targeted OVSDB queries.
+
+### scripts/analyze_windows_logs.py
+Parses Windows node, HNS, containerd, and hybrid-overlay logs from must-gather archives.
+
 ## Tips for Analysis
 
 1. **Start with Cluster Operators**: They often reveal system-wide issues

--- a/plugins/olm-team/.claude-plugin/plugin.json
+++ b/plugins/olm-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "olm-team",
   "description": "OLM team development utilities and onboarding tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/olm-team/commands/dev-setup.md
+++ b/plugins/olm-team/commands/dev-setup.md
@@ -56,7 +56,6 @@ Check for required tools and authentication:
 1. **If target directory is provided as argument**:
    - Use the provided directory path
    - Expand `~` to home directory if present
-   - Create directory if it doesn't exist
 
 2. **If no target directory provided**:
    - Ask user for preferred location using AskUserQuestion tool
@@ -64,9 +63,10 @@ Check for required tools and authentication:
      - `~/go/src/github.com/` (Go workspace convention)
      - `~/src/` (Simple source directory)
      - `~/code/olm/` (OLM-specific directory)
-   - Create the chosen directory if it doesn't exist
 
-3. **Verify directory is writable**:
+3. **Create the selected directory if it does not exist**
+
+4. **Verify directory is writable**:
    ```bash
    test -w <target-directory> && echo "writable" || echo "not writable"
    ```

--- a/plugins/olm-team/skills/k8s-ocp-olm-expert/SKILL.md
+++ b/plugins/olm-team/skills/k8s-ocp-olm-expert/SKILL.md
@@ -15,6 +15,8 @@ You are an elite software engineer with deep, specialized expertise in Kubernete
 
 The configuration file should be located at: `~/.config/claude-code/olm-agent-config.json`
 
+Use [config-template.json](config-template.json) as the schema-oriented starting point and [config-example.json](config-example.json) as a populated example when creating it.
+
 ```bash
 # Check if configuration file exists
 if [ -f ~/.config/claude-code/olm-agent-config.json ]; then

--- a/plugins/olm/.claude-plugin/plugin.json
+++ b/plugins/olm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "olm",
   "description": "OLM (Operator Lifecycle Manager) plugin for operator management and debugging",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/olm/commands/opm.md
+++ b/plugins/olm/commands/opm.md
@@ -177,12 +177,13 @@ Verify required tools are installed:
 ### Step 3: Route to Action Handler
 Based on the action, call the appropriate implementation:
 
+For both index-image build actions, default arch=`multi`, base-image=`quay.io/operator-framework/opm:latest`, and builder-image=`quay.io/operator-framework/opm:latest`.
+
 #### For `build-index-image`:
 1. **Parse Arguments and Set Defaults**
    - Extract catalog path from `$2`
    - Extract index image tag from `$3`
    - Parse optional flags: `--cacheless`, `--arch`, `--base-image`, `--builder-image`
-   - Set defaults: arch=`multi`, base-image=`quay.io/operator-framework/opm:latest`, builder-image=`quay.io/operator-framework/opm:latest`
 
 2. **Verify Catalog Directory**
    - Check catalog directory exists: `test -d <catalog-path>`
@@ -228,7 +229,6 @@ Based on the action, call the appropriate implementation:
    - Extract semver template file from `$2`
    - Extract index image tag from `$3`
    - Parse optional flags: `--cacheless`, `--arch`, `--base-image`, `--builder-image`
-   - Set defaults: arch=`multi`, base-image=`quay.io/operator-framework/opm:latest`, builder-image=`quay.io/operator-framework/opm:latest`
 
 2. **Verify Template File**
    - Check file exists: `test -f <semver-template-file>`

--- a/plugins/openshift/.claude-plugin/plugin.json
+++ b/plugins/openshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "openshift",
   "description": "OpenShift development utilities and helpers",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/openshift/commands/bootstrap-om.md
+++ b/plugins/openshift/commands/bootstrap-om.md
@@ -319,7 +319,7 @@ func runOutputResources(ctx context.Context) (*libraryoutputresources.OutputReso
 }
 ```
 
-Build, test, and commit with title: "Populate OM output-resources with discovered resources"
+Commit the verified output-resource implementation as "Populate OM output-resources with discovered resources".
 
 #### 3.5 Create apply-configuration Command Stub and Commit
 

--- a/plugins/ote-migration/.claude-plugin/plugin.json
+++ b/plugins/ote-migration/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ote-migration",
   "description": "Automate OpenShift Tests Extension (OTE) migration for component repositories",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": {
     "name": "minl@redhat.com"
   }

--- a/plugins/ote-migration/skills/ote-migration-workflow/SKILL.md
+++ b/plugins/ote-migration/skills/ote-migration-workflow/SKILL.md
@@ -2533,7 +2533,7 @@ Use the `<dockerfile-choice>` and `<selected-dockerfiles>` variables collected i
 
 If user chose manual integration:
 
-```markdown
+````markdown
 ========================================
 Manual Dockerfile Integration Instructions
 ========================================
@@ -2642,7 +2642,7 @@ Replace <extension-name> with your actual extension name.
 **Note:** The Makefile uses `-mod=vendor` by default, which means all dependencies are built from the vendored code. This eliminates the need for SSH authentication or network access during Docker builds.
 
 ========================================
-```
+````
 
 Exit Phase 7 after providing instructions.
 
@@ -3633,4 +3633,3 @@ This skill provides complete automation for OTE migration with:
 - **Comprehensive validation** at each phase
 
 Follow each phase sequentially for successful migration. All phases include error handling and validation to ensure migration integrity.
-

--- a/plugins/teams/.claude-plugin/plugin.json
+++ b/plugins/teams/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "teams",
   "description": "Team structure knowledge and health analysis commands for OpenShift teams",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/teams/commands/health-check-jiras.md
+++ b/plugins/teams/commands/health-check-jiras.md
@@ -250,7 +250,6 @@ For each component:
    - Queries all team components in one invocation
    - Returns overall team summary
    - Includes per-component breakdowns
-   - Use `/teams:list-teams` to see available team names
 
 7. **Combine multiple filters**:
 

--- a/plugins/teams/commands/health-check-regressions.md
+++ b/plugins/teams/commands/health-check-regressions.md
@@ -241,7 +241,6 @@ For each component (from `components.*.summary`):
    Summarizes regressions for all components owned by the "API Server" team:
    - Automatically looks up all team components from team_component_map.json
    - Provides overall team-level summary (not per-component breakdown)
-   - Use `/teams:list-teams` to see available team names
 
 8. **Team summary with custom date range**:
 

--- a/plugins/teams/commands/health-check.md
+++ b/plugins/teams/commands/health-check.md
@@ -85,7 +85,7 @@ Grading is subjective and not meant to be a critique of team performance. This i
 
    **IMPORTANT**: This step is REQUIRED for the analyze command. Regression data must ALWAYS be fetched automatically without user prompting. The analyze command combines both regression and bug metrics - it is incomplete without both data sources.
 
-   - Fetch JIRA data automatically for every analysis.
+   - Fetch regression data automatically for every analysis.
    - If `--team` was provided:
      - Execute: `/teams:health-check-regressions <release> --team "<team>"`
    - Else (if `--components` was provided):

--- a/plugins/teams/commands/health-check.md
+++ b/plugins/teams/commands/health-check.md
@@ -85,7 +85,7 @@ Grading is subjective and not meant to be a critique of team performance. This i
 
    **IMPORTANT**: This step is REQUIRED for the analyze command. Regression data must ALWAYS be fetched automatically without user prompting. The analyze command combines both regression and bug metrics - it is incomplete without both data sources.
 
-   - **ALWAYS execute this step** - do not skip or wait for user to request it
+   - Fetch JIRA data automatically for every analysis.
    - If `--team` was provided:
      - Execute: `/teams:health-check-regressions <release> --team "<team>"`
    - Else (if `--components` was provided):
@@ -311,7 +311,6 @@ If HTML report is generated:
    - Provides comprehensive team-level health analysis
    - Shows per-component breakdowns within the team
    - Identifies which team components need attention
-   - Use `/teams:list-teams` to see available team names
 
 2. **Analyze specific components (exact match)**:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pyyaml
 pytest
-skillsaw==0.17.0
+skillsaw==0.19.0


### PR DESCRIPTION
## Summary

- upgrade the Python dependency, GitHub Actions, configuration version, and generated docs to skillsaw 0.19.0
- explicitly enable security-dynamic-context, content-progressive-disclosure, and content-inline-tool-examples; use a 6,500-token skill threshold and narrowly allowlist the two intentional dynamic-context examples
- fix all correctness, security, unreferenced-file, repeated-directive, and fence findings exposed by the upgrade
- baseline only the deferred migration debt: 79 content-description-routing findings and 3 large skills that need progressive-disclosure refactors
- bump the affected plugin patch versions and synchronize marketplace metadata

The initial 0.19.0 scan reported 128 blocking findings. This resolves 46 now and records the remaining 82 individually, so new findings continue to fail lint without broad rule exclusions.

## Validation

- make lint (0 errors, 0 warnings, 82 baseline-suppressed)
- uv run --with-requirements requirements-dev.txt make test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added marketplace author information and safer rendering for plugin navigation and metadata links.
  * Expanded guidance for CI payload validation, log analysis, issue triage, configuration setup, and diagnostic workflows.

* **Bug Fixes**
  * Clarified Jira search examples, automatic regression-data retrieval, and directory setup instructions.

* **Documentation**
  * Updated plugin versions across Jira, CI, Teams, OLM, OpenShift, HCP, and related tools.
  * Refined code review, migration, build, and helper-script guidance.
  * Updated quality-check configuration and warning baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->