### PR TITLE
[wip] feat(ci): validate payload root-cause evidence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.92",
+      "version": "0.0.93",
       "category": "ci",
       "keywords": [
         "prow",

--- a/docs/index.html
+++ b/docs/index.html
@@ -544,7 +544,7 @@ footer a { color: var(--primary); }
     {
       "name": "ci",
       "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-      "version": "0.0.92",
+      "version": "0.0.93",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/evals/eval-payload-analysis.yaml
+++ b/plugins/ci/evals/eval-payload-analysis.yaml
@@ -1,15 +1,33 @@
 name: ci-payload-analysis-eval
 description: Evaluate the payload-analysis skill's ability to analyze OCP payload snapshots, trace root causes, correlate with PRs, and produce actionable HTML reports with revert recommendations
 execution:
-  skill: ci:payload-analysis
   mode: case
-  arguments: "{payload_tag} --snapshot-dir $EVAL_SNAPSHOT_DIR/{payload_tag} --as-of {payload_completed_at}"
   timeout: 3600
   max_budget_usd: 25.0
   parallelism: 3
   env:
     EVAL_SNAPSHOT_DIR: $EVAL_SNAPSHOT_DIR
     GITHUB_TOKEN: $GITHUB_TOKEN
+  steps:
+    - id: analyze
+      skill: ci:payload-analysis
+      arguments: "{payload_tag} --snapshot-dir $EVAL_SNAPSHOT_DIR/{payload_tag} --as-of {payload_completed_at}"
+    - id: evidence-review
+      prompt: |
+        Review the payload analysis in this workspace using only its generated
+        files. Start by reading evidence-validation.txt and the hydrated
+        payload-evidence-*.md document.
+
+        If validation failed, correct the cited artifact paths or line ranges
+        from the real local artifacts; never invent replacement excerpts. Run
+        the validator command recorded in evidence-validator-command.txt until
+        evidence-validation.txt begins with OK.
+
+        Then check whether each causal-chain answer follows from the preceding
+        layer and is actually proved by its excerpts. Keep an unresolved cause
+        unresolved when the evidence ends. Correct the evidence JSON and the
+        final HTML/YAML/JSON outputs wherever they overstate the validated
+        evidence. Do not redo unrelated investigation.
 
 runner:
   type: claude-code
@@ -57,6 +75,9 @@ permissions:
     - "WebFetch"
     - "Write"
     - "Read"
+    - "Edit"
+    - "Grep"
+    - "Glob"
   deny: []
 
 mlflow:
@@ -98,6 +119,23 @@ dataset:
     running evals. Run:
       export EVAL_SNAPSHOT_DIR=$(plugins/ci/evals/scripts/extract-payload-analysis-snapshots.sh <tag>)
 
+hooks:
+  after_step:
+    - description: Validate and hydrate every causal citation
+      command: |
+        tag=$(python3 -c 'import sys,yaml; print(yaml.safe_load(open(sys.argv[1]))["payload_tag"])' "$CASE_INPUT")
+        evidence_json=$(find "$CASE_WORKSPACE" -maxdepth 1 -name 'payload-evidence-*.json' -print -quit)
+        validator="$AGENT_EVAL_PROJECT_ROOT/plugins/ci/skills/payload-analysis/scripts/validate_evidence.py"
+        summary="$EVAL_SNAPSHOT_DIR/$tag/summary.json"
+        command_file="$CASE_WORKSPACE/evidence-validator-command.txt"
+        printf 'python3 "%s" "%s" --root "%s" --summary "%s" --render "%s" > "%s" 2>&1\n' \
+          "$validator" "$evidence_json" "$CASE_WORKSPACE" "$summary" \
+          "$CASE_WORKSPACE/payload-evidence-$tag.md" \
+          "$CASE_WORKSPACE/evidence-validation.txt" > "$command_file"
+        bash "$command_file"
+      timeout: 120
+      on_failure: continue
+
 outputs:
   - path: "output"
     schema: |
@@ -121,6 +159,10 @@ outputs:
          candidate PR) pair. All row values are strings. Fields include payload_tag,
          version, stream, architecture, phase, job_name, prow_url, failure_type,
          root_cause_summary, candidate_pr_url, candidate_confidence_score.
+      4. payload-evidence-{sanitized_tag}.json — agent-authored recursive
+         why-chains with exact artifact paths and inclusive line ranges.
+      5. payload-evidence-{sanitized_tag}.md — deterministic hydration of those
+         citations with the exact line-numbered log and code excerpts.
 
       Judges should check outputs["files"] and outputs["modified_files"] for files
       matching these naming patterns.
@@ -132,6 +174,41 @@ traces:
   metrics: true
 
 judges:
+  - name: evidence_validator_passed
+    description: The final deterministic evidence-validation pass succeeded.
+    check: |
+      files = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
+      reports = [content for path, content in files.items()
+                 if path.endswith("evidence-validation.txt")]
+      if not reports:
+          return (False, "evidence-validation.txt was not produced")
+      final = reports[-1].strip()
+      if not final.startswith("OK:"):
+          return (False, final or "evidence validator produced no output")
+      return (True, final)
+
+  - name: every_root_cause_has_a_validated_chain
+    description: Every failed job has a non-empty proof-backed causal chain.
+    check: |
+      import json
+      files = {**outputs.get("files", {}), **outputs.get("modified_files", {})}
+      docs = [content for path, content in files.items()
+              if path.endswith(".json") and "payload-evidence-" in path]
+      if not docs:
+          return (False, "payload evidence JSON was not produced")
+      data = json.loads(docs[-1])
+      jobs = data.get("jobs", [])
+      if not jobs:
+          return (False, "payload evidence contains no jobs")
+      gaps = []
+      for job in jobs:
+          chain = job.get("causal_chain") or []
+          if not chain or any(not (link.get("proof") or []) for link in chain):
+              gaps.append(job.get("job_name", "<unnamed>"))
+      if gaps:
+          return (False, "jobs with missing chain/proof: " + ", ".join(gaps))
+      return (True, f"{len(jobs)} failed job(s) have proof-backed causal chains")
+
   - name: output_files_exist
     description: |
       Verify all three required output files are produced: HTML report,
@@ -788,6 +865,10 @@ judges:
                quarantines tempting post-hoc signals.
 
 thresholds:
+  evidence_validator_passed:
+    min_pass_rate: 1.0
+  every_root_cause_has_a_validated_chain:
+    min_pass_rate: 1.0
   output_files_exist:
     min_pass_rate: 1.0
   yaml_results_valid:

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -50,6 +50,7 @@ Use this skill when you need to:
 Load these only at the step that needs them — not up front:
 
 - **`references/investigation-subagent.md`** — the verbatim per-job subagent prompt and `ANALYSIS_RESULT` format (Step 4)
+- **`references/evidence-contract.md`** — causal-chain proof schema and deterministic validator (Step 4a)
 - **`references/report-guide.md`** — per-section content rules for the HTML report (Step 7)
 - **`references/completeness-review.md`** — the completeness-reviewer prompt and response handling (Step 9)
 - **`assets/report-template.html`** — the fill-in-the-blanks HTML report template (Step 7)
@@ -67,6 +68,15 @@ OUTPUT_DIR="$(pwd)"
 ```
 
 All three output files — the payload results YAML (Step 6.5), the HTML report (Step 7), and the autodl JSON (Step 8) — MUST be written under `$OUTPUT_DIR`, never into a snapshot subdirectory or a path a later `cd` may have changed. The Step 10 self-check verifies them at `$OUTPUT_DIR`.
+
+Create a stable evidence staging directory beside those outputs. Per-job
+subagents copy every artifact they cite beneath this directory so citations can
+be checked after the subagent returns:
+
+```bash
+EVIDENCE_DIR="$OUTPUT_DIR/payload-evidence"
+mkdir -p "$EVIDENCE_DIR"
+```
 
 The first argument is a **full payload tag** (e.g., `4.22.0-0.nightly-2026-02-25-152806`). Parse from it:
 - `tag`: The specific payload tag to analyze
@@ -297,6 +307,25 @@ After collecting subagent results, look for patterns across multiple jobs:
   - Jobs with `rhcos10-default` count as RHCOS 10 for this check
   - Jobs with `rhcos9_10` (heterogeneous) count toward both variants for this check
   - Variant isolation is strong diagnostic context — it narrows the root cause to OS-specific changes (kernel, systemd, SELinux, package differences between RHEL 9 and RHEL 10).
+
+### Step 4a: Validate and Hydrate the Causal Evidence
+
+Read `references/evidence-contract.md`. Assemble every subagent's
+`causal_chain` into `$OUTPUT_DIR/payload-evidence-<sanitized_tag>.json`, then
+run the bundled validator exactly as shown in that reference. Pass the snapshot
+`summary.json` so the validator proves that every failed blocking job has an
+evidence entry.
+
+If validation fails, correct the cited path or line range from the real
+artifact, or re-run the affected investigation. Never manufacture an excerpt
+to satisfy the validator. Continue only after it writes
+`$OUTPUT_DIR/payload-evidence-<sanitized_tag>.md` successfully.
+
+Read that hydrated Markdown before scoring candidates. Treat its exact excerpts
+as the authoritative evidence for the causal chain, candidate rationale, HTML
+failure details, and completeness review. A plausible statement that is absent
+from the validated chain remains a hypothesis and cannot justify a root-cause
+or revert claim.
 
 ### Step 4b: Consult Previous Claude Analyses
 
@@ -531,6 +560,10 @@ Before presenting, confirm that **all Step 4 investigation subagents and the Ste
 2. **The HTML contains every required section** from the Step 7 template: header + executive summary (including the payload-chain context), the revert verdict (or the "No Recommended Reverts" verdict), the force-accept verdict when applicable, the blocking-jobs summary table, a collapsible details block for **every** failed job, the RHCOS Changes section when any payload has RHCOS changes, the informing-tests section when such tests exist, and the Adversarial Review section. No unfilled `{placeholder}` and no `BEGIN`/`END` marker comments remain.
 3. **Cross-output consistency**: phase, failure counts, per-job root causes (including any adjudicated in Step 5b), and scored candidates agree across the HTML, YAML, and JSON.
 4. **Every affirmative root cause appears as a scored `candidates[]` entry** — including causal CI-infrastructure changes, even when `failure_type: infra`.
+5. **Evidence validation passes again** using the Step 4a command, and every
+   affirmative root-cause and revert rationale in the final outputs is supported
+   by at least one validated causal-chain link. Do not silently weaken or replace
+   a validated conclusion while rendering the final files.
 
 If any check fails, fix it before presenting.
 

--- a/plugins/ci/skills/payload-analysis/references/completeness-review.md
+++ b/plugins/ci/skills/payload-analysis/references/completeness-review.md
@@ -9,8 +9,9 @@ The reviewer receives **only** the following (NOT the full conversation history)
 1. The `summary.json` snapshot data (payload metadata, failed jobs, streaks, test regressions, RHCOS changes)
 2. The scored candidate list with per-component rubric breakdowns from Step 6
 3. The `ANALYSIS_RESULT` blocks from all subagents in Step 4
-4. The revert recommendations (if any)
-5. The RHCOS RPM candidates (if any, identified by `type: "rhcos_rpm"` in the scored candidates)
+4. The hydrated `payload-evidence-<tag>.md` from Step 4a
+5. The revert recommendations (if any)
+6. The RHCOS RPM candidates (if any, identified by `type: "rhcos_rpm"` in the scored candidates)
 
 ## Reviewer prompt
 
@@ -21,6 +22,8 @@ Use this prompt:
 > **Snapshot data**: {summary.json contents — metadata, failed jobs with streaks, test regressions}
 >
 > **Subagent analyses**: {ANALYSIS_RESULT blocks for each failed job}
+>
+> **Deterministically validated evidence**: {hydrated payload evidence Markdown}
 >
 > **Scored candidates**: {list of (job, PR, score, rubric breakdown) tuples}
 >
@@ -34,9 +37,14 @@ Use this prompt:
 >
 > 3. **Incomplete coverage**: Are there failed jobs with no subagent analysis or with only a one-line summary? Every failed blocking job deserves a thorough investigation.
 >
-> 4. **Wrong reference for failure type**: Did the analysis route to the correct reference — install (and metal for metal jobs) for install failures, and the test/flaky-test reference for test failures? Using the wrong reference produces misdirected analysis.
+> 4. **Broken causal links**: Does each answer follow from the previous layer,
+> and does the cited excerpt actually prove that answer? Flag leaps from a
+> high-level symptom directly to a PR, citations from adjacent operations, or
+> conclusions whose decisive evidence is absent from the hydrated document.
 >
-> 5. **Missing RHCOS RPM candidates**: If RHCOS RPM changes exist in the originating payload and failures are variant-isolated or involve OS-level components, were the RPM changes scored as candidates alongside PRs? Were the RPM changelogs read and cited as evidence in the rubric breakdown? An RHCOS RPM change whose changelog was not consulted is like a PR candidate whose `code.diff` was never read — an incomplete investigation.
+> 5. **Wrong reference for failure type**: Did the analysis route to the correct reference — install (and metal for metal jobs) for install failures, and the test/flaky-test reference for test failures? Using the wrong reference produces misdirected analysis.
+>
+> 6. **Missing RHCOS RPM candidates**: If RHCOS RPM changes exist in the originating payload and failures are variant-isolated or involve OS-level components, were the RPM changes scored as candidates alongside PRs? Were the RPM changelogs read and cited as evidence in the rubric breakdown? An RHCOS RPM change whose changelog was not consulted is like a PR candidate whose `code.diff` was never read — an incomplete investigation.
 >
 > **Rules**:
 > - Do NOT suggest lowering confidence scores. If the rubric signals fired (error message match, new failure, component exclusivity), the score is correct. Period.

--- a/plugins/ci/skills/payload-analysis/references/evidence-contract.md
+++ b/plugins/ci/skills/payload-analysis/references/evidence-contract.md
@@ -1,0 +1,87 @@
+# Payload Analysis Evidence Contract
+
+Use this contract after the per-job investigations finish and before candidate
+scoring. It makes each root-cause claim independently checkable instead of
+leaving citations embedded only in prose.
+
+## Document
+
+Write `payload-evidence-<sanitized-tag>.json` in the analysis output directory:
+
+```json
+{
+  "payload_tag": "4.22.0-0.nightly-2026-02-25-152806",
+  "jobs": [
+    {
+      "job_name": "periodic-ci-...-e2e-aws-ovn",
+      "causal_chain": [
+        {
+          "question": "Why did this job fail?",
+          "answer": "The test timed out because ovnkube-controller repeatedly failed to reconcile the gateway.",
+          "proof": [
+            {
+              "type": "log",
+              "artifact": "payload-evidence/e2e-aws-ovn/ovnkube-controller.log",
+              "artifact_url": "https://gcsweb-ci.example/artifacts/ovnkube-controller.log",
+              "lines": [412, 417],
+              "note": "These retries cover the failing operation and end with the timeout reported by the test."
+            }
+          ]
+        },
+        {
+          "question": "Why did gateway reconciliation fail?",
+          "answer": "The controller rejected the selected gateway mode as unsupported.",
+          "proof": [
+            {
+              "type": "log",
+              "artifact": "payload-evidence/e2e-aws-ovn/ovnkube-controller.log",
+              "artifact_url": "https://gcsweb-ci.example/artifacts/ovnkube-controller.log",
+              "lines": [389, 396],
+              "note": "The controller emits the unsupported-mode error from the reconcile path immediately before retrying."
+            },
+            {
+              "type": "code",
+              "artifact": "payload-evidence/e2e-aws-ovn/pr-2037-controller.diff",
+              "artifact_url": "https://github.com/openshift/cno/pull/2037/files",
+              "lines": [73, 91],
+              "note": "The candidate changes the branch that validates the same gateway-mode value."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Rules
+
+- Start every chain with exactly `Why did this job fail?`.
+- Use one causal layer per link. The next question must ask why the previous
+  answer occurred; do not jump directly from a test symptom to a candidate PR.
+- Every link needs at least one proof. Stop with an explicit unknown when the
+  next layer cannot be proved.
+- `artifact` is a path relative to the analysis output directory. Copy each
+  cited log or diff under `payload-evidence/<job-slug>/`; do not cite transient
+  paths outside the output directory.
+- `lines` is a 1-indexed inclusive range in that exact local artifact.
+- `artifact_url` is the durable upstream URL when one exists.
+- `note` explains how the excerpt proves the answer. It must not introduce a
+  separate unsupported claim.
+
+## Validate and hydrate
+
+Run:
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/validate_evidence.py" \
+  "$OUTPUT_DIR/payload-evidence-$SANITIZED_TAG.json" \
+  --root "$OUTPUT_DIR" \
+  --summary "$SNAPSHOT_DIR/summary.json" \
+  --render "$OUTPUT_DIR/payload-evidence-$SANITIZED_TAG.md"
+```
+
+The command fails for missing artifacts, escaping paths, malformed or
+out-of-range line references, empty answers, missing failed jobs, or unsupported causal links. The
+rendered Markdown contains the exact line-numbered excerpts and is the evidence
+document supplied to scoring, report generation, and completeness review.

--- a/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
+++ b/plugins/ci/skills/payload-analysis/references/investigation-subagent.md
@@ -20,6 +20,16 @@ Use the following prompt **verbatim** (substituting the placeholder values) when
 >
 > **Do NOT classify a failure as "infrastructure flake" or "transient" unless you have affirmative evidence** of an infrastructure problem (cloud API errors, quota exceeded, network timeouts from the cloud provider, Boskos lease failures, CI platform outages). The absence of an obvious code-level explanation does NOT make something infrastructure — it means you need to investigate deeper. Default to treating failures as potential product regressions until evidence proves otherwise.
 >
+> **Build a cited causal chain**: Start with exactly `Why did this job fail?`,
+> answer one causal layer at a time, and ask the next natural "why" until you
+> reach the deepest cause the artifacts prove. Every answer needs at least one
+> exact log or code citation. Copy each cited source file under
+> `<evidence_dir>/<job_slug>/` and report its path relative to `<output_dir>`,
+> with a 1-indexed inclusive line range and a note explaining how the excerpt
+> proves that answer. Preserve the durable GCS, Prow, or GitHub URL as
+> `artifact_url`. If the evidence ends, say the next cause is unknown; do not
+> fill the gap with a plausible mechanism.
+>
 > Return a concise summary including: failure type (install vs test), root cause, key error messages, and any relevant log excerpts. Do not ask user questions. Keep the output concise for inclusion in a summary report.
 >
 > If the job is an aggregated job (has `aggregated-` prefix in the name or an `aggregator` container/step), also return the **underlying job name** (e.g., `periodic-ci-openshift-release-main-ci-4.22-e2e-aws-upgrade-ovn-single-node`). This is found in the junit-aggregated.xml artifacts — each `<testcase>` has `<system-out>` YAML data with a `humanurl` field linking to individual runs whose URL path contains the underlying job name. The underlying job name cannot be derived from the aggregated job name — it must be extracted from the artifacts.
@@ -33,6 +43,10 @@ Where `<rhcos_version>` is the `rhcos_version` field from the snapshot's failed 
 - For **`rhcos9_10`** (heterogeneous): "This is a heterogeneous cluster with both RHCOS 9 and RHCOS 10 nodes. Failures may be specific to one node variant — check whether failing nodes are RHCOS 9 or RHCOS 10 when node-level logs are available."
 
 `<summary_json_path>` is the absolute path to the snapshot's `summary.json` file, and `<originating_payload_tag>` is the failure mode's `first_failed_in` value (Step 3.3/Step 5) — not the job-level `streak.originating_payload`, which can predate the regression when a job has multiple failure modes.
+
+`<output_dir>` is the analysis output directory captured in Step 1 and
+`<evidence_dir>` is its `payload-evidence` child. Give each subagent a unique
+`<job_slug>` child so parallel investigations never overwrite one another.
 
 Under `--as-of` (Step 1), append the cutoff timestamp to the prompt and instruct the subagent to discard post-cutoff artifacts and discussion.
 
@@ -54,6 +68,23 @@ ANALYSIS_RESULT:
 - rhcos_rpm_correlation: none|possible|likely
 - rhcos_rpm_suspect_packages: <comma-separated package names if correlation is possible or likely, or "none">
 - rhcos_rpm_changelog_evidence: <for each suspect package, the specific changelog entry that relates to the failure, or "none" if the changelog was read but contained no relevant entries, or "unavailable" if no changelog data exists in the snapshot>
+- causal_chain:
+  - question: Why did this job fail?
+    answer: <one causal layer, directly supported by the proof below>
+    proof:
+      - type: log|code
+        artifact: payload-evidence/<job_slug>/<copied-source-file>
+        artifact_url: <durable GCS, Prow, or GitHub URL when available>
+        lines: [<1-indexed-start>, <inclusive-end>]
+        note: <why this exact excerpt proves the answer>
+  - question: <the next why raised by the previous answer>
+    answer: <the next proven causal layer, or an explicit statement that the trail ends>
+    proof:
+      - type: log|code
+        artifact: payload-evidence/<job_slug>/<copied-source-file>
+        artifact_url: <durable upstream URL when available>
+        lines: [<1-indexed-start>, <inclusive-end>]
+        note: <why this exact excerpt proves the answer>
 ```
 
 The `rhcos_rpm_correlation` field indicates whether the failure may be related to RHCOS RPM changes found in `summary.json`:

--- a/plugins/ci/skills/payload-analysis/references/report-guide.md
+++ b/plugins/ci/skills/payload-analysis/references/report-guide.md
@@ -46,7 +46,7 @@ One `failed-job` collapsible block per failed blocking job:
 - Summary line: job name, `badge-new` ("New Failure") or `badge-persistent` ("Failing for N payloads"), and the RHCOS badge.
 - Prow line: Prow and GCS Artifacts links; for aggregated jobs, append the underlying job name.
 - `variant-callout` — include only when the failure is variant-isolated; fill in which variant is affected.
-- `analysis_from_subagent` — the subagent's failure analysis (Step 4), adjudicated where Step 5b applied. Preserve its structure (failure type, root cause, key errors with `<code>`, retry comparison).
+- `analysis_from_subagent` — the subagent's failure analysis (Step 4), adjudicated where Step 5b applied. Render its Step 4a validated causal chain in order (question, answer, exact hydrated excerpts, and proof notes), followed by the failure type and retry comparison. Do not substitute uncited prose for the hydrated excerpts.
 - `known-symptoms` — include only when the subagent reported symptoms other than "none".
 - Candidates: use `candidates-table` (one `candidate-row` per scored candidate with its tiered score class) when candidates exist; otherwise use `candidates-none`, whose prose must state **why** no candidate explains the failure (Step 6.1) — never leave it blank or generic.
 

--- a/plugins/ci/skills/payload-analysis/scripts/test_validate_evidence.py
+++ b/plugins/ci/skills/payload-analysis/scripts/test_validate_evidence.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from validate_evidence import validate_and_render
+
+
+class ValidateEvidenceTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        evidence = self.root / "payload-evidence" / "job"
+        evidence.mkdir(parents=True)
+        (evidence / "build-log.txt").write_text(
+            "starting test\nwaiting for operator\nreconcile failed: unsupported gateway mode\nretrying reconcile\ntest timed out\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _write_document(self, proof=None):
+        if proof is None:
+            proof = {
+                "type": "log",
+                "artifact": "payload-evidence/job/build-log.txt",
+                "artifact_url": "https://example.invalid/build-log.txt",
+                "lines": [3, 4],
+                "note": "The failing operation emits the error and immediately retries.",
+            }
+        data = {
+            "payload_tag": "4.22.0-0.nightly-example",
+            "jobs": [
+                {
+                    "job_name": "periodic-ci-example",
+                    "causal_chain": [
+                        {
+                            "question": "Why did this job fail?",
+                            "answer": "The test timed out after gateway reconciliation failed.",
+                            "proof": [proof],
+                        }
+                    ],
+                }
+            ],
+        }
+        path = self.root / "payload-evidence.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        return path
+
+    def test_valid_document_hydrates_exact_lines(self):
+        errors, markdown = validate_and_render(self._write_document(), self.root)
+        self.assertEqual([], errors)
+        self.assertIn("3 | reconcile failed: unsupported gateway mode", markdown)
+        self.assertIn("4 | retrying reconcile", markdown)
+        self.assertNotIn("5 | test timed out", markdown)
+
+    def test_rejects_out_of_range_lines(self):
+        path = self._write_document(
+            {
+                "type": "log",
+                "artifact": "payload-evidence/job/build-log.txt",
+                "lines": [4, 99],
+                "note": "Invalid range",
+            }
+        )
+        errors, _ = validate_and_render(path, self.root)
+        self.assertTrue(any("exceed artifact length" in error for error in errors))
+
+    def test_rejects_path_escape(self):
+        outside = self.root.parent / "outside-evidence.txt"
+        outside.write_text("secret\n", encoding="utf-8")
+        self.addCleanup(outside.unlink)
+        path = self._write_document(
+            {
+                "type": "log",
+                "artifact": "../outside-evidence.txt",
+                "lines": [1, 1],
+                "note": "Must not be readable",
+            }
+        )
+        errors, _ = validate_and_render(path, self.root)
+        self.assertTrue(any("escapes evidence root" in error for error in errors))
+
+    def test_requires_proof_for_every_link(self):
+        path = self._write_document()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["jobs"][0]["causal_chain"][0]["proof"] = []
+        path.write_text(json.dumps(data), encoding="utf-8")
+        errors, _ = validate_and_render(path, self.root)
+        self.assertTrue(any("proof must be a non-empty array" in error for error in errors))
+
+    def test_requires_every_expected_failed_job(self):
+        path = self._write_document()
+        errors, _ = validate_and_render(
+            path, self.root, {"periodic-ci-example", "periodic-ci-missing"}
+        )
+        self.assertTrue(any("periodic-ci-missing" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/hydrated-evidence.md
+++ b/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/hydrated-evidence.md
@@ -1,0 +1,56 @@
+# Validated evidence for `4.22.0-0.nightly-2026-08-27-example`
+
+## `periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn`
+
+### 1. Why did this job fail?
+
+The cluster install timed out because the worker MachineConfigPool remained degraded.
+
+Proof 1 (log, [payload-evidence/e2e-aws-ovn/build-log.txt](https://gcsweb-ci.example/artifacts/build-log.txt), lines 4-6):
+
+```text
+4 | ERROR Cluster not ready after 40m0s
+5 | ERROR MachineConfigPool worker is Degraded=True
+6 | ERROR timed out waiting for the condition
+```
+
+Why it supports the answer: The failing install step names the degraded worker pool as the condition that exhausted the timeout.
+
+### 2. Why did the worker MachineConfigPool remain degraded?
+
+The machine-config daemon could not complete the rendered-config rollout on worker-2 because CRI-O repeatedly failed to start.
+
+Proof 1 (log, [payload-evidence/e2e-aws-ovn/machine-config-daemon.log](https://gcsweb-ci.example/artifacts/machine-config-daemon.log), lines 2-4):
+
+```text
+2 | E0827 update.go:244] worker-2: failed to start crio.service
+3 | E0827 update.go:245] systemctl start crio.service exited with status 1
+4 | E0827 daemon.go:902] blocking rendered config rollout until service recovers
+```
+
+Why it supports the answer: The daemon reports the exact node and blocks rollout after CRI-O fails during the update.
+
+### 3. Why did CRI-O fail to start on worker-2?
+
+The generated CRI-O configuration contained the unsupported field enable_pod_events, which the candidate change began emitting unconditionally.
+
+Proof 1 (log, [payload-evidence/e2e-aws-ovn/machine-config-daemon.log](https://gcsweb-ci.example/artifacts/machine-config-daemon.log), lines 5-7):
+
+```text
+5 | E0827 crio.go:118] parsing /etc/crio/crio.conf.d/99-mco.conf
+6 | E0827 crio.go:119] unknown field "enable_pod_events" in table crio.runtime
+7 | E0827 crio.go:120] configuration validation failed; refusing to start
+```
+
+Why it supports the answer: CRI-O's parser rejects enable_pod_events and exits, directly explaining the service-start failure.
+
+Proof 2 (code, [payload-evidence/e2e-aws-ovn/pr-12345.diff](https://github.com/openshift/machine-config-operator/pull/12345/files), lines 3-6):
+
+```text
+3 | --- a/pkg/controller/container-runtime-config/helpers.go
+4 | +++ b/pkg/controller/container-runtime-config/helpers.go
+5 | @@ -210,0 +211 @@ func renderCrioConfig(cfg *Config) string {
+6 | +enable_pod_events = true
+```
+
+Why it supports the answer: The candidate diff adds the same rejected field to every generated CRI-O configuration.

--- a/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence-example.json
+++ b/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence-example.json
@@ -1,0 +1,56 @@
+{
+  "payload_tag": "4.22.0-0.nightly-2026-08-27-example",
+  "jobs": [
+    {
+      "job_name": "periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn",
+      "causal_chain": [
+        {
+          "question": "Why did this job fail?",
+          "answer": "The cluster install timed out because the worker MachineConfigPool remained degraded.",
+          "proof": [
+            {
+              "type": "log",
+              "artifact": "payload-evidence/e2e-aws-ovn/build-log.txt",
+              "artifact_url": "https://gcsweb-ci.example/artifacts/build-log.txt",
+              "lines": [4, 6],
+              "note": "The failing install step names the degraded worker pool as the condition that exhausted the timeout."
+            }
+          ]
+        },
+        {
+          "question": "Why did the worker MachineConfigPool remain degraded?",
+          "answer": "The machine-config daemon could not complete the rendered-config rollout on worker-2 because CRI-O repeatedly failed to start.",
+          "proof": [
+            {
+              "type": "log",
+              "artifact": "payload-evidence/e2e-aws-ovn/machine-config-daemon.log",
+              "artifact_url": "https://gcsweb-ci.example/artifacts/machine-config-daemon.log",
+              "lines": [2, 4],
+              "note": "The daemon reports the exact node and blocks rollout after CRI-O fails during the update."
+            }
+          ]
+        },
+        {
+          "question": "Why did CRI-O fail to start on worker-2?",
+          "answer": "The generated CRI-O configuration contained the unsupported field enable_pod_events, which the candidate change began emitting unconditionally.",
+          "proof": [
+            {
+              "type": "log",
+              "artifact": "payload-evidence/e2e-aws-ovn/machine-config-daemon.log",
+              "artifact_url": "https://gcsweb-ci.example/artifacts/machine-config-daemon.log",
+              "lines": [5, 7],
+              "note": "CRI-O's parser rejects enable_pod_events and exits, directly explaining the service-start failure."
+            },
+            {
+              "type": "code",
+              "artifact": "payload-evidence/e2e-aws-ovn/pr-12345.diff",
+              "artifact_url": "https://github.com/openshift/machine-config-operator/pull/12345/files",
+              "lines": [3, 6],
+              "note": "The candidate diff adds the same rejected field to every generated CRI-O configuration."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence/e2e-aws-ovn/build-log.txt
+++ b/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence/e2e-aws-ovn/build-log.txt
@@ -1,0 +1,7 @@
+INFO starting openshift-install wait-for install-complete
+INFO waiting up to 40m0s for the cluster to initialize
+INFO Cluster operator machine-config is not available
+ERROR Cluster not ready after 40m0s
+ERROR MachineConfigPool worker is Degraded=True
+ERROR timed out waiting for the condition
+INFO collecting cluster artifacts

--- a/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence/e2e-aws-ovn/pr-12345.diff
+++ b/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/payload-evidence/e2e-aws-ovn/pr-12345.diff
@@ -1,0 +1,7 @@
+diff --git a/pkg/controller/container-runtime-config/helpers.go b/pkg/controller/container-runtime-config/helpers.go
+index 1111111..2222222 100644
+--- a/pkg/controller/container-runtime-config/helpers.go
++++ b/pkg/controller/container-runtime-config/helpers.go
+@@ -210,0 +211 @@ func renderCrioConfig(cfg *Config) string {
++enable_pod_events = true
+ }

--- a/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/summary.json
+++ b/plugins/ci/skills/payload-analysis/scripts/testdata/evidence-demo/summary.json
@@ -1,0 +1,9 @@
+{
+  "blocking_jobs": {
+    "failed_jobs": [
+      {
+        "name": "periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn"
+      }
+    ]
+  }
+}

--- a/plugins/ci/skills/payload-analysis/scripts/validate_evidence.py
+++ b/plugins/ci/skills/payload-analysis/scripts/validate_evidence.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Validate payload causal-chain citations and render their exact excerpts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+FIRST_QUESTION = "Why did this job fail?"
+PROOF_TYPES = {"log", "code"}
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _resolve_artifact(root: Path, value: object) -> tuple[Path | None, str | None]:
+    artifact = _text(value)
+    if not artifact:
+        return None, "missing non-empty 'artifact'"
+    candidate = Path(artifact)
+    if candidate.is_absolute():
+        return None, "'artifact' must be relative to --root"
+
+    root = root.resolve()
+    resolved = (root / candidate).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        return None, f"artifact escapes evidence root: {artifact!r}"
+    if not resolved.is_file():
+        return None, f"artifact does not exist or is not a file: {artifact!r}"
+    return resolved, None
+
+
+def validate_and_render(
+    document: Path, root: Path, expected_jobs: set[str] | None = None
+) -> tuple[list[str], str]:
+    errors: list[str] = []
+    rendered: list[str] = []
+
+    try:
+        data = json.loads(document.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [f"document not found: {document}"], ""
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return [f"cannot read JSON document: {exc}"], ""
+
+    if not isinstance(data, dict):
+        return ["document root must be an object"], ""
+
+    payload_tag = _text(data.get("payload_tag"))
+    if not payload_tag:
+        errors.append("missing non-empty 'payload_tag'")
+    rendered.extend([f"# Validated evidence for `{payload_tag or 'unknown payload'}`", ""])
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list) or not jobs:
+        errors.append("'jobs' must be a non-empty array")
+        jobs = []
+
+    seen_jobs: list[str] = []
+    for job_index, job in enumerate(jobs):
+        job_at = f"jobs[{job_index}]"
+        if not isinstance(job, dict):
+            errors.append(f"{job_at} must be an object")
+            continue
+
+        job_name = _text(job.get("job_name"))
+        if not job_name:
+            errors.append(f"{job_at} missing non-empty 'job_name'")
+            job_name = f"job {job_index + 1}"
+        else:
+            seen_jobs.append(job_name)
+        rendered.extend([f"## `{job_name}`", ""])
+
+        chain = job.get("causal_chain")
+        if not isinstance(chain, list) or not chain:
+            errors.append(f"{job_at}.causal_chain must be a non-empty array")
+            continue
+
+        for link_index, link in enumerate(chain):
+            link_at = f"{job_at}.causal_chain[{link_index}]"
+            if not isinstance(link, dict):
+                errors.append(f"{link_at} must be an object")
+                continue
+
+            question = _text(link.get("question"))
+            answer = _text(link.get("answer"))
+            if not question:
+                errors.append(f"{link_at} missing non-empty 'question'")
+            elif link_index == 0 and question != FIRST_QUESTION:
+                errors.append(
+                    f"{link_at}.question must be exactly {FIRST_QUESTION!r}"
+                )
+            if not answer:
+                errors.append(f"{link_at} missing non-empty 'answer'")
+
+            rendered.extend(
+                [f"### {link_index + 1}. {question or 'Missing question'}", "", answer, ""]
+            )
+
+            proofs = link.get("proof")
+            if not isinstance(proofs, list) or not proofs:
+                errors.append(f"{link_at}.proof must be a non-empty array")
+                continue
+
+            for proof_index, proof in enumerate(proofs):
+                proof_at = f"{link_at}.proof[{proof_index}]"
+                if not isinstance(proof, dict):
+                    errors.append(f"{proof_at} must be an object")
+                    continue
+
+                proof_type = _text(proof.get("type"))
+                if proof_type not in PROOF_TYPES:
+                    errors.append(
+                        f"{proof_at}.type must be one of {sorted(PROOF_TYPES)}"
+                    )
+
+                note = _text(proof.get("note"))
+                if not note:
+                    errors.append(f"{proof_at} missing non-empty 'note'")
+
+                artifact, artifact_error = _resolve_artifact(root, proof.get("artifact"))
+                if artifact_error:
+                    errors.append(f"{proof_at}: {artifact_error}")
+                    continue
+
+                lines = proof.get("lines")
+                if (
+                    not isinstance(lines, list)
+                    or len(lines) != 2
+                    or any(not isinstance(number, int) or isinstance(number, bool) for number in lines)
+                    or lines[0] < 1
+                    or lines[1] < lines[0]
+                ):
+                    errors.append(
+                        f"{proof_at}.lines must be two 1-indexed integers with start <= end"
+                    )
+                    continue
+
+                try:
+                    artifact_lines = artifact.read_text(encoding="utf-8", errors="replace").splitlines()
+                except OSError as exc:
+                    errors.append(f"{proof_at}: cannot read artifact: {exc}")
+                    continue
+
+                start, end = lines
+                if end > len(artifact_lines):
+                    errors.append(
+                        f"{proof_at}.lines [{start}, {end}] exceed artifact length "
+                        f"({len(artifact_lines)} lines)"
+                    )
+                    continue
+
+                artifact_label = _text(proof.get("artifact"))
+                artifact_url = _text(proof.get("artifact_url"))
+                source = f"[{artifact_label}]({artifact_url})" if artifact_url else f"`{artifact_label}`"
+                rendered.extend(
+                    [
+                        f"Proof {proof_index + 1} ({proof_type or 'unknown'}, {source}, lines {start}-{end}):",
+                        "",
+                        "```text",
+                    ]
+                )
+                width = len(str(end))
+                for number in range(start, end + 1):
+                    rendered.append(f"{number:>{width}} | {artifact_lines[number - 1]}")
+                rendered.extend(["```", "", f"Why it supports the answer: {note}", ""])
+
+    duplicates = sorted({name for name in seen_jobs if seen_jobs.count(name) > 1})
+    if duplicates:
+        errors.append(f"duplicate job evidence entries: {', '.join(duplicates)}")
+    if expected_jobs is not None:
+        actual_jobs = set(seen_jobs)
+        missing = sorted(expected_jobs - actual_jobs)
+        unexpected = sorted(actual_jobs - expected_jobs)
+        if missing:
+            errors.append(f"missing evidence for failed job(s): {', '.join(missing)}")
+        if unexpected:
+            errors.append(f"evidence contains unexpected job(s): {', '.join(unexpected)}")
+
+    return errors, "\n".join(rendered).rstrip() + "\n"
+
+
+def expected_jobs_from_summary(path: Path) -> tuple[set[str] | None, str | None]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, f"summary not found: {path}"
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"cannot read summary JSON: {exc}"
+
+    try:
+        jobs = data["blocking_jobs"]["failed_jobs"]
+    except (KeyError, TypeError):
+        return None, "summary missing blocking_jobs.failed_jobs"
+    if not isinstance(jobs, list):
+        return None, "summary blocking_jobs.failed_jobs must be an array"
+
+    names = {
+        _text(job.get("name"))
+        for job in jobs
+        if isinstance(job, dict) and _text(job.get("name"))
+    }
+    if len(names) != len(jobs):
+        return None, "every summary blocking_jobs.failed_jobs entry must have a unique name"
+    return names, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("document", type=Path)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Allowed artifact root (defaults to the document directory)",
+    )
+    parser.add_argument("--render", type=Path, help="Write hydrated Markdown here")
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        help="Snapshot summary.json; require evidence for every failed blocking job",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root or args.document.parent
+    expected_jobs = None
+    if args.summary:
+        expected_jobs, summary_error = expected_jobs_from_summary(args.summary)
+        if summary_error:
+            print(f"FAIL: {summary_error}")
+            return 1
+    errors, markdown = validate_and_render(args.document, root, expected_jobs)
+    if errors:
+        print(f"FAIL: {len(errors)} evidence error(s)")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    if args.render:
+        args.render.write_text(markdown, encoding="utf-8")
+        print(f"OK: evidence validated; hydrated report written to {args.render}")
+    else:
+        print("OK: evidence validated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- require per-job recursive why-chains with exact log/code artifact line references
- add a deterministic validator that rejects missing, escaping, or out-of-range citations and hydrates the real excerpts into Markdown
- feed hydrated evidence into candidate scoring, HTML rendering, and completeness review
- add a two-step agent-eval-harness prototype: payload analysis, deterministic evidence validation, then focused evidence repair
- include a small synthetic fixture showing the rendered result

## Why

The payload skill already asks agents to investigate deeply, but its structured subagent result does not preserve machine-checkable evidence locations. This prototypes the validate → hydrate → review pattern used by hcpctl without replacing the existing payload orchestration.

## Validation

- `python3 -m unittest discover -s plugins/ci/skills/payload-analysis/scripts -p 'test_validate_evidence.py' -v`
- eval YAML parsed with the local agent-eval-harness `EvalConfig`
- `git diff --check upstream/main...HEAD`

The full agent eval has not been run yet. A focused case can be run with the existing extracted snapshots:

```bash
export EVAL_SNAPSHOT_DIR=$HOME/git/historical-payload-data
/eval-run \
  --config plugins/ci/evals/eval-payload-analysis.yaml \
  --model claude-opus-4-8 \
  --cases case-001 \
  --run-id payload-evidence-case-001
```

## Prototype output

The checked-in hydrated fixture demonstrates this chain:

`install timeout → degraded MachineConfigPool → CRI-O rejected generated configuration → candidate diff introduced the rejected field`

Every arrow is backed by an exact, line-numbered excerpt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validated causal-chain evidence to payload analysis, including artifact references, line-level proof, and hydrated Markdown reports.
  * Added checks for broken links, missing evidence, invalid artifacts, and incomplete failed-job coverage.
  * Added evidence review guidance and sample evidence fixtures.

* **Bug Fixes**
  * Improved failure analysis accuracy by requiring root-cause and revert recommendations to be supported by validated evidence.

* **Tests**
  * Added coverage for valid evidence rendering and invalid paths, line ranges, proof, and job data.

* **Chores**
  * Updated the CI plugin version to 0.0.93.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->