### PR TITLE
ci: add regression escape analysis

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -105,7 +105,7 @@
       "name": "ci",
       "source": "./plugins/ci",
       "description": "A plugin to work with OpenShift CI and analyze Prow job results",
-      "version": "0.0.93",
+      "version": "0.0.94",
       "category": "ci",
       "keywords": [
         "prow",

--- a/plugins/ci/.claude-plugin/plugin.json
+++ b/plugins/ci/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ci",
   "description": "Tools for working with OpenShift CI and analyzing Prow job results",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "author": {
     "name": "github.com/openshift-eng"
   }

--- a/plugins/ci/skills/payload-analysis/SKILL.md
+++ b/plugins/ci/skills/payload-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: payload-analysis
-description: Analyze a payload snapshot to identify root causes of blocking job failures, score candidate PRs, and produce an HTML report with revert recommendations
+description: Use when analyzing a payload snapshot to identify root causes of blocking job failures, score candidate PRs, explain how high-confidence regressions escaped pre-merge CI, and produce an HTML report with revert recommendations
 argument-hint: "<payload-tag> [--snapshot-dir DIR] [--as-of TIMESTAMP]"
 ---
 
@@ -19,6 +19,7 @@ Use this skill when you need to:
 - Assess whether an in-progress ("Ready") payload is likely to be rejected
 - Determine whether failures are new or persistent
 - Identify which PRs likely caused new failures
+- Explain what allowed a high-confidence PR regression to merge
 - Get a comprehensive overview of payload health with actionable root cause analysis
 - Re-analyze a historical payload against its original snapshot data
 
@@ -55,7 +56,9 @@ Load these only at the step that needs them — not up front:
 - **`assets/report-template.html`** — the fill-in-the-blanks HTML report template (Step 7)
 - **`references/ship-status-component-map.md`** — SHIP Status slug mapping (Step 6.5)
 
-The `payload-results-yaml` and `payload-autodl-json` skills define the structured output schemas; load each via the Skill tool at its point of use (Steps 6.7 and 8).
+The `regression-escape-analysis`, `payload-results-yaml`, and
+`payload-autodl-json` skills define reusable analysis/output contracts; load
+each via the Skill tool at its point of use (Steps 6.2b, 6.7, and 8).
 
 ## Implementation Steps
 
@@ -162,6 +165,9 @@ For each failed job, read its `job.json` (at `SNAPSHOT_DIR/<job_json>` path) to 
 For each failed job's `streak.originating_payload`, find the matching entry in `summary.json` → `payloads[]`. Its `prs[]` array contains the PRs introduced in that payload:
 - `url`, `component`, `number`, `description`
 - Paths to local artifacts: `diff`, `comments`, `jobs`
+- `escape_analysis` (when collected): merge-time PR metadata, complete status
+  attempt history on the merged head SHA, chat-ops actions with normalized
+  actors, and paths to frozen Prow/ci-operator and repository workflow config
 
 Treat this as a **preliminary** list only. The job-level streak merges unrelated failure modes, so its originating payload is frequently earlier than the regression being investigated — and candidates gathered from it can omit the causal PR entirely. Before scoring, re-derive the originating payload **per failure mode** from `test_failures.blocking[].first_failed_in` (Step 5) and collect the candidates from *that* payload.
 
@@ -477,6 +483,44 @@ Otherwise, recommend force-accepting when **all** of the following are true:
 
 Instead, recommend the correct action: **wait for the RHCOS with the rebuilt kubelet to land** (i.e., for the transient build lag from Step 6.2 to resolve). Once the updated kubelet is delivered, the skew clears and the payload passes on its own.
 
+#### 6.2b: Explain How High-Confidence PR Regressions Escaped
+
+For every `type: "pr"` candidate scoring >= 85, load the
+`regression-escape-analysis` skill and follow it with:
+
+- the already-adjudicated regression mechanism from Steps 4-6.1 (affected
+  jobs/environments, distinct failure modes, failing tests/operations, root
+  cause, and key error patterns),
+- the candidate PR URL, and
+- the PR's `escape_analysis` path from `summary.json` when present.
+
+This is a downstream analysis, not another culprit search. Do not let it
+re-score or replace the causal attribution established by the payload rubric.
+It answers whether matching presubmit coverage existed, whether it ran on the
+exact SHA that merged, what each terminal attempt reported, whether signal was
+optional/retried/overridden, and who performed any handling action.
+
+Prefer the snapshot artifact and the frozen config paths it names. Make no live
+GitHub lookup when that evidence is complete. If the candidate came from the
+live CI-infrastructure search in Step 3.6 or an older snapshot lacks the
+artifact, run the escape skill's bundled collector into `.work/` and record
+that fallback as a limitation. The collector still cuts evidence off at the PR
+merge timestamp.
+
+Attach the structured result to the candidate as `escape_analysis` using the
+schema in that skill. If required evidence is incomplete, attach an
+`outcome: unknown` result with exact limitations rather than omitting the
+analysis or guessing. In particular:
+
+- Do not infer a coverage gap from a periodic/presubmit job-name mismatch;
+  compare scenarios, test suites, configuration, and code paths.
+- Ignore failures on superseded PR commits. Only the head SHA that merged can
+  show ignored, retried, or overridden signal for the shipped code.
+- Attribute Chai only when the evidence says `actor_kind: chai`; preserve the
+  distinction between human, Chai, and other automation actors.
+- `/verified` is not automatically an override. Call it a verification bypass
+  only when it substituted for missing or failing matching CI.
+
 #### Failure type
 
 Set `failure_type` from the **root cause**, not the job family (an `e2e-*-upgrade` job can still be `infra`).
@@ -513,7 +557,7 @@ Stamp `action` / `outage_id` / `dashboard_url` onto each job from the tool resul
 
 Load the `payload-results-yaml` skill now (via the Skill tool) — this is its point of use — and follow it to create `$OUTPUT_DIR/payload-results-{tag}.yaml` (the `$OUTPUT_DIR` captured in Step 1).
 
-This file contains ALL scored candidates across all confidence tiers (HIGH, MEDIUM, LOW), enabling downstream commands to filter by their own criteria. RHCOS RPM candidates (Step 6.1b) are included in `candidates[]` with `type: "rhcos_rpm"` alongside PR candidates (`type: "pr"`), not in a separate array.
+This file contains ALL scored candidates across all confidence tiers (HIGH, MEDIUM, LOW), enabling downstream commands to filter by their own criteria. RHCOS RPM candidates (Step 6.1b) are included in `candidates[]` with `type: "rhcos_rpm"` alongside PR candidates (`type: "pr"`), not in a separate array. Every PR candidate scoring >= 85 also carries the Step 6.2b `escape_analysis` object.
 
 **Every affirmatively-identified root cause must be represented as a scored `candidates[]` entry** — including causal CI-infrastructure / step-registry changes (Step 3.6) and RHCOS RPM changes (Step 6.1b), even when the failure's `failure_type` is `infra`. A failure whose cause is known must not leave `candidates[]` empty; each entry carries its itemized rubric breakdown (Step 6.1) in its `rationale`.
 
@@ -564,8 +608,9 @@ Before presenting, confirm that **all Step 4 investigation subagents and the Ste
 2. **The HTML contains every required section** from the Step 7 template: header + executive summary (including the payload-chain context), the revert verdict (or the "No Recommended Reverts" verdict), the force-accept verdict when applicable, the blocking-jobs summary table, a collapsible details block for **every** failed job, the RHCOS Changes section when any payload has RHCOS changes, the informing-tests section when such tests exist, and the Adversarial Review section. No unfilled `{placeholder}` and no `BEGIN`/`END` marker comments remain.
 3. **Cross-output consistency**: phase, failure counts, per-job root causes (including any adjudicated in Step 5b), and scored candidates agree across the HTML, YAML, and JSON.
 4. **Every affirmative root cause appears as a scored `candidates[]` entry** — including causal CI-infrastructure changes, even when `failure_type: infra`.
-5. **HTML filename** ends with `-summary.html`. If a `payload-analysis-*.html` file exists without that suffix, rename it — do not leave the short name as the report.
-6. **SHIP Status**: every `failure_type: infra` job has a `ship_status` observation if `get_outages_during` / `list_components` are in the tool list. Omit the key only when those tools are absent. Mapped slugs must follow `references/ship-status-component-map.md` (broken system, not `spec.cluster` as a default).
+5. **Escape analysis**: every `type: pr` candidate scoring >= 85 has a structured `escape_analysis` in YAML and a matching HTML block. An incomplete evidence bundle yields `outcome: unknown` plus limitations, never a missing analysis.
+6. **HTML filename** ends with `-summary.html`. If a `payload-analysis-*.html` file exists without that suffix, rename it — do not leave the short name as the report.
+7. **SHIP Status**: every `failure_type: infra` job has a `ship_status` observation if `get_outages_during` / `list_components` are in the tool list. Omit the key only when those tools are absent. Mapped slugs must follow `references/ship-status-component-map.md` (broken system, not `spec.cluster` as a default).
 
 If any check fails, fix it before presenting.
 
@@ -609,6 +654,7 @@ Note: PR diff data not available in snapshot. Scoring based on component match a
 ## See Also
 
 - Related Skill: `payload-snapshot` — creates the snapshot data this skill consumes
+- Related Skill: `regression-escape-analysis` — explains how a known PR regression passed pre-merge controls
 - Related Skill: `payload-results-yaml` — schema for the results YAML
 - Related Skill: `payload-autodl-json` — schema for the autodl JSON data file
 - Related Skill: `prow-job-analysis` — deep test/install failure investigation (used by subagents)

--- a/plugins/ci/skills/payload-analysis/assets/report-template.html
+++ b/plugins/ci/skills/payload-analysis/assets/report-template.html
@@ -76,6 +76,8 @@ code { font-family: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace; fo
 .score-low { color: var(--text-muted); }
 .informing-note { background: rgba(88,166,255,0.1); border-left: 4px solid var(--blue); padding: 0.75rem 1rem; border-radius: 0 0.3rem 0.3rem 0; margin: 0.75rem 0; font-size: 0.9rem; }
 .rhcos-candidate { background: rgba(188,140,255,0.1); border-left: 4px solid var(--purple); padding: 0.75rem 1rem; border-radius: 0 0.3rem 0.3rem 0; margin: 0.75rem 0; }
+.escape-analysis { border-left: 4px solid var(--blue); padding-left: 1rem; margin: 1rem 0; }
+.escape-factor { margin-bottom: 0.4rem; }
 .footer { color: var(--text-muted); font-size: 0.8rem; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); }
 </style>
 </head>
@@ -145,6 +147,28 @@ code { font-family: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace; fo
   <p>Baseline: <a target="_blank" href="{baseline_url}">{baseline_tag}</a> ({hours_since_baseline}h ago)</p>
 </div>
 <!-- END: force-accept-verdict -->
+
+<!-- BEGIN: escape-analyses — include when at least one type: pr candidate scores >= 85 -->
+<div class="card">
+  <h2>Regression Escape Analysis</h2>
+  <p>Why each high-confidence regression passed the culprit PR's pre-merge controls.</p>
+  <!-- BEGIN: escape-analysis — one per type: pr candidate scoring >= 85 -->
+  <div class="escape-analysis">
+    <h3><a target="_blank" href="{pr_url}">#{pr_number}</a>: {escape_outcome}</h3>
+    <p>{escape_summary}</p>
+    <p><strong>Relevant presubmits:</strong> {escape_relevant_presubmits_summary}</p>
+    <ul>
+      <!-- BEGIN: escape-factor — one per contributing factor -->
+      <li class="escape-factor"><strong>{escape_factor_type}</strong>: {escape_factor_evidence}{escape_factor_actor_suffix}</li>
+      <!-- END: escape-factor -->
+    </ul>
+    <p><strong>Merge:</strong> {escape_merged_at}, by {escape_merged_by} ({escape_merged_by_kind})</p>
+    <p><strong>Recommended controls:</strong> {escape_recommendations}</p>
+    <p><strong>Limitations:</strong> {escape_limitations_or_none}</p>
+  </div>
+  <!-- END: escape-analysis -->
+</div>
+<!-- END: escape-analyses -->
 
 <!-- Blocking Jobs Summary Table -->
 <div class="card">

--- a/plugins/ci/skills/payload-analysis/references/completeness-review.md
+++ b/plugins/ci/skills/payload-analysis/references/completeness-review.md
@@ -11,6 +11,7 @@ The reviewer receives **only** the following (NOT the full conversation history)
 3. The `ANALYSIS_RESULT` blocks from all subagents in Step 4
 4. The revert recommendations (if any)
 5. The RHCOS RPM candidates (if any, identified by `type: "rhcos_rpm"` in the scored candidates)
+6. The structured escape analysis for every PR candidate scoring >= 85
 
 ## Reviewer prompt
 
@@ -37,6 +38,8 @@ Use this prompt:
 > 4. **Wrong reference for failure type**: Did the analysis route to the correct reference — install (and metal for metal jobs) for install failures, and the test/flaky-test reference for test failures? Using the wrong reference produces misdirected analysis.
 >
 > 5. **Missing RHCOS RPM candidates**: If RHCOS RPM changes exist in the originating payload and failures are variant-isolated or involve OS-level components, were the RPM changes scored as candidates alongside PRs? Were the RPM changelogs read and cited as evidence in the rubric breakdown? An RHCOS RPM change whose changelog was not consulted is like a PR candidate whose `code.diff` was never read — an incomplete investigation.
+>
+> 6. **Incomplete escape analysis**: Does every PR candidate scoring >= 85 explain merge-time presubmit coverage, runs on the exact SHA that merged, terminal retry history, optional/required status, explicit override/skip/verified actions, and actor attribution? Reject claims of retry masking based only on superseded commits, and reject Chai attribution unless the frozen evidence identifies `actor_kind: chai`. When evidence is missing, require an `outcome: unknown` result with exact limitations rather than a guess.
 >
 > **Rules**:
 > - Do NOT suggest lowering confidence scores. If the rubric signals fired (error message match, new failure, component exclusivity), the score is correct. Period.

--- a/plugins/ci/skills/payload-analysis/references/report-guide.md
+++ b/plugins/ci/skills/payload-analysis/references/report-guide.md
@@ -6,7 +6,7 @@ The report is produced by filling `assets/report-template.html` — never by wri
 
 - Replace every `{placeholder}` with a computed value. Any placeholder left in the final file is a defect (Step 10 check).
 - Blocks bounded by `<!-- BEGIN: name -->` / `<!-- END: name -->` comments are conditional or repeatable; the comment states the rule. Duplicate repeatable blocks once per item, drop conditional blocks whose condition is false, and remove all marker comments (and the leading contract comment) from the final file.
-- Keep the section order exactly as the template has it: header + metadata → executive summary → verdicts → blocking jobs summary → failed job details → RHCOS changes → informing tests → adversarial review → footer.
+- Keep the section order exactly as the template has it: header + metadata → executive summary → verdicts → regression escape analysis → blocking jobs summary → failed job details → RHCOS changes → informing tests → adversarial review → footer.
 - All `<a>` links use `target="_blank"` (already present in the template).
 - The file must remain fully self-contained: embedded CSS only, no external resources.
 
@@ -28,6 +28,24 @@ Placed immediately after the executive summary, before the blocking-jobs summary
 - `revert-verdict` — include when revert candidates exist (score >= 85). One `revert-row` per candidate. Keep the `/ci:payload-revert {payload_tag}` copy block.
 - `no-revert-verdict` — include when there are no revert candidates. Exactly one of these two blocks appears.
 - `force-accept-verdict` — include only when Step 6.4 recommends force-accept.
+
+## Regression escape analysis
+
+Include `escape-analyses` when at least one `type: "pr"` candidate scores >= 85.
+Render one `escape-analysis` block per such candidate from its structured
+`escape_analysis` object (Step 6.2b):
+
+- Show `outcome` and `summary` verbatim except for normal HTML escaping.
+- Summarize every `relevant_presubmits[]` entry with name, coverage,
+  required/optional/unknown, whether it ran on the merge SHA, and its
+  chronological `terminal_results`. Do not collapse a failure→success sequence
+  to the final result.
+- Render one `escape-factor` per factor. Include actor login and actor kind only
+  when present; preserve `human`, `chai`, and other `automation` attribution.
+- Fill merge actor/timestamp from `merge`, not from present-day GitHub state.
+- Join recommendations clearly. Render limitations as `None` when the array is
+  empty; otherwise list the missing evidence. An `outcome: unknown` block is
+  still required when evidence was incomplete.
 
 ## Blocking jobs summary
 

--- a/plugins/ci/skills/payload-results-yaml/SKILL.md
+++ b/plugins/ci/skills/payload-results-yaml/SKILL.md
@@ -79,6 +79,29 @@ candidates:
     rationale: "temporal match + component match + error references code changed"
     failing_jobs:
       - "periodic-ci-...-e2e-aws-ovn"
+    escape_analysis:
+      outcome: "false_negative"
+      summary: "The matching required presubmit ran and passed, but did not assert on the regressed path."
+      relevant_presubmits:
+        - name: "ci/prow/e2e-aws-ovn"
+          coverage: "partial"
+          required: true
+          selection: "always"
+          ran_on_merge_sha: true
+          terminal_results: ["success"]
+          assessment: "Exercises the component but not the failing gateway-mode case."
+      factors:
+        - type: "test_false_negative"
+          evidence: "e2e-aws-ovn passed on the merged SHA without exercising the failing assertion."
+          actor_login: ""
+          actor_kind: "unknown"
+      merge:
+        merged_at: "2026-02-20T12:00:00Z"
+        merged_by: "openshift-merge-bot[bot]"
+        merged_by_kind: "automation"
+      recommendations:
+        - "Add the gateway-mode case to the required e2e-aws-ovn presubmit."
+      limitations: []
     actions:
       - type: "revert"
         status: "staged"
@@ -178,6 +201,24 @@ Candidates reference failing jobs by `job_name` via the `failing_jobs` string ar
 | `pr_number` | int | PR number |
 | `component` | string | OCP component name |
 | `title` | string | PR title |
+| `escape_analysis` | object | Required for PR candidates with `confidence_score >= 85`. Merge-time explanation produced by `regression-escape-analysis`; see below. Omit on lower-confidence candidates because causality is not established strongly enough for an escape analysis. |
+
+#### `candidates[].escape_analysis`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outcome` | string | `coverage_gap`, `signal_handling`, `false_negative`, `mixed`, or `unknown` |
+| `summary` | string | Concise explanation of how the regression passed pre-merge controls |
+| `relevant_presubmits` | array | Matching jobs with `name`, `coverage`, `required`, `selection`, `ran_on_merge_sha`, `terminal_results`, and `assessment` |
+| `factors` | array | Contributing factors. Each has `type`, concrete `evidence`, and actor attribution when applicable (`actor_login`, `actor_kind`) |
+| `merge` | object | `merged_at`, `merged_by`, and `merged_by_kind` from frozen evidence |
+| `recommendations` | array of strings | Control improvements tied to demonstrated factors |
+| `limitations` | array of strings | Missing evidence or unresolved questions; required even when empty |
+
+Valid factor types are `coverage_gap`, `conditional_not_selected`,
+`optional_signal`, `did_not_run`, `retry_masking`, `override`,
+`verification_bypass`, `test_false_negative`, and `unknown`. Valid actor kinds
+are `human`, `chai`, `automation`, and `unknown`.
 
 **`type: "rhcos_rpm"` fields:**
 
@@ -235,7 +276,7 @@ Payload validation jobs triggered against the revert PR.
 
 ### Create (used by `payload-analysis`)
 
-Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, and `candidates` populated. All failed blocking jobs are recorded in `failing_jobs`. Every candidate carries a `type` (`"pr"` or `"rhcos_rpm"`). Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis for a `type: "pr"` candidate, append an action with `type: "revert"` and `status: "open"` or `"merged"`.
+Write a new `payload-results-{tag}.yaml` with `metadata`, `failing_jobs`, and `candidates` populated. All failed blocking jobs are recorded in `failing_jobs`. Every candidate carries a `type` (`"pr"` or `"rhcos_rpm"`). Every PR candidate scoring >= 85 carries `escape_analysis`; use `outcome: unknown` with limitations when its evidence is incomplete. Candidates with no pre-existing revert start with `actions: []`. If a pre-existing revert PR is discovered during analysis for a `type: "pr"` candidate, append an action with `type: "revert"` and `status: "open"` or `"merged"`.
 
 ### Read Candidates (used by `payload-revert`, `payload-experiment`)
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/test_validate.py
@@ -38,6 +38,8 @@ if __name__ == "__main__":
         ("invalid ship_status action", f"{TESTDATA}/invalid_ship_status_action.yaml", 1),
         ("invalid ship_status action missing or null", f"{TESTDATA}/invalid_ship_status_action_missing.yaml", 1),
         ("invalid ship_status null", f"{TESTDATA}/invalid_ship_status_null.yaml", 1),
+        ("invalid escape analysis", f"{TESTDATA}/invalid_escape_analysis.yaml", 1),
+        ("invalid high-confidence PR without escape analysis", f"{TESTDATA}/invalid_high_confidence_pr_without_escape.yaml", 1),
         ("file not found", f"{TESTDATA}/nonexistent.yaml", 1),
     ]
 

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_escape_analysis.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_escape_analysis.yaml
@@ -1,0 +1,24 @@
+metadata:
+  payload_tag: "4.22.0-0.nightly-2026-02-25-152806"
+  version: "4.22"
+  stream: "nightly"
+  architecture: "amd64"
+failing_jobs: []
+candidates:
+  - type: "pr"
+    pr_url: "https://github.com/openshift/example/pull/1"
+    confidence_score: 95
+    rationale: "test"
+    failing_jobs: []
+    escape_analysis:
+      outcome: "guessed"
+      summary: "invalid"
+      relevant_presubmits: []
+      factors:
+        - type: "override"
+          evidence: ""
+          actor_kind: "robot"
+      merge: {}
+      recommendations: []
+      limitations: []
+    actions: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_high_confidence_pr_without_escape.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/invalid_high_confidence_pr_without_escape.yaml
@@ -1,0 +1,13 @@
+metadata:
+  payload_tag: "4.22.0-0.nightly-2026-02-25-152806"
+  version: "4.22"
+  stream: "nightly"
+  architecture: "amd64"
+failing_jobs: []
+candidates:
+  - type: "pr"
+    pr_url: "https://github.com/openshift/example/pull/1"
+    confidence_score: 95
+    rationale: "high confidence"
+    failing_jobs: []
+    actions: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid.yaml
+++ b/plugins/ci/skills/payload-results-yaml/scripts/testdata/valid.yaml
@@ -24,4 +24,27 @@ candidates:
     rationale: "temporal match + component match + error references code changed"
     failing_jobs:
       - "periodic-ci-openshift-release-main-ci-4.22-e2e-aws-ovn"
+    escape_analysis:
+      outcome: "signal_handling"
+      summary: "The matching optional job failed and was explicitly overridden."
+      relevant_presubmits:
+        - name: "ci/prow/e2e-aws-ovn"
+          coverage: "full"
+          required: false
+          selection: "always"
+          ran_on_merge_sha: true
+          terminal_results: ["failure"]
+          assessment: "Reported the payload regression's failure signature."
+      factors:
+        - type: "override"
+          evidence: "A maintainer posted /override ci/prow/e2e-aws-ovn after the matching failure."
+          actor_login: "maintainer"
+          actor_kind: "human"
+      merge:
+        merged_at: "2026-02-20T12:00:00Z"
+        merged_by: "openshift-merge-bot[bot]"
+        merged_by_kind: "automation"
+      recommendations:
+        - "Require an explicit regression-specific rationale for overrides."
+      limitations: []
     actions: []

--- a/plugins/ci/skills/payload-results-yaml/scripts/validate.py
+++ b/plugins/ci/skills/payload-results-yaml/scripts/validate.py
@@ -12,6 +12,19 @@ REQUIRED_CANDIDATE_FIELDS_BY_TYPE = {
     "rhcos_rpm": ["package", "rhcos_tag", "changelog_evidence"],
 }
 SHIP_STATUS_ACTIONS = {"pending", "created", "linked", "skipped"}
+ESCAPE_OUTCOMES = {
+    "coverage_gap", "signal_handling", "false_negative", "mixed", "unknown",
+}
+ESCAPE_REQUIRED_FIELDS = {
+    "outcome", "summary", "relevant_presubmits", "factors", "merge",
+    "recommendations", "limitations",
+}
+ESCAPE_FACTOR_TYPES = {
+    "coverage_gap", "conditional_not_selected", "optional_signal",
+    "did_not_run", "retry_masking", "override", "verification_bypass",
+    "test_false_negative", "unknown",
+}
+ACTOR_KINDS = {"human", "chai", "automation", "unknown"}
 
 
 def validate(path):
@@ -104,6 +117,19 @@ def validate(path):
                     errors.append(
                         f"candidates[{i}] (type '{cand_type}') missing '{field}'"
                     )
+            score = cand.get("confidence_score")
+            if (
+                cand_type == "pr"
+                and isinstance(score, int)
+                and score >= 85
+                and "escape_analysis" not in cand
+            ):
+                errors.append(
+                    f"candidates[{i}] (high-confidence PR) missing "
+                    "'escape_analysis'"
+                )
+            if "escape_analysis" in cand:
+                _validate_escape_analysis(cand["escape_analysis"], i, errors)
 
     if errors:
         print(f"FAIL: {len(errors)} error(s)")
@@ -119,6 +145,42 @@ def validate(path):
         parts.append(f"{rhcos_rpm_cands} RHCOS RPM candidates")
     print(f"OK: {', '.join(parts)}")
     return 0
+
+
+def _validate_escape_analysis(escape, candidate_index, errors):
+    prefix = f"candidates[{candidate_index}].escape_analysis"
+    if not isinstance(escape, dict):
+        errors.append(f"{prefix} is not an object")
+        return
+    for field in sorted(ESCAPE_REQUIRED_FIELDS):
+        if field not in escape:
+            errors.append(f"{prefix} missing '{field}'")
+    outcome = escape.get("outcome")
+    if outcome not in ESCAPE_OUTCOMES:
+        errors.append(
+            f"{prefix}.outcome must be one of {sorted(ESCAPE_OUTCOMES)}, "
+            f"got {outcome!r}"
+        )
+    for field in ("relevant_presubmits", "factors", "recommendations", "limitations"):
+        if field in escape and not isinstance(escape[field], list):
+            errors.append(f"{prefix}.{field} is not a list")
+    for index, factor in enumerate(escape.get("factors", [])):
+        factor_prefix = f"{prefix}.factors[{index}]"
+        if not isinstance(factor, dict):
+            errors.append(f"{factor_prefix} is not an object")
+            continue
+        if factor.get("type") not in ESCAPE_FACTOR_TYPES:
+            errors.append(
+                f"{factor_prefix}.type must be one of "
+                f"{sorted(ESCAPE_FACTOR_TYPES)}, got {factor.get('type')!r}"
+            )
+        if not factor.get("evidence"):
+            errors.append(f"{factor_prefix}.evidence is required")
+        if "actor_kind" in factor and factor["actor_kind"] not in ACTOR_KINDS:
+            errors.append(
+                f"{factor_prefix}.actor_kind must be one of "
+                f"{sorted(ACTOR_KINDS)}, got {factor['actor_kind']!r}"
+            )
 
 
 if __name__ == "__main__":

--- a/plugins/ci/skills/payload-snapshot/SKILL.md
+++ b/plugins/ci/skills/payload-snapshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: payload-snapshot
-description: Snapshot OpenShift payload data (release controller, PR diffs, comments, CI jobs, JUnit results, regression tracking) to a local directory for offline analysis
+description: Use when snapshotting OpenShift payload data (release controller, PR diffs, merge-time CI evidence, JUnit results, regression tracking) to a local directory for offline analysis
 ---
 
 # Payload Snapshot
@@ -87,7 +87,7 @@ The script will:
 7. For each failed blocking job, download build-log.txt from GCS and extract error/warning lines + log tail
 8. Track test failure regressions — when did each failure first appear?
 9. Track per-job failure streaks — consecutive failures, originating payload, failure pattern
-10. For each unique PR across all changelogs, fetch the git diff, comments, and CI jobs via `gh`
+10. For each unique PR across all changelogs, fetch the git diff, comments, current CI rollup, and a merge-time escape-analysis evidence bundle via `gh`; freeze the repository's Prow and GitHub Actions configuration at the revisions effective when the PR merged
 11. For each payload in the chain, extract the full RPM database from RHCOS images via `podman`
 12. Diff the target payload's RPM changelogs against every older payload in the chain, using the extracted RPMDBs
 13. Generate summary.json with comprehensive triage data, plus AGENTS.md/CLAUDE.md for agent orientation
@@ -126,6 +126,8 @@ payload/
               code.diff                    # Git diff of the PR
               comments.json                # PR comments and reviews
               jobs.json                    # CI check runs
+              escape-analysis.json         # Merge-time statuses, chat-ops, actors, and CI config index
+              ci-config/                   # Frozen Prow/ci-operator and GitHub Actions files
         rpmdb/                             # RPMDB from RHCOS images
           rhel-coreos/                     # queryable with rpm --dbpath
             rpmdb.sqlite
@@ -214,7 +216,7 @@ Comprehensive stream-level triage data — start here. Contains:
 - `informing_jobs.failed_jobs[]` — job name strings
 - `test_failures.blocking[]` — **gating** failures only: `test_name`, `jobs`, `first_failed_in`, `payloads_failing`, `failure_message`, `failure_text` (full, not truncated). These are the failures that can fail a job and therefore reject the payload.
 - `test_failures.informing[]` / `test_failures.flakes[]` — `test_name`, `jobs`. Neither can fail a job. No onset is tracked for them, because an onset implies there is a culprit to find.
-- `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments paths, `rhcos_changes[]` with RPM diffs per RHCOS variant (package versions only — no changelog text), and, on every payload but the target, `rpm_changelogs[]` pointing at the report holding that text
+- `payloads[]` — per-payload entries with `tag`, `phase`, `source`, `changelog_source`, relative file paths, `prs[]` with component/diff/comments/jobs paths and optional `escape_analysis` path, `rhcos_changes[]` with RPM diffs per RHCOS variant (package versions only — no changelog text), and, on every payload but the target, `rpm_changelogs[]` pointing at the report holding that text
 - `rhcos_rpms[]` — RPMDB metadata for the target payload's RHCOS variants: `tag`, `name`, `pullspec`, `rpmdb` (relative path to rpmdb.sqlite)
 - `rpm_changelogs[]` — one RPM diff per (RHCOS variant, older payload in the chain): `variant`, `compared_tag`, `is_baseline`, `changed`/`added`/`removed` counts, and `changelogs` (relative path to the full report). The oldest surviving comparison per variant — normally the chain baseline — also carries `diff` inline, so target-vs-baseline needs no file read: `diff.changed[]` with `package`, `old`, `new` and `changelog` (the entries that version added), plus `diff.added[]` / `diff.removed[]` with `package` and `version`. The intermediate hops are a subset of that diff and stay behind their `changelogs` path; read them to find which hop introduced a given package bump. If the true chain baseline's RPMDB couldn't be read for a variant, the next-oldest readable comparison takes over `is_baseline`/`diff` instead, flagged with `baseline_rpmdb_missing: true` so consumers know the diff doesn't reach all the way back to the chain's actual start.
 - `data_complete` — `true` when all requested data was ultimately collected, including via a fallback after an initial read failed. `false` means some requested data could not be read at all.
@@ -387,6 +389,25 @@ Parsed JUnit test failures for a specific job. Only includes failed/error tests.
 
 PR artifacts from GitHub (unchanged from previous version).
 
+### `escape-analysis.json` and `ci-config/`
+
+A deterministic, merge-time evidence bundle for the `regression-escape-analysis`
+skill. It records PR/merge metadata, normalized chat-ops commands with actors,
+review history, every commit-status terminal attempt on the exact head SHA that
+merged, checks-api runs, and paths to frozen CI configuration.
+
+Events after the PR's `merged_at` timestamp are excluded. Prow and ci-operator
+configuration comes from the last `openshift/release` commit at or before the
+merge (or the PR base SHA for an openshift/release PR). Repository-owned
+`.ci-operator.yaml` and `.github/workflows/*` files come from the PR base SHA.
+This makes it possible to decide offline whether relevant coverage existed,
+ran, was optional, was retried, or was explicitly overridden.
+
+`redhat-chai-bot` is normalized as actor kind `chai`; human and other automation
+actors remain distinct. The bundle carries its own `data_complete` and
+`collection_errors` fields. A partial required read also marks the overall
+payload snapshot incomplete.
+
 ## Chain Logic
 
 The script chains backwards from the target payload until it finds a payload where **all blocking jobs succeeded**. This is stricter than the `Accepted` phase — a payload can be force-accepted with failed blocking jobs, which does not count as a stop point.
@@ -430,7 +451,7 @@ Aggregated jobs run the same underlying test multiple times with statistical ana
 ## Notes
 
 - The script uses only Python standard library — no pip dependencies
-- PR data is deduplicated across payloads — each PR is fetched once
+- PR data is deduplicated across payloads — each PR, including its merge-time escape evidence, is fetched once
 - JUnit and build-log download are scoped to failed blocking jobs only (informing jobs get `job.json` but no JUnit or build log)
 - The `--workers` flag controls parallelism for all subprocess calls (default 8)
 - Summary is always regenerated on re-run (not skipped like other files)

--- a/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
+++ b/plugins/ci/skills/payload-snapshot/scripts/payload_snapshot.py
@@ -731,9 +731,9 @@ class ChangelogCollector(Collector):
 
 
 class PullRequestCollector(Collector):
-    """Fetches diff, comments, and job data for a single GitHub PR.
+    """Fetches code, review, CI, and merge-time escape data for a GitHub PR.
 
-    Unlike other collectors that produce a single file, this writes three
+    Unlike other collectors that produce a single file, this writes several
     files into a directory.  ``output_path`` is the PR directory.
     """
 
@@ -744,7 +744,7 @@ class PullRequestCollector(Collector):
         self.pr_number = pr_number
 
     def collect(self) -> bool:
-        """Fetch all three PR artifacts independently."""
+        """Fetch all PR artifacts independently."""
         os.makedirs(self.output_path, exist_ok=True)
         wrote_any = False
 
@@ -781,6 +781,57 @@ class PullRequestCollector(Collector):
                 if result is not None:
                     _write_text(path, result)
                     wrote_any = True
+
+        escape_path = os.path.join(self.output_path, "escape-analysis.json")
+        existing_evidence = _read_json(escape_path)
+        if existing_evidence and not existing_evidence.get("data_complete", False):
+            os.remove(escape_path)
+        if not os.path.exists(escape_path):
+            script_path = (
+                Path(__file__).resolve().parents[2]
+                / "regression-escape-analysis"
+                / "scripts"
+                / "collect_pr_evidence.py"
+            )
+            command = [
+                sys.executable,
+                str(script_path),
+                f"https://github.com/{self.org}/{self.repo}/pull/{self.pr_number}",
+                "--output-dir",
+                self.output_path,
+            ]
+            try:
+                result = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                result = None
+                _record_collection_error(
+                    "command_failed",
+                    command,
+                    detail=str(exc),
+                    stage="pr_escape_evidence",
+                )
+            if result is not None and result.returncode == 0:
+                wrote_any = True
+                evidence = _read_json(escape_path)
+                if evidence and not evidence.get("data_complete", False):
+                    _record_collection_error(
+                        "command_failed",
+                        command,
+                        detail="merge-time PR evidence is partial",
+                        stage="pr_escape_evidence",
+                    )
+            elif result is not None:
+                _record_collection_error(
+                    "command_failed",
+                    command,
+                    detail=result.stderr,
+                    stage="pr_escape_evidence",
+                )
 
         return wrote_any
 
@@ -2010,6 +2061,8 @@ class SummaryGenerator:
             "          code.diff         # Full git diff",
             "          comments.json     # PR comments and reviews",
             "          jobs.json         # CI check runs",
+            "          escape-analysis.json # Merge-time CI/merge evidence",
+            "          ci-config/        # Frozen presubmit/workflow config",
             "    rpmdb/                    # RPMDB from RHCOS images",
             "      rhel-coreos/           # queryable with rpm --dbpath",
             "        rpmdb.sqlite",
@@ -2038,6 +2091,9 @@ class SummaryGenerator:
             "  payload, `payloads_failing` counts how many payloads it spans.",
             "- **Build log**: Error/warning lines extracted from the Prow",
             "  build-log.txt, plus the last 20% of the log for context.",
+            "- **Escape evidence**: Each PR may carry merge-time status",
+            "  attempts, chat-ops actors, and frozen CI configuration in",
+            "  `escape-analysis.json` for offline escape analysis.",
             "",
             "## summary.json Schema",
             "",
@@ -2056,7 +2112,8 @@ class SummaryGenerator:
             "  `failure_text`",
             "- `payloads[]` — per-payload entries with `tag`, `phase`,",
             "  `source`, `changelog_source`, relative paths, `prs[]` with",
-            "  component/diff/comments paths,",
+            "  component/diff/comments/jobs paths and optional",
+            "  `escape_analysis` path,",
             "  `rhcos_changes[]` with RPM diffs per RHCOS variant",
             "  (versions only — no changelog text),",
             "  `rhcos_rpms[]` with rpmdb.sqlite per variant, and, on every",
@@ -2264,6 +2321,16 @@ class SummaryGenerator:
                             "diff": f"{tag_rel}/{p['component']}/prs/{p['number']}/code.diff",
                             "comments": f"{tag_rel}/{p['component']}/prs/{p['number']}/comments.json",
                             "jobs": f"{tag_rel}/{p['component']}/prs/{p['number']}/jobs.json",
+                            **({
+                                "escape_analysis": (
+                                    f"{tag_rel}/{p['component']}/prs/"
+                                    f"{p['number']}/escape-analysis.json"
+                                )
+                            } if os.path.exists(os.path.join(
+                                self.base_dir, tag_name, p["component"],
+                                "prs", str(p["number"]),
+                                "escape-analysis.json",
+                            )) else {}),
                         }
                         for p in prs
                     ]

--- a/plugins/ci/skills/regression-escape-analysis/SKILL.md
+++ b/plugins/ci/skills/regression-escape-analysis/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: regression-escape-analysis
+description: Use when explaining how a known regression escaped through a culprit pull request by comparing the regression with merge-time CI coverage, execution history, retries, and overrides. Requires an already-identified regression and likely culprit PR.
+---
+
+# Regression Escape Analysis
+
+Analyze why a known regression was allowed to merge. This skill does not find
+the culprit: the caller must provide both the regression and a likely causal
+PR. Its job is to distinguish missing coverage, a test that ran but missed the
+problem, optional or skipped signal, retry masking, and an explicit override.
+
+Prefer frozen evidence produced by the bundled collector. A payload snapshot
+stores that evidence as the PR's `escape_analysis` artifact, so payload analysis
+normally requires no live GitHub calls.
+
+## Inputs
+
+Require:
+
+- A regression description containing the affected jobs or environments, the
+  failing tests or operations, the failure mechanism, and key error patterns.
+- The culprit PR URL.
+- Preferably, an `escape-analysis.json` evidence path.
+
+If the evidence path is absent, collect it before analysis:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/regression-escape-analysis/scripts/collect_pr_evidence.py" \
+  <pr-url> --output-dir .work/regression-escape/<owner>-<repo>-<number>
+```
+
+Do not use present-day PR state as a substitute for merge-time evidence. The
+collector cuts comments, reviews, statuses, and checks off at `pr.merged_at`
+and snapshots CI configuration at the revision effective when the PR merged.
+
+Read [references/evidence-schema.md](references/evidence-schema.md) when
+interpreting the evidence or producing the structured result.
+
+## Analysis
+
+1. Establish the regression mechanism before looking at CI job names. Reduce it
+   to the scenario, phase, component/code path, and failure signature that a
+   useful presubmit would need to exercise.
+2. Read every file listed under `ci_configuration`. Compare the mechanism with
+   the configured presubmits and repository workflows. A differently named job
+   may still cover the same scenario; a similarly named job may not.
+3. Identify relevant presubmits and classify each as required, optional,
+   conditional/manual, or unknown from its configuration. `optional: true`
+   means Tide can ignore its result. `always_run: false` plus a trigger or
+   `run_if_changed` means the job is conditional; determine whether this PR
+   should have selected it.
+4. Use only status/check history for `pr.head_sha`, the revision that merged.
+   Failures on superseded commits are not evidence that failing signal was
+   ignored. Count terminal attempts, not pending status updates. Use
+   `ci_reported_failures[]` to cross-check the tested commit, required flag,
+   rerun command, and Prow run URL from the bot's own test report.
+5. Compare the relevant terminal attempts with chat-ops actions:
+   - A failure followed by a pass on the same SHA is a retry pattern. Call it
+     masking only when the failed attempt shows the regression's failure mode
+     and the later pass did not establish that the first failure was unrelated
+     infrastructure.
+   - `/override` and `/skip` are explicit signal-handling actions. Attribute
+     them to the normalized `actor_kind` in the evidence.
+   - `/verified` is verification evidence, not automatically a CI override.
+     Treat it as a bypass only when the evidence shows that it satisfied a
+     merge requirement despite missing or failing relevant CI.
+   - Do not infer that another bot is Chai. Only evidence normalized as
+     `actor_kind: chai` has that attribution.
+6. Determine the escape factors. More than one can apply:
+   - `coverage_gap`: no configured presubmit exercises the regression scenario.
+   - `conditional_not_selected`: relevant coverage existed but was not selected.
+   - `optional_signal`: relevant CI failed but was non-required.
+   - `did_not_run`: a relevant required job was configured but has no run on the
+     merge SHA.
+   - `retry_masking`: the matching failure was replaced by a passing retry on
+     the same SHA without a code change.
+   - `override`: matching failed CI was explicitly overridden or skipped.
+   - `verification_bypass`: a verification action substituted for missing or
+     failing matching CI.
+   - `test_false_negative`: relevant required CI ran and passed, but its
+     assertions or environment did not expose the regression.
+   - `unknown`: evidence is too incomplete to decide.
+7. State what should change: add or broaden coverage, make an existing job
+   required, repair selection rules, limit retries, or tighten override policy.
+   Tie every recommendation to a demonstrated factor.
+
+## Guardrails
+
+- Do not claim a coverage gap from job-name mismatch alone.
+- Do not claim retry masking without a matching failed attempt on the merge SHA.
+- Do not call a failed optional job an override; optionality itself explains why
+  it did not gate.
+- Do not treat a green job as proof of adequate coverage. If it exercised only
+  an adjacent scenario, the factor is still a coverage gap; if it exercised the
+  scenario but lacked the right assertion, it is a false negative.
+- Preserve uncertainty. If `data_complete` is false or a required config/status
+  source is missing, identify exactly which conclusion cannot be made.
+
+Return the structured result defined in the evidence reference. Keep the
+summary concise, but retain concrete job names, attempt results, actors, and
+timestamps in the evidence lines.

--- a/plugins/ci/skills/regression-escape-analysis/references/evidence-schema.md
+++ b/plugins/ci/skills/regression-escape-analysis/references/evidence-schema.md
@@ -1,0 +1,87 @@
+# Escape Evidence and Result Schema
+
+## Collector output
+
+`escape-analysis.json` is a frozen merge-time evidence bundle:
+
+- `schema_version`: evidence schema version.
+- `collected_at`: collector timestamp.
+- `cutoff`: normally the PR merge timestamp. Events after this are excluded.
+- `data_complete`: false when a required GitHub or CI-configuration read failed.
+- `collection_errors[]`: source and error for unavailable reads.
+- `pr`: URL, repository, number, author, base branch/base SHA, merge head SHA,
+  merge commit, merge timestamp, merge actor, labels, and merge mechanism.
+- `chatops_actions[]`: normalized command, action, arguments, timestamp, actor,
+  and `actor_kind` (`human`, `chai`, `automation`, or `unknown`).
+- `ci_reported_failures[]`: normalized rows from Prow's PR test-report comments,
+  including context, tested commit, Prow URL, required flag, rerun command,
+  report timestamp, and report actor.
+- `reviews[]`: review state, commit, timestamp, and normalized actor.
+- `status_contexts[]`: one entry per commit-status context on the merge head.
+  `events` contains all status updates chronologically; `terminal_attempts`
+  contains only success/failure/error terminals and is the retry history.
+- `check_runs[]`: checks-api runs on the merge head, for CI systems that use
+  Checks rather than commit statuses.
+- `ci_configuration`: frozen source revisions and snapshot-relative paths for:
+  - `openshift_release.ci_operator_configs[]`
+  - `openshift_release.prow_presubmits[]`
+  - `repository.ci_operator[]`
+  - `repository.workflows[]`
+
+The openshift/release files are selected by PR repository and base branch at
+the last openshift/release commit at or before merge. For a PR against
+openshift/release itself, the PR's base SHA is used.
+
+Prow terminal attempts are distinct terminal status events, normally with
+distinct `target_url` build IDs. Pending events do not count as attempts.
+
+`redhat-chai-bot` is normalized to `actor_kind: chai` even though the GitHub
+account is represented as a user. Other bots remain `automation`; do not infer
+additional Chai identities.
+
+## Analysis result
+
+Attach this object to the culprit candidate as `escape_analysis`:
+
+```yaml
+escape_analysis:
+  outcome: mixed
+  summary: "The relevant job was optional and its matching failure was replaced by a green retry."
+  relevant_presubmits:
+    - name: "ci/prow/e2e-aws"
+      coverage: full
+      required: false
+      selection: always
+      ran_on_merge_sha: true
+      terminal_results: [failure, success]
+      assessment: "Exercises the failing AWS upgrade path and reported the same error."
+  factors:
+    - type: optional_signal
+      evidence: "e2e-aws has optional: true and failed on the merge SHA."
+      actor_login: ""
+      actor_kind: unknown
+    - type: retry_masking
+      evidence: "Build 123 failed with the regression signature; build 124 passed on the same SHA after /retest."
+      actor_login: "contributor"
+      actor_kind: human
+  merge:
+    merged_at: "2026-01-02T03:04:05Z"
+    merged_by: "openshift-merge-bot[bot]"
+    merged_by_kind: automation
+  recommendations:
+    - "Make e2e-aws required for changes to the affected path."
+  limitations: []
+```
+
+Rules:
+
+- `outcome`: `coverage_gap`, `signal_handling`, `false_negative`, `mixed`, or
+  `unknown`.
+- `coverage`: `full`, `partial`, `none`, or `unknown`.
+- `required`: boolean or null when unavailable.
+- `selection`: `always`, `conditional`, `manual`, or `unknown`.
+- `terminal_results`: chronological terminal conclusions on the merge SHA.
+- `factors[].type`: one of the factor names in the main skill.
+- `actor_kind`: `human`, `chai`, `automation`, or `unknown`. Leave actor fields
+  empty/unknown when the factor has no actor.
+- `limitations` is required, even when empty.

--- a/plugins/ci/skills/regression-escape-analysis/scripts/collect_pr_evidence.py
+++ b/plugins/ci/skills/regression-escape-analysis/scripts/collect_pr_evidence.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Collect frozen merge-time evidence for regression escape analysis."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+CHAI_LOGINS = {"redhat-chai-bot", "redhat-chai-bot[bot]"}
+TERMINAL_STATES = {"success", "failure", "error"}
+CHATOPS_RE = re.compile(
+    r"^\s*/(override|skip|retest-required|retest|test|verified|lgtm|approve|hold|unhold)"
+    r"(?:[ \t]+([^\r\n]*?))?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+PROW_REPORT_ROW_RE = re.compile(
+    r"^\s*(ci/prow/[^|]+?)\s*\|\s*([0-9a-f]{7,40})\s*\|\s*"
+    r"\[link\]\((https://prow\.ci\.openshift\.org/[^)]+)\)\s*\|\s*"
+    r"(true|false)\s*\|\s*`?(/[^`\r\n]+)`?\s*$",
+    re.IGNORECASE,
+)
+
+
+def parse_pr_url(url):
+    match = re.fullmatch(
+        r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)/?", url.strip()
+    )
+    if not match:
+        raise ValueError(f"not a GitHub pull request URL: {url}")
+    return match.group(1), match.group(2), int(match.group(3))
+
+
+def run_gh_json(endpoint, paginate=False):
+    args = ["gh", "api"]
+    if paginate:
+        args.extend(["--paginate", "--slurp"])
+    args.append(endpoint)
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=180, check=False
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return None, str(exc)
+    if result.returncode != 0:
+        error = result.stderr.strip() or f"gh exited {result.returncode}"
+        if "HTTP 404" in error or "Not Found" in error:
+            return None, "not_found"
+        return None, error[:500]
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc}"
+    if not paginate:
+        return data, None
+    flattened = []
+    for page in data:
+        if isinstance(page, list):
+            flattened.extend(page)
+        else:
+            flattened.append(page)
+    return flattened, None
+
+
+def actor(user):
+    if not isinstance(user, dict):
+        return {"login": "", "type": "", "kind": "unknown"}
+    login = user.get("login") or ""
+    user_type = user.get("type") or ""
+    lowered = login.lower()
+    if lowered in CHAI_LOGINS:
+        kind = "chai"
+    elif user_type.lower() == "bot" or lowered.endswith("[bot]"):
+        kind = "automation"
+    elif login:
+        kind = "human"
+    else:
+        kind = "unknown"
+    return {"login": login, "type": user_type, "kind": kind}
+
+
+def at_or_before(timestamp, cutoff):
+    return bool(timestamp) and (not cutoff or timestamp <= cutoff)
+
+
+def extract_chatops_actions(comments, cutoff):
+    actions = []
+    for comment in comments or []:
+        created_at = comment.get("created_at", "")
+        if not at_or_before(created_at, cutoff):
+            continue
+        who = actor(comment.get("user"))
+        for match in CHATOPS_RE.finditer(comment.get("body") or ""):
+            action = match.group(1).lower()
+            arguments = (match.group(2) or "").strip()
+            command = f"/{action}" + (f" {arguments}" if arguments else "")
+            actions.append({
+                "action": action,
+                "arguments": arguments,
+                "command": command,
+                "created_at": created_at,
+                "actor": who,
+                "url": comment.get("html_url", ""),
+            })
+    return sorted(actions, key=lambda item: item["created_at"])
+
+
+def normalize_reviews(reviews, cutoff):
+    normalized = []
+    for review in reviews or []:
+        submitted_at = review.get("submitted_at", "")
+        if not at_or_before(submitted_at, cutoff):
+            continue
+        normalized.append({
+            "state": (review.get("state") or "").lower(),
+            "commit_id": review.get("commit_id") or "",
+            "submitted_at": submitted_at,
+            "actor": actor(review.get("user")),
+            "url": review.get("html_url", ""),
+        })
+    return sorted(normalized, key=lambda item: item["submitted_at"])
+
+
+def extract_ci_reported_failures(comments, cutoff):
+    failures = []
+    for comment in comments or []:
+        created_at = comment.get("created_at", "")
+        if not at_or_before(created_at, cutoff):
+            continue
+        for line in (comment.get("body") or "").splitlines():
+            match = PROW_REPORT_ROW_RE.match(line)
+            if not match:
+                continue
+            failures.append({
+                "context": match.group(1).strip(),
+                "commit_sha": match.group(2),
+                "prow_url": match.group(3),
+                "required": match.group(4).lower() == "true",
+                "rerun_command": match.group(5).strip(),
+                "reported_at": created_at,
+                "report_actor": actor(comment.get("user")),
+                "report_url": comment.get("html_url", ""),
+            })
+    return sorted(failures, key=lambda item: (item["reported_at"], item["context"]))
+
+
+def normalize_status_contexts(statuses, cutoff):
+    grouped = defaultdict(list)
+    for status in statuses or []:
+        created_at = status.get("created_at", "")
+        if not at_or_before(created_at, cutoff):
+            continue
+        grouped[status.get("context") or "(unnamed)"].append({
+            "state": (status.get("state") or "").lower(),
+            "created_at": created_at,
+            "updated_at": status.get("updated_at") or "",
+            "target_url": status.get("target_url") or "",
+            "description": status.get("description") or "",
+            "actor": actor(status.get("creator")),
+        })
+
+    contexts = []
+    for context, events in grouped.items():
+        events.sort(key=lambda item: (item["created_at"], item["updated_at"]))
+        terminals = [event for event in events if event["state"] in TERMINAL_STATES]
+        contexts.append({
+            "context": context,
+            "events": events,
+            "terminal_attempts": terminals,
+            "retry_count": max(0, len(terminals) - 1),
+        })
+    return sorted(contexts, key=lambda item: item["context"])
+
+
+def normalize_check_runs(pages, cutoff):
+    runs = []
+    for page in pages or []:
+        candidates = page.get("check_runs", []) if isinstance(page, dict) else []
+        for check in candidates:
+            started_at = check.get("started_at") or check.get("created_at") or ""
+            if not at_or_before(started_at, cutoff):
+                continue
+            completed_at = check.get("completed_at")
+            completed_by_cutoff = at_or_before(completed_at, cutoff)
+            runs.append({
+                "name": check.get("name") or "",
+                "status": check.get("status") if completed_by_cutoff else "in_progress",
+                "conclusion": check.get("conclusion") if completed_by_cutoff else None,
+                "started_at": started_at,
+                "completed_at": completed_at if completed_by_cutoff else None,
+                "details_url": check.get("details_url") or "",
+                "app": (check.get("app") or {}).get("slug", ""),
+            })
+    return sorted(runs, key=lambda item: (item["name"], item["started_at"]))
+
+
+def download_file(url, destination):
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "regression-escape-analysis/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        content = response.read()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(content)
+
+
+def branch_prefix(org, repo, branch):
+    branch_slug = branch.replace("/", "-")
+    return f"{org}-{repo}-{branch_slug}"
+
+
+def snapshot_entries(entries, output_dir, subdir, predicate, errors):
+    saved = []
+    for entry in entries or []:
+        if entry.get("type") != "file" or not predicate(entry.get("name", "")):
+            continue
+        destination = output_dir / "ci-config" / subdir / entry["name"]
+        try:
+            download_file(entry["download_url"], destination)
+        except (OSError, urllib.error.URLError) as exc:
+            errors.append({
+                "source": entry.get("path", entry["name"]),
+                "error": str(exc),
+            })
+            continue
+        saved.append({
+            "source_path": entry.get("path", ""),
+            "source_sha": entry.get("sha", ""),
+            "snapshot_path": str(destination.relative_to(output_dir)),
+        })
+    return saved
+
+
+def fetch_directory(repo, path, ref, errors, required=False):
+    endpoint = (
+        f"repos/{repo}/contents/{path}?ref={urllib.parse.quote(ref, safe='')}"
+    )
+    data, error = run_gh_json(endpoint)
+    if error == "not_found":
+        return []
+    if error:
+        errors.append({"source": path, "error": error, "required": required})
+        return []
+    return data if isinstance(data, list) else []
+
+
+def fetch_file_entry(repo, path, ref, errors):
+    endpoint = (
+        f"repos/{repo}/contents/{path}?ref={urllib.parse.quote(ref, safe='')}"
+    )
+    data, error = run_gh_json(endpoint)
+    if error == "not_found":
+        return []
+    if error:
+        errors.append({"source": path, "error": error, "required": False})
+        return []
+    return [data] if isinstance(data, dict) else []
+
+
+def collect_ci_configuration(org, repo, pr_meta, output_dir, errors):
+    base_ref = pr_meta.get("base", {}).get("ref") or ""
+    base_sha = pr_meta.get("base", {}).get("sha") or ""
+    merged_at = pr_meta.get("merged_at") or ""
+    full_repo = f"{org}/{repo}"
+
+    if full_repo == "openshift/release":
+        release_ref = base_sha
+    else:
+        commits, error = run_gh_json(
+            "repos/openshift/release/commits"
+            f"?until={urllib.parse.quote(merged_at, safe=':-TZ')}&per_page=1"
+        )
+        if error or not commits:
+            errors.append({
+                "source": "openshift/release merge-time revision",
+                "error": error or "no commit found",
+                "required": True,
+            })
+            release_ref = ""
+        else:
+            release_ref = commits[0].get("sha", "")
+
+    prefix = branch_prefix(org, repo, base_ref)
+    release_config = []
+    release_jobs = []
+    if release_ref:
+        config_path = f"ci-operator/config/{org}/{repo}"
+        job_path = f"ci-operator/jobs/{org}/{repo}"
+        config_entries = fetch_directory(
+            "openshift/release", config_path, release_ref, errors, required=True
+        )
+        job_entries = fetch_directory(
+            "openshift/release", job_path, release_ref, errors, required=True
+        )
+        release_config = snapshot_entries(
+            config_entries,
+            output_dir,
+            "openshift-release",
+            lambda name: name == f"{prefix}.yaml"
+            or (name.startswith(f"{prefix}__") and name.endswith(".yaml")),
+            errors,
+        )
+        release_jobs = snapshot_entries(
+            job_entries,
+            output_dir,
+            "openshift-release",
+            lambda name: name == f"{prefix}-presubmits.yaml",
+            errors,
+        )
+
+    workflow_entries = fetch_directory(
+        full_repo, ".github/workflows", base_sha, errors, required=False
+    )
+    workflows = snapshot_entries(
+        workflow_entries,
+        output_dir,
+        "repository-workflows",
+        lambda name: name.endswith((".yml", ".yaml")),
+        errors,
+    )
+    local_ci_entries = fetch_file_entry(
+        full_repo, ".ci-operator.yaml", base_sha, errors
+    )
+    local_ci = snapshot_entries(
+        local_ci_entries,
+        output_dir,
+        "repository",
+        lambda name: name == ".ci-operator.yaml",
+        errors,
+    )
+
+    return {
+        "openshift_release": {
+            "repository": "openshift/release",
+            "ref": release_ref,
+            "selected_at": merged_at,
+            "ci_operator_configs": release_config,
+            "prow_presubmits": release_jobs,
+        },
+        "repository": {
+            "repository": full_repo,
+            "ref": base_sha,
+            "ci_operator": local_ci,
+            "workflows": workflows,
+        },
+    }
+
+
+def collect(pr_url, output_dir):
+    org, repo, number = parse_pr_url(pr_url)
+    errors = []
+    pr_meta, error = run_gh_json(f"repos/{org}/{repo}/pulls/{number}")
+    if error or not pr_meta:
+        raise RuntimeError(error or "pull request metadata unavailable")
+    if not pr_meta.get("merged_at"):
+        raise RuntimeError("pull request has not merged; no escape point exists")
+
+    cutoff = pr_meta["merged_at"]
+    head_sha = pr_meta.get("head", {}).get("sha") or ""
+    sources = {}
+    endpoints = {
+        "comments": (f"repos/{org}/{repo}/issues/{number}/comments?per_page=100", True),
+        "reviews": (f"repos/{org}/{repo}/pulls/{number}/reviews?per_page=100", True),
+        "statuses": (f"repos/{org}/{repo}/commits/{head_sha}/statuses?per_page=100", True),
+        "checks": (f"repos/{org}/{repo}/commits/{head_sha}/check-runs?filter=all&per_page=100", True),
+    }
+    for name, (endpoint, paginate) in endpoints.items():
+        value, source_error = run_gh_json(endpoint, paginate=paginate)
+        if source_error == "not_found" and name == "checks":
+            value, source_error = [], None
+        if source_error:
+            errors.append({"source": name, "error": source_error, "required": name != "checks"})
+            value = []
+        sources[name] = value
+
+    ci_configuration = collect_ci_configuration(
+        org, repo, pr_meta, output_dir, errors
+    )
+    merged_by = actor(pr_meta.get("merged_by"))
+    merge_mechanism = (
+        "tide"
+        if "openshift-merge-bot" in merged_by["login"].lower()
+        else "direct_or_other"
+    )
+    labels = sorted(label.get("name", "") for label in pr_meta.get("labels", []))
+
+    evidence = {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "cutoff": cutoff,
+        "data_complete": not any(error.get("required") for error in errors),
+        "collection_errors": errors,
+        "pr": {
+            "url": pr_meta.get("html_url") or pr_url,
+            "repository": f"{org}/{repo}",
+            "number": number,
+            "title": pr_meta.get("title") or "",
+            "author": actor(pr_meta.get("user")),
+            "base_ref": pr_meta.get("base", {}).get("ref") or "",
+            "base_sha": pr_meta.get("base", {}).get("sha") or "",
+            "head_sha": head_sha,
+            "merge_commit_sha": pr_meta.get("merge_commit_sha") or "",
+            "merged_at": cutoff,
+            "merged_by": merged_by,
+            "merge_mechanism": merge_mechanism,
+            "labels_at_collection": labels,
+        },
+        "chatops_actions": extract_chatops_actions(sources["comments"], cutoff),
+        "ci_reported_failures": extract_ci_reported_failures(
+            sources["comments"], cutoff
+        ),
+        "reviews": normalize_reviews(sources["reviews"], cutoff),
+        "status_contexts": normalize_status_contexts(sources["statuses"], cutoff),
+        "check_runs": normalize_check_runs(sources["checks"], cutoff),
+        "ci_configuration": ci_configuration,
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / "escape-analysis.json"
+    destination.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+    return destination
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect merge-time PR evidence for regression escape analysis."
+    )
+    parser.add_argument("pr_url")
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+    try:
+        destination = collect(args.pr_url, Path(args.output_dir).resolve())
+    except (ValueError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/ci/skills/regression-escape-analysis/scripts/test_collect_pr_evidence.py
+++ b/plugins/ci/skills/regression-escape-analysis/scripts/test_collect_pr_evidence.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Tests for deterministic PR escape-evidence collection."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "collect_pr_evidence", HERE / "collect_pr_evidence.py"
+)
+evidence = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(evidence)
+
+
+def test_actor_classifies_chai_user_explicitly():
+    assert evidence.actor({"login": "redhat-chai-bot", "type": "User"})["kind"] == "chai"
+    assert evidence.actor({"login": "openshift-ci[bot]", "type": "Bot"})["kind"] == "automation"
+    assert evidence.actor({"login": "maintainer", "type": "User"})["kind"] == "human"
+
+
+def test_chatops_actions_are_cut_off_at_merge():
+    comments = [
+        {
+            "created_at": "2026-01-01T01:00:00Z",
+            "body": "/retest\n/override ci/prow/e2e-aws",
+            "user": {"login": "redhat-chai-bot", "type": "User"},
+        },
+        {
+            "created_at": "2026-01-03T01:00:00Z",
+            "body": "/override ci/prow/unit",
+            "user": {"login": "maintainer", "type": "User"},
+        },
+    ]
+
+    actions = evidence.extract_chatops_actions(comments, "2026-01-02T00:00:00Z")
+
+    assert [item["action"] for item in actions] == ["retest", "override"]
+    assert actions[1]["arguments"] == "ci/prow/e2e-aws"
+    assert actions[1]["actor"]["kind"] == "chai"
+
+
+def test_status_history_counts_terminal_attempts_not_pending_updates():
+    statuses = [
+        {"context": "ci/prow/e2e", "state": "pending", "created_at": "2026-01-01T00:00:00Z"},
+        {"context": "ci/prow/e2e", "state": "failure", "created_at": "2026-01-01T01:00:00Z", "target_url": "build/1"},
+        {"context": "ci/prow/e2e", "state": "pending", "created_at": "2026-01-01T02:00:00Z"},
+        {"context": "ci/prow/e2e", "state": "success", "created_at": "2026-01-01T03:00:00Z", "target_url": "build/2"},
+    ]
+
+    contexts = evidence.normalize_status_contexts(statuses, "2026-01-02T00:00:00Z")
+
+    assert len(contexts) == 1
+    assert [attempt["state"] for attempt in contexts[0]["terminal_attempts"]] == [
+        "failure",
+        "success",
+    ]
+    assert contexts[0]["retry_count"] == 1
+
+
+def test_ci_report_rows_preserve_commit_required_flag_and_run_url():
+    comments = [{
+        "created_at": "2026-01-01T04:00:00Z",
+        "user": {"login": "openshift-ci[bot]", "type": "Bot"},
+        "body": (
+            "ci/prow/e2e-aws | abcdef123 | "
+            "[link](https://prow.ci.openshift.org/view/gs/bucket/build) | "
+            "false | `/test e2e-aws`"
+        ),
+    }]
+
+    failures = evidence.extract_ci_reported_failures(
+        comments, "2026-01-02T00:00:00Z"
+    )
+
+    assert failures == [{
+        "context": "ci/prow/e2e-aws",
+        "commit_sha": "abcdef123",
+        "prow_url": "https://prow.ci.openshift.org/view/gs/bucket/build",
+        "required": False,
+        "rerun_command": "/test e2e-aws",
+        "reported_at": "2026-01-01T04:00:00Z",
+        "report_actor": {
+            "login": "openshift-ci[bot]",
+            "type": "Bot",
+            "kind": "automation",
+        },
+        "report_url": "",
+    }]
+
+
+def test_check_finishing_after_merge_is_still_in_progress_at_cutoff():
+    pages = [{"check_runs": [{
+        "name": "unit",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": "2026-01-01T23:00:00Z",
+        "completed_at": "2026-01-02T01:00:00Z",
+    }]}]
+
+    runs = evidence.normalize_check_runs(pages, "2026-01-02T00:00:00Z")
+
+    assert runs[0]["status"] == "in_progress"
+    assert runs[0]["conclusion"] is None
+    assert runs[0]["completed_at"] is None
+
+
+def test_collect_writes_self_contained_merge_time_bundle(tmp_path, monkeypatch):
+    pr_meta = {
+        "html_url": "https://github.com/openshift/example/pull/7",
+        "title": "Break the example",
+        "merged_at": "2026-01-02T00:00:00Z",
+        "merge_commit_sha": "merge",
+        "merged_by": {"login": "openshift-merge-bot[bot]", "type": "Bot"},
+        "user": {"login": "author", "type": "User"},
+        "base": {"ref": "release-4.22", "sha": "base"},
+        "head": {"sha": "head"},
+        "labels": [{"name": "verified"}],
+    }
+
+    def fake_gh(endpoint, paginate=False):
+        if endpoint == "repos/openshift/example/pulls/7":
+            return pr_meta, None
+        if "/issues/7/comments" in endpoint:
+            return [{
+                "created_at": "2026-01-01T22:00:00Z",
+                "body": "/override ci/prow/e2e",
+                "user": {"login": "maintainer", "type": "User"},
+            }], None
+        if "/pulls/7/reviews" in endpoint:
+            return [], None
+        if "/statuses" in endpoint:
+            return [{
+                "context": "ci/prow/e2e",
+                "state": "failure",
+                "created_at": "2026-01-01T21:00:00Z",
+                "target_url": "build/1",
+            }], None
+        if "/check-runs" in endpoint:
+            return [], None
+        if endpoint.startswith("repos/openshift/release/commits?"):
+            return [{"sha": "release-ref"}], None
+        if "contents/ci-operator/config/openshift/example" in endpoint:
+            return [{
+                "type": "file",
+                "name": "openshift-example-release-4.22.yaml",
+                "path": "ci-operator/config/openshift/example/openshift-example-release-4.22.yaml",
+                "sha": "config-blob",
+                "download_url": "https://example/config",
+            }], None
+        if "contents/ci-operator/jobs/openshift/example" in endpoint:
+            return [{
+                "type": "file",
+                "name": "openshift-example-release-4.22-presubmits.yaml",
+                "path": "ci-operator/jobs/openshift/example/openshift-example-release-4.22-presubmits.yaml",
+                "sha": "jobs-blob",
+                "download_url": "https://example/jobs",
+            }], None
+        if "contents/.github/workflows" in endpoint:
+            return None, "not_found"
+        if "contents/.ci-operator.yaml" in endpoint:
+            return None, "not_found"
+        raise AssertionError(endpoint)
+
+    def fake_download(url, destination):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(f"source: {url}\n", encoding="utf-8")
+
+    monkeypatch.setattr(evidence, "run_gh_json", fake_gh)
+    monkeypatch.setattr(evidence, "download_file", fake_download)
+
+    destination = evidence.collect(
+        "https://github.com/openshift/example/pull/7", tmp_path
+    )
+    bundle = json.loads(destination.read_text(encoding="utf-8"))
+
+    assert bundle["data_complete"] is True
+    assert bundle["pr"]["head_sha"] == "head"
+    assert bundle["pr"]["merge_mechanism"] == "tide"
+    assert bundle["chatops_actions"][0]["actor"]["kind"] == "human"
+    assert bundle["status_contexts"][0]["terminal_attempts"][0]["state"] == "failure"
+    release = bundle["ci_configuration"]["openshift_release"]
+    assert release["ref"] == "release-ref"
+    assert len(release["ci_operator_configs"]) == 1
+    assert len(release["prow_presubmits"]) == 1
+    for item in release["ci_operator_configs"] + release["prow_presubmits"]:
+        assert (tmp_path / item["snapshot_path"]).exists()


### PR DESCRIPTION
## Summary

- collect deterministic, merge-time PR CI evidence into payload snapshots, including CI configuration, attempts, chatops, overrides, and merge actors
- add a reusable regression escape-analysis skill for a known regression and culprit PR
- integrate structured escape findings into high-confidence payload culprit analysis and reports

## Validation

- skillsaw . (Skillsaw 0.19.0): zero errors and warnings
- targeted payload snapshot, results validator, and collector tests: 82 passed
- repository tests: 26 passed
- payload results fixture suite: 16/16 passed
- live evidence-collector smoke test against a merged OpenShift PR

The make lint wrapper could not launch in this environment because neither Docker nor Podman is installed; the exact pinned Skillsaw version used by that target was run directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added regression escape analysis for high-confidence pull requests to explain how regressions passed pre-merge controls.
  - Reports now include contributing factors, merge details, relevant CI results, recommendations, and evidence limitations.
  - Added merge-time evidence collection, including CI configuration snapshots and status or action history.

- **Bug Fixes**
  - High-confidence pull request results now require validated escape-analysis data, with incomplete evidence clearly marked as unknown.

- **Chores**
  - Updated the CI plugin version to 0.0.94.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->