### PR TITLE
nid-team: add Predrag Knezevic (pedjak) to team config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -563,7 +563,7 @@
       "name": "nid-team",
       "source": "./plugins/nid-team",
       "description": "Development and workflow tools for the Network Ingress & DNS team",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "development",
       "keywords": [
         "nid",

--- a/docs/index.html
+++ b/docs/index.html
@@ -1872,7 +1872,7 @@ footer a { color: var(--primary); }
     {
       "name": "nid-team",
       "description": "NI&D team PR triage and review workflow tools",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "has_readme": true,
       "commands": [
         {

--- a/plugins/nid-team/.claude-plugin/plugin.json
+++ b/plugins/nid-team/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nid-team",
   "description": "NI&D team PR triage and review workflow tools",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/nid-team/scripts/pr-dashboard/config.sh
+++ b/plugins/nid-team/scripts/pr-dashboard/config.sh
@@ -39,7 +39,8 @@ bentito|Brett T.|Brett Tofel
 jcmoraisjr|Joao M.|Joao Morais
 aswinsuryan|Aswin S.|Aswin Suryanarayanan
 melvinjoseph86|Melvin J.|Melvin Joseph
-rhamini3|Ishmam A.|Ishmam Amin"
+rhamini3|Ishmam A.|Ishmam Amin
+pedjak|Predrag K.|Predrag Knezevic"
 
 # Derive the plain login list (indexed arrays work on all bash versions).
 TEAM_USERNAMES=()


### PR DESCRIPTION
## Summary

- Adds `pedjak` (Predrag Knezevic) to the NID team member table in `config.sh`
- Display name: `Predrag K.`, fullname: `Predrag Knezevic`
- Enables reviewer assignment, author classification, and shared PR tracking for pedjak

## Test plan

- [ ] Run `/nid-team:sync-pr-dashboard` and confirm pedjak's PRs are classified as Team author type
- [ ] Confirm Primary/Secondary Reviewer dropdown shows "Predrag Knezevic"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the team directory to include Predrag Knezevic.
  * Refreshed team roster information for improved accuracy in the PR dashboard.
  * Updated the nid-team plugin version from 0.1.2 to 0.1.3 across marketplace and plugin metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->