### PR TITLE
OAPE-958: `compliance:analyze-cve` Enhance the CVE analysis command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -294,7 +294,7 @@
       "name": "compliance",
       "source": "./plugins/compliance",
       "description": "Security compliance and vulnerability analysis tools for Go projects",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "category": "security",
       "keywords": [
         "cve",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -294,7 +294,7 @@
       "name": "compliance",
       "source": "./plugins/compliance",
       "description": "Security compliance and vulnerability analysis tools for Go projects",
-      "version": "0.0.3",
+      "version": "0.3.0",
       "category": "security",
       "keywords": [
         "cve",

--- a/plugins/compliance/.claude-plugin/plugin.json
+++ b/plugins/compliance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compliance",
   "description": "Security compliance and vulnerability analysis tools for Go projects",
-  "version": "0.0.3",
+  "version": "0.3.0",
   "author": {
     "name": "chiragkyal"
   }

--- a/plugins/compliance/.claude-plugin/plugin.json
+++ b/plugins/compliance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compliance",
   "description": "Security compliance and vulnerability analysis tools for Go projects",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "author": {
     "name": "chiragkyal"
   }

--- a/plugins/compliance/README.md
+++ b/plugins/compliance/README.md
@@ -4,26 +4,40 @@ Security compliance and vulnerability analysis tools for Go projects.
 
 ## Command
 
-### `/compliance:analyze-cve <CVE-ID> [--algo=vta|rta|cha|static]`
+### `/compliance:analyze-cve <CVE-ID> | --jira=<PROJ-NNN> | --jql="..." [--repo=<url-or-component>] [--algo=vta|rta|cha|static] [--auto-approve=yes|no]`
 
-Analyzes Go codebases to determine CVE impact with multi-level confidence assessment.
+Resolves and clones the affected Go repository, then analyzes it to determine CVE impact with multi-level confidence assessment. Can be driven directly by a CVE ID, or resolve the CVE (and the affected repository/branch) from a Jira ticket — single ticket or a JQL-selected queue — and, with approval, apply a fix and open a GitHub pull request.
 
-**Example:**
+**Examples:**
 ```text
-/compliance:analyze-cve CVE-2024-24783
+/compliance:analyze-cve CVE-2024-24783 --repo=https://github.com/golang/net
+/compliance:analyze-cve --jira=OCPBUGS-12345
+/compliance:analyze-cve --jql="project = OCPBUGS AND labels = needs-cve-analysis ORDER BY created ASC"
+```
+
+**Unattended run** (e.g. scheduled/periodic), applying fixes and opening a PR without prompts:
+```bash
+claude --print "/compliance:analyze-cve --jql=\"project = OCPBUGS AND labels = needs-cve-analysis\" --auto-approve=yes"
 ```
 
 **Features:**
-- Fetches CVE details from NVD, MITRE, and Go Vulnerability Database
+- Resolves and clones the affected repository — via `--repo=`, a Jira ticket's image name (`image-repo-mapping` skill), or a repo already cloned by a previous run — with correct branch mapping (including release repos with git submodules)
+- Fetches CVE details from NVD, MITRE, and the Go Vulnerability Database
+- Optionally resolves the CVE and enrichment context (CVSS, CWE, priority, workarounds) from a Jira ticket, directly or via a JQL-selected queue
 - Multi-level verification (dependency check → static analysis → govulncheck → **call graph reachability**)
-- Generates reports with confidence levels (HIGH/MEDIUM/LOW)
+- Generates reports with confidence levels (HIGH/MEDIUM/LOW/NEEDS_REVIEW)
 - Provides exact remediation commands
-- Optionally applies fixes with approval
+- Optionally applies fixes with approval, then opens a GitHub PR and posts the report/PR link back to the source Jira ticket
+- `--auto-approve=yes` runs the full pipeline (analysis → fix → PR) without interactive prompts, for headless/scheduled use — hard-fail conditions (embargoed CVEs, ambiguous CVE matches, missing file allowlists) are never bypassed by this flag
 
 **Output:**
-- `.work/compliance/analyze-cve/{CVE-ID}/report.md` - Full analysis with confidence assessment
+- `.work/compliance/analyze-cve/repos/{repo-name}` - Cloned repository (`REPO_DIR`), reused across runs against the same repo
+- `.work/compliance/analyze-cve/{CVE-ID}/report.md` - Full analysis with confidence assessment (gitignored, not committed)
 - `.work/compliance/analyze-cve/{CVE-ID}/callgraph.svg` - Visual execution path (if call graph analysis performed)
 - `.work/compliance/analyze-cve/{CVE-ID}/govulncheck-output.txt` - Scanner results
+- `.work/compliance/analyze-cve/{CVE-ID}/phase5-files.txt` - Allowlist of files changed by an applied fix (used to scope the PR commit)
+- A GitHub pull request (if a fix was applied, verified, and the user approved PR creation)
+- A comment (+ `ai-cve-analyzed` label) on the source Jira ticket, if `--jira=`/`--jql=` was used
 
 ## Verification Levels
 
@@ -35,11 +49,35 @@ The command uses multiple methods with increasing confidence:
 4. **Call graph reachability** → Proves execution path (HIGHEST confidence)
 5. **Context analysis** → Checks security controls
 
-Reports include confidence level (HIGH/MEDIUM/LOW) based on verification methods used.
+Reports include confidence level (HIGH/MEDIUM/LOW/NEEDS_REVIEW) based on verification methods used.
+
+## Input Modes
+
+- **Direct CVE**: `<CVE-ID>` — analyze a known CVE, resolving the repo via `--repo=` (see [Repository Resolution](#repository-resolution) below).
+- **Jira ticket**: `--jira=PROJ-NNN` — fetch the ticket, extract the CVE ID, affected image name, and internal context (CVSS, CWE, priority, workarounds, embargo status), then resolve the repo/branch and analyze.
+- **JQL queue**: `--jql="..."` — fetch a batch of matching tickets, skip any already labeled `ai-cve-analyzed`, and process exactly one per run. Re-running the same JQL periodically works through the queue over time.
+
+Jira/PR features require an Atlassian MCP server (or `jira-cli`) and, for PR creation, an authenticated `gh` CLI. These are optional — direct CVE analysis (with `--repo=`) works without them.
+
+## Repository Resolution
+
+The command always analyzes a **cloned repository** (`REPO_DIR`, under `.work/compliance/analyze-cve/repos/`) — it does not analyze whatever directory it happens to be invoked from. Resolution order (see [Phase 0.7](commands/analyze-cve.md#phase-07-repository-resolution-and-cloning) for full detail):
+
+1. A repo already cloned into `.work/compliance/analyze-cve/repos/` by a previous run (used automatically if there's exactly one, and `--repo=` wasn't passed)
+2. `--repo=<url>` — a full GitHub URL, used directly
+3. `--repo=<short-name>` or a Jira ticket's extracted image name — resolved to a repo URL + branch via the [image-repo-mapping](skills/image-repo-mapping/SKILL.md) skill's static component table (including release repos that pin components as git submodules)
+4. Otherwise, the command prompts for a repo URL or image name (or hard-fails under `--auto-approve=yes`, since guessing a repo is a correctness risk, not a convenience trade-off)
+
+The [image-repo-mapping](skills/image-repo-mapping/SKILL.md) table is scoped to the components this command has been validated against — extend it as new components come up.
+
+## Runtime Configuration
+
+- **`AI_HELPERS_WORKSPACE`** (optional, default: cwd): relocates the base directory for cloned repos, reports, and Phase 5/6 artifacts (all under `${AI_HELPERS_WORKSPACE}/.work/compliance/analyze-cve/`). Set this when running somewhere the invocation directory isn't a stable, writable location — e.g. `AI_HELPERS_WORKSPACE=/workspace` on a Remote Workspace pod.
+- **`FORK_ORG`** (optional): if set, Phase 6 pushes the fix branch to a fork under this org and opens a cross-repo PR instead of pushing directly to the resolved repo's `origin`. Use this for a bot identity that isn't a direct collaborator on every repo `image-repo-mapping` might resolve to (e.g. an unattended CI/RWS runner). See [create-fix-pr's Fork Mode](skills/create-fix-pr/SKILL.md#fork-mode-fork_org-set).
 
 ## Prerequisites
 
-**All tools are REQUIRED.** The command will exit with an error if any are missing.
+**Required for all modes.** The command exits with an error if any are missing.
 
 ```bash
 # Install all required Go tools
@@ -53,20 +91,29 @@ brew install graphviz  # macOS
 
 **Required:**
 - Go toolchain (`go version`)
-- `go.mod` file in workspace
+- `git` - repository cloning (Phase 0.7)
 - `govulncheck` - vulnerability scanner
 - `callgraph` - call graph analysis
 - `digraph` - graph traversal
 
-The command validates all tools in Phase 0 and provides installation instructions if any are missing.
+**Optional (feature-gated, warn-only if missing):**
+- `gh` (authenticated via `gh auth login`) - required only to create/update a GitHub PR (Phase 6)
+- An Atlassian MCP server or `jira-cli` - required only for `--jira=`/`--jql=` input modes and posting reports back to Jira
+
+The command validates required tools in Phase 0 and provides installation instructions if any are missing.
 
 ## Fallback Mode
 
-If internet access fails, the command prompts for manual CVE information (description, affected packages, versions, fixes). Analysis proceeds with user-provided data, clearly marked in the report.
+If internet access fails, the command prompts for manual CVE information (description, affected packages, versions, fixes). Analysis proceeds with user-provided data, clearly marked in the report. In `--auto-approve=yes` mode there is no one to prompt, so this case exits with an error instead of fabricating CVE details.
+
+## Autonomous Mode
+
+`--auto-approve=yes` answers every yes/no approval prompt in the pipeline (proceed past `NEEDS_REVIEW`, apply fixes, create a PR, post to Jira with reduced visibility if restricted posting isn't available) so the command can run end-to-end unattended. It never bypasses hard-fail safety checks: embargoed Jira tickets, ambiguous CVE matches within a ticket, or a fix-file allowlist that can't be determined all stop the run regardless of this flag. See the [`analyze-cve` command's Autonomous Mode section](commands/analyze-cve.md#autonomous-mode---auto-approveyesno) for the full decision table.
 
 ## Report Includes
 
 - **Executive Summary**: Risk level (HIGH/MEDIUM/LOW/NEEDS REVIEW) with confidence
+- **Jira Context** (if applicable): ticket link, priority, status, assignee, target versions, internal notes
 - **Analysis Methodology**: Which verification methods were used
 - **Impact Assessment**: Evidence from codebase, call chains (if found)
 - **Remediation Steps**: Exact commands and fixes
@@ -76,13 +123,13 @@ If internet access fails, the command prompts for manual CVE information (descri
 
 ### Basic usage
 ```text
-/compliance:analyze-cve CVE-2024-24783
+/compliance:analyze-cve CVE-2024-24783 --repo=https://github.com/golang/go
 ```
-Analyzes codebase for crypto/x509 vulnerability, provides upgrade command if affected.
+Clones the repo, analyzes it for the crypto/x509 vulnerability, provides upgrade command if affected.
 
 ### High-confidence analysis
 ```text
-/compliance:analyze-cve CVE-2024-45338
+/compliance:analyze-cve CVE-2024-45338 --repo=https://github.com/golang/net
 ```
 **Result:**
 - Finds `golang.org/x/net/html v0.21.0` (vulnerable)
@@ -90,3 +137,14 @@ Analyzes codebase for crypto/x509 vulnerability, provides upgrade command if aff
 - **Risk Level**: HIGH
 - Generates `callgraph.svg` showing call chain
 - Recommends: `go get golang.org/x/net@v0.23.0`
+
+### Jira-driven analysis with automatic fix and PR
+```text
+/compliance:analyze-cve --jira=OCPBUGS-12345 --auto-approve=yes
+```
+**Result:**
+- Extracts `CVE-2024-45338` and internal context from the ticket
+- Runs the same verification pipeline as above
+- Applies the dependency bump, verifies build/tests pass
+- Opens a GitHub PR titled `CVE-2024-45338: bump golang.org/x/net to v0.23.0 [OCPBUGS-12345]`
+- Posts the report and PR link back to `OCPBUGS-12345`, labels it `ai-cve-analyzed`

--- a/plugins/compliance/commands/analyze-cve.md
+++ b/plugins/compliance/commands/analyze-cve.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze Go codebase for CVE vulnerabilities and suggest fixes
-argument-hint: <CVE-ID> [--algo=vta|rta|cha|static]
+argument-hint: "<CVE-ID> | --jira=<PROJ-NNN> | --jql=\"...\" [--repo=<url-or-component>] [--algo=vta|rta|cha|static] [--auto-approve=yes|no]"
 ---
 
 ## Name
@@ -8,52 +8,395 @@ compliance:analyze-cve
 
 ## Synopsis
 ```
-/compliance:analyze-cve <CVE-ID> [--algo=vta|rta|cha|static]
+/compliance:analyze-cve <CVE-ID> [--repo=<url-or-component>] [--algo=vta|rta|cha|static] [--auto-approve=yes|no]
+/compliance:analyze-cve --jira=<PROJ-NNN> [--repo=...] [--algo=...] [--auto-approve=yes|no]
+/compliance:analyze-cve --jql="<JQL query>" [--repo=...] [--algo=...] [--auto-approve=yes|no]
 ```
 
 ## Description
-The `compliance:analyze-cve` command performs comprehensive security vulnerability analysis for Go projects. Given a CVE identifier, it gathers vulnerability intelligence, analyzes the codebase for impact, generates a risk report, and optionally applies fixes.
+The `compliance:analyze-cve` command performs comprehensive security vulnerability analysis for Go projects. Given a CVE identifier — supplied directly, or resolved from a Jira ticket — it resolves and clones the affected repository, gathers vulnerability intelligence, analyzes the codebase for impact, generates a risk report, optionally applies fixes, and optionally opens a GitHub pull request after a verified fix.
+
+Repository resolution works in three ways, in priority order: (1) an explicit `--repo=` (full URL or short image/component name), (2) an image name extracted from a Jira ticket's summary/labels/custom fields when `--jira=`/`--jql=` was used, or (3) a repository already cloned from a previous run in this workspace. See [Phase 0.7](#phase-07-repository-resolution-and-cloning) for the full resolution and cloning logic.
+
+Designed for both interactive use and headless execution (e.g. `claude --print "/compliance:analyze-cve --jira=OCPBUGS-12345 --auto-approve=yes"`) for scheduled/periodic runs.
+
+## Arguments
+
+Exactly one of the following input modes is required:
+
+- **`<CVE-ID>`** — Direct CVE identifier (format: `CVE-YYYY-NNNNN`, case-insensitive). Use when you already know the CVE.
+- **`--jira=PROJ-NNN`** — Jira ticket key (e.g. `--jira=OCPBUGS-12345`). The command fetches the ticket and extracts the CVE ID, affected image name, and enrichment context (CVSS, CWE, priority, workarounds) from it.
+- **`--jql="..."`** — JQL query (e.g. `--jql="project = OCPBUGS AND labels = needs-cve-analysis"`). The command fetches a batch of matching issues, filters out any already labeled `ai-cve-analyzed`, and processes exactly **one** of the remainder per run (see [Phase 0.3](#phase-03-jql-resolution-only-when---jql-is-provided)). Re-running the same JQL periodically works through the queue over multiple invocations.
+
+Optional flags:
+
+- **`--repo=<url-or-component>`**: Repository to analyze. Accepts:
+  - A full GitHub URL: `--repo=https://github.com/openshift/cert-manager-operator`
+  - A short image/component name: `--repo=cert-manager-operator-rhel9` (resolved via the [image-repo-mapping](../skills/image-repo-mapping/SKILL.md) skill)
+  - If omitted, the command checks for a repo already cloned in this workspace first, then resolves from the Jira ticket's image name (if `--jira`/`--jql` was used), then prompts the user.
+- **`--algo`** (default: `vta`): Call graph construction algorithm.
+  - `vta` — Most precise, fewest false positives (recommended)
+  - `rta` — Good balance of precision and speed
+  - `cha` — Fast, less precise
+  - `static` — Fastest, least precise
+- **`--auto-approve=yes|no`** (default: `no`): Run end-to-end without interactive approval prompts. See [Autonomous Mode](#autonomous-mode---auto-approveyesno) below. Intended for scheduled/headless runs.
+
+## Autonomous Mode (`--auto-approve=yes|no`)
+
+`AUTO_APPROVE` is parsed **once**, in Phase 0, from `--auto-approve` (default `no`). It is the **single source of truth** for every approval prompt in this command and its skills — every phase and skill below reads this same value instead of asking independently. Do not add new local "yes/no" prompts anywhere; gate them on `AUTO_APPROVE` the same way.
+
+`AUTO_APPROVE` only answers **yes/no risk decisions** that a human would otherwise approve — it does **not** authorize guessing when required information is missing or ambiguous. Guessing in those cases (wrong repo, wrong branch, wrong CVE, wrong file set) is a correctness/security risk, not a convenience trade-off, so those points **always hard-fail** regardless of `AUTO_APPROVE`, exactly as they do today for a human who doesn't answer.
+
+| # | Decision point | Interactive (`AUTO_APPROVE=no`) | `AUTO_APPROVE=yes` |
+|---|---|---|---|
+| 1 | Phase 2: risk = `NEEDS_REVIEW` — proceed to remediation guidance? | Ask | Proceed (yes) |
+| 2 | Phase 4: apply fixes automatically (→ Phase 5)? | Ask | Proceed (yes) |
+| 3 | Phase 6: create a GitHub PR (→ `create-fix-pr`)? | Ask | Proceed (yes) |
+| 4 | `create-fix-pr` Step 2: conflicting open PR found (title match) | Ask: stack / wait / independent — do not guess | Always **`wait`** — skip PR creation this run; never auto-stack onto or auto-duplicate someone else's PR |
+| 5 | `report-to-jira` Step 3b: restricted-visibility posting unavailable, only public MCP/CLI fallback works — proceed? | Ask | Proceed (yes) — post via the fallback, clearly logged as posted without the visibility restriction |
+
+**Always hard-fail regardless of `AUTO_APPROVE`** (never guess):
+
+| Decision point | Behavior |
+|---|---|
+| Phase 0.7 Step 1: multiple pre-cloned repos found | Exit with error listing the candidates; require `--repo=` |
+| Phase 0.7 Step 2: repo URL/image still unresolved | Exit with error (unchanged from today) |
+| Phase 0.7 Step 3a: mapped Jira branch doesn't exist, and the verbatim-Jira-value fallback *also* doesn't exist | Exit with error; do not invent a branch name |
+| `jira-cve-extraction` Step 4: multiple CVE IDs found in one ticket | Exit with error listing them; require the caller to disambiguate (e.g. re-run with a direct `<CVE-ID>`) |
+| `cve-intelligence-gathering` Step 6: no CVE data from any source | Exit with error; do not proceed on fabricated CVE details |
+| `create-fix-pr` Step 3b: `PHASE5_FILES` allowlist missing/empty and cannot be rebuilt | Return `status: failed` (`phase5_files_missing`) immediately — never prompt |
+| `create-fix-pr` Step 0/3b: branch diff contains paths outside `PHASE5_FILES` | Return `status: failed` (`phase5_files_mismatch`) immediately — never prompt; committed history is never silently dropped or included |
+
+All other absolute rules are unaffected by `AUTO_APPROVE`: embargo abort, credential handling, no force-push to `main`/`master`, no `--no-verify`, and "never change code without approval."
+
+---
+
+## Security — Credential Handling
+
+> **This rule applies to every shell command, log line, and model response in this command, without exception.**
+
+- **Never print, echo, log, or display credentials in any form.** This includes API tokens, passwords, PATs, service-account keys, and any environment variable whose name contains `TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `PAT`, `CREDENTIAL`, or `AUTH`.
+- If a command requires a credential, pass it directly via the environment variable reference (e.g. `$JIRA_API_TOKEN`). Never interpolate the value into a string that will be printed or logged.
+- If a credential accidentally appears in command output, **do not repeat or quote it** in any subsequent message or log.
+- When logging command invocations for debugging, **mask** credential arguments:
+  ```bash
+  # Good — value never appears in output
+  curl -H "Authorization: Bearer $JIRA_API_TOKEN" ...
+  echo "Calling Jira API with Bearer token (masked)"
+
+  # Bad — token value exposed in log
+  echo "Token is: $JIRA_API_TOKEN"
+  curl -v -H "Authorization: Bearer eyJhb..."
+  ```
+- The same rule applies to SSH keys, `~/.netrc` contents, Git credential helpers, and any secrets mounted as files.
+
+---
+
+## Runtime Configuration
+
+- **`AI_HELPERS_WORKSPACE`** (optional, default: `.` — the current working directory): base directory for everything this command writes — cloned repos (`${AI_HELPERS_WORKSPACE}/.work/compliance/analyze-cve/repos/`), reports, and Phase 5 artifacts (`${AI_HELPERS_WORKSPACE}/.work/compliance/analyze-cve/{CVE-ID}/`). Leave unset for normal local/CLI use. Set it when this command runs somewhere the caller's cwd isn't a stable, writable location for `.work/` — e.g. a Remote Workspace pod (set `AI_HELPERS_WORKSPACE=/workspace`) or another headless/CI runner with its own persistent mount.
+- **`FORK_ORG`** (optional): if set, Phase 6 pushes the fix branch to a fork under this org instead of the resolved repo's own `origin`, and opens a cross-repo PR. See `create-fix-pr`'s [Fork Mode](../skills/create-fix-pr/SKILL.md#fork-mode-fork_org-set). Use this when the identity running Phase 6 isn't a direct collaborator on every repo `image-repo-mapping` might resolve to (common for a bot identity in CI/RWS).
+
+---
 
 ## Implementation
 
 ### Phase 0: Setup and Tool Validation
 
 1. **Parse Arguments**
-   - Extract `<CVE-ID>` (required) from the first argument
-   - Extract `--algo` value if provided (optional, default: `vta`)
-   - Valid `--algo` values: `vta`, `rta`, `cha`, `static`
+   - Determine input mode:
+     - IF `--jql="..."` provided → set `JQL_QUERY`, resolve to a single ticket in Phase 0.3
+     - ELSE IF `--jira=PROJ-NNN` provided → set `JIRA_TICKET=PROJ-NNN`, CVE-ID to be resolved in Phase 0.5
+     - ELSE IF a bare `CVE-YYYY-NNNNN` token is present → set `CVE_ID` directly
+     - ELSE → exit with error: "Provide a CVE ID, a Jira ticket (--jira=), or a JQL query (--jql=)"
+   - Extract `--repo` value if provided (optional); store as `REPO_INPUT`.
+   - Extract `--algo` value if provided (optional, default: `vta`). Valid values: `vta`, `rta`, `cha`, `static`.
+   - Extract `--auto-approve` value if provided (optional, default: `no`); store as `AUTO_APPROVE`. Valid values: `yes`, `no` (case-insensitive). Any other value → warn and treat as `no`. See [Autonomous Mode](#autonomous-mode---auto-approveyesno) — this single value is passed to every phase and skill below instead of asking independently.
 
 2. **Check Required Tools**
 
    ```bash
    go version 2>/dev/null || echo "MISSING: go"
-   [ -f go.mod ] || echo "MISSING: go.mod"
    which govulncheck 2>/dev/null || echo "MISSING: govulncheck"
    which callgraph 2>/dev/null || echo "MISSING: callgraph"
    which digraph 2>/dev/null || echo "MISSING: digraph"
+   which git 2>/dev/null || echo "MISSING: git"
    ```
 
 3. **If ANY Tool is Missing** → Display installation instructions and **exit with error**:
 
-   ```
+   ```bash
    go install golang.org/x/vuln/cmd/govulncheck@latest
    go install golang.org/x/tools/cmd/callgraph@latest
    go install golang.org/x/tools/cmd/digraph@latest
    ```
 
-4. **If All Tools Present** → Continue to Phase 1
+   `git` has no install command here — it's expected to already be present; if missing, point the user at their OS package manager.
+
+4. **Optional Phase 6 tool** (warn only, do not exit):
+
+   ```bash
+   which gh 2>/dev/null || echo "OPTIONAL: gh (needed only for Phase 6 GitHub PR creation)"
+   ```
+
+5. **If all required tools present** → Continue to Phase 0.3 (if JQL mode), Phase 0.5 (if Jira mode), or Phase 0.7 (if direct CVE mode).
+
+---
+
+### Phase 0.3: JQL Resolution _(only when `--jql` is provided)_
+
+Run the JQL query once, fetch a small batch of candidates, and select exactly **one** ticket to process this run — this phase never drains a whole queue in a single invocation. The rest are left for a future run.
+
+```python
+results = searchJiraIssuesUsingJql(
+    jql=JQL_QUERY,
+    fields=["key", "summary", "labels"],
+    maxResults=10   # a candidate batch, not a work queue to process in one run
+)
+```
+
+**Decision Point:**
+- IF query returns 0 results → exit with: `No Jira issues matched the JQL query: <JQL_QUERY>`
+- IF query returns 1 or more results → continue to Step 1.
+
+#### Step 1: Filter Out Already-Processed Tickets
+
+Partition the batch:
+
+```python
+unprocessed = [r for r in results if "ai-cve-analyzed" not in r["fields"]["labels"]]
+already_done = [r for r in results if "ai-cve-analyzed" in r["fields"]["labels"]]
+```
+
+This exists to avoid a "stuck forever" failure mode: naively always taking `results[0]` would keep re-selecting the same already-processed ticket on every scheduled re-run whenever the caller's JQL doesn't explicitly exclude `ai-cve-analyzed`. Filtering here — not just relying on the idempotency check in `jira-cve-extraction` Step 2.5 — is what makes repeatedly invoking the *same* JQL an actual way to drain a queue over time.
+
+- IF `unprocessed` is empty (every fetched candidate already has `ai-cve-analyzed`) → exit with:
+
+  ```
+  All <N> ticket(s) matching this JQL in the fetched batch are already processed (ai-cve-analyzed).
+  There may be more matches beyond this batch of 10 — narrow the JQL or re-run later.
+  ```
+
+  Do not fall back to an already-processed ticket, and do not fetch further pages automatically.
+
+#### Step 2: Select One Ticket from the Unprocessed Set
+
+- IF `JQL_QUERY` contains an explicit `ORDER BY` clause (case-insensitive substring match) → **respect it**: select `unprocessed[0]`.
+- IF `JQL_QUERY` has **no** `ORDER BY` clause → Jira's default ordering is not a documented/guaranteed sort, so **pick uniformly at random** from `unprocessed` instead of always taking whichever ticket happens to sort first. Combined with Step 1's filtering, repeated invocations of the same unordered JQL naturally work through the whole matching set over time.
+- Set `JIRA_TICKET` to the selected ticket's key.
+
+#### Step 3: Report
+
+Print a summary table covering every fetched candidate, not just the selected one:
+
+```
+JQL matched <N> issue(s) in this batch (there may be more beyond max_results=10).
+
+✅  <PROJ-NNN>  <summary>          ← selected — processing now
+♻️   <PROJ-NNN>  <summary>          ← already processed (ai-cve-analyzed) — skipped
+⏭   <PROJ-NNN>  <summary>          ← unprocessed, not selected this run — left for a future run
+...
+```
+
+- Continue to Phase 0.5 with `JIRA_TICKET` set.
+
+---
+
+### Phase 0.5: Jira CVE Extraction _(only when `--jira` or `--jql` is provided)_
+
+- **Skill**: [jira-cve-extraction](../skills/jira-cve-extraction/SKILL.md)
+- **Input**: Jira ticket key from `--jira=` (or resolved in Phase 0.3), `AUTO_APPROVE`
+- **Output**: `CVE_ID`, `IMAGE_NAME`, `BRANCH`, `SOURCE_TICKET`, and full `jira_context` enrichment block
+
+**Extraction priority (per skill):**
+1. Parse ticket **summary** — format `CVE-YYYY-NNNNN <image>: <desc> [branch]` — provides CVE ID, image name, and branch in one step
+2. `pscomponent:` label → image name fallback
+3. `Downstream Component Name` custom field → image name fallback
+4. `Custom field (CVE ID)` → CVE ID fallback
+
+**Decision Point:**
+- IF ticket not found or access denied → Exit with error
+- IF `embargo_status = True` → **Exit immediately. Do not proceed. Do not output any ticket data.**
+- IF label `ai-cve-analyzed` already present → Exit with `status: skipped` (already processed)
+- IF no CVE ID found → IF `AUTO_APPROVE=no`, prompt user to supply manually; if declined → Exit. IF `AUTO_APPROVE=yes`, exit immediately (never gated).
+- IF no image name found → Leave blank; Phase 0.7 will prompt (or hard-fail if `AUTO_APPROVE=yes`, per its own rules)
+- IF resolved → Set `CVE_ID` + `IMAGE_NAME`, carry `jira_context` (includes CVSS, CWE, priority, versions) forward → Continue to Phase 0.7
+
+---
+
+### Phase 0.7: Repository Resolution and Cloning
+
+- **Skill**: [image-repo-mapping](../skills/image-repo-mapping/SKILL.md)
+
+#### Storage path
+
+Cloned repos are stored under this command's own workspace directory (see [Runtime Configuration](#runtime-configuration) for `AI_HELPERS_WORKSPACE`), gitignored and persistent across runs:
+
+```bash
+REPOS_BASE="${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/repos"
+mkdir -p "${REPOS_BASE}"
+```
+
+#### Step 1: Check for a Pre-Cloned Repository
+
+```bash
+ls "${REPOS_BASE}/" 2>/dev/null
+```
+
+- IF `REPOS_BASE` contains exactly one directory AND `--repo=` was not passed → use it as `REPO_DIR`, skip to Step 4.
+- IF `REPOS_BASE` contains multiple directories AND `--repo=` was not passed → **always** list them and exit with an error asking the caller to re-run with `--repo=`. This is not gated by `AUTO_APPROVE` — guessing the wrong repo is a correctness risk, not a convenience trade-off.
+- IF `REPOS_BASE` is empty, or `--repo=` was explicitly passed → continue to Step 2.
+
+#### Step 2: Resolve Repository URL
+
+Determine `REPO_URL` using the first applicable source:
+
+1. **`--repo` flag provided**:
+   - Full URL (`https://...`) → use directly.
+   - Short name or image name → run `image-repo-mapping` skill.
+2. **`--jira`/`--jql` was used and `IMAGE_NAME` was extracted** → run `image-repo-mapping` skill with `IMAGE_NAME`.
+3. **Neither** → prompt user: "Please provide the repository URL or image name (e.g. https://github.com/openshift/cert-manager-operator or --repo=cert-manager-operator-rhel9)." IF `AUTO_APPROVE=yes` (no user to prompt) → skip straight to exiting with error below.
+
+**Decision Point:**
+- IF `REPO_URL` still unresolved after prompting → Exit with error. Always exits this way regardless of `AUTO_APPROVE` — there is no safe default repository to guess.
+
+#### Step 3: Resolve the Target Branch and Repository Pattern
+
+Check whether the image maps to a **Pattern A** (direct repo) or **Pattern B** (release repo + submodules) component — this is indicated in the `image-repo-mapping` skill output.
+
+**If Pattern B:** the `REPO_URL` returned by `image-repo-mapping` is the release repo URL. Continue to Step 3a (release repo clone), then Step 3c (submodule resolution), then Step 3b (component clone).
+
+**If Pattern A:** skip Steps 3a and 3c. Proceed directly to Step 3b with `GIT_BRANCH` from Step 3 below.
+
+##### Step 3a (Pattern B only): Clone the Release Repo and Read `.gitmodules`
+
+Use `BRANCH` extracted by `jira-cve-extraction` (e.g. `openshift-4.17`, `ztwim-1.0`), resolved per its "Branch Resolution" section (Pattern A table) or passed through verbatim for Pattern B (this skill's own release-branch table handles it).
+
+**Verify the branch exists before cloning:**
+
+```bash
+git ls-remote --heads "${REPO_URL}" "${GIT_BRANCH}" | grep -q "${GIT_BRANCH}"
+```
+
+- IF branch exists → clone with `-b "${GIT_BRANCH}"` in Step 3b.
+- IF branch does not exist → try the Jira value verbatim as a fallback (same automatic step regardless of `AUTO_APPROVE`).
+  - IF the verbatim fallback branch exists → use it, and note in the report that the mapped branch name was not found and the verbatim Jira value was used instead.
+  - IF the verbatim fallback **also** does not exist → IF `AUTO_APPROVE=no`, warn the user and ask them to confirm or provide the correct branch name. IF `AUTO_APPROVE=yes`, there is no one to ask — **exit with error** instead of guessing a branch name. This case is never gated by `AUTO_APPROVE`.
+- IF `BRANCH` was not extracted (direct CVE mode, no Jira ticket, and `--repo=` was a bare URL with no branch hint) → clone default branch; note this in the analysis.
+
+##### Step 3c (Pattern B only): Read `.gitmodules` and Resolve Component Repo
+
+```bash
+# Clone release repo (shallow, no submodule content needed)
+echo "Cloning release repo ${RELEASE_REPO_URL} @ ${GIT_BRANCH} ..."
+timeout 120 git clone --depth=1 -b "${GIT_BRANCH}" "${RELEASE_REPO_URL}" /tmp/release-repo
+if [ $? -eq 124 ]; then
+  echo "ERROR: release repo clone timed out after 120s"
+  exit 1
+fi
+echo "✓ Release repo cloned"
+
+# Print .gitmodules so the model can parse it
+cat /tmp/release-repo/.gitmodules
+```
+
+From `.gitmodules`, find the entry matching the target image (use the submodule name from the `image-repo-mapping` skill output). Extract:
+- `url` → the component repo to clone (`COMPONENT_URL`)
+- `branch` → clone at this branch (`COMPONENT_BRANCH`)
+- `tag` → if present instead of `branch`, clone at this tag (`COMPONENT_TAG`)
+
+Set `REPO_URL = COMPONENT_URL` and `GIT_BRANCH = COMPONENT_BRANCH` (or `COMPONENT_TAG`) for Step 3b.
+
+##### Step 3b: Clone the Repository
+
+```bash
+REPO_NAME=$(basename "${REPO_URL}" .git)
+REPO_DIR="${REPOS_BASE}/${REPO_NAME}"
+
+if [ ! -d "${REPO_DIR}/.git" ]; then
+  echo "Cloning ${REPO_URL} (branch: ${GIT_BRANCH:-default}) into ${REPO_DIR} ..."
+  mkdir -p "${REPOS_BASE}"
+  if [ -n "${GIT_BRANCH}" ]; then
+    timeout -k 10 300 git clone --depth=50 -b "${GIT_BRANCH}" "${REPO_URL}" "${REPO_DIR}"
+  else
+    timeout -k 10 300 git clone --depth=50 "${REPO_URL}" "${REPO_DIR}"
+  fi
+  CLONE_EXIT=$?
+  if [ $CLONE_EXIT -eq 124 ] || [ $CLONE_EXIT -eq 137 ]; then
+    echo "ERROR: git clone timed out after 300s for ${REPO_URL}"
+    echo "The repository may be too large or the network too slow."
+    exit 1
+  elif [ $CLONE_EXIT -ne 0 ]; then
+    echo "ERROR: git clone failed (exit ${CLONE_EXIT}) for ${REPO_URL}"
+    exit 1
+  fi
+else
+  CURRENT_BRANCH=$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)
+  if [ -n "${GIT_BRANCH}" ] && [ "${CURRENT_BRANCH}" != "${GIT_BRANCH}" ]; then
+    echo "Switching from ${CURRENT_BRANCH} to ${GIT_BRANCH} ..."
+    timeout -k 10 120 git -C "${REPO_DIR}" fetch origin "${GIT_BRANCH}"
+    git -C "${REPO_DIR}" checkout "${GIT_BRANCH}"
+  fi
+  timeout -k 10 120 git -C "${REPO_DIR}" pull --ff-only
+fi
+
+# Explicit verification — always print this so it's visible in the session
+echo "✓ Repository ready: ${REPO_DIR}"
+echo "  Branch : $(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)"
+echo "  Commit : $(git -C "${REPO_DIR}" rev-parse --short HEAD)"
+echo "  go.mod : $([ -f "${REPO_DIR}/go.mod" ] && echo 'present' || echo 'MISSING')"
+```
+
+- IF clone times out → exit with instructions to pre-clone or retry.
+- IF clone fails → exit with error details.
+- IF clone succeeds → `REPO_DIR` and `GIT_BRANCH` are set as working context for all subsequent phases.
+- The verification block at the end **must always print** — this confirms to the user that the repo is ready and is visible in the session context.
+
+#### Step 4: Verify Go Project
+
+```bash
+[ -f "${REPO_DIR}/go.mod" ] || echo "WARNING: no go.mod found in ${REPO_DIR}"
+```
+
+- IF `go.mod` missing → warn user; call graph and govulncheck steps will be skipped, dependency-based methods only.
+- IF `go.mod` present → Continue to Phase 1.
+
+#### Repo Guard — Re-clone if Missing
+
+Even though repos are cloned under this command's own `.work/` directory (not a temp mount), external cleanup (e.g. `git clean -fdx`, a stray `rm -rf .work`) can still remove `REPO_DIR` between phases. Every phase that needs `REPO_DIR` runs this guard first:
+
+```bash
+if [ ! -f "${REPO_DIR}/go.mod" ]; then
+  echo "⚠ Repo missing at ${REPO_DIR} — re-cloning..."
+  mkdir -p "${REPOS_BASE}"
+  if [ -n "${GIT_BRANCH}" ]; then
+    timeout -k 10 300 git clone --depth=50 -b "${GIT_BRANCH}" "${REPO_URL}" "${REPO_DIR}"
+  else
+    timeout -k 10 300 git clone --depth=50 "${REPO_URL}" "${REPO_DIR}"
+  fi
+  if [ $? -ne 0 ]; then
+    echo "✗ Re-clone failed. Cannot continue without the repository."
+    exit 1
+  fi
+  echo "✓ Re-cloned: ${REPO_DIR} @ $(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)"
+fi
+```
+
+Run this guard at the start of **Phase 2, Phase 4, Phase 5, and Phase 6**.
 
 ---
 
 ### Phase 1: CVE Intelligence Gathering
 
 - **Skill**: [cve-intelligence-gathering](../skills/cve-intelligence-gathering/SKILL.md)
-- **Input**: CVE-ID from arguments
-- **Output**: CVE profile (severity, affected packages, fixed versions, remediation guidance, Go relevance)
+- **Input**: `CVE_ID` (from argument or Phase 0.5) **+ `jira_context` from Phase 0.5 (if `--jira`/`--jql` was provided)**
+- **Output**: Merged CVE profile combining Jira internal data (when present) with public sources (NVD, GHSA, Go vulndb)
+
+Pass the full `jira_context` object from Phase 0.5 into the skill, when present. The skill uses Jira fields (CVSS, CWE, affected versions, internal notes, workarounds, release note text) as a pre-populated starting point, then uses web searches to verify, fill gaps, and add public context. Neither source replaces the other — both are combined.
 
 **Decision Point:**
 - IF invalid CVE format → Exit with error
-- IF CVE not found AND user declines to provide info → Exit with error
+- IF CVE not found AND (user declines to provide info, or `AUTO_APPROVE=yes` with no one to ask) → Exit with error
 - IF CVE is not Go-related → Generate "Not Applicable" report → Exit
 - IF CVE details found → Continue to Phase 2
 
@@ -61,31 +404,33 @@ The `compliance:analyze-cve` command performs comprehensive security vulnerabili
 
 ### Phase 2: Codebase Impact Analysis
 
+**Before starting:** Run the [Repo Guard](#repo-guard--re-clone-if-missing) to verify `REPO_DIR` still exists. Re-clone if needed.
+
 - **Skill**: [codebase-impact-analysis](../skills/codebase-impact-analysis/SKILL.md)
   - Sub-skill: [call-graph-analysis](../skills/call-graph-analysis/SKILL.md)
+- **Working directory**: `REPO_DIR` set in Phase 0.7 (e.g. `.work/compliance/analyze-cve/repos/hypershift`)
 - **Input**: CVE profile from Phase 1, `--algo` preference
 - **Output**: Risk level (HIGH/MEDIUM/LOW/NEEDS_REVIEW), evidence package, confidence assessment
 
 **Decision Point:**
 - IF HIGH RISK or MEDIUM RISK → Generate report (Phase 3) → Proceed to Phase 4
 - IF LOW RISK → Generate report (Phase 3) → Recommend manual review → Exit
-- IF NEEDS REVIEW → Generate report (Phase 3) → Ask user if they want remediation guidance
-  - IF yes → Proceed to Phase 4
-  - IF no → Exit
+- IF NEEDS REVIEW → Generate report (Phase 3) → IF `AUTO_APPROVE=no`, ask user if they want remediation guidance: IF yes → Proceed to Phase 4; IF no → Exit. IF `AUTO_APPROVE=yes` → proceed to Phase 4 automatically.
 
 ---
 
 ### Phase 3: Report Generation
 
-Generate analysis report at `.work/compliance/analyze-cve/{CVE-ID}/report.md`
+Generate analysis report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/{CVE-ID}/report.md` — the same workspace base as Phase 0.7's `REPOS_BASE`, so the report lands in the configured workspace regardless of the caller's current directory.
 
 **Report structure:**
 - Executive Summary: risk level, confidence, key takeaway
 - CVE Context: vulnerability description, sources (tag verified vs user-provided)
+- Jira Context _(if `--jira`/`--jql` was provided)_: ticket URL, priority, status, assignee, target versions, components, internal notes, linked issues
 - Analysis Methods: what was used, why, and what was found
 - Findings: specific evidence (file paths, versions, code snippets, call chains)
-- Risk Assessment: severity + actual exposure + exploitability in this context
-- Next Steps: remediation guidance or monitoring recommendations
+- Risk Assessment: severity + actual exposure + exploitability in this context; escalate if `jira_context.analysis_hints.urgency_override` is set
+- Next Steps: remediation guidance or monitoring recommendations; note any existing workarounds from the Jira ticket
 - Sources and Limitations: tools used, gaps, analysis date
 
 **Additional artifacts** (as generated):
@@ -97,27 +442,46 @@ Generate analysis report at `.work/compliance/analyze-cve/{CVE-ID}/report.md`
 
 ### Phase 4: Remediation Guidance
 
+**Before starting:** Run the [Repo Guard](#repo-guard--re-clone-if-missing) to verify `REPO_DIR` still exists. Re-clone if needed.
+
 - **Skill**: [remediation-planning](../skills/remediation-planning/SKILL.md)
 - **Input**: CVE profile from Phase 1, risk level and evidence from Phase 2
 - **Output**: Remediation plan (strategy, commands, verification steps, risk assessment)
 
 **Decision Point:**
 - Present remediation plan to user
-- Ask: "Would you like me to apply these fixes automatically?"
-- IF yes → Continue to Phase 5
-- IF no → Exit with report and manual instructions
+- IF `AUTO_APPROVE=no` → Ask: "Would you like me to apply these fixes automatically?" IF yes → Continue to Phase 5. IF no → Exit with report and manual instructions.
+- IF `AUTO_APPROVE=yes` → Continue to Phase 5 automatically. Still present the plan in the session output first — automation skips the prompt, not the transparency.
+
+After presenting the report (regardless of whether the user proceeds to Phase 5), IF a Jira ticket is involved (`--jira`/`--jql` was used), invoke the report-to-jira skill:
+
+- **Skill**: [report-to-jira](../skills/report-to-jira/SKILL.md)
+- **Input**: completed report, `CVE_ID`, risk level, `SOURCE_TICKET`, `AUTO_APPROVE`
+- **Output**: comment and `ai-cve-analyzed` label posted to `SOURCE_TICKET`; skipped silently in direct CVE mode; if posting fails, comment body is displayed in session for manual copy-paste
 
 ---
 
 ### Phase 5: Interactive Fix Application
 
-Requires explicit user approval before proceeding.
+**Before starting:** Run the [Repo Guard](#repo-guard--re-clone-if-missing) to verify `REPO_DIR` still exists. Re-clone if needed.
 
-1. **Apply Fixes**
-   - Update `go.mod`/`go.sum`: `go get -u <package>@<fixed-version>` + `go mod tidy`
-   - Modify source code if required (as identified in Phase 4)
+Requires **explicit approval** before proceeding — this is the Phase 4 decision point above (`AUTO_APPROVE=yes` counts as that approval; no separate prompt here). Do not change live cluster or production-environment configuration. Repo-tracked config files are allowed only as the approved remediation.
 
-2. **Verify Changes**
+**Before applying anything**, snapshot the worktree so Phase 6 can stage only Phase 5 files (including new untracked paths). `WORK_CVE` is in **this command's own workspace**, not inside `REPO_DIR` — derive it from the same base as `REPOS_BASE` (Phase 0.7), not a bare relative path, so it doesn't depend on the caller's current directory:
+
+```bash
+WORK_CVE="${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}"
+mkdir -p "${WORK_CVE}"
+git -C "${REPO_DIR}" status --porcelain > "${WORK_CVE}/phase5-before.status"
+```
+
+1. **Apply Fixes** (all commands below run against `REPO_DIR`)
+   - Dependency bump: update `go.mod`/`go.sum` with `go get -u <package>@<fixed-version>` + `go mod tidy`
+   - **Vendor sync (dependency bumps only):** IF `go.mod`/`go.sum` changed **and** `vendor/` exists → run `go mod vendor` (or `make vendor` if that target exists) now, before writing `PHASE5_FILES`. Doing this later, in Phase 6, would generate `vendor/` paths that never make it into the allowlist and get silently dropped from the commit.
+   - Source changes if required (as identified in Phase 4)
+   - Repo-tracked config (YAML, Dockerfiles, scripts) if that is the approved remediation
+
+2. **Verify Changes** (after vendor sync, so the vendored tree is what gets verified; run inside `REPO_DIR`)
    - Check for Makefile targets first, fall back to standard Go commands:
      - Verify: `make verify` or `go mod verify`
      - Build: `make build` or `go build ./...`
@@ -125,55 +489,112 @@ Requires explicit user approval before proceeding.
    - Re-check: `govulncheck ./...`
 
 3. **Document Changes**
-   - Summary of changes, files modified, git diff, suggested commit message
+   - Summary of changes, files modified, git diff, suggested commit message (Phase 6 uses this if the user approves a PR)
+   - Write `PHASE5_FILES` (one **repo-relative** path per line, no porcelain status prefix) to `${WORK_CVE}/phase5-files.txt`. Include every path Phase 5 added, modified, or deleted — including untracked files, and every `vendor/` path touched by the sync above. Union of:
+     - porcelain-status paths that are new or whose status code changed vs `phase5-before.status`
+     - paths this phase actually edited (so a pre-dirty file Phase 5 touched is not dropped)
+   - Exclude `.work/`, analysis reports, and credentials. Do not list pre-existing dirty files that Phase 5 did not touch.
+
+**Decision Point:**
+- IF verification failed → stop. Do not offer a PR. Leave the tree for the user to inspect.
+- IF verification succeeded → Continue to Phase 6.
+
+---
+
+### Phase 6: GitHub PR Creation
+
+**Before starting:** Run the [Repo Guard](#repo-guard--re-clone-if-missing) to verify `REPO_DIR` still exists. Re-clone if needed.
+
+- **Skill**: [create-fix-pr](../skills/create-fix-pr/SKILL.md)
+- **Input**: `REPO_DIR`, `GIT_BRANCH`, `REPO_URL`, `CVE_ID`, `SOURCE_TICKET` (if `--jira`/`--jql` was provided), `PHASE5_FILES` allowlist, Phase 5 change summary, module bump (`old` → `new`) **only if** the fix is a dependency bump, `AUTO_APPROVE`, and `FORK_ORG` (optional env var — if set, the skill pushes to a fork under that org and opens a cross-repo PR instead of pushing directly to the resolved upstream repo; see the skill's [Fork Mode](../skills/create-fix-pr/SKILL.md#fork-mode-fork_org-set) section)
+- **Output**: GitHub PR URL (created or updated); optional follow-up Jira comment with that URL
+
+Requires **explicit approval** before any commit, push, or `gh pr create`. This is a separate approval from Phase 5 (applying the fix locally does not imply opening a PR) — `AUTO_APPROVE=yes` must satisfy both approvals independently.
+
+1. IF `AUTO_APPROVE=no` → Ask: "The fix is applied and verified locally. Create a GitHub PR against `<GIT_BRANCH>`?" IF no → Exit. Leave local changes uncommitted (or committed only if the user asked). Print the suggested commit message from Phase 5.
+2. IF `AUTO_APPROVE=yes` → treat as yes automatically, skip the prompt.
+3. IF proceeding → Run `create-fix-pr`, passing `AUTO_APPROVE` through (`git` and `gh` are **hard requirements of that skill** — if either is missing or `gh` is unauthenticated, fail Phase 6; do not create the PR another way):
+   - Check open PRs on the same `org/repo` + base branch whose **title** contains this `CVE_ID` or `SOURCE_TICKET` (title only — ignore files, body, and module versions)
+   - If a title match exists: IF `AUTO_APPROVE=no` → present **stack / wait / independent** and wait for the user; do not guess. IF `AUTO_APPROVE=yes` → always **`wait`** (return `status: skipped`, `user_wait_for_pr_auto`, with the existing PR URL) — never auto-stack onto or auto-duplicate someone else's PR unattended.
+   - Branch from the mapped release branch, commit **only `PHASE5_FILES`** (for a version bump that is often `go.mod` / `go.sum` / `vendor/`, already vendor-synced in Phase 5; other remediations may be source or config only), using the repo's own commit convention when detectable (e.g. `UPSTREAM:` style) and signing off (DCO) by default
+   - Push to `origin` and open a same-repo PR by default, or — if `FORK_ORG` is set — push to a fork under that org and open a cross-repo PR instead (see `create-fix-pr`'s Fork Mode)
+   - Validate the staged (and, for `stack`, the branch) path set exactly matches `PHASE5_FILES`; reject/unstage anything extra before continuing
+   - Push and `gh pr create` (or update the stacked PR)
+   - PR title/body include `CVE_ID`, a summary of the actual Phase 5 change (module/version only when the fix is a dependency bump), short CVE description, and — in Jira mode — a `Fixes:` link to `SOURCE_TICKET`
+   - Direct CVE mode (no `--jira`/`--jql`): create the PR **without** Jira links
+4. After the PR exists, post the PR URL as a **new** comment on `SOURCE_TICKET` (do not replace the Phase 4 analysis comment). Skip Jira posting in direct CVE mode.
+5. Embargo abort and "never change code without approval" still apply. Never force-push `<GIT_BRANCH>`/`main`/`master`.
+
+---
 
 ## Return Value
 
-- **Format**: Markdown report at `.work/compliance/analyze-cve/{CVE-ID}/report.md`
-- **Content**: Vulnerability details, risk assessment, evidence, remediation recommendations, applied fixes (if approved)
+- **Format**: Markdown report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/{CVE-ID}/report.md`
+- **Content**: Vulnerability details, risk assessment, evidence, remediation recommendations, applied fixes (if approved), GitHub PR URL (if Phase 6 ran)
 
 ## Arguments
 
 - `<CVE-ID>`: The CVE identifier to analyze (e.g., CVE-2024-1234, CVE-2023-45678)
   - Format: CVE-YYYY-NNNNN
   - Case insensitive
-  - Required argument
+  - Required unless `--jira=` or `--jql=` is used
+- `--jira=PROJ-NNN`: A Jira ticket key to extract the CVE from (e.g. `--jira=OCPBUGS-12345`)
+- `--jql="..."`: A JQL query to select one unprocessed ticket per run (e.g. `--jql="project = OCPBUGS AND labels = needs-cve-analysis"`)
+- `--repo=<url-or-component>`: Repository to analyze — a full GitHub URL, or a short image/component name resolved via [image-repo-mapping](../skills/image-repo-mapping/SKILL.md) (optional; see [Phase 0.7](#phase-07-repository-resolution-and-cloning) for resolution order)
 - `--algo`: Call graph construction algorithm (optional, default: `vta`)
   - `vta` - Most precise, fewest false positives (recommended)
   - `rta` - Good balance of precision and speed
   - `cha` - Fast, less precise
   - `static` - Fastest, least precise
+- `--auto-approve=yes|no`: Run end-to-end without interactive approval prompts (optional, default: `no`). See [Autonomous Mode](#autonomous-mode---auto-approveyesno).
 
 ## Examples
 
-1. **Basic CVE analysis**:
+1. **Basic CVE analysis against an explicit repo**:
    ```
-   /compliance:analyze-cve CVE-2024-45338
+   /compliance:analyze-cve CVE-2024-45338 --repo=https://github.com/golang/net
    ```
 
 2. **With specific algorithm**:
    ```
-   /compliance:analyze-cve CVE-2024-45338 --algo=rta
+   /compliance:analyze-cve CVE-2024-45338 --repo=https://github.com/golang/net --algo=rta
+   ```
+
+3. **Starting from a Jira ticket (repo/branch resolved automatically from the ticket's image name)**:
+   ```
+   /compliance:analyze-cve --jira=OCPBUGS-12345
+   ```
+
+4. **Unattended run from a JQL queue, applying fixes and opening a PR without prompts**:
+   ```bash
+   claude --print "/compliance:analyze-cve --jql=\"project = OCPBUGS AND labels = needs-cve-analysis ORDER BY created ASC\" --auto-approve=yes"
    ```
 
 ## Prerequisites
 
-All tools are **required**. The command exits with an error if any are missing.
+All tools below are **required**. The command exits with an error if any are missing.
 
 ```bash
 # Install all required Go tools
 go install golang.org/x/vuln/cmd/govulncheck@latest
 go install golang.org/x/tools/cmd/callgraph@latest
 go install golang.org/x/tools/cmd/digraph@latest
+
+# git is also required (Phase 0.7 repository cloning) — install via your OS package manager
 ```
 
-**Optional**: `graphviz` for visual call graph generation (`brew install graphviz` or `sudo apt-get install graphviz`)
+**Optional**:
+- `graphviz` for visual call graph generation (`brew install graphviz` or `sudo apt-get install graphviz`)
+- `gh` (GitHub CLI, authenticated via `gh auth login`) for Phase 6 pull-request creation. Missing `gh` does **not** fail Phase 0 — analysis and local fixes still run; Phase 6 is skipped until it's available.
+- An Atlassian MCP server (e.g. the `jira` plugin's bundled Rovo MCP) or `jira-cli` for `--jira=`/`--jql=` input modes and posting reports back to Jira
 
 **Internet access** is recommended for CVE data fetching but not required if you can provide CVE details manually.
 
 ## Notes
 
-- Focuses on Go-specific vulnerabilities
-- Falls back to user-provided information if internet access fails
-- Does NOT make changes without explicit user approval
-- Reports are saved locally and not committed to git
+- Focuses on Go-specific vulnerabilities.
+- Resolves and clones the target repository automatically — via `--repo=`, Jira image-name mapping, or reusing a repo already cloned into `.work/compliance/analyze-cve/repos/` by a previous run — see [Phase 0.7](#phase-07-repository-resolution-and-cloning). All analysis and fix-application phases run against that cloned `REPO_DIR`, not the directory the command happened to be invoked from.
+- Falls back to user-provided information if internet access fails.
+- Does NOT make changes, commits, or pull requests without explicit approval — either interactive, or given once upfront via `--auto-approve=yes` (see [Autonomous Mode](#autonomous-mode---auto-approveyesno)).
+- Reports are saved locally (`.work/compliance/analyze-cve/`, gitignored) and not committed to git — see [Runtime Configuration](#runtime-configuration) (`AI_HELPERS_WORKSPACE`) to relocate this base directory.
+- Never process or disclose embargoed CVEs — if a Jira ticket's Embargo Status is `True`, the command stops immediately and outputs nothing about the ticket.

--- a/plugins/compliance/commands/analyze-cve.md
+++ b/plugins/compliance/commands/analyze-cve.md
@@ -47,25 +47,25 @@ Optional flags:
 
 `AUTO_APPROVE` only answers **yes/no risk decisions** that a human would otherwise approve — it does **not** authorize guessing when required information is missing or ambiguous. Guessing in those cases (wrong repo, wrong branch, wrong CVE, wrong file set) is a correctness/security risk, not a convenience trade-off, so those points **always hard-fail** regardless of `AUTO_APPROVE`, exactly as they do today for a human who doesn't answer.
 
-| # | Decision point | Interactive (`AUTO_APPROVE=no`) | `AUTO_APPROVE=yes` |
-|---|---|---|---|
-| 1 | Phase 2: risk = `NEEDS_REVIEW` — proceed to remediation guidance? | Ask | Proceed (yes) |
-| 2 | Phase 4: apply fixes automatically (→ Phase 5)? | Ask | Proceed (yes) |
-| 3 | Phase 6: create a GitHub PR (→ `create-fix-pr`)? | Ask | Proceed (yes) |
-| 4 | `create-fix-pr` Step 2: conflicting open PR found (title match) | Ask: stack / wait / independent — do not guess | Always **`wait`** — skip PR creation this run; never auto-stack onto or auto-duplicate someone else's PR |
-| 5 | `report-to-jira` Step 3b: restricted-visibility posting unavailable, only public MCP/CLI fallback works — proceed? | Ask | Proceed (yes) — post via the fallback, clearly logged as posted without the visibility restriction |
+| #   | Decision point                                                                                                     | Interactive (`AUTO_APPROVE=no`)                | `AUTO_APPROVE=yes`                                                                                       |
+| --- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1   | Phase 2: risk = `NEEDS_REVIEW` — proceed to remediation guidance?                                                  | Ask                                            | Proceed (yes)                                                                                            |
+| 2   | Phase 4: apply fixes automatically (→ Phase 5)?                                                                    | Ask                                            | Proceed (yes)                                                                                            |
+| 3   | Phase 6: create a GitHub PR (→ `create-fix-pr`)?                                                                   | Ask                                            | Proceed (yes)                                                                                            |
+| 4   | `create-fix-pr` Step 2: conflicting open PR found (title match)                                                    | Ask: stack / wait / independent — do not guess | Always **`wait`** — skip PR creation this run; never auto-stack onto or auto-duplicate someone else's PR |
+| 5   | `report-to-jira` Step 3b: restricted-visibility posting unavailable, only public MCP/CLI fallback works — proceed? | Ask                                            | Proceed (yes) — post via the fallback, clearly logged as posted without the visibility restriction       |
 
 **Always hard-fail regardless of `AUTO_APPROVE`** (never guess):
 
-| Decision point | Behavior |
-|---|---|
-| Phase 0.7 Step 1: multiple pre-cloned repos found | Exit with error listing the candidates; require `--repo=` |
-| Phase 0.7 Step 2: repo URL/image still unresolved | Exit with error (unchanged from today) |
-| Phase 0.7 Step 3a: mapped Jira branch doesn't exist, and the verbatim-Jira-value fallback *also* doesn't exist | Exit with error; do not invent a branch name |
-| `jira-cve-extraction` Step 4: multiple CVE IDs found in one ticket | Exit with error listing them; require the caller to disambiguate (e.g. re-run with a direct `<CVE-ID>`) |
-| `cve-intelligence-gathering` Step 6: no CVE data from any source | Exit with error; do not proceed on fabricated CVE details |
-| `create-fix-pr` Step 3b: `PHASE5_FILES` allowlist missing/empty and cannot be rebuilt | Return `status: failed` (`phase5_files_missing`) immediately — never prompt |
-| `create-fix-pr` Step 0/3b: branch diff contains paths outside `PHASE5_FILES` | Return `status: failed` (`phase5_files_mismatch`) immediately — never prompt; committed history is never silently dropped or included |
+| Decision point                                                                                                 | Behavior                                                                                                                              |
+| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 0.7 Step 1: multiple pre-cloned repos found                                                              | Exit with error listing the candidates; require `--repo=`                                                                             |
+| Phase 0.7 Step 2: repo URL/image still unresolved                                                              | Exit with error (unchanged from today)                                                                                                |
+| Phase 0.7 Step 3a: mapped Jira branch doesn't exist, and the verbatim-Jira-value fallback *also* doesn't exist | Exit with error; do not invent a branch name                                                                                          |
+| `jira-cve-extraction` Step 4: multiple CVE IDs found in one ticket                                             | Exit with error listing them; require the caller to disambiguate (e.g. re-run with a direct `<CVE-ID>`)                               |
+| `cve-intelligence-gathering` Step 6: no CVE data from any source                                               | Exit with error; do not proceed on fabricated CVE details                                                                             |
+| `create-fix-pr` Step 3b: `PHASE5_FILES` allowlist missing/empty and cannot be rebuilt                          | Return `status: failed` (`phase5_files_missing`) immediately — never prompt                                                           |
+| `create-fix-pr` Step 0/3b: branch diff contains paths outside `PHASE5_FILES`                                   | Return `status: failed` (`phase5_files_mismatch`) immediately — never prompt; committed history is never silently dropped or included |
 
 All other absolute rules are unaffected by `AUTO_APPROVE`: embargo abort, credential handling, no force-push to `main`/`master`, no `--no-verify`, and "never change code without approval."
 
@@ -526,12 +526,14 @@ Pass the full `jira_context` object from Phase 0.5 into the skill, when present.
 
 Generate analysis report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/{CVE-ID}/report.md` — the same workspace base as Phase 0.7's `REPOS_BASE`, so the report lands in the configured workspace regardless of the caller's current directory.
 
+When `--jira`/`--jql` is used, Phase 4 posts **this file in full** to the source ticket (see [report-to-jira](../skills/report-to-jira/SKILL.md)). Include all collected evidence here.
+
 **Report structure:**
 - Executive Summary: risk level, confidence, key takeaway
 - CVE Context: vulnerability description, sources (tag verified vs user-provided)
 - Jira Context _(if `--jira`/`--jql` was provided)_: ticket URL, priority, status, assignee, target versions, components, internal notes, linked issues
 - Analysis Methods: what was used, why, and what was found
-- Findings: specific evidence (file paths, versions, code snippets, call chains)
+- Findings: specific evidence (file paths, versions, code snippets, call chains) — include govulncheck excerpts, the four-algorithm call graph table, and manual verification command output when those analyses ran
 - Risk Assessment: severity + actual exposure + exploitability in this context; escalate if `analysis_hints.urgency_override` is set
 - Next Steps: remediation guidance or monitoring recommendations; note any existing workarounds from the Jira ticket
 - Sources and Limitations: tools used, gaps, analysis date
@@ -559,7 +561,7 @@ Generate analysis report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze
 After presenting the report (regardless of whether the user proceeds to Phase 5), IF a Jira ticket is involved (`--jira`/`--jql` was used), invoke the report-to-jira skill:
 
 - **Skill**: [report-to-jira](../skills/report-to-jira/SKILL.md)
-- **Input**: completed report, `CVE_ID`, risk level, `SOURCE_TICKET`, `jira_context` (label snapshot from Phase 0.5), `AUTO_APPROVE`
+- **Input**: completed report (`report.md`), `CVE_ID`, risk level, `SOURCE_TICKET`, `jira_context` (label snapshot from Phase 0.5), `AUTO_APPROVE`
 - **Output**: comment and `ai-cve-analyzed` label posted to `SOURCE_TICKET`; skipped silently in direct CVE mode; if posting fails, comment body is displayed in session for manual copy-paste
 
 ---

--- a/plugins/compliance/commands/analyze-cve.md
+++ b/plugins/compliance/commands/analyze-cve.md
@@ -16,7 +16,7 @@ compliance:analyze-cve
 ## Description
 The `compliance:analyze-cve` command performs comprehensive security vulnerability analysis for Go projects. Given a CVE identifier — supplied directly, or resolved from a Jira ticket — it resolves and clones the affected repository, gathers vulnerability intelligence, analyzes the codebase for impact, generates a risk report, optionally applies fixes, and optionally opens a GitHub pull request after a verified fix.
 
-Repository resolution works in three ways, in priority order: (1) an explicit `--repo=` (full URL or short image/component name), (2) an image name extracted from a Jira ticket's summary/labels/custom fields when `--jira=`/`--jql=` was used, or (3) a repository already cloned from a previous run in this workspace. See [Phase 0.7](#phase-07-repository-resolution-and-cloning) for the full resolution and cloning logic.
+Repository resolution works in four ways, in priority order: (1) an explicit `--repo=` (full URL or short image/component name), (2) exactly one pre-cloned repository already present in this workspace's `repos/` directory when `--repo=` was not passed, (3) an image name extracted from a Jira ticket's summary/labels/custom fields when `--jira=`/`--jql=` was used, or (4) an interactive prompt for the repository URL or image name. See [Phase 0.7](#phase-07-repository-resolution-and-cloning) for the full resolution and cloning logic.
 
 Designed for both interactive use and headless execution (e.g. `claude --print "/compliance:analyze-cve --jira=OCPBUGS-12345 --auto-approve=yes"`) for scheduled/periodic runs.
 
@@ -33,7 +33,7 @@ Optional flags:
 - **`--repo=<url-or-component>`**: Repository to analyze. Accepts:
   - A full GitHub URL: `--repo=https://github.com/openshift/cert-manager-operator`
   - A short image/component name: `--repo=cert-manager-operator-rhel9` (resolved via the [image-repo-mapping](../skills/image-repo-mapping/SKILL.md) skill)
-  - If omitted, the command checks for a repo already cloned in this workspace first, then resolves from the Jira ticket's image name (if `--jira`/`--jql` was used), then prompts the user.
+  - If omitted, Phase 0.7 checks for exactly one pre-cloned repo in this workspace first, then resolves from the Jira ticket's image name (if `--jira`/`--jql` was used), then prompts the user.
 - **`--algo`** (default: `vta`): Call graph construction algorithm.
   - `vta` — Most precise, fewest false positives (recommended)
   - `rta` — Good balance of precision and speed
@@ -78,14 +78,18 @@ All other absolute rules are unaffected by `AUTO_APPROVE`: embargo abort, creden
 - **Never print, echo, log, or display credentials in any form.** This includes API tokens, passwords, PATs, service-account keys, and any environment variable whose name contains `TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `PAT`, `CREDENTIAL`, or `AUTH`.
 - If a command requires a credential, pass it directly via the environment variable reference (e.g. `$JIRA_API_TOKEN`). Never interpolate the value into a string that will be printed or logged.
 - If a credential accidentally appears in command output, **do not repeat or quote it** in any subsequent message or log.
-- When logging command invocations for debugging, **mask** credential arguments:
+- When logging command invocations for debugging, **mask** credential arguments. Pass auth headers via a `chmod 600` curl config file (`curl -K`) — never as a `-H "Authorization: ..."` argv flag, which exposes the token to `ps aux` / `/proc/<pid>/cmdline` while `curl` runs:
   ```bash
-  # Good — value never appears in output
-  curl -H "Authorization: Bearer $JIRA_API_TOKEN" ...
+  # Good — credential stays out of argv and stdout
+  curl_cfg=$(mktemp); chmod 600 "${curl_cfg}"
+  printf 'header = "Authorization: Bearer %s"\n' "${JIRA_API_TOKEN}" > "${curl_cfg}"
+  curl -s -K "${curl_cfg}" "${JIRA_BASE_URL}/rest/api/2/issue/PROJ-123"
+  rm -f "${curl_cfg}"
   echo "Calling Jira API with Bearer token (masked)"
 
-  # Bad — token value exposed in log
+  # Bad — token value exposed in log or process list
   echo "Token is: $JIRA_API_TOKEN"
+  curl -H "Authorization: Bearer $JIRA_API_TOKEN" ...
   curl -v -H "Authorization: Bearer eyJhb..."
   ```
 - The same rule applies to SSH keys, `~/.netrc` contents, Git credential helpers, and any secrets mounted as files.
@@ -206,7 +210,7 @@ JQL matched <N> issue(s) in this batch (there may be more beyond max_results=10)
 
 - **Skill**: [jira-cve-extraction](../skills/jira-cve-extraction/SKILL.md)
 - **Input**: Jira ticket key from `--jira=` (or resolved in Phase 0.3), `AUTO_APPROVE`
-- **Output**: `CVE_ID`, `IMAGE_NAME`, `BRANCH`, `SOURCE_TICKET`, and full `jira_context` enrichment block
+- **Output**: `CVE_ID`, `IMAGE_NAME`, `BRANCH`, `SOURCE_TICKET`, full `jira_context` enrichment block, and top-level `analysis_hints` (including `urgency_override`)
 
 **Extraction priority (per skill):**
 1. Parse ticket **summary** — format `CVE-YYYY-NNNNN <image>: <desc> [branch]` — provides CVE ID, image name, and branch in one step
@@ -302,25 +306,46 @@ cat /tmp/release-repo/.gitmodules
 
 From `.gitmodules`, find the entry matching the target image (use the submodule name from the `image-repo-mapping` skill output). Extract:
 - `url` → the component repo to clone (`COMPONENT_URL`)
-- `branch` → clone at this branch (`COMPONENT_BRANCH`)
-- `tag` → if present instead of `branch`, clone at this tag (`COMPONENT_TAG`)
+- `path` → submodule path within the release repo (`SUBMODULE_PATH`)
+- `branch` → informational only for Pattern B — the release repo tree pins the exact commit
+- `tag` → if present instead of `branch`, clone at this tag (`COMPONENT_TAG`) for non-submodule flows
 
-Set `REPO_URL = COMPONENT_URL` and `GIT_BRANCH = COMPONENT_BRANCH` (or `COMPONENT_TAG`) for Step 3b.
+Read the **pinned commit** recorded in the release repo tree (do not guess from `.gitmodules` branch alone):
+
+```bash
+PINNED_COMMIT=$(git -C /tmp/release-repo ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
+echo "Pinned commit for ${SUBMODULE_PATH}: ${PINNED_COMMIT}"
+```
+
+Set `REPO_URL = COMPONENT_URL` and `GIT_BRANCH = ${PINNED_COMMIT}` (detached checkout) for Step 3b. IF `PINNED_COMMIT` is empty → exit with error; do not clone at an unpinned branch.
 
 ##### Step 3b: Clone the Repository
 
 ```bash
-REPO_NAME=$(basename "${REPO_URL}" .git)
-REPO_DIR="${REPOS_BASE}/${REPO_NAME}"
+# Canonical owner/repo slug avoids basename collisions (org-a/foo vs org-b/foo)
+REPO_SLUG="$(printf '%s' "${REPO_URL}" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##')"
+REPO_DIR="${REPOS_BASE}/$(echo "${REPO_SLUG}" | tr '/' '-')"
+
+normalize_git_url() {
+  printf '%s' "$1" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##; s#^git@github\.com:##'
+}
+
+clone_repo_at_ref() {
+  local url="$1" dir="$2" ref="${3:-}"
+  if [ -n "${ref}" ] && [[ "${ref}" =~ ^[0-9a-f]{7,40}$ ]]; then
+    timeout -k 10 300 git clone --depth=50 "${url}" "${dir}"
+    git -C "${dir}" checkout "${ref}"
+  elif [ -n "${ref}" ]; then
+    timeout -k 10 300 git clone --depth=50 -b "${ref}" "${url}" "${dir}"
+  else
+    timeout -k 10 300 git clone --depth=50 "${url}" "${dir}"
+  fi
+}
 
 if [ ! -d "${REPO_DIR}/.git" ]; then
-  echo "Cloning ${REPO_URL} (branch: ${GIT_BRANCH:-default}) into ${REPO_DIR} ..."
+  echo "Cloning ${REPO_URL} (ref: ${GIT_BRANCH:-default}) into ${REPO_DIR} ..."
   mkdir -p "${REPOS_BASE}"
-  if [ -n "${GIT_BRANCH}" ]; then
-    timeout -k 10 300 git clone --depth=50 -b "${GIT_BRANCH}" "${REPO_URL}" "${REPO_DIR}"
-  else
-    timeout -k 10 300 git clone --depth=50 "${REPO_URL}" "${REPO_DIR}"
-  fi
+  clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
   CLONE_EXIT=$?
   if [ $CLONE_EXIT -eq 124 ] || [ $CLONE_EXIT -eq 137 ]; then
     echo "ERROR: git clone timed out after 300s for ${REPO_URL}"
@@ -331,6 +356,14 @@ if [ ! -d "${REPO_DIR}/.git" ]; then
     exit 1
   fi
 else
+  CURRENT_ORIGIN="$(git -C "${REPO_DIR}" remote get-url origin 2>/dev/null || true)"
+  EXPECTED_SLUG="$(normalize_git_url "${REPO_URL}")"
+  CURRENT_SLUG="$(normalize_git_url "${CURRENT_ORIGIN}")"
+  if [ -n "${EXPECTED_SLUG}" ] && [ -n "${CURRENT_SLUG}" ] && [ "${EXPECTED_SLUG}" != "${CURRENT_SLUG}" ]; then
+    echo "⚠ Existing clone at ${REPO_DIR} points at ${CURRENT_ORIGIN}, expected ${REPO_URL} — removing and re-cloning"
+    rm -rf "${REPO_DIR}"
+    clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
+  fi
   CURRENT_BRANCH=$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)
   if [ -n "${GIT_BRANCH}" ] && [ "${CURRENT_BRANCH}" != "${GIT_BRANCH}" ]; then
     echo "Switching from ${CURRENT_BRANCH} to ${GIT_BRANCH} ..."
@@ -366,14 +399,10 @@ echo "  go.mod : $([ -f "${REPO_DIR}/go.mod" ] && echo 'present' || echo 'MISSIN
 Even though repos are cloned under this command's own `.work/` directory (not a temp mount), external cleanup (e.g. `git clean -fdx`, a stray `rm -rf .work`) can still remove `REPO_DIR` between phases. Every phase that needs `REPO_DIR` runs this guard first:
 
 ```bash
-if [ ! -f "${REPO_DIR}/go.mod" ]; then
+if [ ! -d "${REPO_DIR}/.git" ]; then
   echo "⚠ Repo missing at ${REPO_DIR} — re-cloning..."
   mkdir -p "${REPOS_BASE}"
-  if [ -n "${GIT_BRANCH}" ]; then
-    timeout -k 10 300 git clone --depth=50 -b "${GIT_BRANCH}" "${REPO_URL}" "${REPO_DIR}"
-  else
-    timeout -k 10 300 git clone --depth=50 "${REPO_URL}" "${REPO_DIR}"
-  fi
+  clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
   if [ $? -ne 0 ]; then
     echo "✗ Re-clone failed. Cannot continue without the repository."
     exit 1
@@ -429,7 +458,7 @@ Generate analysis report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze
 - Jira Context _(if `--jira`/`--jql` was provided)_: ticket URL, priority, status, assignee, target versions, components, internal notes, linked issues
 - Analysis Methods: what was used, why, and what was found
 - Findings: specific evidence (file paths, versions, code snippets, call chains)
-- Risk Assessment: severity + actual exposure + exploitability in this context; escalate if `jira_context.analysis_hints.urgency_override` is set
+- Risk Assessment: severity + actual exposure + exploitability in this context; escalate if `analysis_hints.urgency_override` is set
 - Next Steps: remediation guidance or monitoring recommendations; note any existing workarounds from the Jira ticket
 - Sources and Limitations: tools used, gaps, analysis date
 
@@ -456,7 +485,7 @@ Generate analysis report at `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze
 After presenting the report (regardless of whether the user proceeds to Phase 5), IF a Jira ticket is involved (`--jira`/`--jql` was used), invoke the report-to-jira skill:
 
 - **Skill**: [report-to-jira](../skills/report-to-jira/SKILL.md)
-- **Input**: completed report, `CVE_ID`, risk level, `SOURCE_TICKET`, `AUTO_APPROVE`
+- **Input**: completed report, `CVE_ID`, risk level, `SOURCE_TICKET`, `jira_context` (label snapshot from Phase 0.5), `AUTO_APPROVE`
 - **Output**: comment and `ai-cve-analyzed` label posted to `SOURCE_TICKET`; skipped silently in direct CVE mode; if posting fails, comment body is displayed in session for manual copy-paste
 
 ---

--- a/plugins/compliance/commands/analyze-cve.md
+++ b/plugins/compliance/commands/analyze-cve.md
@@ -78,13 +78,16 @@ All other absolute rules are unaffected by `AUTO_APPROVE`: embargo abort, creden
 - **Never print, echo, log, or display credentials in any form.** This includes API tokens, passwords, PATs, service-account keys, and any environment variable whose name contains `TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `PAT`, `CREDENTIAL`, or `AUTH`.
 - If a command requires a credential, pass it directly via the environment variable reference (e.g. `$JIRA_API_TOKEN`). Never interpolate the value into a string that will be printed or logged.
 - If a credential accidentally appears in command output, **do not repeat or quote it** in any subsequent message or log.
-- When logging command invocations for debugging, **mask** credential arguments. Pass auth headers via a `chmod 600` curl config file (`curl -K`) — never as a `-H "Authorization: ..."` argv flag, which exposes the token to `ps aux` / `/proc/<pid>/cmdline` while `curl` runs:
+- When logging command invocations for debugging, **mask** credential arguments. Pass auth headers via a `chmod 600` curl config file (`curl -K`) — never as a `-H "Authorization: ..."` argv flag, which exposes the token to `ps aux` / `/proc/<pid>/cmdline` while `curl` runs. Reject non-HTTPS `JIRA_BASE_URL` values before sending credentials:
   ```bash
   # Good — credential stays out of argv and stdout
+  case "${JIRA_BASE_URL}" in https://*) ;; *) echo "ERROR: JIRA_BASE_URL must use HTTPS"; exit 1 ;; esac
   curl_cfg=$(mktemp); chmod 600 "${curl_cfg}"
+  trap 'rm -f "${curl_cfg}"' EXIT INT TERM
   printf 'header = "Authorization: Bearer %s"\n' "${JIRA_API_TOKEN}" > "${curl_cfg}"
   curl -s -K "${curl_cfg}" "${JIRA_BASE_URL}/rest/api/2/issue/PROJ-123"
   rm -f "${curl_cfg}"
+  trap - EXIT INT TERM
   echo "Calling Jira API with Bearer token (masked)"
 
   # Bad — token value exposed in log or process list
@@ -245,10 +248,15 @@ mkdir -p "${REPOS_BASE}"
 
 ```bash
 ls "${REPOS_BASE}/" 2>/dev/null
+PRECLONE_CANDIDATE=""
+if [ "$(find "${REPOS_BASE}" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)" -eq 1 ]; then
+  PRECLONE_CANDIDATE="$(find "${REPOS_BASE}" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)"
+fi
 ```
 
-- IF `REPOS_BASE` contains exactly one directory AND `--repo=` was not passed → use it as `REPO_DIR`, skip to Step 4.
 - IF `REPOS_BASE` contains multiple directories AND `--repo=` was not passed → **always** list them and exit with an error asking the caller to re-run with `--repo=`. This is not gated by `AUTO_APPROVE` — guessing the wrong repo is a correctness risk, not a convenience trade-off.
+- IF exactly one directory AND `--repo=` was not passed AND **`--jira`/`--jql` was NOT used** → set `REPO_DIR="${PRECLONE_CANDIDATE}"`. IF `[ ! -d "${REPO_DIR}/.git" ]` or `git -C "${REPO_DIR}" remote get-url origin` does not normalize to a valid `owner/repo` slug → exit with error. Otherwise set `REPO_URL` from that origin and skip to Step 4.
+- IF exactly one directory AND `--jira`/`--jql` was used → **do not reuse yet**; continue to Step 2 so `IMAGE_NAME` maps to the expected `REPO_URL`/`GIT_BRANCH`, then validate the checkout in Step 3b before reuse.
 - IF `REPOS_BASE` is empty, or `--repo=` was explicitly passed → continue to Step 2.
 
 #### Step 2: Resolve Repository URL
@@ -291,17 +299,24 @@ git ls-remote --heads "${REPO_URL}" "${GIT_BRANCH}" | grep -q "${GIT_BRANCH}"
 ##### Step 3c (Pattern B only): Read `.gitmodules` and Resolve Component Repo
 
 ```bash
-# Clone release repo (shallow, no submodule content needed)
+# Fresh per-run release clone — never reuse a shared /tmp path across executions
+RELEASE_CLONE_DIR="${REPOS_BASE}/.release-clones/$(echo "${RELEASE_REPO_URL}" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##' | tr '/' '-')-${GIT_BRANCH}"
+rm -rf "${RELEASE_CLONE_DIR}"
+mkdir -p "$(dirname "${RELEASE_CLONE_DIR}")"
 echo "Cloning release repo ${RELEASE_REPO_URL} @ ${GIT_BRANCH} ..."
-timeout 120 git clone --depth=1 -b "${GIT_BRANCH}" "${RELEASE_REPO_URL}" /tmp/release-repo
-if [ $? -eq 124 ]; then
+timeout 120 git clone --depth=1 -b "${GIT_BRANCH}" "${RELEASE_REPO_URL}" "${RELEASE_CLONE_DIR}"
+RELEASE_CLONE_EXIT=$?
+if [ $RELEASE_CLONE_EXIT -eq 124 ]; then
   echo "ERROR: release repo clone timed out after 120s"
+  exit 1
+elif [ $RELEASE_CLONE_EXIT -ne 0 ]; then
+  echo "ERROR: release repo clone failed for ${RELEASE_REPO_URL}"
   exit 1
 fi
 echo "✓ Release repo cloned"
 
 # Print .gitmodules so the model can parse it
-cat /tmp/release-repo/.gitmodules
+cat "${RELEASE_CLONE_DIR}/.gitmodules"
 ```
 
 From `.gitmodules`, find the entry matching the target image (use the submodule name from the `image-repo-mapping` skill output). Extract:
@@ -313,8 +328,12 @@ From `.gitmodules`, find the entry matching the target image (use the submodule 
 Read the **pinned commit** recorded in the release repo tree (do not guess from `.gitmodules` branch alone):
 
 ```bash
-PINNED_COMMIT=$(git -C /tmp/release-repo ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
+PINNED_COMMIT=$(git -C "${RELEASE_CLONE_DIR}" ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
 echo "Pinned commit for ${SUBMODULE_PATH}: ${PINNED_COMMIT}"
+if [ -z "${PINNED_COMMIT}" ]; then
+  echo "ERROR: no pinned commit found for submodule ${SUBMODULE_PATH} in ${RELEASE_REPO_URL}@${GIT_BRANCH}"
+  exit 1
+fi
 ```
 
 Set `REPO_URL = COMPONENT_URL` and `GIT_BRANCH = ${PINNED_COMMIT}` (detached checkout) for Step 3b. IF `PINNED_COMMIT` is empty → exit with error; do not clone at an unpinned branch.
@@ -322,29 +341,98 @@ Set `REPO_URL = COMPONENT_URL` and `GIT_BRANCH = ${PINNED_COMMIT}` (detached che
 ##### Step 3b: Clone the Repository
 
 ```bash
-# Canonical owner/repo slug avoids basename collisions (org-a/foo vs org-b/foo)
-REPO_SLUG="$(printf '%s' "${REPO_URL}" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##')"
-REPO_DIR="${REPOS_BASE}/$(echo "${REPO_SLUG}" | tr '/' '-')"
-
 normalize_git_url() {
   printf '%s' "$1" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##; s#^git@github\.com:##'
 }
 
+is_commit_ref() {
+  [[ "${1}" =~ ^[0-9a-f]{7,40}$ ]]
+}
+
+validate_repo_slug() {
+  local slug="$1"
+  [[ "${slug}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+  case "${slug}" in ..*|*/..|*../*|*/*/) return 1 ;; esac
+  return 0
+}
+
+assert_repo_dir_under_base() {
+  local abs_base abs_dir
+  abs_base="$(cd "${REPOS_BASE}" && pwd)"
+  abs_dir="$(cd "${REPO_DIR}" 2>/dev/null && pwd || echo "${abs_base}/$(basename "${REPO_DIR}")")"
+  case "${abs_dir}" in
+    "${abs_base}"/*) return 0 ;;
+    *) echo "ERROR: REPO_DIR ${REPO_DIR} escapes REPOS_BASE ${REPOS_BASE}"; exit 1 ;;
+  esac
+}
+
+REPO_SLUG="$(normalize_git_url "${REPO_URL}")"
+if ! validate_repo_slug "${REPO_SLUG}"; then
+  echo "ERROR: invalid repository URL slug from ${REPO_URL}"
+  exit 1
+fi
+REPO_DIR="${REPOS_BASE}/$(echo "${REPO_SLUG}" | tr '/' '-')"
+mkdir -p "${REPOS_BASE}"
+assert_repo_dir_under_base
+
 clone_repo_at_ref() {
   local url="$1" dir="$2" ref="${3:-}"
-  if [ -n "${ref}" ] && [[ "${ref}" =~ ^[0-9a-f]{7,40}$ ]]; then
-    timeout -k 10 300 git clone --depth=50 "${url}" "${dir}"
-    git -C "${dir}" checkout "${ref}"
+  if [ -n "${ref}" ] && is_commit_ref "${ref}"; then
+    timeout -k 10 300 git clone "${url}" "${dir}" || return $?
+    timeout -k 10 120 git -C "${dir}" fetch origin "${ref}" || return $?
+    git -C "${dir}" checkout "${ref}" || return $?
   elif [ -n "${ref}" ]; then
-    timeout -k 10 300 git clone --depth=50 -b "${ref}" "${url}" "${dir}"
+    timeout -k 10 300 git clone --depth=50 -b "${ref}" "${url}" "${dir}" || return $?
   else
-    timeout -k 10 300 git clone --depth=50 "${url}" "${dir}"
+    timeout -k 10 300 git clone --depth=50 "${url}" "${dir}" || return $?
   fi
+}
+
+sync_existing_repo() {
+  local expected_slug current_slug current_origin
+  expected_slug="$(normalize_git_url "${REPO_URL}")"
+  current_origin="$(git -C "${REPO_DIR}" remote get-url origin 2>/dev/null || true)"
+  current_slug="$(normalize_git_url "${current_origin}")"
+  if [ -z "${current_slug}" ] || [ "${expected_slug}" != "${current_slug}" ]; then
+    echo "⚠ Existing clone at ${REPO_DIR} points at ${current_origin:-unknown}, expected ${REPO_URL} — removing and re-cloning"
+    assert_repo_dir_under_base
+    rm -rf "${REPO_DIR}"
+    clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
+    if [ $? -ne 0 ]; then
+      echo "ERROR: re-clone failed after origin mismatch for ${REPO_URL}"
+      exit 1
+    fi
+    return
+  fi
+
+  if [ -n "${GIT_BRANCH}" ] && is_commit_ref "${GIT_BRANCH}"; then
+    local current_head
+    current_head="$(git -C "${REPO_DIR}" rev-parse HEAD 2>/dev/null || true)"
+    if [ "${current_head}" != "${GIT_BRANCH}" ]; then
+      echo "Switching to pinned commit ${GIT_BRANCH} ..."
+      timeout -k 10 120 git -C "${REPO_DIR}" fetch origin "${GIT_BRANCH}"
+      git -C "${REPO_DIR}" checkout "${GIT_BRANCH}"
+    fi
+    return
+  fi
+
+  local current_branch
+  current_branch="$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ -n "${GIT_BRANCH}" ] && ! is_commit_ref "${GIT_BRANCH}" && [ "${current_branch}" != "${GIT_BRANCH}" ]; then
+    echo "Switching from ${current_branch} to ${GIT_BRANCH} ..."
+    timeout -k 10 120 git -C "${REPO_DIR}" fetch origin "${GIT_BRANCH}"
+    git -C "${REPO_DIR}" checkout "${GIT_BRANCH}"
+    current_branch="$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  fi
+  if [ "${current_branch}" = "HEAD" ] || is_commit_ref "${GIT_BRANCH}"; then
+    echo "Detached HEAD — skipping git pull --ff-only"
+    return
+  fi
+  timeout -k 10 120 git -C "${REPO_DIR}" pull --ff-only
 }
 
 if [ ! -d "${REPO_DIR}/.git" ]; then
   echo "Cloning ${REPO_URL} (ref: ${GIT_BRANCH:-default}) into ${REPO_DIR} ..."
-  mkdir -p "${REPOS_BASE}"
   clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
   CLONE_EXIT=$?
   if [ $CLONE_EXIT -eq 124 ] || [ $CLONE_EXIT -eq 137 ]; then
@@ -356,21 +444,7 @@ if [ ! -d "${REPO_DIR}/.git" ]; then
     exit 1
   fi
 else
-  CURRENT_ORIGIN="$(git -C "${REPO_DIR}" remote get-url origin 2>/dev/null || true)"
-  EXPECTED_SLUG="$(normalize_git_url "${REPO_URL}")"
-  CURRENT_SLUG="$(normalize_git_url "${CURRENT_ORIGIN}")"
-  if [ -n "${EXPECTED_SLUG}" ] && [ -n "${CURRENT_SLUG}" ] && [ "${EXPECTED_SLUG}" != "${CURRENT_SLUG}" ]; then
-    echo "⚠ Existing clone at ${REPO_DIR} points at ${CURRENT_ORIGIN}, expected ${REPO_URL} — removing and re-cloning"
-    rm -rf "${REPO_DIR}"
-    clone_repo_at_ref "${REPO_URL}" "${REPO_DIR}" "${GIT_BRANCH}"
-  fi
-  CURRENT_BRANCH=$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD)
-  if [ -n "${GIT_BRANCH}" ] && [ "${CURRENT_BRANCH}" != "${GIT_BRANCH}" ]; then
-    echo "Switching from ${CURRENT_BRANCH} to ${GIT_BRANCH} ..."
-    timeout -k 10 120 git -C "${REPO_DIR}" fetch origin "${GIT_BRANCH}"
-    git -C "${REPO_DIR}" checkout "${GIT_BRANCH}"
-  fi
-  timeout -k 10 120 git -C "${REPO_DIR}" pull --ff-only
+  sync_existing_repo
 fi
 
 # Explicit verification — always print this so it's visible in the session

--- a/plugins/compliance/skills/call-graph-analysis/SKILL.md
+++ b/plugins/compliance/skills/call-graph-analysis/SKILL.md
@@ -80,6 +80,26 @@ echo "Main packages: ${MAIN_PKGS}"
 Pick the most relevant main package for the analysis (typically the controller or server binary, not CLI tools or test helpers). If unsure, prefer the package that imports the vulnerable package's parent tree.
 
 ```bash
+# Select exactly one TARGET_PKG before running callgraph
+if [ -z "${TARGET_PKG:-}" ]; then
+  TARGET_PKG=$(printf '%s\n' ${MAIN_PKGS} | grep -E '(^|/)(cmd/)?(controller|manager|operator|server|main)(/|$)' | head -1)
+  [ -z "${TARGET_PKG}" ] && TARGET_PKG=$(printf '%s\n' ${MAIN_PKGS} | head -1)
+fi
+
+# Normalize to a package path callgraph accepts (./cmd/foo or .)
+case "${TARGET_PKG}" in
+  .|./) TARGET_PKG="." ;;
+  *) TARGET_PKG="./${TARGET_PKG#./}" ;;
+esac
+
+if [ -z "${TARGET_PKG}" ] || [ "${TARGET_PKG}" = "./" ]; then
+  echo "ERROR: No main package found for call graph analysis"
+  exit 1
+fi
+echo "Selected TARGET_PKG=${TARGET_PKG}"
+```
+
+```bash
 ALGO="${USER_ALGO:-vta}"
 OUT_DIR="${OUT_DIR:-${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}}"
 mkdir -p "${OUT_DIR}"
@@ -133,8 +153,9 @@ cat "${OUT_DIR}/callgraph.txt" | digraph nodes | grep "${VULN_FUNC}$"
 ```
 
 **Decision Point:**
-- IF function found → Continue to Step 4
-- IF function NOT found → Report as LOW RISK → Recommend manual review → Exit skill
+- IF function found in this `TARGET_PKG` graph → Continue to Step 4
+- IF function NOT found in this graph → Try the next candidate from `MAIN_PKGS` (different `TARGET_PKG`) before concluding
+- IF every examined main package shows no path → Return **NEEDS_REVIEW** (or MEDIUM if other evidence exists) — do **not** assign LOW RISK from a single unexamined or inconclusive graph
 
 ### Step 4: Find Execution Paths from Entry Points
 

--- a/plugins/compliance/skills/call-graph-analysis/SKILL.md
+++ b/plugins/compliance/skills/call-graph-analysis/SKILL.md
@@ -33,13 +33,20 @@ Use this skill when:
 - Workspace path to analyze
 - Algorithm preference (optional, default: `vta`) — passed via `--algo` from parent command
 - `CVE_ID` — used to construct the output directory
-- `OUT_DIR` (optional, default: `.work/compliance/analyze-cve/${CVE_ID}`) — where artifacts are written
+- `OUT_DIR` (optional, default: `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}`) — where artifacts are written; same workspace base as Phase 0.7's `REPOS_BASE`
+
+## Critical Rules
+
+> 1. **Always use `timeout -k 10`** — plain `timeout` sends SIGTERM but `callgraph` can ignore it when stuck in SSA construction or type resolution. `-k 10` sends SIGKILL after 10s grace, guaranteeing termination.
+> 2. **Never run `callgraph` on `./...`** for repos with more than ~50 packages. Target specific main packages (e.g. `./cmd/controller`, `./main.go`) and let the tool pull in transitive deps automatically.
+> 3. **Always redirect output to a file** (`> file 2>&1`). Never pipe callgraph output to another command — if the reader closes, callgraph can hang on SIGPIPE.
 
 ## Timeout and Algorithm Convention
 
 - Use the algorithm specified by the user via `--algo` (default: `vta`).
-- All `callgraph` invocations use `timeout 300` (5 minutes) to prevent hanging on large codebases.
-- If the chosen algorithm times out: fall back to the next faster algorithm (`vta` → `rta` → `cha`), then narrow scope to specific packages (e.g., `./cmd/...`, `./pkg/...`).
+- All `callgraph` invocations use `timeout -k 10 300` (5 minutes + 10s force-kill) to prevent hanging.
+- Scope: target the **specific main package** (e.g. `./cmd/controller`), not `./...`. The `callgraph` tool resolves transitive deps automatically — there is no need to include the entire repo.
+- If the chosen algorithm times out: fall back to the next faster algorithm (`vta` → `rta` → `cha`), then narrow scope further to a single binary entry point.
 
 ## Implementation Steps
 
@@ -60,28 +67,60 @@ which sfdp || echo "graphviz not found - visual graphs won't be generated (optio
 - IF callgraph OR digraph missing → Exit this skill, return to parent analysis
 - IF both present → Continue
 
-### Step 2: Build Complete Call Graph
+### Step 2: Identify Main Packages and Build Call Graph
+
+First, discover the main packages that serve as entry points:
 
 ```bash
-# ALGO defaults to "vta" unless user specified --algo
-ALGO="${USER_ALGO:-vta}"
+# Find main packages
+MAIN_PKGS=$(find . -name "main.go" -exec dirname {} \; | sort -u)
+echo "Main packages: ${MAIN_PKGS}"
+```
 
-# Output directory — aligns with parent command report location
-OUT_DIR="${OUT_DIR:-.work/compliance/analyze-cve/${CVE_ID}}"
+Pick the most relevant main package for the analysis (typically the controller or server binary, not CLI tools or test helpers). If unsure, prefer the package that imports the vulnerable package's parent tree.
+
+```bash
+ALGO="${USER_ALGO:-vta}"
+OUT_DIR="${OUT_DIR:-${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}}"
 mkdir -p "${OUT_DIR}"
 
-# Build call graph from workspace root
-# Timeout after 300s (5 minutes) to avoid hanging on large codebases
-timeout 300 callgraph -algo "${ALGO}" -format=digraph . > "${OUT_DIR}/callgraph.txt"
+# TARGET_PKG is the specific main package (e.g. ./cmd/controller, .)
+# NEVER use ./... — it causes VTA to explode on large repos
+echo "Building call graph: algo=${ALGO}, target=${TARGET_PKG}"
+timeout -k 10 300 env CGO_ENABLED=0 callgraph -algo "${ALGO}" -format=digraph "${TARGET_PKG}" > "${OUT_DIR}/callgraph.txt" 2>&1
+CG_EXIT=$?
+echo "callgraph exit: ${CG_EXIT}, lines: $(wc -l < "${OUT_DIR}/callgraph.txt")"
+```
+
+**Progressive fallback if the command times out or fails:**
+
+```bash
+# Fallback 1: faster algorithm
+if [ $CG_EXIT -eq 124 ] || [ $CG_EXIT -eq 137 ]; then
+  echo "⚠ ${ALGO} timed out — falling back to rta"
+  timeout -k 10 300 env CGO_ENABLED=0 callgraph -algo rta -format=digraph "${TARGET_PKG}" > "${OUT_DIR}/callgraph.txt" 2>&1
+  CG_EXIT=$?
+fi
+
+# Fallback 2: fastest algorithm
+if [ $CG_EXIT -eq 124 ] || [ $CG_EXIT -eq 137 ]; then
+  echo "⚠ rta timed out — falling back to cha"
+  timeout -k 10 300 env CGO_ENABLED=0 callgraph -algo cha -format=digraph "${TARGET_PKG}" > "${OUT_DIR}/callgraph.txt" 2>&1
+  CG_EXIT=$?
+fi
+
+if [ $CG_EXIT -eq 124 ] || [ $CG_EXIT -eq 137 ]; then
+  echo "✗ All algorithms timed out — call graph analysis skipped"
+fi
 ```
 
 **Error Handling:**
 - IF build fails (compilation errors) → Note in report that call graph cannot be built
-- IF command times out → Fall back to next faster algorithm (`vta` → `rta` → `cha`) and retry
-- IF all algorithms time out → Narrow scope: `timeout 300 callgraph -algo rta -format=digraph ./cmd/... ./pkg/... > "${OUT_DIR}/callgraph.txt"`
+- IF command times out → Fallback chain: `vta` → `rta` → `cha`, all on the same target package
+- IF all algorithms time out → Skip call graph, assign NEEDS_REVIEW
 - IF successful → Continue to Step 3
 
-**Output:** `${OUT_DIR}/callgraph.txt` containing the full program call graph
+**Output:** `${OUT_DIR}/callgraph.txt` containing the call graph rooted at the target binary
 
 ### Step 3: Check if Vulnerable Function Exists in Graph
 
@@ -216,7 +255,9 @@ Return structured result to parent analysis:
 
 ### Very Large Codebases
 - IF chosen algorithm times out (>5 minutes) → Fall back to next faster algorithm (`vta` → `rta` → `cha`)
-- IF all algorithms time out → Narrow scope: `timeout 300 callgraph -algo rta -format=digraph ./cmd/... ./pkg/... > "${OUT_DIR}/callgraph.txt"`
+- IF all algorithms time out on the chosen main package → Try a narrower entry point (single binary)
+- IF still failing → Skip call graph, assign NEEDS_REVIEW, document the limitation
+- NEVER use `./...` as scope — always target a specific main package
 
 ### Missing Entry Points
 - IF `command-line-arguments.main` not found → Look for other entry points
@@ -230,41 +271,34 @@ Return structured result to parent analysis:
 ## Example: Generic Analysis Workflow
 
 ```bash
-# Setup: set CVE_ID and output directory
-$ CVE_ID="CVE-YYYY-NNNNN"
-$ OUT_DIR=".work/compliance/analyze-cve/${CVE_ID}"
-$ mkdir -p "${OUT_DIR}"
+# Setup
+CVE_ID="CVE-YYYY-NNNNN"
+OUT_DIR="${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}"
+mkdir -p "${OUT_DIR}"
 
-# Step 1: Build call graph (default: vta; user can override with --algo)
-$ timeout 300 callgraph -algo vta -format=digraph . > "${OUT_DIR}/callgraph.txt"
+# Step 1: Build call graph targeting a specific main package
+timeout -k 10 300 env CGO_ENABLED=0 callgraph -algo vta -format=digraph ./cmd/controller > "${OUT_DIR}/callgraph.txt" 2>&1
 
 # Step 2: Check if function is called
-$ cat "${OUT_DIR}/callgraph.txt" | digraph nodes | grep "<package-path>.<vulnerable-function>$"
-<package-path>.<vulnerable-function>
+digraph nodes < "${OUT_DIR}/callgraph.txt" | grep "<package-path>.<vulnerable-function>$"
 
 # Step 3: Find path from main
-$ cat "${OUT_DIR}/callgraph.txt" | digraph somepath command-line-arguments.main <package-path>.<vulnerable-function>
-digraph {
-    "command-line-arguments.main" -> "<app-package>.Handler";
-    "<app-package>.Handler" -> "<app-package>.ProcessFunction";
-    "<app-package>.ProcessFunction" -> "<intermediate-package>.HelperFunction";
-    "<intermediate-package>.HelperFunction" -> "<vulnerable-package>.<vulnerable-function>";
-}
+digraph somepath command-line-arguments.main "<package-path>.<vulnerable-function>" < "${OUT_DIR}/callgraph.txt"
 
-# Step 4: Generate visual graph
-$ cat "${OUT_DIR}/callgraph.txt" | digraph somepath command-line-arguments.main <package-path>.<vulnerable-function> | digraph to dot | sfdp -Tsvg -o"${OUT_DIR}/callgraph.svg"
+# Step 4: Generate visual graph (if graphviz available)
+digraph somepath command-line-arguments.main "<package-path>.<vulnerable-function>" < "${OUT_DIR}/callgraph.txt" | \
+  digraph to dot | sfdp -Tsvg -o"${OUT_DIR}/callgraph.svg"
 
 # Result: HIGH RISK — reachable path found
-# Call chain: main → Handler → ProcessFunction → HelperFunction → <vulnerable-function>
 ```
 
 ## Integration with Parent Command
 
-This skill is called from Method 4 of the [codebase-impact-analysis](../codebase-impact-analysis/SKILL.md) skill.
+This skill is called from Method 5 of the [codebase-impact-analysis](../codebase-impact-analysis/SKILL.md) skill.
 
 **When to Invoke:**
 - After basic dependency checks show package is present
-- When highest confidence assessment is needed
+- Mandatory whenever the vulnerable package is in `go.mod` (see codebase-impact-analysis Method 5) — not just for "highest confidence"
 - When tools are available (checked in Phase 0)
 
 **Return to Parent:**

--- a/plugins/compliance/skills/codebase-impact-analysis/SKILL.md
+++ b/plugins/compliance/skills/codebase-impact-analysis/SKILL.md
@@ -33,6 +33,7 @@ Use this skill when:
 
 **From Parent Command:**
 - `--algo` preference for call graph analysis (default: `vta`)
+- `REPO_DIR` — the repository cloned in Phase 0.7 (e.g. `.work/compliance/analyze-cve/repos/hypershift`). All commands below run against this directory, not necessarily the shell's current working directory.
 
 ## Implementation Steps
 
@@ -71,17 +72,132 @@ go list -m <vulnerable-package>
 
 #### Method 2: Go Vulnerability Scanner
 
+> **CRITICAL RULES — read before running anything:**
+> 1. **Run govulncheck AT MOST ONCE.** If `/tmp/govulncheck-source.txt` already exists and is non-empty, read that file. Do NOT re-run.
+> 2. **Never pipe govulncheck to `head`, `tail`, `grep`, or any other command.** Always redirect to a file (`> file 2>&1`). Piping causes govulncheck to hang (SIGPIPE) when the reader closes.
+> 3. **"No findings" is a valid and final result** — it means the CVE is not yet in the Go vuln database. Proceed to Method 3 immediately. Do NOT re-run in a different mode or format.
+> 4. **Always use `timeout -k 10`** to force-kill if SIGTERM is ignored. Plain `timeout` sends SIGTERM but govulncheck can ignore it when stuck in package loading.
+
+This method has 4 sequential steps. If any step fails or times out, skip the remaining steps and proceed to Method 3 — govulncheck is one signal, not the only one.
+
+---
+
+**Step 2a — go.mod check (instant)**
+
 ```bash
-# Run official Go vulnerability scanner
-govulncheck ./...
+VULN_PKG="google.golang.org/grpc"   # replace with actual vulnerable package
+echo "=== Step 2a: go.mod check for ${VULN_PKG} ==="
+grep "${VULN_PKG}" "${REPO_DIR}/go.mod" && echo "FOUND in go.mod" || echo "NOT FOUND in go.mod"
 ```
 
-- Parse output for CVE matches
-- Check if vulnerable symbols are reported as called
+- IF **NOT FOUND** → record "package not in module graph" as LOW signal; **skip Steps 2b–2d entirely**; proceed to Method 3
+- IF **FOUND** → note the version; continue
 
-**Decision Point:**
-- IF govulncheck confirms vulnerability → Strong evidence for HIGH RISK
-- IF govulncheck does not find it → Continue to Method 3 (CVE may not be in Go vulndb yet)
+---
+
+**Step 2b — Pre-flight: download modules and verify toolchain (max 2 min)**
+
+Large repos (300+ deps like spiffe-spire) need all modules cached before govulncheck can load them. Separate this from the scan to isolate network issues from analysis hangs.
+
+```bash
+cd "${REPO_DIR}"
+echo "=== Step 2b: Pre-flight ==="
+
+# Download all modules (network-bound, do first)
+echo "Downloading modules..."
+timeout -k 10 120 env CGO_ENABLED=0 go mod download > /tmp/go-mod-download.txt 2>&1
+if [ $? -ne 0 ]; then
+  echo "⚠ go mod download failed or timed out — govulncheck may fail"
+  cat /tmp/go-mod-download.txt
+fi
+
+# Verify the Go toolchain can load the package graph
+echo "Loading package list..."
+timeout -k 10 60 env CGO_ENABLED=0 go list ./... > /tmp/go-list-packages.txt 2>&1
+LIST_EXIT=$?
+PKG_COUNT=$(wc -l < /tmp/go-list-packages.txt 2>/dev/null || echo 0)
+echo "Package count: ${PKG_COUNT}, exit code: ${LIST_EXIT}"
+
+if [ $LIST_EXIT -ne 0 ]; then
+  echo "✗ go list failed — skipping govulncheck entirely"
+  echo "go list failed (exit ${LIST_EXIT})" > /tmp/govulncheck-source.txt
+  cat /tmp/go-list-packages.txt >> /tmp/govulncheck-source.txt
+  # Skip to Method 3 — if go list can't work, govulncheck won't either
+fi
+```
+
+- IF `go list` fails or times out → write the error to `/tmp/govulncheck-source.txt`, **skip Steps 2c–2d**, proceed to Method 3
+- IF `go list` succeeds → continue. The package count helps estimate scan time.
+
+---
+
+**Step 2c — CGO probe (max 60s, skip if compiler absent)**
+
+```bash
+echo "=== Step 2c: CGO probe ==="
+CGO_SETTING=0
+if command -v gcc >/dev/null 2>&1 || command -v cc >/dev/null 2>&1; then
+  timeout -k 10 60 env CGO_ENABLED=1 go build ./... > /tmp/cgo-probe.txt 2>&1
+  if [ $? -eq 0 ]; then
+    CGO_SETTING=1
+    echo "✓ CGO works — using CGO_ENABLED=1"
+  else
+    echo "✗ CGO build failed — using CGO_ENABLED=0"
+  fi
+else
+  echo "✗ No C compiler — using CGO_ENABLED=0"
+fi
+echo "CGO_ENABLED=${CGO_SETTING}"
+```
+
+---
+
+**Step 2d — govulncheck scan (max 5 min)**
+
+Use `-scan=package` first (fast, checks if CVE is in vuln DB and package imported). Only escalate to symbol-level if package-level finds something.
+
+```bash
+if [ ! -s /tmp/govulncheck-source.txt ]; then
+  # Package-level scan first (fast — no symbol resolution)
+  echo "=== Step 2d: govulncheck package scan ==="
+  timeout -k 10 120 env CGO_ENABLED=${CGO_SETTING} govulncheck -scan=package ./... > /tmp/govulncheck-package.txt 2>&1
+  PKG_EXIT=$?
+  echo "govulncheck -scan=package exit: ${PKG_EXIT}"
+  cat /tmp/govulncheck-package.txt
+
+  # Check if the package scan found anything worth escalating to symbol level
+  if grep -qi "Vulnerability\|finding\|${VULN_PKG}" /tmp/govulncheck-package.txt 2>/dev/null; then
+    echo "=== Step 2d: govulncheck symbol scan (escalating — CVE found at package level) ==="
+    timeout -k 10 300 env CGO_ENABLED=${CGO_SETTING} govulncheck ./... > /tmp/govulncheck-source.txt 2>&1
+    SOURCE_EXIT=$?
+    if [ $SOURCE_EXIT -eq 124 ] || [ $SOURCE_EXIT -eq 137 ]; then
+      echo "govulncheck symbol scan timed out or was killed — using package-level results"
+      cp /tmp/govulncheck-package.txt /tmp/govulncheck-source.txt
+    fi
+  else
+    echo "Package scan found no findings — CVE likely not in Go vuln DB yet"
+    cp /tmp/govulncheck-package.txt /tmp/govulncheck-source.txt
+  fi
+  echo "govulncheck complete"
+else
+  echo "=== govulncheck (using cached result) ==="
+fi
+cat /tmp/govulncheck-source.txt
+
+# Verify repo is still accessible after govulncheck
+echo "=== Post-govulncheck repo check ==="
+ls "${REPO_DIR}/go.mod" > /dev/null 2>&1 && echo "✓ Repo intact at ${REPO_DIR}" || echo "✗ WARNING: Repo missing at ${REPO_DIR}"
+```
+
+- IF CGO was disabled → note in report: "CGO-gated code paths excluded from analysis"
+- IF package scan found no findings → CVE is not in Go vuln DB; do NOT escalate to symbol scan; proceed to Method 3
+- IF symbol scan timed out → use package-level results instead; proceed to Method 3
+- Save `/tmp/govulncheck-source.txt` as a workflow artifact
+
+**Decision Point — govulncheck is ONE signal. Always continue to Method 3 next.**
+- IF scan reports vulnerable symbols called → Strong evidence for HIGH RISK; still continue to Method 3
+- IF scan reports **no findings** → CVE likely not yet in Go vuln database. **Do NOT re-run.** Proceed to Method 3.
+- IF scan timed out or was skipped → Proceed to Method 3; note the gap in the report
 
 #### Method 3: Direct Dependency Check
 
@@ -100,13 +216,26 @@ go list -mod=mod <vulnerable-package>
 - Identify actual code paths that use vulnerable functions
 - Check if vulnerable functions are called in reachable code
 
-#### Method 5: Call Graph Reachability Analysis (Highest Confidence)
+#### Method 5: Call Graph Reachability Analysis (Mandatory when package is present)
 
 Delegate to the [call-graph-analysis](../call-graph-analysis/SKILL.md) skill.
 
 - **Pass**: `--algo` preference from user, vulnerable function signature, package path
 - **Receive**: Risk level, call chain, evidence files
-- **Only run if**: Codebase compiles successfully and highest confidence assessment is needed
+
+> **Scope rule:** Never invoke `callgraph` with `./...`. Always target a specific main package (e.g. `./cmd/controller`, `.`). The tool resolves transitive dependencies automatically. Running on `./...` causes VTA to exhaust resources on repos with >50 packages (external-secrets has 138, spiffe-spire has 300+). See the call-graph-analysis skill for the progressive fallback chain (`vta` → `rta` → `cha`).
+
+**This method is REQUIRED whenever the vulnerable package is present in `go.mod`** — regardless of what Methods 2, 3, or 4 found. Source code analysis (Method 4) is heuristic: it can miss indirect calls through interfaces, generated code, and runtime dispatch. Only a call graph provides provable reachability.
+
+**Valid reasons to skip call graph:**
+- Package is NOT in `go.mod` (genuinely unreachable — LOW RISK by definition)
+- Codebase does not compile (note the limitation; rely on other methods)
+- Vulnerable function signature is unknown (note the gap; rely on govulncheck and source analysis)
+
+**NOT a valid reason to skip:**
+- Source code analysis found no direct calls to the vulnerable function
+- govulncheck did not flag it (CVE may not be in the Go vuln DB yet)
+- The analysis "feels" complete from earlier methods
 
 #### Method 6: Configuration and Context Analysis
 
@@ -122,10 +251,10 @@ Each method provides increasing confidence:
 1. **Basic Presence** (Low) — Package in `go.mod` (Method 1, 3)
 2. **Import & Version Analysis** (Medium) — Package imported, version in vulnerable range, function names found (Method 4)
 3. **Vulnerability Scanner** (Medium-High) — `govulncheck` confirms reachable vulnerable symbols (Method 2)
-4. **Call Graph Reachability** (Highest) — Proven execution path from entry point to vulnerable function (Method 5)
+4. **Call Graph Reachability** (Definitive) — Proven execution path from entry point to vulnerable function (Method 5)
 5. **Context Analysis** — Mitigating or aggravating factors (Method 6)
 
-Use multiple methods. Confidence determination should be data-driven, not formula-based.
+**Required minimum:** If the package is in `go.mod`, the analysis is not complete until Method 5 has run or a valid skip reason has been documented. Never stop at Method 4 alone.
 
 ### Step 3: Build Evidence Package
 
@@ -133,7 +262,7 @@ Collect evidence from all methods used:
 
 - **Dependency Evidence**: `go.mod` entries, `go list` output, version info
 - **Static Code Evidence**: File paths, line numbers, code snippets showing usage
-- **Reachability Evidence**: Call graph output, execution paths, DOT visualization (saved to `.work/compliance/analyze-cve/{CVE-ID}/callgraph.svg`)
+- **Reachability Evidence**: Call graph output, execution paths, DOT visualization (saved to `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/{CVE-ID}/callgraph.svg`, outside `REPO_DIR`)
 - **Scanner Evidence**: `govulncheck` output, vulnerability findings
 - **Mitigation Factors**: Input validation, disabled features, feature flags, security controls
 
@@ -145,13 +274,16 @@ Evaluate all evidence and assign a risk level. The determination should be data-
 - Call graph shows reachable path to vulnerable function, OR govulncheck confirms vulnerability
 
 **MEDIUM RISK:**
-- Package + vulnerable version found in dependencies, usage evidence present but reachability not fully proven
+- Package + vulnerable version in dependencies, usage evidence present, but call graph could not run (build failure or unknown function signature) — reachability not definitively proven
 
 **LOW RISK:**
-- Package not in dependencies, OR version not in vulnerable range, OR no reachable path found
+- Package not in dependencies (call graph skipped — genuinely unreachable), OR version not in vulnerable range, OR call graph ran and found no reachable path
 
 **NEEDS REVIEW:**
-- Conflicting signals, incomplete analysis, or low-confidence evidence
+- Package is in `go.mod` but call graph was skipped for any reason other than package absence or build failure — escalate; do not leave as LOW based on source code analysis alone
+- Conflicting signals or incomplete analysis
+
+> **Rule:** If package is in `go.mod` and call graph was skipped because source analysis "found nothing", assign **NEEDS REVIEW**, not LOW RISK. Document the skip reason explicitly.
 
 ## Return Value
 
@@ -180,7 +312,8 @@ Return structured result to parent command:
       "algorithm": "<vta|rta|cha|static>",
       "reachable_from_main": true,
       "call_chain": "main -> handler -> parse -> VULN",
-      "evidence_files": ["callgraph.dot", "callgraph.svg"]
+      "evidence_files": ["callgraph.dot", "callgraph.svg"],
+      "skip_reason": "<null if ran | 'package_not_in_gomod' | 'build_failure' | 'unknown_function_signature'>"
     },
     "source_analysis": {
       "import_found": true,
@@ -206,15 +339,19 @@ Return structured result to parent command:
 - IF govulncheck doesn't know about this CVE → Continue with other methods, note gap
 
 ### Large Codebases
-- IF call graph times out → Follow fallback strategy in call-graph-analysis skill (algorithm fallback, then scope narrowing)
+- IF call graph times out → Follow fallback strategy in call-graph-analysis skill: algorithm fallback (`vta` → `rta` → `cha`), always targeting a specific main package. Never use `./...` as scope.
 
 ### Incomplete CVE Information
-- IF vulnerable function signature unknown → Skip call graph method, rely on dependency and scanner methods
+- IF vulnerable function signature unknown → Skip call graph, note `skip_reason: unknown_function_signature`, assign MEDIUM at best — do NOT assign LOW based on source analysis alone
+
+### Source Code Analysis Shows No Usage
+- This is **NOT** a valid reason to skip call graph. Proceed with Method 5.
+- Source code search misses interface dispatch, generated code, and indirect call paths.
 
 ## Integration with Parent Command
 
-This skill is called from Phase 2 of the `/compliance:analyze-cve` command.
+This skill is called from Phase 2 of the `/compliance:analyze-cve` command, after the [Repo Guard](../../commands/analyze-cve.md#repo-guard--re-clone-if-missing) has confirmed `REPO_DIR` still exists.
 
-**Input:** CVE profile from Phase 1, `--algo` preference from user
+**Input:** CVE profile from Phase 1, `--algo` preference from user, `REPO_DIR` set in Phase 0.7
 **Output:** Risk level, evidence package, confidence assessment
 **Next:** Parent command uses risk level to decide whether to generate report and proceed to remediation

--- a/plugins/compliance/skills/codebase-impact-analysis/SKILL.md
+++ b/plugins/compliance/skills/codebase-impact-analysis/SKILL.md
@@ -73,12 +73,17 @@ go list -m <vulnerable-package>
 #### Method 2: Go Vulnerability Scanner
 
 > **CRITICAL RULES — read before running anything:**
-> 1. **Run govulncheck AT MOST ONCE.** If `/tmp/govulncheck-source.txt` already exists and is non-empty, read that file. Do NOT re-run.
+> 1. **Run govulncheck AT MOST ONCE per analysis run.** Keep all Method 2 scratch and cache files under `${OUT_DIR}/` (same per-CVE workspace as call-graph artifacts). The canonical result is `${OUT_DIR}/govulncheck-source.txt` — if it already exists and is non-empty for this run, read it and do not re-run.
 > 2. **Never pipe govulncheck to `head`, `tail`, `grep`, or any other command.** Always redirect to a file (`> file 2>&1`). Piping causes govulncheck to hang (SIGPIPE) when the reader closes.
 > 3. **"No findings" is a valid and final result** — it means the CVE is not yet in the Go vuln database. Proceed to Method 3 immediately. Do NOT re-run in a different mode or format.
 > 4. **Always use `timeout -k 10`** to force-kill if SIGTERM is ignored. Plain `timeout` sends SIGTERM but govulncheck can ignore it when stuck in package loading.
 
 This method has 4 sequential steps. If any step fails or times out, skip the remaining steps and proceed to Method 3 — govulncheck is one signal, not the only one.
+
+```bash
+OUT_DIR="${OUT_DIR:-${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}}"
+mkdir -p "${OUT_DIR}"
+```
 
 ---
 
@@ -105,29 +110,26 @@ echo "=== Step 2b: Pre-flight ==="
 
 # Download all modules (network-bound, do first)
 echo "Downloading modules..."
-timeout -k 10 120 env CGO_ENABLED=0 go mod download > /tmp/go-mod-download.txt 2>&1
+timeout -k 10 120 env CGO_ENABLED=0 go mod download > "${OUT_DIR}/go-mod-download.txt" 2>&1
 if [ $? -ne 0 ]; then
   echo "⚠ go mod download failed or timed out — govulncheck may fail"
-  cat /tmp/go-mod-download.txt
+  cat "${OUT_DIR}/go-mod-download.txt"
 fi
 
-# Verify the Go toolchain can load the package graph
-echo "Loading package list..."
-timeout -k 10 60 env CGO_ENABLED=0 go list ./... > /tmp/go-list-packages.txt 2>&1
+# Verify the Go toolchain can load the package graph (CGO disabled first — many repos fail only with CGO enabled)
+echo "Loading package list (CGO_ENABLED=0)..."
+timeout -k 10 60 env CGO_ENABLED=0 go list ./... > "${OUT_DIR}/go-list-packages.txt" 2>&1
 LIST_EXIT=$?
-PKG_COUNT=$(wc -l < /tmp/go-list-packages.txt 2>/dev/null || echo 0)
+PKG_COUNT=$(wc -l < "${OUT_DIR}/go-list-packages.txt" 2>/dev/null || echo 0)
 echo "Package count: ${PKG_COUNT}, exit code: ${LIST_EXIT}"
 
 if [ $LIST_EXIT -ne 0 ]; then
-  echo "✗ go list failed — skipping govulncheck entirely"
-  echo "go list failed (exit ${LIST_EXIT})" > /tmp/govulncheck-source.txt
-  cat /tmp/go-list-packages.txt >> /tmp/govulncheck-source.txt
-  # Skip to Method 3 — if go list can't work, govulncheck won't either
+  echo "go list with CGO_ENABLED=0 failed — retrying after CGO probe (Step 2c) before skipping govulncheck"
 fi
 ```
 
-- IF `go list` fails or times out → write the error to `/tmp/govulncheck-source.txt`, **skip Steps 2c–2d**, proceed to Method 3
-- IF `go list` succeeds → continue. The package count helps estimate scan time.
+- IF `go list` succeeds with `CGO_ENABLED=0` → continue to Step 2c, then 2d
+- IF `go list` still fails after Step 2c's CGO probe (with the chosen `CGO_SETTING`) → write the error to `${OUT_DIR}/govulncheck-source.txt`, **skip Steps 2c–2d**, proceed to Method 3
 
 ---
 
@@ -137,7 +139,7 @@ fi
 echo "=== Step 2c: CGO probe ==="
 CGO_SETTING=0
 if command -v gcc >/dev/null 2>&1 || command -v cc >/dev/null 2>&1; then
-  timeout -k 10 60 env CGO_ENABLED=1 go build ./... > /tmp/cgo-probe.txt 2>&1
+  timeout -k 10 60 env CGO_ENABLED=1 go build ./... > "${OUT_DIR}/cgo-probe.txt" 2>&1
   if [ $? -eq 0 ]; then
     CGO_SETTING=1
     echo "✓ CGO works — using CGO_ENABLED=1"
@@ -148,7 +150,23 @@ else
   echo "✗ No C compiler — using CGO_ENABLED=0"
 fi
 echo "CGO_ENABLED=${CGO_SETTING}"
+
+if [ $LIST_EXIT -ne 0 ]; then
+  echo "Retrying go list with CGO_ENABLED=${CGO_SETTING}..."
+  timeout -k 10 60 env CGO_ENABLED=${CGO_SETTING} go list ./... > "${OUT_DIR}/go-list-packages.txt" 2>&1
+  LIST_EXIT=$?
+  PKG_COUNT=$(wc -l < "${OUT_DIR}/go-list-packages.txt" 2>/dev/null || echo 0)
+  echo "Retry package count: ${PKG_COUNT}, exit code: ${LIST_EXIT}"
+  if [ $LIST_EXIT -ne 0 ]; then
+    echo "✗ go list failed after CGO probe — skipping govulncheck entirely"
+    echo "go list failed (exit ${LIST_EXIT})" > "${OUT_DIR}/govulncheck-source.txt"
+    cat "${OUT_DIR}/go-list-packages.txt" >> "${OUT_DIR}/govulncheck-source.txt"
+  fi
+fi
 ```
+
+- IF `go list` still fails after retry → `${OUT_DIR}/govulncheck-source.txt` is populated; skip Step 2d and proceed to Method 3
+- IF `go list` succeeds → continue
 
 ---
 
@@ -157,32 +175,32 @@ echo "CGO_ENABLED=${CGO_SETTING}"
 Use `-scan=package` first (fast, checks if CVE is in vuln DB and package imported). Only escalate to symbol-level if package-level finds something.
 
 ```bash
-if [ ! -s /tmp/govulncheck-source.txt ]; then
+if [ ! -s "${OUT_DIR}/govulncheck-source.txt" ] && [ $LIST_EXIT -eq 0 ]; then
   # Package-level scan first (fast — no symbol resolution)
   echo "=== Step 2d: govulncheck package scan ==="
-  timeout -k 10 120 env CGO_ENABLED=${CGO_SETTING} govulncheck -scan=package ./... > /tmp/govulncheck-package.txt 2>&1
+  timeout -k 10 120 env CGO_ENABLED=${CGO_SETTING} govulncheck -scan=package ./... > "${OUT_DIR}/govulncheck-package.txt" 2>&1
   PKG_EXIT=$?
   echo "govulncheck -scan=package exit: ${PKG_EXIT}"
-  cat /tmp/govulncheck-package.txt
+  cat "${OUT_DIR}/govulncheck-package.txt"
 
   # Check if the package scan found anything worth escalating to symbol level
-  if grep -qi "Vulnerability\|finding\|${VULN_PKG}" /tmp/govulncheck-package.txt 2>/dev/null; then
+  if grep -qi "Vulnerability\|finding\|${VULN_PKG}" "${OUT_DIR}/govulncheck-package.txt" 2>/dev/null; then
     echo "=== Step 2d: govulncheck symbol scan (escalating — CVE found at package level) ==="
-    timeout -k 10 300 env CGO_ENABLED=${CGO_SETTING} govulncheck ./... > /tmp/govulncheck-source.txt 2>&1
+    timeout -k 10 300 env CGO_ENABLED=${CGO_SETTING} govulncheck ./... > "${OUT_DIR}/govulncheck-source.txt" 2>&1
     SOURCE_EXIT=$?
     if [ $SOURCE_EXIT -eq 124 ] || [ $SOURCE_EXIT -eq 137 ]; then
       echo "govulncheck symbol scan timed out or was killed — using package-level results"
-      cp /tmp/govulncheck-package.txt /tmp/govulncheck-source.txt
+      cp "${OUT_DIR}/govulncheck-package.txt" "${OUT_DIR}/govulncheck-source.txt"
     fi
   else
     echo "Package scan found no findings — CVE likely not in Go vuln DB yet"
-    cp /tmp/govulncheck-package.txt /tmp/govulncheck-source.txt
+    cp "${OUT_DIR}/govulncheck-package.txt" "${OUT_DIR}/govulncheck-source.txt"
   fi
   echo "govulncheck complete"
 else
   echo "=== govulncheck (using cached result) ==="
 fi
-cat /tmp/govulncheck-source.txt
+cat "${OUT_DIR}/govulncheck-source.txt"
 
 # Verify repo is still accessible after govulncheck
 echo "=== Post-govulncheck repo check ==="
@@ -192,7 +210,7 @@ ls "${REPO_DIR}/go.mod" > /dev/null 2>&1 && echo "✓ Repo intact at ${REPO_DIR}
 - IF CGO was disabled → note in report: "CGO-gated code paths excluded from analysis"
 - IF package scan found no findings → CVE is not in Go vuln DB; do NOT escalate to symbol scan; proceed to Method 3
 - IF symbol scan timed out → use package-level results instead; proceed to Method 3
-- Save `/tmp/govulncheck-source.txt` as a workflow artifact
+- Save `${OUT_DIR}/govulncheck-source.txt` as a workflow artifact
 
 **Decision Point — govulncheck is ONE signal. Always continue to Method 3 next.**
 - IF scan reports vulnerable symbols called → Strong evidence for HIGH RISK; still continue to Method 3
@@ -271,7 +289,8 @@ Collect evidence from all methods used:
 Evaluate all evidence and assign a risk level. The determination should be data-driven, not formula-based.
 
 **HIGH RISK:**
-- Call graph shows reachable path to vulnerable function, OR govulncheck confirms vulnerability
+- Call graph shows a reachable path to the vulnerable function, OR
+- Symbol-level `govulncheck` confirms **called** vulnerable symbols (package-level import alone is not sufficient)
 
 **MEDIUM RISK:**
 - Package + vulnerable version in dependencies, usage evidence present, but call graph could not run (build failure or unknown function signature) — reachability not definitively proven

--- a/plugins/compliance/skills/create-fix-pr/SKILL.md
+++ b/plugins/compliance/skills/create-fix-pr/SKILL.md
@@ -305,6 +305,13 @@ if [ -n "${EXTRA}" ]; then
     git -C "${REPO_DIR}" restore --staged -- "${x}"
   done <<< "${EXTRA}"
 fi
+
+MISSING="$(comm -23 <(sort "${PHASE5_FILES}") <(sort "${WORK_CVE}/staged-files.txt"))"
+if [ -n "${MISSING}" ]; then
+  echo "ERROR: PHASE5_FILES paths missing from the staged set:"
+  echo "${MISSING}"
+  exit 1   # return status: failed (phase5_files_incomplete)
+fi
 ```
 
 IF any path was rejected → tell the user which paths were unstaged and why before continuing. Re-run the diff after unstaging to confirm the index now matches `PHASE5_FILES` exactly (accounting for deletions).

--- a/plugins/compliance/skills/create-fix-pr/SKILL.md
+++ b/plugins/compliance/skills/create-fix-pr/SKILL.md
@@ -1,0 +1,515 @@
+---
+name: create-fix-pr
+description: After a CVE fix is applied and verified locally, create (or update) a GitHub pull request and optionally post the PR URL back to the source Jira ticket
+---
+
+# Create Fix PR
+
+Opens a GitHub pull request for the CVE fix already applied in `REPO_DIR` (Phase 5). Never commits, pushes, or opens a PR without **explicit approval** — interactive, or `AUTO_APPROVE=yes` recorded once upfront (see [Autonomous Mode](../../commands/analyze-cve.md#autonomous-mode---auto-approveyesno)). Direct CVE mode (no `--jira=`/`--jql=`) still creates the PR; it just omits Jira `Fixes:` links and the Jira follow-up comment.
+
+Called from **Phase 6** of `/compliance:analyze-cve` after Phase 5 verification succeeds.
+
+---
+
+## When to Use This Skill
+
+Use this skill when:
+
+- Phase 5 applied a fix in `REPO_DIR` and verification passed
+- The user approved creating a GitHub PR
+- `embargo_status` is not `True`
+
+Do **not** use this skill to apply the fix itself (that is Phase 5) or to post the analysis report (that is `report-to-jira` in Phase 4).
+
+---
+
+## Required Inputs
+
+From the parent command:
+
+| Input | Source | Required |
+|---|---|---|
+| `REPO_DIR` | Phase 0.7 | Yes |
+| `GIT_BRANCH` | Phase 0.7 (mapped release branch, e.g. `release-4.17`) | Yes |
+| `REPO_URL` | Phase 0.7 | Yes |
+| `CVE_ID` | Phase 0.5 / direct CVE mode | Yes |
+| `SOURCE_TICKET` | `--jira=` / `--jql=` | No |
+| `AUTO_APPROVE` | Phase 0 (`--auto-approve`, default `no`) | Yes |
+| `FORK_ORG` | Caller environment (e.g. CI/RWS runner) | No — enables [Fork Mode](#fork-mode-fork_org-set) when set |
+| `PHASE5_FILES` | Phase 5 allowlist (incl. untracked) | Yes |
+| Module path, old version, new version | Phase 4 / 5 | Yes if a dependency bump |
+| Short CVE description | Phase 1 | Recommended |
+| Phase 5 change summary | Phase 5 "Document Changes" | Yes |
+
+---
+
+## Prerequisites
+
+Hard requirements **for this skill**. Phase 0 does **not** treat `gh` as required (warn-only). This skill must not assume either tool is present — re-check both, then **fail** if either is missing. Do not create a PR another way.
+
+```bash
+which git 2>/dev/null || echo "MISSING: git"
+which gh 2>/dev/null || echo "MISSING: gh"
+gh auth status 2>/dev/null || echo "MISSING: gh auth"
+```
+
+- IF `git` is missing → print install instructions and return `status: failed` (`git_missing`). Stop. Do not commit or push.
+- IF `gh` is missing → print install instructions (`https://cli.github.com/`) and return `status: failed` (`gh_missing`). Stop. Do not commit or push.
+- IF `gh auth status` fails → print `gh auth login` instructions and return `status: failed` (`gh_unauthenticated`). Stop. Do not commit or push.
+- Do not print token or login output that contains credentials.
+
+> **Credential rule:** Never print, echo, or log tokens, PATs, or `gh` auth output that contains credentials. Reference credentials only via environment variable names.
+
+---
+
+## Fork Mode (`FORK_ORG` set)
+
+By default (no `FORK_ORG`) this skill pushes the fix branch directly to the cloned repo's own `origin` and opens a same-repo branch→base PR. That requires the authenticated `gh`/`git` identity to have **direct write access** to every upstream repo `image-repo-mapping` might resolve to (e.g. `openshift/cert-manager-operator`, `openshift/cert-manager`, `openshift/secrets-store-csi-driver-operator`, ...). In an unattended CI/RWS runner that isn't a collaborator on all of those repos, that's the wrong default.
+
+**IF the environment variable `FORK_ORG` is set** (e.g. a bot-owned org), push to a fork under that org instead and open a cross-repo PR — mirrors the fork/upstream model used elsewhere for automated OpenShift PRs. This section only changes **where the branch is pushed** and **how the PR's `--head` is specified**; Step 0 (safety gates), Step 1 (org/repo/base-branch resolution from `origin`), Step 2 (conflicting-PR detection), and Step 3b (commit, allowlist validation) are unchanged and still operate against `REPO_DIR`/`ORG`/`REPO`/`BASE_BRANCH` resolved from `origin`.
+
+### Resolve the fork repo
+
+```bash
+FORK_REPO="${FORK_ORG}/${REPO}"   # REPO = repo name parsed from origin in Step 1, e.g. "cert-manager-operator"
+```
+
+### Ensure the fork exists and is actually a fork of this repo
+
+Never assume a repo at `${FORK_REPO}` is the right push target just because the name matches — verify its fork lineage first. Reusing an unrelated (or unexpectedly renamed/transferred) repo that happens to occupy that name would push the fix branch and open a PR from somewhere unintended.
+
+```bash
+if FORK_JSON=$(gh repo view "${FORK_REPO}" --json isFork,parent 2>/dev/null); then
+  IS_FORK=$(echo "$FORK_JSON" | jq -r '.isFork')
+  PARENT_FULL_NAME=$(echo "$FORK_JSON" | jq -r '.parent.fullName // empty')
+else
+  IS_FORK=""
+  PARENT_FULL_NAME=""
+fi
+```
+
+- IF `${FORK_REPO}` exists (the `gh repo view` above succeeded) **and** (`IS_FORK` is not exactly `true` **or** `PARENT_FULL_NAME` is not exactly `${ORG}/${REPO}`) → **stop immediately**, do not add the `fork` remote or push anything, and return `status: failed` (`fork_wrong_lineage`).
+- IF `${FORK_REPO}` exists and lineage matches → skip fork creation below, continue to Step 3a.
+- IF `${FORK_REPO}` does not exist → create it:
+
+```bash
+gh repo fork "${ORG}/${REPO}" --org "${FORK_ORG}" --remote=false --clone=false --default-branch-only=false
+FORK_CREATE_EXIT=$?
+```
+
+- IF `FORK_CREATE_EXIT` is non-zero → **stop immediately** and return `status: failed` (`fork_create_failed`). Do not poll, do not add the `fork` remote, do not push — the create call already reported failure, so there is nothing to wait for.
+- IF `FORK_CREATE_EXIT` is `0` → the fork was accepted; poll briefly, since GitHub creates forks asynchronously:
+
+```bash
+for i in $(seq 1 10); do
+  gh repo view "${FORK_REPO}" >/dev/null 2>&1 && break
+  sleep 3
+done
+```
+
+- IF the fork still doesn't exist after polling → return `status: failed` (`fork_create_failed`). Do not fall back to pushing to `origin` — that would silently switch to requiring direct upstream write access, which is exactly what `FORK_ORG` was set to avoid.
+
+### 3a (fork mode). Branch — same as default mode
+
+Branch creation/naming is identical to the non-fork case below (`BRANCH_NAME` derived from `CVE_ID`/`SOURCE_TICKET`, checked out from `BASE_BRANCH`).
+
+### 3c (fork mode). Push to the fork, not `origin`
+
+```bash
+git -C "${REPO_DIR}" remote add fork "https://github.com/${FORK_REPO}.git" 2>/dev/null \
+  || git -C "${REPO_DIR}" remote set-url fork "https://github.com/${FORK_REPO}.git"
+
+# Keep the fork in sync with the upstream base branch before pushing a branch built on top of it,
+# so the PR diff is just this fix — not a stale-fork drift diff.
+git -C "${REPO_DIR}" fetch origin "${BASE_BRANCH}"
+git -C "${REPO_DIR}" push fork "refs/remotes/origin/${BASE_BRANCH}:refs/heads/${BASE_BRANCH}" --force-with-lease 2>/dev/null || true
+
+git -C "${REPO_DIR}" push -u fork "${BRANCH_NAME}"
+```
+
+Never force-push `${BASE_BRANCH}` on `origin` (the upstream repo) — the force-with-lease sync above only ever targets the `fork` remote's copy of that branch name, never `origin`.
+
+### Step 4 (fork mode). Create the PR across fork → upstream
+
+**Do not use `gh pr create --head "${FORK_ORG}:${BRANCH_NAME}"`.** `gh pr create --head` only supports a **user**-owned head repo via the `owner:branch` syntax — per `gh pr create --help`: "Using an organization as the owner is currently not supported" (tracked at [cli/cli#10093](https://github.com/cli/cli/issues/10093)). Since `FORK_ORG` may be a GitHub organization, use the REST API's `head_repo` parameter instead (via `gh api`), which unambiguously names the head repository regardless of whether `FORK_ORG` is a user or an org:
+
+```bash
+printf '%s' "${PR_BODY}" > "${WORK_CVE}/pr-body.md"
+
+PR_URL=$(gh api \
+  "repos/${ORG}/${REPO}/pulls" \
+  -f head_repo="${FORK_REPO}" \
+  -f head="${BRANCH_NAME}" \
+  -f base="${BASE_BRANCH}" \
+  -f title="${PR_TITLE}" \
+  -F body=@"${WORK_CVE}/pr-body.md" \
+  --jq '.html_url')
+```
+
+`head` is the **bare branch name** here (no `owner:` prefix) — disambiguation comes entirely from the separate `head_repo` field, so this works whether `FORK_ORG`/`FORK_REPO` is user- or org-owned. Everything else (title/body construction, stacked-PR update path) is unchanged; `PR_URL` is captured directly from the API response instead of `gh pr create`'s output.
+
+### Auth note
+
+`gh auth status` in Prerequisites must reflect a token with `public_repo` (classic PAT) or equivalent fork/push/PR scope on `${FORK_ORG}` and PR-creation scope against the upstream repo — this is set up by the caller before this skill runs (not part of this skill). Never echo the token itself.
+
+---
+
+## Step 0: Safety Gates
+
+1. IF `embargo_status = True` → **abort immediately**. Do not commit, push, create a PR, or mention ticket contents.
+2. IF Phase 5 did not complete successfully → return `status: skipped` (`phase5_incomplete`).
+3. Confirm there are local changes to commit:
+
+   ```bash
+   git -C "${REPO_DIR}" status --porcelain
+   git -C "${REPO_DIR}" diff --stat
+   ```
+
+   - IF working tree is clean **and** HEAD is already on a fix branch with the Phase 5 remediation committed (dependency bump, source, or config) → **validate that branch's changes against `PHASE5_FILES`** (see the check in Step 3b) before skipping to Step 4. A clean worktree only means nothing is *uncommitted*; it does not prove the existing commit(s) contain only Phase 5 paths. IF the branch diff vs `${BASE_BRANCH}` contains paths outside `PHASE5_FILES` → **always return `status: failed` (`phase5_files_mismatch`) immediately. Never gated by `AUTO_APPROVE` and never prompt.**
+   - IF working tree is clean and HEAD is still `${GIT_BRANCH}` with no Phase 5 commit → return `status: skipped` (`no_local_changes`).
+4. IF `AUTO_APPROVE=no` (and the parent hasn't already recorded a yes) → Ask:
+
+   ```
+   Phase 5 applied the fix locally. Create a GitHub PR against <GIT_BRANCH>?
+   ```
+
+   - IF no → return `status: skipped` (`user_declined`). Leave the working tree as-is.
+   - IF yes → continue. Still do not commit until Step 3.
+
+   IF `AUTO_APPROVE=yes` → treat as yes, skip the prompt, continue. Still do not commit until Step 3.
+
+---
+
+## Step 1: Resolve GitHub Repo and Base Branch
+
+```bash
+git -C "${REPO_DIR}" remote get-url origin
+```
+
+Parse `ORG/REPO` from the origin URL (`github.com/openshift/hypershift.git` → `openshift/hypershift`). If origin is SSH (`git@github.com:org/repo.git`), parse the same way.
+
+`BASE_BRANCH` = `GIT_BRANCH` from Phase 0.7 (the mapped release branch the clone is on). Do **not** open the PR against `main` unless that is actually `GIT_BRANCH`.
+
+---
+
+## Step 2: Detect Conflicting Open PRs
+
+**Title match only.** Do not inspect PR files, body, module versions, or `go.mod` diffs.
+
+```bash
+gh pr list --repo "${ORG}/${REPO}" --state open --base "${BASE_BRANCH}" \
+  --json number,title,url,headRefName,author
+```
+
+A PR is a **match** if its **title** contains (case-insensitive) either this `CVE_ID`, or `SOURCE_TICKET` (when set).
+
+IF none → continue to Step 3 with strategy `new`.
+
+IF any match:
+
+- **`AUTO_APPROVE=no`** → present the list and wait for the user:
+
+  ```text
+  Open PR(s) on <ORG/REPO> base <BASE_BRANCH> already have this CVE/Jira in the title:
+
+    #<N>  <title>  <url>  head=<branch>
+
+  How should I proceed?
+    1. stack     — check out that PR branch, commit this fix on top, push (PR updates)
+    2. wait      — stop; do not open a competing PR
+    3. independent — new branch from <BASE_BRANCH> (may need rebase later)
+  ```
+
+  | Choice | Action |
+  | --- | --- |
+  | `stack` | `git fetch origin <headRefName> && git checkout <headRefName> && git pull`. Re-apply leftover Phase 5 changes if they are not already on that branch (same method as Phase 5 — bump, patch, or config edit). Strategy = `stack`. |
+  | `wait` | Return `status: skipped` (`user_wait_for_pr`) including the existing PR URL. |
+  | `independent` | Warn that a second PR on the same base may need rebase later. If `go.mod` is in this diff, mention possible module-file conflicts. Strategy = `new`. |
+  | No answer | **Do not guess.** Ask again. |
+
+- **`AUTO_APPROVE=yes`** → **always `wait`**, automatically, with no exceptions: return `status: skipped` (`user_wait_for_pr_auto`) including the existing PR URL. Never auto-choose `stack` (that pushes commits onto a branch nobody reviewed for this run) or `independent` (that opens a second, possibly duplicate/conflicting PR) unattended. Log clearly that this run stopped because of the existing PR, so a human can revisit with `--auto-approve=no` if a different resolution is actually wanted.
+
+---
+
+## Step 3: Branch, Commit, Push
+
+Work only inside `REPO_DIR`.
+
+**Vendor:** Phase 5 already ran `go mod vendor`/`make vendor` (if applicable) and included any resulting paths in `PHASE5_FILES` before verification. Do **not** run vendor sync here — doing so after `PHASE5_FILES` was written would generate paths that never make it into the allowlist and get silently dropped from the commit. IF a dependency bump is present in `PHASE5_FILES` but `vendor/` looks out of sync (e.g. `go mod vendor` reports diffs) → stop and tell the user to re-run Phase 5, rather than fixing it here.
+
+### 3a. Branch
+
+**New PR (`strategy = new`):**
+
+```bash
+git -C "${REPO_DIR}" fetch origin "${BASE_BRANCH}"
+git -C "${REPO_DIR}" checkout "${BASE_BRANCH}"
+git -C "${REPO_DIR}" pull --ff-only origin "${BASE_BRANCH}"
+
+SLUG="$(echo "${CVE_ID}" | tr '[:upper:]' '[:lower:]')"
+if [ -n "${SOURCE_TICKET}" ]; then
+  BRANCH_NAME="fix/${SLUG}-$(echo "${SOURCE_TICKET}" | tr '[:upper:]' '[:lower:]')"
+else
+  BRANCH_NAME="fix/${SLUG}"
+fi
+
+git -C "${REPO_DIR}" checkout -b "${BRANCH_NAME}"
+```
+
+Re-apply the Phase 5 changes on this branch if checking out `BASE_BRANCH` discarded uncommitted work. Prefer not discarding: stash before checkout if the working tree is dirty, then stash pop onto `BRANCH_NAME`.
+
+**Stack (`strategy = stack`):** already on the existing PR branch. Set `BRANCH_NAME` to that head ref. Do not create a new branch.
+
+### 3b. Commit
+
+Stage **only `PHASE5_FILES`**, not the whole worktree. That allowlist is written in Phase 5 (`phase5-files.txt`) and includes new untracked files. `go.mod`, `go.sum`, `go.work`, and `vendor/` are common for **dependency version bumps**, but other CVE remediations may only touch source, config, Dockerfiles, or scripts.
+
+`WORK_CVE` is in the **command's own workspace** (`.work/`), not inside `REPO_DIR`. Paths in the allowlist are relative to `REPO_DIR`.
+
+```bash
+WORK_CVE="${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}"
+PHASE5_FILES="${WORK_CVE}/phase5-files.txt"
+```
+
+IF `phase5-files.txt` is missing or empty → rebuild it from Phase 5 "Document Changes" (and `phase5-before.status` if present). IF the allowlist still cannot be determined → **always return `status: failed` (`phase5_files_missing`) immediately. Never gated by `AUTO_APPROVE` and never prompt.** Do **not** fall back to whole-worktree `git diff` / `git add -A` / `git add .` in any case.
+
+```bash
+# inspect current tree for sanity, but do not use it as the stage set
+git -C "${REPO_DIR}" status --porcelain
+
+while IFS= read -r f; do
+  [ -n "${f}" ] || continue
+  git -C "${REPO_DIR}" add -- "${f}"
+done < "${PHASE5_FILES}"
+```
+
+`git add -- <path>` stages modifications, deletions, and untracked files. Examples of what belongs on the allowlist:
+
+- Dependency bump: `go.mod`, `go.sum`, and `go.work` / `vendor/` only if Phase 5 changed them
+- Code/config fix: the source or config files Phase 5 added or edited
+- Mixed: the union of those paths
+
+Do **not** add `.work/`, analysis reports, or credentials. Do **not** add pre-existing dirty files that are absent from `PHASE5_FILES`. Do **not** `git add` `go.mod` / `vendor/` unless they are on the allowlist.
+
+**Validate the staged set exactly matches the allowlist.** The loop above only *adds* allowlisted paths — it does not prove the index is free of anything else (e.g. leftover pre-existing staged files). Diff the two sets and reject extras instead of committing them silently:
+
+```bash
+git -C "${REPO_DIR}" diff --cached --name-only > "${WORK_CVE}/staged-files.txt"
+
+EXTRA="$(comm -23 <(sort "${WORK_CVE}/staged-files.txt") <(sort "${PHASE5_FILES}"))"
+if [ -n "${EXTRA}" ]; then
+  echo "Unstaging paths not in PHASE5_FILES:"
+  echo "${EXTRA}"
+  while IFS= read -r x; do
+    [ -n "${x}" ] || continue
+    git -C "${REPO_DIR}" restore --staged -- "${x}"
+  done <<< "${EXTRA}"
+fi
+```
+
+IF any path was rejected → tell the user which paths were unstaged and why before continuing. Re-run the diff after unstaging to confirm the index now matches `PHASE5_FILES` exactly (accounting for deletions).
+
+**On a `stack` branch, or when Step 0 skipped ahead because a Phase 5 commit already existed,** run the equivalent check against the branch, not just the index:
+
+```bash
+git -C "${REPO_DIR}" diff --name-only "${BASE_BRANCH}...HEAD" > "${WORK_CVE}/branch-files.txt"
+comm -23 <(sort "${WORK_CVE}/branch-files.txt") <(sort "${PHASE5_FILES}")
+```
+
+IF that reports any path outside `PHASE5_FILES` → stop; do not push or open/update the PR. **Always return `status: failed` (`phase5_files_mismatch`) immediately, for manual follow-up. Never gated by `AUTO_APPROVE` and never prompt.**
+
+**Commit message.** Match the **actual** Phase 5 change, not a canned module bump. Use the repo's own convention when detectable — e.g. many OpenShift repos expect `UPSTREAM: <upstream-pr-or-carry>: <subject>`:
+
+```bash
+git -C "${REPO_DIR}" log --oneline -20
+```
+
+If the recent history shows the `UPSTREAM:` convention and a dependency bump with a known upstream fix PR number (from the Phase 4 remediation plan):
+```
+UPSTREAM: <upstream-pr>: Bump <module> to <new> for <CVE_ID>
+```
+
+If a dependency bump that is downstream-only / fork / carry (no tracked upstream PR, but repo uses `UPSTREAM:` convention):
+```
+UPSTREAM: <carry>: Bump <module> to <new> for <CVE_ID>
+```
+
+If the repo does not use the `UPSTREAM:` convention, use a plain subject. Dependency bump:
+```
+Bump <module> to <new> for <CVE_ID>
+```
+
+If the fix is **not** a version bump (code, config, workaround), regardless of convention:
+```
+Fix <CVE_ID>: <short description of the change>
+```
+
+Body: one or two sentences describing what changed and why. Include `Fixes: <SOURCE_TICKET>` in Jira mode; omit that line in direct CVE mode. For a bump, include old → new versions. Do not claim a module bump if Phase 5 did not bump a module.
+
+```bash
+git -C "${REPO_DIR}" commit --signoff -m "${COMMIT_SUBJECT}" -m "${COMMIT_BODY}"
+```
+
+Sign off (DCO) by default — most upstream/downstream OpenShift-style repos require it and a missing sign-off is a common, avoidable PR-check failure. Never use `--no-verify` or skip hooks unless the user explicitly asks.
+
+### 3c. Push
+
+```bash
+git -C "${REPO_DIR}" push -u origin "${BRANCH_NAME}"
+```
+
+Default is a normal push. Amending an existing commit and force-pushing is never authorized by `AUTO_APPROVE`; it always requires an interactive user (moot in practice, since `AUTO_APPROVE=yes` never selects `stack` — see Step 2).
+
+---
+
+## Step 4: Create or Update the GitHub PR
+
+### Title
+
+Dependency bump:
+```
+<CVE_ID>: bump <module-short> to <new> [<SOURCE_TICKET>]
+```
+Omit `[<SOURCE_TICKET>]` in direct CVE mode. Example: `CVE-2026-33186: bump google.golang.org/grpc to v1.79.3 [OCPBUGS-80452]`
+
+Non-bump fix:
+```
+<CVE_ID>: <short description> [<SOURCE_TICKET>]
+```
+
+### Body
+
+Read the repo's PR template if one exists (`cat "${REPO_DIR}/.github/PULL_REQUEST_TEMPLATE.md" 2>/dev/null`) and structure the body around it. Otherwise use:
+
+**Jira mode** — every Jira key must be a markdown link. Use a `Fixes:` line (do not use a bare key):
+
+```markdown
+## Summary
+
+Fixes: [<SOURCE_TICKET>](<JIRA_BASE_URL>/browse/<SOURCE_TICKET>)
+
+<What Phase 5 changed and why — e.g. bump `<module>` from `<old>` to `<new>`, or a code/config workaround.>
+
+<2–3 sentence CVE description from Phase 1>
+
+## Changes
+
+- <file- or behavior-level bullets from the Phase 5 diff>
+
+## Verification
+
+- `make verify` / `go mod verify` (if modules changed)
+- `make build` / `go build ./...`
+- `govulncheck ./...`
+
+---
+Always review AI generated responses prior to use.
+AI-assisted change via compliance plugin (`/compliance:analyze-cve`)
+```
+
+**Direct CVE mode** — same body **without** the `Fixes:` line and without Jira URLs.
+
+Do not include hostnames, cluster names, routes, usernames, passwords, or tokens in the title, body, or comments.
+
+### Create vs update
+
+**New PR (default mode — no `FORK_ORG`):**
+
+```bash
+gh pr create \
+  --repo "${ORG}/${REPO}" \
+  --base "${BASE_BRANCH}" \
+  --head "${BRANCH_NAME}" \
+  --title "${PR_TITLE}" \
+  --body "${PR_BODY}"
+```
+
+**New PR (fork mode — `FORK_ORG` set):** use the [Fork Mode](#fork-mode-fork_org-set) Step 4 variant (`gh api repos/.../pulls -f head_repo=...`) instead of the `gh pr create` call above.
+
+**Stacked on existing PR:** push is enough (to `origin` by default, or `fork` in Fork Mode). Optionally:
+
+```bash
+gh pr comment "${EXISTING_PR}" --repo "${ORG}/${REPO}" \
+  --body "Added <CVE_ID> fix: <what Phase 5 changed>."
+```
+
+And `gh pr edit` to append the CVE / Jira key to title and the `Fixes:` line if missing.
+
+Capture `PR_URL` from `gh pr create` output or `gh pr view --json url` (default mode), or from the `gh api` response (Fork Mode).
+
+IF create fails (permissions, fork needed) → show the exact `gh` error (no secrets). If the error indicates missing write access and `FORK_ORG` is not set, suggest re-running with `FORK_ORG` configured (see [Fork Mode](#fork-mode-fork_org-set)) rather than guessing at a fork target. Otherwise give the user the title/body to paste, return `status: failed` (`pr_create_failed`). Do not retry more than once.
+
+---
+
+## Step 5: Post PR URL to Jira (Jira mode only)
+
+**Skip this step** if `SOURCE_TICKET` is unset (direct CVE mode) → still `status: success` for the GitHub PR.
+
+Use the [report-to-jira](../report-to-jira/SKILL.md) skill's **Follow-up: PR URL comment** section. Do not edit or replace the Phase 4 analysis comment. Do not add/remove labels here.
+
+IF posting fails → display the comment in session for manual paste. The GitHub PR is still a success (`jira_followup: failed`).
+
+---
+
+## Return Value
+
+**Success:**
+
+```json
+{
+  "skill": "create-fix-pr",
+  "status": "success",
+  "action": "created | updated",
+  "pr_url": "https://github.com/<org>/<repo>/pull/<n>",
+  "pr_number": 123,
+  "branch": "fix/cve-yyyy-nnnnn-ocpbugs-12345",
+  "base_branch": "release-4.17",
+  "cve_id": "CVE-YYYY-NNNNN",
+  "source_ticket": "OCPBUGS-12345 or null",
+  "jira_followup": "posted | skipped | failed"
+}
+```
+
+**Skipped:**
+
+```json
+{
+  "skill": "create-fix-pr",
+  "status": "skipped",
+  "reason": "user_declined | no_local_changes | phase5_incomplete | user_wait_for_pr | user_wait_for_pr_auto | embargo"
+}
+```
+
+**Failed:**
+
+```json
+{
+  "skill": "create-fix-pr",
+  "status": "failed",
+  "reason": "git_missing | gh_missing | gh_unauthenticated | pr_create_failed | commit_failed | phase5_files_missing | phase5_files_mismatch | fork_wrong_lineage | fork_create_failed",
+  "error": "<message without secrets>"
+}
+```
+
+---
+
+## Integration with Parent Command
+
+Called from **Phase 6** of `/compliance:analyze-cve` after Phase 5 verification succeeds. Runs after the [Repo Guard](../../commands/analyze-cve.md#repo-guard--re-clone-if-missing) has confirmed `REPO_DIR` still exists.
+
+---
+
+## Guardrails
+
+- Never commit, push, or open a PR without explicit approval — interactive, or `AUTO_APPROVE=yes` recorded once upfront
+- Never force-push to `BASE_BRANCH` / `main` / `master` / `release-*`
+- Never skip git hooks unless the user asks
+- Never stage paths outside `PHASE5_FILES`; never `git add -A` or `git add .`
+- Never commit/push/PR without validating the staged (and, for `stack`, the branch) path set against `PHASE5_FILES` and rejecting extras
+- Never run vendor sync in Phase 6 — it happens in Phase 5, before `PHASE5_FILES` is written
+- Never push to, or open a PR from, a `FORK_ORG` repo without first verifying its fork lineage (`isFork` + `parent.fullName` match) — never reuse a same-named repo that isn't actually a fork of the target
+- Never let `AUTO_APPROVE=yes` auto-select `stack` or `independent` on a PR-title conflict — always `wait` unattended
+- Never let `AUTO_APPROVE=yes` skip a hard-fail case (missing/mismatched `PHASE5_FILES`, ambiguous conflict resolution) — those always require a human, flag or not
+- Never include secrets in commit messages, PR text, or Jira comments
+- Stop immediately on embargo
+- Direct CVE mode must still produce a PR

--- a/plugins/compliance/skills/create-fix-pr/SKILL.md
+++ b/plugins/compliance/skills/create-fix-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-fix-pr
-description: After a CVE fix is applied and verified locally, create (or update) a GitHub pull request and optionally post the PR URL back to the source Jira ticket
+description: Use when opening or updating a GitHub pull request after Phase 5 of `/compliance:analyze-cve` has applied and verified a CVE fix locally.
 ---
 
 # Create Fix PR

--- a/plugins/compliance/skills/cve-intelligence-gathering/SKILL.md
+++ b/plugins/compliance/skills/cve-intelligence-gathering/SKILL.md
@@ -523,10 +523,10 @@ This skill is called from Phase 1 of the `/compliance:analyze-cve` command.
 - `AUTO_APPROVE` (`yes`/`no`, default `no`) — governs the Step 6 fallback-prompt gating
 
 **Output to parent:**
-- Merged vulnerability profile (Jira internal context + public sources, when Jira mode was used; public sources only otherwise)
-- Information quality assessment (noting which fields came from which source)
-- Conflict log (where Jira and public sources disagreed)
-- Go relevance determination
+- `cve_profile` — merged vulnerability profile (Jira internal context + public sources when Jira mode was used; public sources only otherwise)
+- `information_quality` — completeness assessment (noting which fields came from which source)
+- `conflict_log` — where Jira and public sources disagreed (empty when no Jira context)
+- `go_relevance` — Go applicability determination
 - Decision on whether to proceed to Phase 2
 
 **Decision Flow:**

--- a/plugins/compliance/skills/cve-intelligence-gathering/SKILL.md
+++ b/plugins/compliance/skills/cve-intelligence-gathering/SKILL.md
@@ -50,7 +50,36 @@ fi
 
 **Decision Point:**
 - IF invalid format → Return error to parent command
-- IF valid → Continue to Step 2
+- IF valid → Continue to Step 1.5
+
+### Step 1.5: Seed Profile from Jira Context (if available)
+
+If a `jira_context` object was passed in from the `jira-cve-extraction` skill (i.e. the parent command was invoked with `--jira=` or `--jql=`), pre-populate the vulnerability profile before any web searches. This reduces redundant lookups and surfaces internal context that is not available in public databases.
+
+**Fields to extract and pre-populate:**
+
+| Jira field | Profile field | Notes |
+|---|---|---|
+| `cvss_score` + `cvss_vector` | `severity.cvss_score`, `severity.cvss_vector` | Prefer Jira value; verify against NVD in Step 2 |
+| `cwe_id` | `cwe_id` | Cross-check with NVD; flag if they differ |
+| `summary` (parsed description) | `description` (supplement) | Internal phrasing may be more specific |
+| `affects_versions` | Analysis scope (which project/release versions are affected) | |
+| `target_versions` | Fix target / release window | |
+| `release_note_text` | `remediation.recommended_action` (supplement) | May already describe the fix or upgrade path |
+| `components`, `labels` | Context only | |
+| Description body (workaround scan) | `remediation.workarounds` | Already extracted by `jira-cve-extraction` |
+| Internal notes from description | `internal_context` field in profile | Capture any previous analysis, conclusions, or decisions noted in the ticket body |
+
+**Mark each pre-populated field as `source: jira`** in the profile.
+
+**Conflict resolution:** If Jira and a public source (NVD, GHSA) disagree on CVSS score or CWE:
+- Note both values in the profile
+- Prefer the higher CVSS score for risk assessment (conservative)
+- Flag the discrepancy as a gap
+
+**Decision Point:**
+- IF `jira_context` is null or absent (direct `<CVE-ID>` mode) → Skip this step entirely, proceed to Step 2 as normal
+- IF `jira_context` is present → Pre-populate, then continue to Step 2 to fill remaining gaps and verify
 
 ### Step 2: Search Primary Sources (NVD and MITRE)
 
@@ -206,7 +235,7 @@ Try alternative strategies:
 
 ### Step 6: Request User Input (Fallback)
 
-If automated searches fail, prompt user:
+If automated searches fail: IF `AUTO_APPROVE=yes` → there is no one to prompt; skip straight to "User Response Handling: no" below (return an error to the parent command). This step is never gated to *proceed* automatically — fabricating CVE details is not a safe default, regardless of how much unattended automation the caller wants. IF `AUTO_APPROVE=no` (or unset — the default) → prompt user:
 
 ```text
 ❌ Unable to fetch details for {CVE-ID} from online sources.
@@ -246,9 +275,9 @@ Would you like to provide CVE details? (yes/no)
 - IF yes → Collect information, mark as "User-provided"
 - IF no → Return error to parent command (insufficient data to proceed)
 
-### Step 7: Compile Vulnerability Profile
+### Step 7: Compile Merged Vulnerability Profile
 
-Create structured summary with all gathered information:
+Merge all gathered information — Jira context (Step 1.5, if present) and public sources (Steps 2–6) — into a single profile. Every field records which source(s) populated it.
 
 ```json
 {
@@ -257,7 +286,8 @@ Create structured summary with all gathered information:
   "severity": {
     "rating": "<CRITICAL|HIGH|MEDIUM|LOW>",
     "cvss_score": "<score>",
-    "cvss_vector": "<CVSS vector string>"
+    "cvss_vector": "<CVSS vector string>",
+    "cvss_source": "<jira|nvd|ghsa — which source this came from>"
   },
   "affected_packages": [
     {
@@ -279,9 +309,23 @@ Create structured summary with all gathered information:
   "remediation": {
     "fix_available": true,
     "recommended_action": "<remediation guidance>",
-    "workarounds": []
+    "workarounds": ["<workaround from Jira description or public advisory>"],
+    "fix_target_versions": ["<target versions from Jira target_versions, if any>"],
+    "release_note": "<from Jira release_note_text if present>"
+  },
+  "internal_context": {
+    "jira_ticket": "<PROJ-NNNNN or null>",
+    "affects_versions": ["<affected versions from Jira>"],
+    "previous_analysis_notes": "<any conclusions or analysis captured in Jira description>",
+    "priority": "<Jira priority>",
+    "status": "<Jira status>"
   },
   "information_sources": [
+    {
+      "type": "Jira",
+      "verified": true,
+      "url": "https://redhat.atlassian.net/browse/<PROJ-NNNNN>"
+    },
     {
       "type": "NVD",
       "verified": true,
@@ -295,11 +339,15 @@ Create structured summary with all gathered information:
   ],
   "information_completeness": "COMPLETE",
   "data_quality": "HIGH",
+  "conflicts": [],
   "gaps": []
 }
 ```
 
+`internal_context` and the `Jira` entry in `information_sources` are only populated when a `jira_context` was passed in (Step 1.5); omit them entirely in direct `<CVE-ID>` mode.
+
 **Mark Information Sources:**
+- ✓ "Verified from Jira ticket (internal)"
 - ✓ "Verified from NVD"
 - ✓ "Verified from MITRE"
 - ✓ "Verified from Go vulndb"
@@ -307,6 +355,18 @@ Create structured summary with all gathered information:
 - ⚠️ "Based on user-provided information"
 - ⚠️ "Inferred from package repository"
 - ⚠️ "Partial information - some fields missing"
+
+**Record conflicts** when Jira and public sources disagree:
+```json
+"conflicts": [
+  {
+    "field": "cvss_score",
+    "jira_value": "7.5",
+    "public_value": "6.5",
+    "resolution": "Used higher value (7.5) for conservative risk assessment"
+  }
+]
+```
 
 **Assess Information Completeness:**
 - **COMPLETE**: All critical fields populated from authoritative sources
@@ -458,11 +518,14 @@ Result: Complete vulnerability profile ready for Phase 2 analysis
 This skill is called from Phase 1 of the `/compliance:analyze-cve` command.
 
 **Input from parent:**
-- CVE identifier (from command argument)
+- CVE identifier (from the `<CVE-ID>` argument, or extracted by `jira-cve-extraction` when `--jira=`/`--jql=` was used)
+- `jira_context` object from the `jira-cve-extraction` skill _(optional — only present when `--jira=` or `--jql=` was provided)_
+- `AUTO_APPROVE` (`yes`/`no`, default `no`) — governs the Step 6 fallback-prompt gating
 
 **Output to parent:**
-- Complete vulnerability profile
-- Information quality assessment
+- Merged vulnerability profile (Jira internal context + public sources, when Jira mode was used; public sources only otherwise)
+- Information quality assessment (noting which fields came from which source)
+- Conflict log (where Jira and public sources disagreed)
 - Go relevance determination
 - Decision on whether to proceed to Phase 2
 

--- a/plugins/compliance/skills/image-repo-mapping/SKILL.md
+++ b/plugins/compliance/skills/image-repo-mapping/SKILL.md
@@ -75,18 +75,26 @@ Some components use a dedicated `-release` repo that aggregates all component re
 4. Clone the **component repo** and check out that pinned commit for analysis
 
 ```bash
-# Step 1: Clone release repo at correct branch
-git clone --depth=1 -b "${RELEASE_BRANCH}" "${RELEASE_REPO_URL}" /tmp/release-repo
+# Step 1: Clone release repo at correct branch (per-run path under REPOS_BASE)
+RELEASE_CLONE_DIR="${REPOS_BASE}/.release-clones/$(echo "${RELEASE_REPO_URL}" | sed -E 's#^[a-zA-Z]+://github\.com/##; s#\.git$##; s#/$##' | tr '/' '-')-${RELEASE_BRANCH}"
+rm -rf "${RELEASE_CLONE_DIR}"
+mkdir -p "$(dirname "${RELEASE_CLONE_DIR}")"
+git clone --depth=1 -b "${RELEASE_BRANCH}" "${RELEASE_REPO_URL}" "${RELEASE_CLONE_DIR}"
 
 # Step 2: Read .gitmodules
-cat /tmp/release-repo/.gitmodules
+cat "${RELEASE_CLONE_DIR}/.gitmodules"
 
 # Step 3: Extract submodule path + url from .gitmodules
 # Step 4: Read pinned commit from release repo tree
-PINNED_COMMIT=$(git -C /tmp/release-repo ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
+PINNED_COMMIT=$(git -C "${RELEASE_CLONE_DIR}" ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
+if [ -z "${PINNED_COMMIT}" ]; then
+  echo "ERROR: no pinned commit found for ${SUBMODULE_PATH}"
+  exit 1
+fi
 
-# Step 5: Clone component repo and checkout pinned commit
-git clone --depth=50 "${COMPONENT_URL}" "${REPO_DIR}"
+# Step 5: Clone component repo and checkout pinned commit (fetch SHA explicitly — shallow clone alone may miss it)
+git clone "${COMPONENT_URL}" "${REPO_DIR}"
+git -C "${REPO_DIR}" fetch origin "${PINNED_COMMIT}"
 git -C "${REPO_DIR}" checkout "${PINNED_COMMIT}"
 ```
 

--- a/plugins/compliance/skills/image-repo-mapping/SKILL.md
+++ b/plugins/compliance/skills/image-repo-mapping/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: image-repo-mapping
+description: Map a container image name (from a Jira ticket summary, pscomponent label, or Downstream Component Name field) to the GitHub repository that should be cloned for CVE impact analysis
+---
+
+# Image to Repository Mapping
+
+Translates a container image name into the GitHub repository URL to clone for analysis. Image names appear in the ticket summary, `pscomponent:` labels, and the `Downstream Component Name` custom field.
+
+## When to Use This Skill
+
+Use this skill when:
+- An image name has been extracted from a Jira ticket (summary, label, or custom field)
+- The user passes `--repo=<image-name>` using a short image name rather than a full GitHub URL
+- Phase 0.7 needs to determine which repository to clone
+
+---
+
+## Resolution Order
+
+Apply these in order and stop at the first match:
+
+1. **Full GitHub URL supplied** (`--repo=https://github.com/...`) → use directly, skip this skill.
+2. **Exact image name match** — look the image name up in the table below.
+3. **Prefix match** — strip version suffixes (e.g. `-1-0`, `-1-12-4`, `-rhel9`, `-rhel8`) and re-match.
+4. **Keyword match** — check the per-section keyword rules at the bottom of each group.
+5. **NOT FOUND → Exit immediately** with the error message below. Do not guess. Do not proceed with analysis.
+
+> **Tip:** Strip `pkg:oci/` prefix before matching (e.g. `pkg:oci/ose-ansible-operator` → `ose-ansible-operator`).
+
+### Not-Found Exit
+
+If no match is found after all steps above, **stop immediately** and output:
+
+```
+❌ Repository mapping not found for image: <image_name>
+
+The image "<image_name>" is not in the known mapping table and could not
+be resolved automatically.
+
+To proceed, re-run with an explicit repository URL:
+
+  --repo=https://github.com/org/repo
+
+Or add the mapping to:
+  plugins/compliance/skills/image-repo-mapping/SKILL.md
+
+Do NOT continue analysis without a confirmed source repository.
+```
+
+Do NOT fall back to guessing, fuzzy matching, or prompting the user inline. Exit the command at this point.
+
+---
+
+## Two Repository Patterns
+
+Components fall into one of two patterns. The resolution output is different for each.
+
+### Pattern A — Direct repo
+
+Clone the mapped repo directly at the mapped branch. Used by: Operator SDK, Ansible Operator, must-gather, Secrets Store CSI.
+
+```
+image → repo URL + branch
+```
+
+### Pattern B — Release repo with git submodules
+
+Some components use a dedicated `-release` repo that aggregates all component repos as git submodules. The release repo branch pins each submodule to the exact commit/tag used for that release. Used by: cert-manager, ZTWIM, ESO.
+
+**Resolution steps for Pattern B:**
+1. Clone the **release repo** at the mapped release branch
+2. Read `.gitmodules` from that branch to find the submodule entry matching the target image
+3. Extract the submodule `url` and `branch`/`tag` from `.gitmodules`
+4. Clone the **component repo** at that pinned ref for analysis
+
+```bash
+# Step 1: Clone release repo at correct branch
+git clone --depth=1 -b "${RELEASE_BRANCH}" "${RELEASE_REPO_URL}" /tmp/release-repo
+
+# Step 2: Read .gitmodules
+cat /tmp/release-repo/.gitmodules
+
+# Step 3: Extract the relevant submodule url + branch/tag
+# Step 4: Clone component repo at pinned ref
+git clone --depth=50 -b "${COMPONENT_BRANCH}" "${COMPONENT_URL}" "${REPO_DIR}"
+# or for a tag:
+git clone --depth=1 --branch "${COMPONENT_TAG}" "${COMPONENT_URL}" "${REPO_DIR}"
+```
+
+**Jira branch → release branch naming for Pattern B:**
+
+| Jira `BRANCH` value | Release branch |
+|---|---|
+| `cert-manager-X-Y` | `release-X.Y` in `cert-manager-operator-release` |
+| `external-secrets-X-Y` | `release-X.Y` in `external-secrets-operator-release` |
+| `ztwim-1.0` | **`release-1.0.0`** in `zero-trust-workload-identity-manager-release` _(one-time exception — team confirmed this was a branching mistake; future releases use `release-X.Y`)_ |
+| `ztwim-X.Y` (any other) | `release-X.Y` in `zero-trust-workload-identity-manager-release` |
+
+> **Note:** Jira branch values use hyphens for separators (e.g. `external-secrets-1-0`) while release branches use dots (e.g. `release-1.0`). Strip the component prefix and convert the remaining hyphen-separated version to dot notation.
+
+---
+
+## Image → Repository Map
+
+> Every image name here has appeared in real ticket summaries or labels. This table is intentionally scoped to the components this command has been validated against — extend it as new components come up (see the not-found exit message above).
+
+### cert-manager / jetstack — Pattern B (release repo + submodules)
+
+**Release repo:** `https://github.com/openshift/cert-manager-operator-release`
+**Submodules:** `cert-manager-operator`, `cert-manager`, `cert-manager-istio-csr`
+**Branch mapping:** Jira `cert-manager-X-Y` → `release-X.Y` in the release repo
+
+Clone the release repo at the correct branch, read `.gitmodules` to find the submodule URL and pinned ref for the target image, then clone that component at the pinned ref.
+
+| Image Name / Prefix | Submodule in `.gitmodules` |
+|---|---|
+| `cert-manager/cert-manager-operator-rhel9`, `cert-manager/cert-manager-operator-bundle`, `cert-manager-operator-*` | `cert-manager-operator` |
+| `cert-manager/cert-manager-istio-csr-rhel9` | `cert-manager-istio-csr` |
+| `cert-manager/jetstack-cert-manager-*`, `jetstack-cert-manager-*`, `redhat-user-workloads/jetstack-cert-manager-*` | `cert-manager` |
+
+#### cert-manager-operator (operator + bundle only)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `cert-manager-operator-container` | `https://github.com/openshift/cert-manager-operator` |
+| `cert-manager-operator-rhel9` | `https://github.com/openshift/cert-manager-operator` |
+| `cert-manager/cert-manager-operator-rhel9` | `https://github.com/openshift/cert-manager-operator` |
+| `cert-manager/cert-manager-operator-bundle` | `https://github.com/openshift/cert-manager-operator` |
+
+#### cert-manager-istio-csr
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `cert-manager/cert-manager-istio-csr-rhel9` | `https://github.com/openshift/cert-manager-istio-csr` |
+
+#### jetstack-cert-manager
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `cert-manager/jetstack-cert-manager-rhel9` | `https://github.com/openshift/jetstack-cert-manager` |
+| `cert-manager/jetstack-cert-manager-acmesolver-rhel9` | `https://github.com/openshift/jetstack-cert-manager` |
+| `jetstack-cert-manager-rhel9` | `https://github.com/openshift/jetstack-cert-manager` |
+| `jetstack-cert-manager-container` | `https://github.com/openshift/jetstack-cert-manager` |
+| `jetstack-cert-manager-acmesolver-rhel9` | `https://github.com/openshift/jetstack-cert-manager` |
+| `jetstack-cert-manager-acmesolver-container` | `https://github.com/openshift/jetstack-cert-manager` |
+| `redhat-user-workloads/jetstack-cert-manager-*` | `https://github.com/openshift/jetstack-cert-manager` |
+
+**Namespace prefix match:** `cert-manager` → requires full image name lookup above (multiple repos in this namespace).
+**Keyword match:** `cert-manager-operator` / `cert-manager-operator-bundle` → `cert-manager-operator`; `cert-manager-istio-csr` → `cert-manager-istio-csr`; `jetstack-cert-manager` → `jetstack-cert-manager`.
+
+---
+
+### Operator SDK / Helm Operator (non-ansible images)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `operator-sdk` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift4/ose-operator-sdk-rhel8` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift4/ose-operator-sdk-rhel9` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift-enterprise-operator-sdk-container` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift4/ose-helm-operator` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift4/ose-helm-rhel9-operator` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `openshift-enterprise-helm-operator-container` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `pkg:oci/ose-operator-sdk-rhel8` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `pkg:oci/ose-operator-sdk-rhel9` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `pkg:oci/ose-helm-operator` | `https://github.com/openshift/ocp-release-operator-sdk` |
+| `pkg:oci/openshift-enterprise-helm-operator` | `https://github.com/openshift/ocp-release-operator-sdk` |
+
+---
+
+### Ansible Operator
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `ansible-operator-plugins` | `https://github.com/openshift/ansible-operator-plugins` |
+| `openshift4/ose-ansible-operator` | `https://github.com/openshift/ansible-operator-plugins` |
+| `openshift4/ose-ansible-rhel9-operator` | `https://github.com/openshift/ansible-operator-plugins` |
+| `openshift-enterprise-ansible-operator-container` | `https://github.com/openshift/ansible-operator-plugins` |
+| `pkg:oci/ose-ansible-operator` | `https://github.com/openshift/ansible-operator-plugins` |
+| `pkg:oci/ose-ansible-rhel9-operator` | `https://github.com/openshift/ansible-operator-plugins` |
+
+**Keyword match:** any image containing `ansible-operator` → `https://github.com/openshift/ansible-operator-plugins`
+
+---
+
+### External Secrets Operator — Pattern B (release repo + submodules)
+
+**Release repo:** `https://github.com/openshift/external-secrets-operator-release`
+**Submodules:** `external-secrets-operator`, `external-secrets`, `bitwarden-sdk-server`
+**Branch mapping:** Jira `external-secrets-X-Y` → `release-X.Y` in the release repo
+
+Clone the release repo at the correct branch, read `.gitmodules` to find the submodule URL and pinned ref for the target image, then clone that component at the pinned ref.
+
+| Image Name / Prefix | Submodule in `.gitmodules` |
+|---|---|
+| `external-secrets-operator/external-secrets-operator-rhel9`, `external-secrets-operator/external-secrets-operator-bundle`, `redhat-user-workloads/external-secrets-operator-*` | `external-secrets-operator` |
+| `external-secrets-operator/external-secrets-rhel9`, `redhat-user-workloads/external-secrets-1-0` | `external-secrets` |
+| `external-secrets-operator/bitwarden-sdk-server-rhel9`, `redhat-user-workloads/bitwarden-sdk-server-*` | `bitwarden-sdk-server` |
+
+**Keyword match:** `external-secrets-operator` / `external-secrets-operator-bundle` → submodule `external-secrets-operator`; `bitwarden-sdk-server` → submodule `bitwarden-sdk-server`; `external-secrets-rhel9` / `external-secrets-1-0` → submodule `external-secrets`.
+
+---
+
+### Zero Trust / SPIFFE / SPIRE — Pattern B (release repo + submodules)
+
+**Release repo:** `https://github.com/openshift/zero-trust-workload-identity-manager-release`
+**Submodules:** `zero-trust-workload-identity-manager` (spire-operator), `spiffe-spire`, `spiffe-spire-controller-manager`, `spiffe-spiffe-csi`
+**Branch mapping:** Jira `ztwim-X.Y` → `release-X.Y` in the release repo
+
+Clone the release repo at the correct branch (`--recurse-submodules` is NOT needed — read `.gitmodules` manually and clone only the relevant submodule), then clone that component at the pinned ref.
+
+| Image Name / Prefix | Submodule in `.gitmodules` |
+|---|---|
+| `zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9`, `*-operator-bundle` | `zero-trust-workload-identity-manager` |
+| `zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9`, `*spiffe-spire-server*`, `*spire-oidc*`, `redhat-user-workloads/spiffe-spire-*` | `spiffe-spire` |
+| `zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9` | `spiffe-spire-controller-manager` |
+| `zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9`, `redhat-user-workloads/spiffe-csi-driver-*` | `spiffe-spiffe-csi` |
+| `zero-trust-workload-identity-manager/spiffe-helper-rhel9` | `spiffe-spiffe-helper` |
+
+The `zero-trust-workload-identity-manager` namespace spans **four** repositories — match on the full image name, not just the namespace prefix.
+
+#### spire-operator (operator + bundle only)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-rhel9` | `https://github.com/openshift/spire-operator` |
+| `zero-trust-workload-identity-manager/zero-trust-workload-identity-manager-operator-bundle` | `https://github.com/openshift/spire-operator` |
+
+#### spiffe-spire (agent, server, OIDC discovery provider)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `zero-trust-workload-identity-manager/spiffe-spire-agent-rhel9` | `https://github.com/openshift/spiffe-spire` |
+| `zero-trust-workload-identity-manager/spiffe-spire-server-rhel9` | `https://github.com/openshift/spiffe-spire` |
+| `zero-trust-workload-identity-manager/spiffe-spire-oidc-discovery-provider-rhel9` | `https://github.com/openshift/spiffe-spire` |
+| `redhat-user-workloads/spiffe-spire-agent-*` | `https://github.com/openshift/spiffe-spire` |
+| `redhat-user-workloads/spiffe-spire-server-*` | `https://github.com/openshift/spiffe-spire` |
+| `redhat-user-workloads/spiffe-spire-oidc-discovery-provider-*` | `https://github.com/openshift/spiffe-spire` |
+
+#### spiffe-spire-controller-manager
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `zero-trust-workload-identity-manager/spiffe-spire-controller-manager-rhel9` | `https://github.com/openshift/spiffe-spire-controller-manager` |
+
+#### spiffe-spiffe-csi (CSI driver)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `zero-trust-workload-identity-manager/spiffe-csi-driver-rhel9` | `https://github.com/openshift/spiffe-spiffe-csi` |
+| `redhat-user-workloads/spiffe-csi-driver-*` | `https://github.com/openshift/spiffe-spiffe-csi` |
+
+#### spiffe-spiffe-helper
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `zero-trust-workload-identity-manager/spiffe-helper-rhel9` | `https://github.com/openshift/spiffe-spiffe-helper` |
+
+**Namespace prefix match:** `zero-trust-workload-identity-manager` → requires full image name lookup above (multiple repos in this namespace).
+**Keyword match:** `spire-agent` / `spire-server` / `spire-oidc` → `https://github.com/openshift/spiffe-spire`; `spire-controller-manager` → `https://github.com/openshift/spiffe-spire-controller-manager`; `spiffe-csi-driver` → `https://github.com/openshift/spiffe-spiffe-csi`; `spiffe-helper` → `https://github.com/openshift/spiffe-spiffe-helper`; `zero-trust-workload-identity-manager` (manager/bundle) → `https://github.com/openshift/spire-operator`.
+
+---
+
+### must-gather
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `openshift4/ose-must-gather-rhel9` | `https://github.com/openshift/must-gather` |
+| `openshift4/ose-support-log-gather-rhel9-operator` | `https://github.com/openshift/must-gather-operator` |
+
+---
+
+### Secrets Store CSI
+
+The namespace spans **two** repositories. The mustgather image is built from the operator repo.
+
+#### secrets-store-csi-driver-operator (operator, bundle, mustgather)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `openshift4/ose-secrets-store-csi-driver-rhel9-operator` | `https://github.com/openshift/secrets-store-csi-driver-operator` |
+| `openshift4/ose-secrets-store-csi-driver-operator-bundle` | `https://github.com/openshift/secrets-store-csi-driver-operator` |
+| `ose-secrets-store-csi-driver-operator-container` | `https://github.com/openshift/secrets-store-csi-driver-operator` |
+| `openshift4/ose-secrets-store-csi-mustgather-rhel9` | `https://github.com/openshift/secrets-store-csi-driver-operator` |
+| `ose-secrets-store-csi-mustgather-container` | `https://github.com/openshift/secrets-store-csi-driver-operator` |
+
+#### secrets-store-csi-driver (driver only)
+
+| Image Name / Prefix | GitHub Repository |
+|---|---|
+| `openshift4/ose-secrets-store-csi-driver-rhel9` | `https://github.com/openshift/secrets-store-csi-driver` |
+| `ose-secrets-store-csi-driver-container` | `https://github.com/openshift/secrets-store-csi-driver` |
+
+**Keyword match:** `secrets-store-csi-mustgather` / `secrets-store-csi-driver-operator` / `secrets-store-csi-driver-operator-bundle` → `secrets-store-csi-driver-operator`; `secrets-store-csi-driver-rhel9` (driver image, not operator) → `secrets-store-csi-driver`.
+
+---
+
+## Return Value
+
+**Success:**
+```json
+{
+  "skill": "image-repo-mapping",
+  "status": "success",
+  "resolved_repos": [
+    {
+      "image_name": "openshift4/ose-ansible-rhel9-operator",
+      "repo_url": "https://github.com/openshift/ansible-operator-plugins",
+      "clone_path": ".work/compliance/analyze-cve/repos/ansible-operator-plugins",
+      "confidence": "exact_match",
+      "match_method": "exact"
+    }
+  ],
+  "unresolved": [],
+  "resolution_method": "summary_image_name"
+}
+```
+
+**Not found (exit):**
+```json
+{
+  "skill": "image-repo-mapping",
+  "status": "not_found",
+  "image_name": "<image_name>",
+  "error": "No repository mapping found. Re-run with --repo=https://github.com/org/repo or add the mapping to image-repo-mapping/SKILL.md."
+}
+```
+
+`confidence`: `exact_match`, `prefix_match`, `keyword_match`, `user_provided`
+
+---
+
+## Integration with Parent Command
+
+Called from **Phase 0.7** of `/compliance:analyze-cve` (see `commands/analyze-cve.md`).
+
+**Input:** image name extracted by `jira-cve-extraction` skill (from summary, `pscomponent:` label, or `Downstream Component Name` field), or the short name passed via `--repo=<name>`
+**Output:** `(image_name, repo_url, clone_path)` tuple passed to Phase 0.7 for cloning

--- a/plugins/compliance/skills/image-repo-mapping/SKILL.md
+++ b/plugins/compliance/skills/image-repo-mapping/SKILL.md
@@ -71,8 +71,8 @@ Some components use a dedicated `-release` repo that aggregates all component re
 **Resolution steps for Pattern B:**
 1. Clone the **release repo** at the mapped release branch
 2. Read `.gitmodules` from that branch to find the submodule entry matching the target image
-3. Extract the submodule `url` and `branch`/`tag` from `.gitmodules`
-4. Clone the **component repo** at that pinned ref for analysis
+3. Read the **pinned commit** from the release repo tree (`git ls-tree HEAD <submodule-path>`) — do not clone from the `.gitmodules` branch field alone
+4. Clone the **component repo** and check out that pinned commit for analysis
 
 ```bash
 # Step 1: Clone release repo at correct branch
@@ -81,11 +81,13 @@ git clone --depth=1 -b "${RELEASE_BRANCH}" "${RELEASE_REPO_URL}" /tmp/release-re
 # Step 2: Read .gitmodules
 cat /tmp/release-repo/.gitmodules
 
-# Step 3: Extract the relevant submodule url + branch/tag
-# Step 4: Clone component repo at pinned ref
-git clone --depth=50 -b "${COMPONENT_BRANCH}" "${COMPONENT_URL}" "${REPO_DIR}"
-# or for a tag:
-git clone --depth=1 --branch "${COMPONENT_TAG}" "${COMPONENT_URL}" "${REPO_DIR}"
+# Step 3: Extract submodule path + url from .gitmodules
+# Step 4: Read pinned commit from release repo tree
+PINNED_COMMIT=$(git -C /tmp/release-repo ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')
+
+# Step 5: Clone component repo and checkout pinned commit
+git clone --depth=50 "${COMPONENT_URL}" "${REPO_DIR}"
+git -C "${REPO_DIR}" checkout "${PINNED_COMMIT}"
 ```
 
 **Jira branch → release branch naming for Pattern B:**

--- a/plugins/compliance/skills/image-repo-mapping/SKILL.md
+++ b/plugins/compliance/skills/image-repo-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-repo-mapping
-description: Map a container image name (from a Jira ticket summary, pscomponent label, or Downstream Component Name field) to the GitHub repository that should be cloned for CVE impact analysis
+description: Use when resolving which GitHub repository to clone for CVE analysis from a container image name in a Jira ticket summary, pscomponent label, or Downstream Component Name field.
 ---
 
 # Image to Repository Mapping

--- a/plugins/compliance/skills/jira-cve-extraction/SKILL.md
+++ b/plugins/compliance/skills/jira-cve-extraction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jira-cve-extraction
-description: Fetch a Jira ticket and extract the CVE identifier plus enriched security context for downstream CVE analysis
+description: Use when `/compliance:analyze-cve` is invoked with `--jira=` or `--jql=` and needs the CVE ID, image name, branch, and enriched ticket context from a Jira issue.
 ---
 
 # Jira CVE Extraction

--- a/plugins/compliance/skills/jira-cve-extraction/SKILL.md
+++ b/plugins/compliance/skills/jira-cve-extraction/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: jira-cve-extraction
+description: Fetch a Jira ticket and extract the CVE identifier plus enriched security context for downstream CVE analysis
+---
+
+# Jira CVE Extraction
+
+Fetches a Jira ticket and extracts three things:
+1. **CVE ID** — passed to Phase 1 (`cve-intelligence-gathering`)
+2. **Image name** — passed to Phase 0.7 via the `image-repo-mapping` skill to resolve which repo to clone
+3. **Enriched context** — CVSS, CWE, priority, target versions, workarounds — embedded in the Phase 3 report and used to seed the CVE profile
+
+> **Key insight:** Security tracking tickets (e.g. `OCPBUGS` CVE trackers) follow a consistent summary format: `CVE-YYYY-NNNNN <component>: <description> [<version>]`. Parsing the summary is the most reliable single extraction path and should always be tried first — it typically yields the CVE ID, image name, and branch in one step.
+
+## When to Use This Skill
+
+Use this skill when the user invokes `/compliance:analyze-cve` with `--jira=PROJ-NNN` or `--jql="..."`.
+
+---
+
+## Prerequisites
+
+### Preferred: Atlassian MCP
+
+Use the Atlassian Rovo MCP tools bundled with the `jira` plugin (or an equivalent Atlassian MCP server configured for this Claude Code instance):
+
+- `getJiraIssue` — fetch a single ticket
+- `searchJiraIssuesUsingJql` — fetch a batch of tickets (Phase 0.3 / idempotency lookups)
+- `editJiraIssue` — update labels (idempotency marker)
+
+### Fallback: jira-cli
+
+If the MCP server is unavailable: `jira issue get <TICKET>` and `jira issue edit <TICKET> --label ...` (from [go-jira](https://github.com/go-jira/jira)). Requires `~/.jira.d/config.yml` configured for the target Jira instance.
+
+> **Credential rule:** Never print, echo, or log any token, password, or key value — not in shell commands, not in model responses, not in debug output. Reference credentials only via environment variable names (e.g. `$JIRA_API_TOKEN`).
+
+---
+
+## Implementation Steps
+
+### Step 1: Validate Ticket Format
+
+```
+PROJECT-NNNNN   e.g. OCPBUGS-12345, CNTRLPLANE-678
+```
+
+Pattern: `^[A-Z]+-[0-9]+$`
+
+- IF invalid → Return error: "Invalid Jira ticket format. Expected PROJECT-NNNNN."
+- IF valid → Continue
+
+### Step 2: Fetch the Ticket
+
+```python
+issue = getJiraIssue(issue_key="PROJ-12345")
+```
+
+**Fallback (jira-cli):**
+```bash
+jira issue get PROJ-12345
+```
+
+**Error Handling:**
+- 404 / not found → "Ticket not found. Verify the key and your access."
+- Auth failure → IF `AUTO_APPROVE=no`, prompt user to authenticate and retry. IF `AUTO_APPROVE=yes`, exit with error — there is no credential to fix automatically.
+- Network down → IF `AUTO_APPROVE=no`, ask the user to supply the CVE ID manually and skip the enrichment. IF `AUTO_APPROVE=yes`, exit with error (never gated — cannot fabricate ticket data).
+
+---
+
+### Step 2.5: Idempotency Check — Already Processed?
+
+Inspect the ticket's `labels` list from the response above. Check whether **`ai-cve-analyzed`** is present (case-sensitive exact match). This check always runs here regardless of entry point (`--jira=` direct or `--jql=` batch mode) — it is the authoritative guard against re-processing.
+
+```python
+labels = issue["fields"]["labels"]   # list of strings
+if "ai-cve-analyzed" in labels:
+    # Already processed — exit immediately
+```
+
+**IF label is present → Stop immediately and output:**
+
+```
+⚠️ Skipping analysis — this ticket has already been processed by /compliance:analyze-cve.
+
+Ticket:  <JIRA_KEY>
+Label:   ai-cve-analyzed
+
+To force a re-analysis, remove the label from the ticket and re-run.
+```
+
+Return `status: skipped` and exit. Do not proceed with analysis.
+
+**IF label is absent → Continue to Step 3.**
+
+---
+
+### Step 3: Extract CVE ID and Image Name from Summary
+
+The ticket summary follows this common format:
+```
+CVE-YYYY-NNNNN <image-name>: <vulnerability description> [<branch-or-version>]
+```
+
+Example:
+```
+CVE-2024-45338 openshift4/ose-operator-sdk-rhel9: some-lib: vulnerability description [openshift-4.17]
+```
+
+Parse with:
+```
+^(CVE-\d{4}-\d{4,})\s+([\w/:\-\.@]+)\s*:.*\[([\w\.\-]+)\]
+  group 1 = CVE ID
+  group 2 = image name
+  group 3 = branch/version
+```
+
+This is the **primary and most reliable extraction path**. If this succeeds, groups 1 and 2 are immediately available — no further searching needed for CVE ID or image name.
+
+- IF summary matches → set `CVE_ID`, `IMAGE_NAME`, `BRANCH` → skip to Step 5
+- IF summary does not match → continue to Step 4
+
+---
+
+### Step 4: Fallback Extraction (when summary doesn't match)
+
+Try in order until both `CVE_ID` and `IMAGE_NAME` are found:
+
+**CVE ID fallbacks:**
+1. A dedicated `CVE ID` custom field, if the project has one — always accurate when present
+2. Labels — look for a label matching `CVE-\d{4}-\d{4,}` exactly
+3. Description body — scan for `CVE-\d{4}-\d{4,}` pattern
+
+**Image name fallbacks:**
+1. `pscomponent:` label — parse `pscomponent:<image-name>` from the labels list; strip the `pscomponent:` prefix
+2. `Downstream Component Name` custom field, if the project has one — dedicated field mapping directly to the affected image
+3. Description body — scan for known image name prefixes (`openshift4/`, `cert-manager/`, `external-secrets-operator/`, `zero-trust-workload-identity-manager/`, `redhat-user-workloads/`)
+
+**Multiple CVE IDs found:** List all found. IF `AUTO_APPROVE=no` → ask the user which to analyze (or analyze all with confirmation). IF `AUTO_APPROVE=yes` → **always exit with error** listing the candidates and asking the caller to re-run with a direct `<CVE-ID>` argument (or a ticket/JQL that resolves to a single CVE). This case is never gated by `AUTO_APPROVE` — guessing which CVE to analyze is a correctness risk.
+
+**Decision Point:**
+- IF no CVE ID found anywhere → IF `AUTO_APPROVE=no`, ask the user to supply it manually; if declined → Exit. IF `AUTO_APPROVE=yes`, there is no one to ask → Exit immediately with error (never gated by `AUTO_APPROVE`).
+- IF no image name found → leave `IMAGE_NAME` blank; Phase 0.7 will prompt the user for `--repo=` (or hard-fail if `AUTO_APPROVE=yes`, per its own rules) — this is never guessed.
+
+---
+
+### Step 5: Extract Additional Context Fields
+
+Read the following fields from the ticket response. Field names vary by Jira instance/project — look them up by display name if the custom field ID is unknown (e.g. via issue-type field metadata), rather than hardcoding an ID that may not match this instance.
+
+| Field | Typical location | Notes |
+|---|---|---|
+| Status | `fields.status.name` | |
+| Priority | `fields.priority.name` | Blocker/Critical → urgency escalation |
+| Assignee | `fields.assignee.displayName` | |
+| Components | `fields.components[].name` | |
+| Labels | `fields.labels[]` | Full label list — needed intact for Step 4.5 of `report-to-jira` |
+| Affects versions | `fields.versions[].name` | |
+| Fix versions | `fields.fixVersions[].name` | |
+| Target version | project-specific custom field (e.g. "Target Version") | |
+| CVSS Score | custom field named "CVSS Score" | Format often `7.5 CVSS:3.1/AV:N/...` — extract score and vector separately |
+| CWE ID | custom field named "CWE ID" | e.g. `CWE-409` |
+| Embargo Status | custom field named "Embargo Status" | `True`/`False` — **security-critical, see Step 5.5** |
+| Downstream Component Name | custom field named "Downstream Component Name", if the project has one | Redundant image name source — cross-check against the summary/label extraction |
+| Release Note Text | custom field named "Release Note Text" | May already describe the fix |
+| Description | `fields.description` | Scan for workaround/mitigation keywords |
+
+**Scan description for workarounds:** look for sections or sentences containing "workaround", "mitigation", "disable", "restrict" — extract the first ~300 chars of any such passage.
+
+**Linked issues:**
+```python
+issue["fields"]["issuelinks"]  # each has inwardIssue/outwardIssue + type.name
+```
+
+---
+
+### Step 5.5: Embargo Check — MUST run before returning
+
+Read the `Embargo Status` custom field from the ticket (if the project defines one).
+
+- IF value is `True` (case-insensitive) → **immediately stop all processing** and return:
+  ```
+  ❌ Embargoed CVE — cannot proceed.
+
+  This ticket is marked as embargoed. Embargoed CVEs must not be
+  analysed, disclosed, or shared outside authorised channels.
+
+  Exit.
+  ```
+  Do NOT output any CVE details, CVSS scores, image names, or other ticket data.
+- IF value is `False`, empty, or the field does not exist on this project → Continue to Step 6.
+
+---
+
+### Branch Resolution
+
+The `BRANCH` value extracted in Step 3/4 (e.g. `openshift-4.17`, `ztwim-1.0`) uses a **different naming convention** from actual git branches. Resolve it before Phase 0.7 clones anything — do not pass the raw Jira value straight to `git clone -b`.
+
+**Pattern A components** (direct repo — Operator SDK, Ansible Operator, must-gather, Secrets Store CSI):
+
+| Jira `BRANCH` value | `git_branch` to use |
+|---|---|
+| `openshift-X.Y` | `release-X.Y` (e.g. `openshift-4.17` → `release-4.17`) |
+| `openshift-X.Y.z` | `release-X.Y.z` |
+| Anything else (e.g. `ztwim-1.0`, `main`) | Use verbatim — Pattern B components resolve their own release-repo branch inside `image-repo-mapping` |
+
+Set `git_branch` to the resolved value and `git_branch_source` to `jira_summary`. Phase 0.7 uses `git_branch` directly for the `-b` flag when cloning a Pattern A repo. For a **Pattern B** component (cert-manager, ESO, ZTWIM), pass the raw `BRANCH` value through unchanged — `image-repo-mapping`'s own branch table (e.g. `cert-manager-X-Y` → `release-X.Y` in the release repo) is what actually resolves it, and applying this Pattern A table first would corrupt it.
+
+If `BRANCH` was not extracted (no Jira ticket, or the ticket didn't have a parseable version/branch token): leave `git_branch` unset — Phase 0.7 clones the repository's default branch and notes this in the report.
+
+---
+
+### Step 6: Compile and Return
+
+```json
+{
+  "skill": "jira-cve-extraction",
+  "status": "success",
+  "cve_id": "CVE-YYYY-NNNNN",
+  "image_name": "openshift4/ose-operator-sdk-rhel9",
+  "branch": "openshift-4.17",
+  "jira_context": {
+    "ticket_key": "PROJ-NNNNN",
+    "ticket_url": "https://<jira-host>/browse/PROJ-NNNNN",
+    "summary": "CVE-YYYY-NNNNN openshift4/ose-operator-sdk-rhel9: <lib>: <description> [openshift-4.17]",
+    "status": "New",
+    "priority": "Major",
+    "assignee": "<assignee-display-name>",
+    "components": ["<component>"],
+    "labels": ["CVE-YYYY-NNNNN", "SecurityTracking", "pscomponent:openshift4/ose-operator-sdk-rhel9"],
+    "affects_versions": ["4.17"],
+    "fix_versions": [],
+    "target_versions": [],
+    "cvss_score": "7.5",
+    "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+    "cwe_id": "CWE-NNN",
+    "embargo_status": "False",
+    "downstream_component_name": "openshift4/ose-operator-sdk-rhel9",
+    "internal_notes": "",
+    "release_note_text": "",
+    "linked_issues": []
+  },
+  "analysis_hints": {
+    "urgency_override": null,
+    "workaround_present": false,
+    "cve_extraction_source": "summary",
+    "image_extraction_source": "summary",
+    "git_branch": "release-4.17",
+    "git_branch_source": "jira_summary"
+  }
+}
+```
+
+`cve_extraction_source` values: `summary`, `custom_field`, `label`, `description`, `user_provided`
+`image_extraction_source` values: `summary`, `pscomponent_label`, `downstream_component_field`, `description`, `user_provided`
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|---|---|
+| Ticket not found (404) | Exit with error: "Ticket not found or access denied" |
+| Auth failure | Prompt to authenticate and retry (or exit if `AUTO_APPROVE=yes`) |
+| No CVE ID in ticket | `AUTO_APPROVE=no`: ask user to supply manually. `AUTO_APPROVE=yes`: exit with error (never gated). |
+| No image name in ticket | Leave blank; Phase 0.7 will prompt for `--repo=` (or hard-fail if `AUTO_APPROVE=yes`) |
+| Multiple CVEs | List all. `AUTO_APPROVE=no`: ask user which to analyze. `AUTO_APPROVE=yes`: exit with error (never gated). |
+| Embargo `True` | **Stop immediately.** Return error: "This ticket is under embargo. Embargoed CVEs must not be analysed or disclosed outside authorised channels. Exiting." |
+| Label `ai-cve-analyzed` present | **Stop immediately.** Return `status: skipped` — ticket already processed. |
+
+---
+
+## Integration with Parent Command
+
+Called from **Phase 0.5** of `/compliance:analyze-cve` (see `commands/analyze-cve.md`), only when `--jira=` or `--jql=` was provided.
+
+**Output is used as:**
+- `cve_id` → Phase 1 (`cve-intelligence-gathering`)
+- `image_name` → Phase 0.7 via the `image-repo-mapping` skill to resolve the clone URL
+- `analysis_hints.git_branch` → Phase 0.7 Step 3 — the `-b` flag for `git clone` (Pattern A) or the release-branch lookup (Pattern B)
+- `jira_context` → Phase 1 (merged into vulnerability profile) + Phase 3 report "Jira Context" section
+- `jira_context.cvss_score` + `cvss_vector` → seeds Phase 1 before NVD lookup
+- `analysis_hints.urgency_override` → can escalate the final risk level
+- `analysis_hints.workaround_present` → noted in Phase 4 remediation plan
+- `jira_context.ticket_key` → becomes `SOURCE_TICKET` for `report-to-jira` (Phase 4) and `create-fix-pr` (Phase 6)

--- a/plugins/compliance/skills/report-to-jira/SKILL.md
+++ b/plugins/compliance/skills/report-to-jira/SKILL.md
@@ -18,6 +18,7 @@ Before posting, verify the following are available from the parent command:
 - Final report content (full markdown from Phase 3)
 - CVE ID (e.g. `CVE-2024-45338`)
 - **`SOURCE_TICKET`** — the Jira ticket key from `--jira=`/`--jql=` (e.g. `OCPBUGS-12345`). This is the only ticket this skill writes to.
+- **`jira_context`** — label snapshot from Phase 0.5 (`jira_context["labels"]`); used as a hint only — Step 4.5 re-fetches current labels before writing
 - Risk level (`HIGH` / `MEDIUM` / `LOW` / `NEEDS_REVIEW`)
 - `AUTO_APPROVE` (`yes`/`no`, default `no`) — governs the Step 3b visibility-downgrade fallback prompt
 
@@ -91,15 +92,18 @@ COMMENT_EOF
     # -H flag -- a "-H Authorization: ..." argument would put the credential
     # directly into this process's argv, visible to anything on the same host
     # that can read `ps aux` / /proc/<pid>/cmdline while curl runs.
-    local auth_header="$1" curl_cfg
+    local auth_header="$1" curl_cfg http_code
     curl_cfg=$(mktemp)
     chmod 600 "${curl_cfg}"
+    trap 'rm -f "${curl_cfg}"' RETURN EXIT INT TERM
     [[ $- == *x* ]] && local _was_tracing=true || local _was_tracing=false
     set +x
     printf 'header = "Authorization: %s"\n' "${auth_header}" > "${curl_cfg}"
     $_was_tracing && set -x || true
 
-    curl -s -o /tmp/jira-post-response.txt -w "%{http_code}" \
+    http_code=$(curl -s -o /tmp/jira-post-response.txt -w "%{http_code}" \
+      --connect-timeout 15 \
+      --max-time 60 \
       -X POST \
       -K "${curl_cfg}" \
       "${JIRA_BASE_URL}/rest/api/2/issue/${SOURCE_TICKET}/comment" \
@@ -113,7 +117,8 @@ COMMENT_EOF
   }
 }
 EOF
-    rm -f "${curl_cfg}"
+)
+    echo "${http_code}"
   }
 
   HTTP_STATUS=""
@@ -224,12 +229,17 @@ Add the label **`ai-cve-analyzed`** to `SOURCE_TICKET` to prevent redundant re-p
 Jira's update API **replaces** the entire label list — it does not append. Sending only `["ai-cve-analyzed"]` will **delete all existing labels** on the ticket. This is a destructive operation and must never happen.
 
 **Before writing, always:**
-1. Take the full `labels` list already captured in `jira_context["labels"]` (fetched in Phase 0.5 — no extra API call needed)
-2. Append `ai-cve-analyzed` to that list
+1. Re-fetch the ticket's current labels (do not trust the Phase 0.5 snapshot alone — labels may have changed while analysis ran):
+   ```python
+   fresh = getJiraIssue(issue_key=SOURCE_TICKET)
+   current_labels = fresh["fields"]["labels"]   # never start from an empty list
+   ```
+   Use `jira_context["labels"]` only as a fallback if the re-fetch fails.
+2. Append `ai-cve-analyzed` to `current_labels`
 3. Write the combined list back
 
 ```python
-current_labels = jira_context["labels"]   # never start from an empty list
+# current_labels comes from the mandatory re-fetch above (Step 4.5)
 
 if "ai-cve-analyzed" not in current_labels:
     new_labels = current_labels + ["ai-cve-analyzed"]

--- a/plugins/compliance/skills/report-to-jira/SKILL.md
+++ b/plugins/compliance/skills/report-to-jira/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-to-jira
-description: Post the final CVE analysis report as a comment on the source Jira ticket, prefixed with an AI-analysis attribution header
+description: Use when posting a completed CVE analysis report or PR follow-up as a Jira comment on the source ticket from `/compliance:analyze-cve`.
 ---
 
 # Report to Jira

--- a/plugins/compliance/skills/report-to-jira/SKILL.md
+++ b/plugins/compliance/skills/report-to-jira/SKILL.md
@@ -79,6 +79,11 @@ JIRA_BASE_URL="${JIRA_URL:-}"
 JIRA_EMAIL="${JIRA_EMAIL:-}"
 
 if [ -n "${JIRA_API_TOKEN}" ] && [ -n "${JIRA_BASE_URL}" ]; then
+  case "${JIRA_BASE_URL}" in
+    https://*) ;;
+    *) echo "ERROR: JIRA_BASE_URL must use HTTPS (got: ${JIRA_BASE_URL})"; exit 1 ;;
+  esac
+
   cat > /tmp/cve-report-comment.txt << 'COMMENT_EOF'
 <constructed comment from Step 2>
 COMMENT_EOF
@@ -87,18 +92,22 @@ COMMENT_EOF
   COMMENT_JSON_BODY=$(echo "${COMMENT_BODY}" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
 
   post_comment() {
-    # $1 = full "Authorization" header value, e.g. "Basic xxxx" or "Bearer xxxx"
-    # Write the header to a curl config file (-K) instead of passing it as a
-    # -H flag -- a "-H Authorization: ..." argument would put the credential
-    # directly into this process's argv, visible to anything on the same host
-    # that can read `ps aux` / /proc/<pid>/cmdline while curl runs.
-    local auth_header="$1" curl_cfg http_code
+    # $1 = auth mode: "basic" (email+token) or "bearer" (token only)
+    # Build the Authorization header inside this function after set +x so
+    # credentials never appear in traced argv when post_comment is invoked.
+    local auth_mode="$1" curl_cfg http_code auth_header
     curl_cfg=$(mktemp)
     chmod 600 "${curl_cfg}"
     trap 'rm -f "${curl_cfg}"' RETURN EXIT INT TERM
     [[ $- == *x* ]] && local _was_tracing=true || local _was_tracing=false
     set +x
+    if [ "${auth_mode}" = "basic" ]; then
+      auth_header="Basic $(printf '%s:%s' "${JIRA_EMAIL}" "${JIRA_API_TOKEN}" | base64 | tr -d '\n')"
+    else
+      auth_header="Bearer ${JIRA_API_TOKEN}"
+    fi
     printf 'header = "Authorization: %s"\n' "${auth_header}" > "${curl_cfg}"
+    unset auth_header
     $_was_tracing && set -x || true
 
     http_code=$(curl -s -o /tmp/jira-post-response.txt -w "%{http_code}" \
@@ -124,9 +133,7 @@ EOF
   HTTP_STATUS=""
   if [ -n "${JIRA_EMAIL}" ] && [ -n "${JIRA_API_TOKEN}" ]; then
     echo "Attempting REST post with Basic auth (email + token)..."
-    BASIC_AUTH=$(printf '%s:%s' "${JIRA_EMAIL}" "${JIRA_API_TOKEN}" | base64 | tr -d '\n')
-    HTTP_STATUS=$(post_comment "Basic ${BASIC_AUTH}")
-    unset BASIC_AUTH
+    HTTP_STATUS=$(post_comment basic)
   fi
 
   # Only retry with the other auth scheme when Basic wasn't attempted at all
@@ -137,7 +144,7 @@ EOF
   # malformed. Any other failure goes straight to Step 3b instead of retrying.
   if { [ -z "${HTTP_STATUS}" ] || [ "${HTTP_STATUS}" = "401" ] || [ "${HTTP_STATUS}" = "403" ]; } && [ -n "${JIRA_API_TOKEN}" ]; then
     echo "Attempting REST post with Bearer auth..."
-    HTTP_STATUS=$(post_comment "Bearer ${JIRA_API_TOKEN}")
+    HTTP_STATUS=$(post_comment bearer)
   fi
 
   echo "Jira API HTTP status: ${HTTP_STATUS:-none attempted}"

--- a/plugins/compliance/skills/report-to-jira/SKILL.md
+++ b/plugins/compliance/skills/report-to-jira/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: report-to-jira
+description: Post the final CVE analysis report as a comment on the source Jira ticket, prefixed with an AI-analysis attribution header
+---
+
+# Report to Jira
+
+Posts the completed CVE analysis report as a comment on the **source Jira ticket** — the same ticket the CVE details were read from (`SOURCE_TICKET`, set in Phase 0.5 from `--jira=`/`--jql=`). Always called as the last step of Phase 4, after the report has been generated. Also reused by `create-fix-pr` (Phase 6) for a short follow-up comment containing the PR URL.
+
+If no Jira ticket was involved (direct `<CVE-ID>` mode), this skill is skipped entirely — there is nothing to post to.
+
+---
+
+## Step 1: Confirm Report is Ready
+
+Before posting, verify the following are available from the parent command:
+
+- Final report content (full markdown from Phase 3)
+- CVE ID (e.g. `CVE-2024-45338`)
+- **`SOURCE_TICKET`** — the Jira ticket key from `--jira=`/`--jql=` (e.g. `OCPBUGS-12345`). This is the only ticket this skill writes to.
+- Risk level (`HIGH` / `MEDIUM` / `LOW` / `NEEDS_REVIEW`)
+- `AUTO_APPROVE` (`yes`/`no`, default `no`) — governs the Step 3b visibility-downgrade fallback prompt
+
+**If `SOURCE_TICKET` is not available** (direct CVE mode): return `status: skipped` with reason `"no_source_ticket"`.
+
+If the report is incomplete or Phase 3 did not finish, return `status: skipped` with reason.
+
+---
+
+## Step 2: Build the Comment Body
+
+Write standard Markdown — Jira Cloud renders Markdown natively when posted with `contentFormat: "markdown"` (see [markdown-for-jira reference](../../../jira/reference/markdown-for-jira.md) if that plugin is installed; the syntax is standard CommonMark either way). No wiki-markup conversion is needed.
+
+Prepend the following attribution header before the report:
+
+```markdown
+> ⚠️ **This analysis was performed automatically by `/compliance:analyze-cve`.**
+> Results should be reviewed by a human before acting on remediation steps.
+
+---
+
+```
+
+### Size limit handling
+
+Jira comment bodies are capped at **32,767 characters**. Measure the full comment length before posting:
+
+- **≤ 32,000 chars** → post in full, no changes needed.
+- **> 32,000 chars** → trim raw tool output sections only (full `govulncheck` output, call graph DOT content) and replace each with a one-line note:
+  ```
+  _(govulncheck full output truncated — see `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/<CVE_ID>/govulncheck-output.txt`)_
+  ```
+  Retain all findings, risk assessment, executive summary, and remediation sections in full. Re-measure after trimming and repeat if still over limit.
+
+### Stripping rules (apply regardless of size)
+
+- Remove internal email addresses — replace with the display name only.
+- Do not include embargoed content — if somehow reached here with `embargo_status: True`, abort immediately.
+
+---
+
+## Step 3: Post the Comment
+
+> **Credential rule:** Never print, echo, or log any token, key, or password value. Reference credentials only via environment variable names. Never interpolate a credential value into a logged string.
+
+CVE analysis reports contain security-sensitive findings. Prefer restricted (internal-only) visibility when the Jira instance supports it.
+
+### Step 3a: Direct REST API with restricted visibility (attempt first, if credentials are configured)
+
+If a token is available in the environment, try the REST API directly so the comment can carry a visibility restriction the MCP tool does not support. Try **both** auth schemes and let the HTTP response decide which one worked — credentials may be exposed differently depending on the runtime (a local shell with a bare token vs. a CI/RWS runner with a mounted service-account email+token pair):
+
+1. **Basic auth (email + API token)** — the scheme most Jira Cloud instances actually expect for API tokens. Used when both `JIRA_EMAIL` and a token are available.
+2. **Bearer token only** — fallback for runtimes that expose only a bare token env var with no associated email.
+
+```bash
+JIRA_API_TOKEN="${JIRA_API_TOKEN:-${JIRA_TOKEN:-${ATLASSIAN_API_TOKEN:-}}}"
+JIRA_BASE_URL="${JIRA_URL:-}"
+JIRA_EMAIL="${JIRA_EMAIL:-}"
+
+if [ -n "${JIRA_API_TOKEN}" ] && [ -n "${JIRA_BASE_URL}" ]; then
+  cat > /tmp/cve-report-comment.txt << 'COMMENT_EOF'
+<constructed comment from Step 2>
+COMMENT_EOF
+
+  COMMENT_BODY=$(cat /tmp/cve-report-comment.txt)
+  COMMENT_JSON_BODY=$(echo "${COMMENT_BODY}" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
+
+  post_comment() {
+    # $1 = full "Authorization" header value, e.g. "Basic xxxx" or "Bearer xxxx"
+    # Write the header to a curl config file (-K) instead of passing it as a
+    # -H flag -- a "-H Authorization: ..." argument would put the credential
+    # directly into this process's argv, visible to anything on the same host
+    # that can read `ps aux` / /proc/<pid>/cmdline while curl runs.
+    local auth_header="$1" curl_cfg
+    curl_cfg=$(mktemp)
+    chmod 600 "${curl_cfg}"
+    [[ $- == *x* ]] && local _was_tracing=true || local _was_tracing=false
+    set +x
+    printf 'header = "Authorization: %s"\n' "${auth_header}" > "${curl_cfg}"
+    $_was_tracing && set -x || true
+
+    curl -s -o /tmp/jira-post-response.txt -w "%{http_code}" \
+      -X POST \
+      -K "${curl_cfg}" \
+      "${JIRA_BASE_URL}/rest/api/2/issue/${SOURCE_TICKET}/comment" \
+      -H "Content-Type: application/json" \
+      --data-binary @- << EOF
+{
+  "body": ${COMMENT_JSON_BODY},
+  "visibility": {
+    "type": "group",
+    "value": "Red Hat Employee"
+  }
+}
+EOF
+    rm -f "${curl_cfg}"
+  }
+
+  HTTP_STATUS=""
+  if [ -n "${JIRA_EMAIL}" ] && [ -n "${JIRA_API_TOKEN}" ]; then
+    echo "Attempting REST post with Basic auth (email + token)..."
+    BASIC_AUTH=$(printf '%s:%s' "${JIRA_EMAIL}" "${JIRA_API_TOKEN}" | base64 | tr -d '\n')
+    HTTP_STATUS=$(post_comment "Basic ${BASIC_AUTH}")
+    unset BASIC_AUTH
+  fi
+
+  # Only retry with the other auth scheme when Basic wasn't attempted at all
+  # (no JIRA_EMAIL) or came back with an actual auth failure (401/403). This
+  # POST is not idempotent: retrying it for every other status (400, 429,
+  # 5xx, or curl's own "000") risks creating a duplicate comment if the first
+  # request was actually accepted server-side but the response was lost or
+  # malformed. Any other failure goes straight to Step 3b instead of retrying.
+  if { [ -z "${HTTP_STATUS}" ] || [ "${HTTP_STATUS}" = "401" ] || [ "${HTTP_STATUS}" = "403" ]; } && [ -n "${JIRA_API_TOKEN}" ]; then
+    echo "Attempting REST post with Bearer auth..."
+    HTTP_STATUS=$(post_comment "Bearer ${JIRA_API_TOKEN}")
+  fi
+
+  echo "Jira API HTTP status: ${HTTP_STATUS:-none attempted}"
+  if [ "${HTTP_STATUS}" = "201" ]; then
+    echo "✓ Comment posted with restricted visibility"
+  else
+    echo "✗ REST API failed (HTTP ${HTTP_STATUS:-n/a}) — will fall back to MCP tool"
+    cat /tmp/jira-post-response.txt 2>/dev/null || true
+  fi
+fi
+```
+
+> The `visibility` object above targets `redhat.atlassian.net`. On other Jira Cloud instances, adjust `type`/`value` to match an equivalent internal-only group, or omit `visibility` entirely if none exists.
+
+- IF HTTP 201 (either scheme) → done. Skip Step 3b.
+- IF credentials are not configured → continue to Step 3b.
+- IF HTTP 401/403 on both schemes (or Basic wasn't attempted and Bearer also fails) → credentials not available or insufficient permissions; continue to Step 3b.
+- IF Basic auth returns any other status (400, 429, 5xx, curl error `000`) → do **not** retry with Bearer (the POST is not idempotent) — go directly to Step 3b.
+- Never print `JIRA_API_TOKEN`, `JIRA_EMAIL`, the computed `BASIC_AUTH` value, or the contents of `${curl_cfg}` — only the HTTP status code and response body (which contains no credentials).
+
+---
+
+### Step 3b: MCP tool (default / fallback)
+
+```python
+addCommentToJiraIssue(
+    issue_key=SOURCE_TICKET,
+    comment_body="<constructed comment from Step 2>",
+    contentFormat="markdown"
+)
+```
+
+> ⚠️ The MCP tool does not expose a `visibility` parameter — the comment will be visible to everyone with access to the ticket, not restricted to an internal group.
+
+This visibility downgrade is gated by `AUTO_APPROVE` when it happens **after** Step 3a was actually attempted and failed (i.e. restricted posting was possible in principle but didn't work):
+
+- IF `AUTO_APPROVE=no` and Step 3a was attempted and failed → **ask the user**:
+  ```
+  ⚠️ Restricted-visibility posting is unavailable (no REST credentials, or the request failed). The MCP fallback will post this comment visible to everyone with ticket access. Proceed?
+  ```
+  IF user says **no** → display the full comment body in the session for manual posting instead.
+- IF `AUTO_APPROVE=yes` and Step 3a was attempted and failed → proceed automatically via the MCP fallback. **Clearly log** that this comment was posted without the internal-only restriction.
+- IF Step 3a was never attempted (no REST credentials configured at all) → just post via MCP; this is the normal/expected path for most setups and does not need a prompt.
+
+**Fallback — jira-cli** (if MCP is also unavailable):
+
+```bash
+jira issue comment add "${SOURCE_TICKET}" \
+  --body "$(cat /tmp/cve-report-comment.txt)" \
+  --no-input
+```
+
+---
+
+## Step 4: Confirm and Report
+
+After posting, output to the session:
+
+```
+✅ Report posted to <SOURCE_TICKET>
+   <JIRA_BASE_URL>/browse/<SOURCE_TICKET>
+
+   CVE:        <CVE_ID>
+   Risk level: <level>
+```
+
+If the post fails:
+
+```
+❌ Failed to post report to <SOURCE_TICKET>
+   Error: <error message>
+
+   The full report has been displayed above. Please copy and paste it
+   into <SOURCE_TICKET> manually.
+```
+
+Do not retry more than once. On failure, display the comment body in the session so the user can post it manually.
+
+---
+
+## Step 4.5: Mark Source Ticket as Processed
+
+Add the label **`ai-cve-analyzed`** to `SOURCE_TICKET` to prevent redundant re-processing on future runs.
+
+**Only run this step if Step 3 succeeded.** If Step 3 failed for any reason, **skip this step entirely** — do not add the label to a ticket that did not receive the comment.
+
+### ⚠️ CRITICAL: Existing labels MUST be preserved
+
+Jira's update API **replaces** the entire label list — it does not append. Sending only `["ai-cve-analyzed"]` will **delete all existing labels** on the ticket. This is a destructive operation and must never happen.
+
+**Before writing, always:**
+1. Take the full `labels` list already captured in `jira_context["labels"]` (fetched in Phase 0.5 — no extra API call needed)
+2. Append `ai-cve-analyzed` to that list
+3. Write the combined list back
+
+```python
+current_labels = jira_context["labels"]   # never start from an empty list
+
+if "ai-cve-analyzed" not in current_labels:
+    new_labels = current_labels + ["ai-cve-analyzed"]
+else:
+    new_labels = current_labels   # already marked — nothing to write
+
+editJiraIssue(
+    issue_key=SOURCE_TICKET,
+    fields={"labels": new_labels}
+)
+```
+
+**Fallback — jira-cli** (appends without replacing — safe to use directly):
+
+```bash
+jira issue edit "${SOURCE_TICKET}" --label "ai-cve-analyzed" --no-input
+```
+
+### Verification (mandatory when using the MCP/REST label-replace path)
+
+After the update call, re-fetch the ticket labels and confirm:
+
+```python
+updated = getJiraIssue(issue_key=SOURCE_TICKET)
+updated_labels = updated["fields"]["labels"]
+
+assert "ai-cve-analyzed" in updated_labels, "New label missing"
+for label in current_labels:
+    assert label in updated_labels, f"LABEL LOST: {label}"
+```
+
+**If the new label is missing:** log a non-fatal warning — the report is already posted:
+```
+⚠️ Could not add 'ai-cve-analyzed' label to <SOURCE_TICKET>. Add it manually to prevent re-processing.
+```
+
+**If an existing label was lost:** this is a data integrity error — log it and output the original label list so the user can restore it:
+```
+❌ LABEL INTEGRITY ERROR on <SOURCE_TICKET>
+   The following labels were present before the update but are now missing:
+   <list of lost labels>
+
+   Original full label list (restore manually):
+   <current_labels>
+```
+
+**If both checks pass:**
+```
+✅ Label 'ai-cve-analyzed' added to <SOURCE_TICKET>. Labels verified intact.
+```
+
+---
+
+## Return Value
+
+**Success:**
+```json
+{
+  "skill": "report-to-jira",
+  "status": "success",
+  "source_ticket": "<SOURCE_TICKET>",
+  "cve_id": "<CVE_ID>",
+  "risk_level": "<HIGH|MEDIUM|LOW|NEEDS_REVIEW>",
+  "method": "rest | mcp | jira-cli"
+}
+```
+
+**Skipped:**
+```json
+{
+  "skill": "report-to-jira",
+  "status": "skipped",
+  "reason": "<no_source_ticket | report incomplete | phase 3 did not finish>"
+}
+```
+
+**Failed:**
+```json
+{
+  "skill": "report-to-jira",
+  "status": "failed",
+  "source_ticket": "<SOURCE_TICKET>",
+  "error": "<error message>",
+  "fallback": "comment body displayed in session for manual posting"
+}
+```
+
+---
+
+## Integration with Parent Command
+
+Called from **Phase 4** of `/compliance:analyze-cve` as the final step, after the report has been fully generated.
+
+**Input:** complete report content, CVE ID, risk level, `SOURCE_TICKET` (from Phase 0.5), `AUTO_APPROVE`
+**Output:** confirmation of comment and label posted to `SOURCE_TICKET`, or `status: skipped`/`failed` per above
+
+Also called from **Phase 6** (`create-fix-pr`) for a short follow-up comment containing only the GitHub PR URL. That path uses the section below and must not replace this analysis comment or change labels.
+
+---
+
+## Follow-up: PR URL comment (Phase 6)
+
+Post a **new** comment on `SOURCE_TICKET` after a remediation PR is opened. Invoked by [create-fix-pr](../create-fix-pr/SKILL.md).
+
+**Do not run this path unless** `SOURCE_TICKET` is set, Phase 6 produced a `PR_URL`, and the user approved opening the PR.
+
+**Do not:**
+- Edit or delete the Phase 4 analysis comment
+- Add or remove labels (`ai-cve-analyzed` stays as Phase 4 left it)
+- Re-post the full analysis report
+- Mention embargoed content (if `embargo_status = True`, abort)
+
+### Comment body
+
+```markdown
+### Remediation PR opened
+
+A pull request is open for this CVE.
+
+- **PR:** [<PR_URL>](<PR_URL>)
+- **CVE:** <CVE_ID>
+- **Change:** <what Phase 5 changed — `<module>` <old> → <new> only for a dependency bump; otherwise a short source/config summary>
+- **Base branch:** <BASE_BRANCH>
+```
+
+### Posting
+
+Use the same procedure as Step 3 (REST with restricted visibility first if configured, MCP/jira-cli fallback otherwise).
+
+On failure, print the comment in the session for manual paste. Do not treat a Jira follow-up failure as a GitHub PR failure — the PR itself is still a success.
+
+**Return:**
+```json
+{
+  "skill": "report-to-jira",
+  "status": "success | skipped | failed",
+  "mode": "pr_followup",
+  "source_ticket": "<SOURCE_TICKET>",
+  "pr_url": "<PR_URL>"
+}
+```

--- a/plugins/compliance/skills/report-to-jira/SKILL.md
+++ b/plugins/compliance/skills/report-to-jira/SKILL.md
@@ -30,7 +30,11 @@ If the report is incomplete or Phase 3 did not finish, return `status: skipped` 
 
 ## Step 2: Build the Comment Body
 
+Read `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/${CVE_ID}/report.md` from Phase 3 and post it **in full**. The Jira comment is the report — do **not** pre-emptively shorten it or write a separate `jira-comment.md`.
+
 Write standard Markdown — Jira Cloud renders Markdown natively when posted with `contentFormat: "markdown"` (see [markdown-for-jira reference](../../../jira/reference/markdown-for-jira.md) if that plugin is installed; the syntax is standard CommonMark either way). No wiki-markup conversion is needed.
+
+**Default body = attribution header + entire `report.md`.** If Phase 4 produced a remediation plan not already under `## Remediation` in the report, append it as `## Remediation Plan (Phase 4)`.
 
 Prepend the following attribution header before the report:
 
@@ -44,14 +48,19 @@ Prepend the following attribution header before the report:
 
 ### Size limit handling
 
-Jira comment bodies are capped at **32,767 characters**. Measure the full comment length before posting:
+Jira comment bodies are capped at **32,767 characters**. Apply these steps **in order** — only move to the next step if the comment is still over 32,000 chars:
 
-- **≤ 32,000 chars** → post in full, no changes needed.
-- **> 32,000 chars** → trim raw tool output sections only (full `govulncheck` output, call graph DOT content) and replace each with a one-line note:
-  ```
-  _(govulncheck full output truncated — see `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/<CVE_ID>/govulncheck-output.txt`)_
-  ```
-  Retain all findings, risk assessment, executive summary, and remediation sections in full. Re-measure after trimming and repeat if still over limit.
+1. **Post in full** (≤ 32,000 chars) — no changes.
+2. **Trim raw tool dumps only** (> 32,000 chars) — inside fenced code blocks, replace full `govulncheck` scrollback, call-graph DOT, or megabyte grep output with a one-line pointer:
+   ```
+   _(Full output truncated — see `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/<CVE_ID>/govulncheck-source.txt`)_
+   ```
+   Keep executive summary, CVE context, evidence interpretations, call-graph **results table**, risk assessment, and remediation in full. Re-measure.
+3. **Shortened summary (last resort only)** — if still > 32,000 chars after step 2, replace the body with a condensed summary derived from `report.md`. Retain: risk level, repository/branch/commit, dependency versions, govulncheck conclusion, four-algorithm call-graph table, manual verification findings, recommendation, and artifact paths. Omit repeated narrative and any remaining large code blocks. Note at the top:
+   ```
+   _(Full report exceeded Jira comment limit — summary below. See `${AI_HELPERS_WORKSPACE:-.}/.work/compliance/analyze-cve/<CVE_ID>/report.md`.)_
+   ```
+   Do **not** use a shortened summary unless steps 1–2 are insufficient.
 
 ### Stripping rules (apply regardless of size)
 


### PR DESCRIPTION
## Summary
- Brings `/compliance:analyze-cve` to parity with https://github.com/chiragkyal/ai-workflows flow: image-to-repo mapping, branch resolution, `REPO_DIR` cloning, and fork-mode PR creation.
- Adds supporting skills (`image-repo-mapping`, expanded `jira-cve-extraction`, `create-fix-pr`, `report-to-jira`) plus `AI_HELPERS_WORKSPACE` portability for RWS/CI execution.


## Test plan
- [x] Run `make lint` locally (passes on branch)
- [x] `/compliance:analyze-cve --jira=<ticket>` with image name + branch in summary/labels
- [x] Verify `.work/compliance/analyze-cve/repos/{repo-name}` is cloned and reused
- [x] Confirm Jira comment posting works with configured credentials
- [x] Confirm fork-mode PR creation when upstream write access is unavailable


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CVE analysis from direct CVE IDs, Jira tickets, and JQL queues.
  * Added repository and container-image mapping with branch and pinned-commit resolution.
  * Added validated remediation workflows, pull request creation, and optional fork support.
  * Added Jira and GitHub integrations, runtime configuration, and offline fallback behavior.
  * Added explicit `NEEDS_REVIEW` outcomes for uncertain reachability or incomplete analysis.

* **Documentation**
  * Expanded setup, usage, integration, safety, reporting, and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->